### PR TITLE
add maven-bundle-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
-    
+
     <groupId>org.openhab</groupId>
     <artifactId>pom</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <name>openHAB</name>
-    
+
     <organization>
         <name>openHAB.org</name>
         <url>http://www.openhab.org</url>
     </organization>
-    
+
     <licenses>
         <license>
             <name>Eclipse Public License</name>
             <url>http://www.eclipse.org/legal/epl-v10.html</url>
         </license>
     </licenses>
-    
+
     <scm>
         <connection>scm:git:https://github.com/openhab/openhab2-addons.git</connection>
         <developerConnection>scm:git:https://github.com/openhab/openhab2-addons.git</developerConnection>
         <url>https://github.com/openhab/openhab2-addons</url>
     </scm>
-        
+
     <issueManagement>
         <url>https://github.com/openhab/openhab2-addons/issues</url>
         <system>Github</system>
@@ -44,9 +44,9 @@
             <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
-    
+
     <description>This is the open Home Automation Bus (openHAB)</description>
-    
+
     <properties>
         <esh.version>0.8.0.b2</esh.version>
         <shk.version>1.2</shk.version>
@@ -60,14 +60,14 @@
         <build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <packaging>pom</packaging>
-    
+
     <modules>
-	<module>addons</module>
+        <module>addons</module>
         <module>features</module>
     </modules>
-            
+
     <build>
         <plugins>
             <plugin>
@@ -117,7 +117,7 @@
                 </configuration>
             </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -181,10 +181,23 @@
                     <artifactId>tycho-versions-plugin</artifactId>
                     <version>${tycho-version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
+                            <supportedProjectType>eclipse-plugin</supportedProjectType>
+                        </supportedProjectTypes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-    
+
     <profiles>
         <profile>
             <id>prepare-release</id>
@@ -207,7 +220,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>deploy</id>
             <distributionManagement>
@@ -239,7 +252,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>prepare-next-snapshot</id>
             <build>
@@ -260,7 +273,7 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>        
+        </profile>
     </profiles>
 
 
@@ -268,94 +281,94 @@
 
         <!-- ESH releases -->
         <repository>
-          <id>eclipse-releases</id>
-          <name>Eclipse Release Repository</name>
-          <layout>default</layout>
-          <url>https://repo.eclipse.org/content/repositories/releases/</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
+            <id>eclipse-releases</id>
+            <name>Eclipse Release Repository</name>
+            <layout>default</layout>
+            <url>https://repo.eclipse.org/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
         <!-- ESH Snapshots -->
         <repository>
-          <id>eclipse-snapshots</id>
-          <name>Eclipse Snapshot Repository</name>
-          <layout>default</layout>
-          <url>https://repo.eclipse.org/content/repositories/snapshots/</url>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>always</updatePolicy>
-          </snapshots>
+            <id>eclipse-snapshots</id>
+            <name>Eclipse Snapshot Repository</name>
+            <layout>default</layout>
+            <url>https://repo.eclipse.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
         </repository>
 
         <!-- openHAB releases -->
         <repository>
-          <id>jcenter</id>
-          <name>JCenter Repository</name>
-          <url>https://jcenter.bintray.com/</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
+            <id>jcenter</id>
+            <name>JCenter Repository</name>
+            <url>https://jcenter.bintray.com/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
         <repository>
-          <id>openhab-bintray</id>
-          <name>Bintray Repository for openHAB</name>
-          <url>https://dl.bintray.com/openhab/mvn/</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
+            <id>openhab-bintray</id>
+            <name>Bintray Repository for openHAB</name>
+            <url>https://dl.bintray.com/openhab/mvn/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
         <!-- openHAB snapshots -->
         <repository>
-          <id>jfrog</id>
-          <name>JFrog OSS Repository</name>
-          <url>http://oss.jfrog.org/libs-snapshot/</url>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>always</updatePolicy>
-          </snapshots>
+            <id>jfrog</id>
+            <name>JFrog OSS Repository</name>
+            <url>http://oss.jfrog.org/libs-snapshot/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
         </repository>
 
         <!-- SHK releases -->
         <repository>
-          <id>shk-bintray</id>
-          <name>Bintray Repository for shk</name>
-          <url>https://dl.bintray.com/maggu2810/maven</url>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
+            <id>shk-bintray</id>
+            <name>Bintray Repository for shk</name>
+            <url>https://dl.bintray.com/maggu2810/maven</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
-        <!-- 
-            P2 Repositories for tycho build.
-            This list should match or at least be a subset of the list of URL's in openhab-distro target platform.
-            These repos can be mirrored by maven if needed.
-         -->
+        <!--
+           P2 Repositories for tycho build.
+           This list should match or at least be a subset of the list of URL's in openhab-distro target platform.
+           These repos can be mirrored by maven if needed.
+        -->
         <repository>
             <id>p2-smarthome</id>
             <url>http://download.eclipse.org/smarthome/updates-stable</url>


### PR DESCRIPTION
The configuration has been added, so we could a manual manifest
generation. The generated manifest could be used by developers to
identify missing imports.
The manifest generation could be triggered by:
mvn bundle:manifest -DniceManifest=true
The "nice manifest" option will e.g. add line breaks after every
imported package.
Now you can have a look at the manifest that would be generated by the
bndtool using:
cat target/classes/META-INF/MANIFEST.MF