### PR TITLE
Network: Add DHCPREQUEST packet listener for instantly detecting reappearing devices

### DIFF
--- a/addons/binding/org.openhab.binding.network/README.md
+++ b/addons/binding/org.openhab.binding.network/README.md
@@ -13,7 +13,7 @@ Network devices can be manually discovered by sending a PING to every IP on the 
 ## Thing Configuration
 
 ```
-network:device:1 [ hostname="192.168.0.64", port="0", retry="1", timeout="5000", refresh_interval="60000", use_system_ping="false" ]
+network:device:1 [ hostname="192.168.0.64", port="0", retry="1", timeout="5000", refresh_interval="60000", use_system_ping="false", dhcplisten="true" ]
 ```
 
 - hostname: IP address or hostname of the device
@@ -22,22 +22,36 @@ network:device:1 [ hostname="192.168.0.64", port="0", retry="1", timeout="5000",
 - timeout: How long shall the PING wait for an answer
 - refresh_interval: How often shall the device be checked
 - use\_system\_ping: Uses the ping of the operating system, instead of the Java ping. Useful if the devices cannot be reached by the Java ping.
+- dhcplisten: Listen for DHCP Request messages. If devices leave and reenter a network, they usually request their last IP address by a udp
+              broadcast message (DHCP, Message type Request). If we listen for those messages, we can make the status update more "real-time" and do not
+              have to wait for the next refresh cycle.
+              
+## Limitations
+This binding uses ping packets, if port is set to 0, to detect the status of a device.
+If you want to detect IoT devices, usually you have to configure them to support ping. 
+
+If you want to use "dhcplisten": Please make sure that the process which hosts this binding has elevated privileges for listening to sockets below port 1024.
+For example by setting the **cap_net_bind_service** capability:
+  * __setcap 'cap_net_bind_service=+ep' /usr/bin/java__
+  * Check with: __getcap /usr/bin/java__
+  
+    /usr/bin/java = cap_net_bind_service+ep
 
 ## Channels
 
 All devices support some of the following channels:
 
 | Channel Type ID | Item Type    | Description  |
-|-----------------|------------------------|--------------|----------------- |------------- |
-| online | Switch       | This channel indicates whether a device is online or not |
-| time   | Number       | This channel indicates the Ping time in milliseconds |
+|-----------------|--------------|----------------------------------------------- |
+| online          | Switch       | This channel indicates whether a device is online or not |
+| time            | Number       | This channel indicates the Ping time in milliseconds. Maybe 0 if no time is available. |
 
 
 ## Full Example
 
 demo.things:
 ```
-network:device:1 [ hostname="192.168.0.64", port="0", retry="1", timeout="5000", refresh_interval="60000", use_system_ping="false" ]
+network:device:1 [ hostname="192.168.0.64", port="0", retry="1", timeout="5000", refresh_interval="60000", use_system_ping="false", dhcplisten="true" ]
 ```
 
 demo.items:

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/NetworkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/NetworkBindingConstants.java
@@ -14,15 +14,16 @@ import java.util.Set;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link NetworkBindingConstants} class defines common constants, which are 
+ * The {@link NetworkBindingConstants} class defines common constants, which are
  * used across the whole binding.
- * 
+ *
  * @author Marc Mettke - Initial contribution
+ * @author David Gräff - 2016, Add dhcp listen
  */
 public class NetworkBindingConstants {
 
     public static final String BINDING_ID = "network";
-    
+
     // List of all Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_DEVICE = new ThingTypeUID(BINDING_ID, "device");
 
@@ -34,10 +35,11 @@ public class NetworkBindingConstants {
     public final static String PARAMETER_HOSTNAME = "hostname";
     public final static String PARAMETER_PORT = "port";
     public final static String PARAMETER_RETRY = "retry";
+    public final static String PARAMETER_DHCPLISTEN = "dhcplisten";
     public final static String PARAMETER_TIMEOUT = "timeout";
     public final static String PARAMETER_REFRESH_INTERVAL = "refresh_interval";
     public final static String PARAMETER_USE_SYSTEM_PING = "use_system_ping";
-    
+
     public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_DEVICE);
-    
+
 }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/PingRunnable.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/PingRunnable.java
@@ -1,0 +1,29 @@
+package org.openhab.binding.network.discovery;
+
+import org.eclipse.smarthome.model.script.actions.Ping;
+import org.openhab.binding.network.service.NetworkUtils;
+
+class PingRunnable implements Runnable {
+    final String ip;
+    final NetworkDiscoveryService service;
+
+    public PingRunnable(String ip, NetworkDiscoveryService service) {
+        this.ip = ip;
+        this.service = service;
+        if (ip == null) {
+            throw new RuntimeException("ip may not be null!");
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (Ping.checkVitality(ip, 0, NetworkDiscoveryService.PING_TIMEOUT_IN_MS)) {
+                service.newDevice(ip);
+            } else if (NetworkUtils.nativePing(ip, 0, NetworkDiscoveryService.PING_TIMEOUT_IN_MS)) {
+                service.newDevice(ip);
+            }
+        } catch (Exception e) {
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/PingRunnable.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/PingRunnable.java
@@ -1,8 +1,23 @@
+/**
+ * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.network.discovery;
 
 import org.eclipse.smarthome.model.script.actions.Ping;
 import org.openhab.binding.network.service.NetworkUtils;
 
+/**
+ * This runnable pings the given IP address and is used by the {@see NetworkDiscoveryService}.
+ * If the java ping does not work, a native ping will be tried. This procedure is necessary,
+ * because in some OS versions (e.g. Windows 7) the java ping does not work reliably.
+ *
+ * @author David Graeff <david.graeff@web.de>
+ */
 class PingRunnable implements Runnable {
     final String ip;
     final NetworkDiscoveryService service;

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/handler/NetworkHandler.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/handler/NetworkHandler.java
@@ -128,6 +128,11 @@ public class NetworkHandler extends BaseThingHandler implements StateUpdate {
             networkService.setTimeout(confValueToInt(value));
         }
 
+        value = conf.get(PARAMETER_DHCPLISTEN);
+        if (value != null) {
+            networkService.setDHCPListen(confValueToBoolean(value));
+        }
+
         value = conf.get(PARAMETER_USE_SYSTEM_PING);
         if (value != null) {
             networkService.setUseSystemPing(confValueToBoolean(value));

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/handler/NetworkHandler.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/handler/NetworkHandler.java
@@ -10,12 +10,9 @@ package org.openhab.binding.network.handler;
 
 import static org.openhab.binding.network.NetworkBindingConstants.*;
 
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -32,95 +29,111 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link NetworkHandler} is responsible for handling commands, which are
  * sent to one of the channels.
- * 
+ *
  * @author Marc Mettke - Initial contribution
  */
-public class NetworkHandler extends BaseThingHandler {
+public class NetworkHandler extends BaseThingHandler implements StateUpdate {
     private Logger logger = LoggerFactory.getLogger(NetworkHandler.class);
-	private NetworkService networkService;
-    
-	public NetworkHandler(Thing thing) {
-		super(thing);
-	}
+    private NetworkService networkService;
 
-	
-	@Override
-	public void dispose() {
-		networkService.stopAutomaticRefresh();
-	}
-	
-	@Override
-	public void handleCommand(ChannelUID channelUID, Command command) {
+    public NetworkHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void dispose() {
+        networkService.stopAutomaticRefresh();
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
             switch (channelUID.getId()) {
-	            case CHANNEL_ONLINE:
-	            	try {
-						State state = networkService.updateDeviceState() < 0 ? OnOffType.OFF : OnOffType.ON;
-						updateState(CHANNEL_ONLINE, state);					
-					} catch( InvalidConfigurationException invalidConfigurationException) {
-					    updateStatus(ThingStatus.OFFLINE);
-					}
-	            	break;
-	            case CHANNEL_TIME:
-	            	try {
-						State state = new DecimalType(networkService.updateDeviceState());
-						updateState(CHANNEL_TIME, state);					
-					} catch( InvalidConfigurationException invalidConfigurationException) {
-					    updateStatus(ThingStatus.OFFLINE);
-					}
-	            	break;
-	            default:
-	                logger.debug("Command received for an unknown channel: {}", channelUID.getId());
-	                break;
+                case CHANNEL_ONLINE:
+                    try {
+                        State state = networkService.updateDeviceState() < 0 ? OnOffType.OFF : OnOffType.ON;
+                        updateState(CHANNEL_ONLINE, state);
+                    } catch (InvalidConfigurationException invalidConfigurationException) {
+                        updateStatus(ThingStatus.OFFLINE);
+                    }
+                    break;
+                case CHANNEL_TIME:
+                    try {
+                        State state = new DecimalType(networkService.updateDeviceState());
+                        updateState(CHANNEL_TIME, state);
+                    } catch (InvalidConfigurationException invalidConfigurationException) {
+                        updateStatus(ThingStatus.OFFLINE);
+                    }
+                    break;
+                default:
+                    logger.debug("Command received for an unknown channel: {}", channelUID.getId());
+                    break;
             }
         } else {
             logger.debug("Command {} is not supported for channel: {}", command, channelUID.getId());
-        }	
-	}
-	
-	@Override
-	public void initialize() {
-        logger.debug("Initializing Network handler.");
-		this.networkService = new NetworkService();
-		Configuration conf = this.getConfig();
-		
-		super.initialize();
-		
-		networkService.setHostname(String.valueOf(conf.get(PARAMETER_HOSTNAME)));
-		
-		try {
-			networkService.setPort(Integer.parseInt(String.valueOf(conf.get(PARAMETER_PORT))));
-		} catch (Exception ex) {}
-		
-		try {
-			networkService.setRetry(Integer.parseInt(String.valueOf(conf.get(PARAMETER_RETRY))));
-		} catch (Exception ex) {}
-		
-		try {
-			networkService.setRefreshInterval(Long.parseLong(String.valueOf(conf.get(PARAMETER_REFRESH_INTERVAL))));
-		} catch (Exception ex) {}
+        }
+    }
 
-		try {
-			networkService.setTimeout(Integer.parseInt(String.valueOf(conf.get(PARAMETER_TIMEOUT))));			
-		} catch (Exception ex) {}
-		
-		try {
-			networkService.setUseSystemPing(Boolean.parseBoolean(String.valueOf(conf.get(PARAMETER_USE_SYSTEM_PING))));
-		} catch (Exception ex) {}
-		
-		networkService.startAutomaticRefresh(scheduler, new StateUpdate() {
-            @Override
-            public void newState(double state) {
-    		State onlineState = state < 0 ? OnOffType.OFF : OnOffType.ON;
-    		State timeState = new DecimalType(state);
-    		updateState(CHANNEL_ONLINE, onlineState);
-    		updateState(CHANNEL_TIME, timeState);
-	    }
-            @Override
-            public void invalidConfig() {
-                updateStatus(ThingStatus.OFFLINE);
-            }
-        });
-	}
+    @Override
+    public void newState(double state) {
+        State onlineState = state < 0 ? OnOffType.OFF : OnOffType.ON;
+        State timeState = new DecimalType(state);
+        updateState(CHANNEL_ONLINE, onlineState);
+        updateState(CHANNEL_TIME, timeState);
+    }
+
+    @Override
+    public void invalidConfig() {
+        updateStatus(ThingStatus.OFFLINE);
+    }
+
+    int confValueToInt(Object value) {
+        return value instanceof java.math.BigDecimal ? ((java.math.BigDecimal) value).intValue()
+                : Integer.valueOf((String) value);
+    }
+
+    boolean confValueToBoolean(Object value) {
+        return value instanceof Boolean ? ((Boolean) value) : Boolean.valueOf((String) value);
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Initialize Network handler.");
+        this.networkService = new NetworkService();
+        Configuration conf = this.getConfig();
+
+        super.initialize();
+
+        networkService.setHostname(String.valueOf(conf.get(PARAMETER_HOSTNAME)));
+        Object value;
+
+        value = conf.get(PARAMETER_PORT);
+        if (value != null) {
+            networkService.setPort(confValueToInt(value));
+        }
+
+        value = conf.get(PARAMETER_RETRY);
+        if (value != null) {
+            networkService.setRetry(confValueToInt(value));
+        }
+
+        value = conf.get(PARAMETER_REFRESH_INTERVAL);
+        if (value != null) {
+            networkService.setRefreshInterval(value instanceof java.math.BigDecimal
+                    ? ((java.math.BigDecimal) value).longValue() : Integer.valueOf((String) value));
+        }
+
+        value = conf.get(PARAMETER_TIMEOUT);
+        if (value != null) {
+            networkService.setTimeout(confValueToInt(value));
+        }
+
+        value = conf.get(PARAMETER_USE_SYSTEM_PING);
+        if (value != null) {
+            networkService.setUseSystemPing(confValueToBoolean(value));
+        }
+
+        networkService.startAutomaticRefresh(scheduler, this);
+    }
 
 }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/InvalidConfigurationException.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/InvalidConfigurationException.java
@@ -8,6 +8,11 @@
  */
 package org.openhab.binding.network.service;
 
+/**
+ * This exception is thrown if an invalid configuration is provided.
+ *
+ * @author David Graeff <david.graeff@web.de>
+ */
 public class InvalidConfigurationException extends Exception {
 	private static final long serialVersionUID = -4913760031378662737L;
 

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
@@ -9,22 +9,11 @@
 package org.openhab.binding.network.service;
 
 import java.io.IOException;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.TreeSet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.SystemUtils;
-import org.apache.commons.net.util.SubnetUtils;
 import org.eclipse.smarthome.model.script.actions.Ping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +22,7 @@ import org.slf4j.LoggerFactory;
  * The {@link NetworkService} handles the connection to the Device
  *
  * @author Marc Mettke
+ * @author David Gräff, 2016 - Add DHCP listen for request packets
  */
 public class NetworkService {
 
@@ -98,6 +88,9 @@ public class NetworkService {
         this.retry = retry;
     }
 
+    public void setDHCPListen(boolean dhcplisten) {
+    }
+
     public void setRefreshInterval(long refreshInterval) {
         this.refreshInterval = refreshInterval;
     }
@@ -135,172 +128,36 @@ public class NetworkService {
      */
     public double updateDeviceState() throws InvalidConfigurationException {
         int currentTry = 0;
-        double result;
-
         do {
-            result = updateDeviceState(getHostname(), getPort(), getTimeout(), isUseSystemPing());
-            currentTry++;
-        } while (result < 0 && currentTry < this.retry);
+            boolean success;
+            double pingTime;
 
-        return result;
-    }
-
-    /**
-     * Try's to reach the Device by Ping
-     */
-    private static double updateDeviceState(String hostname, int port, int timeout, boolean useSystemPing)
-            throws InvalidConfigurationException {
-        boolean success = false;
-        double pingTime = -1;
-
-        try {
-            if (!useSystemPing) {
-                pingTime = System.nanoTime();
-                success = Ping.checkVitality(hostname, port, timeout);
-                pingTime = System.nanoTime() - pingTime;
-            } else {
-                Process proc;
-                if (SystemUtils.IS_OS_UNIX) {
-                    pingTime = System.nanoTime();
-                    proc = new ProcessBuilder("ping", "-t", String.valueOf(timeout / 1000), "-c", "1", hostname)
-                            .start();
-                } else if (SystemUtils.IS_OS_WINDOWS) {
-                    pingTime = System.nanoTime();
-                    proc = new ProcessBuilder("ping", "-w", String.valueOf(timeout), "-n", "1", hostname).start();
-                } else {
-                    logger.error("The System Ping is not supported on this Operating System");
-                    throw new InvalidConfigurationException("System Ping not supported");
-                }
-
-                int exitValue = proc.waitFor();
-                pingTime = System.nanoTime() - pingTime;
-                success = exitValue == 0;
-                if (!success) {
-                    logger.debug("Ping stopped with Error Number: " + exitValue + " on Command :" + "ping"
-                            + (SystemUtils.IS_OS_UNIX ? " -t " : " -w ")
-                            + (SystemUtils.IS_OS_UNIX ? String.valueOf(timeout / 1000) : String.valueOf(timeout))
-                            + (SystemUtils.IS_OS_UNIX ? " -c" : " -n") + " 1 " + hostname);
-                }
-            }
-
-            logger.debug("established connection [host '{}' port '{}' timeout '{}']",
-                    new Object[] { hostname, port, timeout });
-        } catch (SocketTimeoutException se) {
-            logger.debug("timed out while connecting to host '{}' port '{}' timeout '{}'",
-                    new Object[] { hostname, port, timeout });
-        } catch (IOException ioe) {
-            logger.debug("couldn't establish network connection [host '{}' port '{}' timeout '{}']",
-                    new Object[] { hostname, port, timeout });
-        } catch (InterruptedException e) {
-            logger.debug("ping program was interrupted");
-        }
-
-        return success ? pingTime / 1000000.0f : -1;
-
-    }
-
-    /**
-     * Handles the whole Discovery
-     */
-    public static void discoverNetwork(DiscoveryCallback discoveryCallback,
-            ScheduledExecutorService scheduledExecutorService) {
-        TreeSet<String> interfaceIPs;
-        LinkedHashSet<String> networkIPs;
-
-        logger.debug("Starting Device Discovery");
-        interfaceIPs = getInterfaceIPs();
-        networkIPs = getNetworkIPs(interfaceIPs);
-        startDiscovery(networkIPs, discoveryCallback, scheduledExecutorService);
-    }
-
-    /**
-     * Gets every IPv4 Address on each Interface except the loopback
-     * The Address format is ip/subnet
-     *
-     * @return The collected IPv4 Addresses
-     */
-    private static TreeSet<String> getInterfaceIPs() {
-        TreeSet<String> interfaceIPs = new TreeSet<String>();
-
-        try {
-            // For each interface ...
-            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
-                NetworkInterface networkInterface = en.nextElement();
-                if (!networkInterface.isLoopback()) {
-
-                    // .. and for each address ...
-                    for (Iterator<InterfaceAddress> it = networkInterface.getInterfaceAddresses().iterator(); it
-                            .hasNext();) {
-
-                        // ... get IP and Subnet
-                        InterfaceAddress interfaceAddress = it.next();
-                        interfaceIPs.add(interfaceAddress.getAddress().getHostAddress() + "/"
-                                + interfaceAddress.getNetworkPrefixLength());
-                    }
-                }
-            }
-        } catch (SocketException e) {
-        }
-
-        return interfaceIPs;
-    }
-
-    /**
-     * Takes the interfaceIPs and fetches every IP which can be assigned on their network
-     *
-     * @param networkIPs The IPs which are assigned to the Network Interfaces
-     * @return Every single IP which can be assigned on the Networks the computer is connected to
-     */
-    private static LinkedHashSet<String> getNetworkIPs(TreeSet<String> interfaceIPs) {
-        LinkedHashSet<String> networkIPs = new LinkedHashSet<String>();
-
-        for (Iterator<String> it = interfaceIPs.iterator(); it.hasNext();) {
             try {
-                // gets every ip which can be assigned on the given network
-                SubnetUtils utils = new SubnetUtils(it.next());
-                String[] addresses = utils.getInfo().getAllAddresses();
-                for (int i = 0; i < addresses.length; i++) {
-                    networkIPs.add(addresses[i]);
+                pingTime = System.nanoTime();
+                if (!useSystemPing) {
+                    success = Ping.checkVitality(hostname, port, timeout);
+                } else {
+                    success = NetworkUtils.nativePing(hostname, port, timeout);
                 }
-
-            } catch (Exception ex) {
+                pingTime = System.nanoTime() - pingTime;
+                if (success) {
+                    logger.debug("established connection [host '{}' port '{}' timeout '{}']",
+                            new Object[] { hostname, port, timeout });
+                    return pingTime / 1000000.0f;
+                }
+            } catch (SocketTimeoutException se) {
+                logger.debug("timed out while connecting to host '{}' port '{}' timeout '{}'",
+                        new Object[] { hostname, port, timeout });
+            } catch (IOException ioe) {
+                logger.debug("couldn't establish network connection [host '{}' port '{}' timeout '{}']",
+                        new Object[] { hostname, port, timeout });
+            } catch (InterruptedException e) {
+                logger.debug("ping program was interrupted");
             }
-        }
 
-        return networkIPs;
-    }
+        } while (currentTry++ < this.retry);
 
-    /**
-     * Starts the DiscoveryThread for each IP on the Networks
-     *
-     * @param allNetworkIPs
-     */
-    private static void startDiscovery(final LinkedHashSet<String> networkIPs,
-            final DiscoveryCallback discoveryCallback, ScheduledExecutorService scheduledExecutorService) {
-        final int PING_TIMEOUT_IN_MS = 500;
-        ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
-
-        for (Iterator<String> it = networkIPs.iterator(); it.hasNext();) {
-            final String ip = it.next();
-            executorService.execute(new Runnable() {
-                @Override
-                public void run() {
-                    if (ip != null) {
-                        try {
-                            if (Ping.checkVitality(ip, 0, PING_TIMEOUT_IN_MS)) {
-                                discoveryCallback.newDevice(ip);
-                            }
-                        } catch (IOException e) {
-                        }
-                    }
-                }
-            });
-        }
-        try {
-            executorService.awaitTermination(PING_TIMEOUT_IN_MS * networkIPs.size(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-        }
-        executorService.shutdown();
+        return -1;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
@@ -129,7 +129,6 @@ public class NetworkService {
             try {
                 ReceiveDHCPRequestPackets.register(InetAddress.getByName(hostname).getHostAddress(), stateUpdate);
             } catch (SocketException | UnknownHostException e) {
-                e.printStackTrace();
                 logger.error("Cannot use DHCP listen: " + e.getMessage());
             }
         }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,6 +23,11 @@ import java.util.TreeSet;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.net.util.SubnetUtils;
 
+/**
+ * Network utility functions for pinging and for determining all interfaces and assigned IP addresses.
+ *
+ * @author David Graeff <david.graeff@web.de>
+ */
 public class NetworkUtils {
 
     /**

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.network.service;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.TreeSet;
+
+import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.net.util.SubnetUtils;
+
+public class NetworkUtils {
+
+    /**
+     * Gets every IPv4 Address on each Interface except the loopback
+     * The Address format is ip/subnet
+     *
+     * @return The collected IPv4 Addresses
+     */
+    public static TreeSet<String> getInterfaceIPs() {
+        TreeSet<String> interfaceIPs = new TreeSet<String>();
+
+        try {
+            // For each interface ...
+            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
+                NetworkInterface networkInterface = en.nextElement();
+                if (!networkInterface.isLoopback()) {
+
+                    // .. and for each address ...
+                    for (Iterator<InterfaceAddress> it = networkInterface.getInterfaceAddresses().iterator(); it
+                            .hasNext();) {
+
+                        // ... get IP and Subnet
+                        InterfaceAddress interfaceAddress = it.next();
+                        interfaceIPs.add(interfaceAddress.getAddress().getHostAddress() + "/"
+                                + interfaceAddress.getNetworkPrefixLength());
+                    }
+                }
+            }
+        } catch (SocketException e) {
+        }
+
+        return interfaceIPs;
+    }
+
+    /**
+     * Takes the interfaceIPs and fetches every IP which can be assigned on their network
+     *
+     * @param networkIPs The IPs which are assigned to the Network Interfaces
+     * @return Every single IP which can be assigned on the Networks the computer is connected to
+     */
+    public static LinkedHashSet<String> getNetworkIPs(TreeSet<String> interfaceIPs) {
+        LinkedHashSet<String> networkIPs = new LinkedHashSet<String>();
+
+        for (Iterator<String> it = interfaceIPs.iterator(); it.hasNext();) {
+            try {
+                // gets every ip which can be assigned on the given network
+                SubnetUtils utils = new SubnetUtils(it.next());
+                String[] addresses = utils.getInfo().getAllAddresses();
+                for (int i = 0; i < addresses.length; i++) {
+                    networkIPs.add(addresses[i]);
+                }
+
+            } catch (Exception ex) {
+            }
+        }
+
+        return networkIPs;
+    }
+
+    /**
+     * Converts 32 bits int to IPv4 <tt>InetAddress</tt>.
+     *
+     * @param val int representation of IPv4 address
+     * @return the address object
+     */
+    public static final InetAddress int2InetAddress(int val) {
+        byte[] value = { (byte) ((val & 0xFF000000) >>> 24), (byte) ((val & 0X00FF0000) >>> 16),
+                (byte) ((val & 0x0000FF00) >>> 8), (byte) ((val & 0x000000FF)) };
+        try {
+            return InetAddress.getByAddress(value);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Converts 32 bits int packaged into a 64bits long to IPv4 <tt>InetAddress</tt>.
+     *
+     * @param val int representation of IPv4 address
+     * @return the address object
+     */
+    public static final InetAddress long2InetAddress(long val) {
+        if ((val < 0) || (val > 0xFFFFFFFFL)) {
+            // TODO exception ???
+        }
+        return int2InetAddress((int) val);
+    }
+
+    /**
+     * Converts IPv4 <tt>InetAddress</tt> to 32 bits int.
+     *
+     * @param addr IPv4 address object
+     * @return 32 bits int
+     * @throws NullPointerException <tt>addr</tt> is <tt>null</tt>.
+     * @throws IllegalArgumentException the address is not IPv4 (Inet4Address).
+     */
+    public static final int inetAddress2Int(InetAddress addr) {
+        if (!(addr instanceof Inet4Address)) {
+            throw new IllegalArgumentException("Only IPv4 supported");
+        }
+
+        byte[] addrBytes = addr.getAddress();
+        return ((addrBytes[0] & 0xFF) << 24) | ((addrBytes[1] & 0xFF) << 16) | ((addrBytes[2] & 0xFF) << 8)
+                | ((addrBytes[3] & 0xFF));
+    }
+
+    /**
+     * Converts IPv4 <tt>InetAddress</tt> to 32 bits int, packages into a 64 bits <tt>long</tt>.
+     *
+     * @param addr IPv4 address object
+     * @return 32 bits int
+     * @throws NullPointerException <tt>addr</tt> is <tt>null</tt>.
+     * @throws IllegalArgumentException the address is not IPv4 (Inet4Address).
+     */
+    public static final long inetAddress2Long(InetAddress addr) {
+        return (inetAddress2Int(addr) & 0xFFFFFFFFL);
+    }
+
+    public static boolean nativePing(String hostname, int port, int timeout)
+            throws InvalidConfigurationException, IOException, InterruptedException {
+        Process proc;
+        if (SystemUtils.IS_OS_UNIX) {
+            proc = new ProcessBuilder("ping", "-t", String.valueOf(timeout / 1000), "-c", "1", hostname).start();
+        } else if (SystemUtils.IS_OS_WINDOWS) {
+            proc = new ProcessBuilder("ping", "-w", String.valueOf(timeout), "-n", "1", hostname).start();
+        } else {
+            throw new InvalidConfigurationException("System Ping not supported");
+        }
+
+        int exitValue = proc.waitFor();
+        if (exitValue != 0) {
+            throw new IOException("Ping stopped with Error Number: " + exitValue + " on Command :" + "ping"
+                    + (SystemUtils.IS_OS_UNIX ? " -t " : " -w ")
+                    + (SystemUtils.IS_OS_UNIX ? String.valueOf(timeout / 1000) : String.valueOf(timeout))
+                    + (SystemUtils.IS_OS_UNIX ? " -c" : " -n") + " 1 " + hostname);
+        }
+        return exitValue == 0;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/StateUpdate.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/StateUpdate.java
@@ -10,9 +10,17 @@ package org.openhab.binding.network.service;
 
 /**
  * Callback for the automatic Refresh
+ *
  * @author Marc Mettke - Initial contribution
  */
 public interface StateUpdate {
-	public void newState(double state);
+    /**
+     * The new reachable state.
+     *
+     * @param state A ping time in ms, 0 if the device is reachable but no time information is available
+     *            or -1 if he device is not reachable.
+     */
+    public void newState(double state);
+
     public void invalidConfig();
 }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/DHCPPacket.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/DHCPPacket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,19 +20,19 @@ import java.util.Map;
 /**
  * Parses a dhcp packet and extracts the OP code and all DHCP Options.
  *
- * @author David Gräff
+ * Example:
+ *   DatagramSocket socket = new DatagramSocket(67);
+ *   while (true) {
+ *      DatagramPacket packet = new DatagramPacket(new byte[1500], 1500);
+ *      socket.receive(packet);
+ *      DHCPPacket dhcp = new DHCPPacket(packet);
+ *      InetAddress requestedAddress = dhcp.getRequestedIPAddress();
+ *   }
  *
- *         DatagramSocket socket = new DatagramSocket(67);
- *         while (true) {
- *         DatagramPacket packet = new DatagramPacket(new byte[1500], 1500);
- *         socket.receive(packet);
- *         DHCPPacket dhcp = new DHCPPacket(packet);
- *         InetAddress requestedAddress = dhcp.getRequestedIPAddress();
- *         }
+ * If used this way, beware that a <tt>BadPacketExpcetion</tt> is thrown
+ * if the datagram contains invalid DHCP data.
  *
- *         In this way, beware that a <tt>BadPacketExpcetion</tt> is thrown
- *         if the datagram contains invalid DHCP data.
- *
+ * @author David Graeff <david.graeff@web.de>
  */
 class DHCPPacket {
     /** DHCP BOOTP CODES **/

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/DHCPPacket.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/DHCPPacket.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.network.service.dhcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Parses a dhcp packet and extracts the OP code and all DHCP Options.
+ *
+ * @author David Gräff
+ *
+ *         DatagramSocket socket = new DatagramSocket(67);
+ *         while (true) {
+ *         DatagramPacket packet = new DatagramPacket(new byte[1500], 1500);
+ *         socket.receive(packet);
+ *         DHCPPacket dhcp = new DHCPPacket(packet);
+ *         InetAddress requestedAddress = dhcp.getRequestedIPAddress();
+ *         }
+ *
+ *         In this way, beware that a <tt>BadPacketExpcetion</tt> is thrown
+ *         if the datagram contains invalid DHCP data.
+ *
+ */
+class DHCPPacket {
+    /** DHCP BOOTP CODES **/
+    static final byte BOOTREQUEST = 1;
+    static final byte BOOTREPLY = 2;
+
+    /** DHCP MESSAGE CODES **/
+    static final byte DHCPDISCOVER = 1;
+
+    static final byte DHCPREQUEST = 3;
+    static final byte DHCPDECLINE = 4;
+
+    static final byte DHCPRELEASE = 7;
+    static final byte DHCPINFORM = 8;
+
+    /** DHCP OPTIONS CODE **/
+    static final byte DHO_PAD = 0;
+
+    static final byte DHO_DHCP_REQUESTED_ADDRESS = 50;
+
+    static final byte DHO_DHCP_MESSAGE_TYPE = 53;
+
+    static final byte DHO_END = -1;
+
+    static final int _BOOTP_ABSOLUTE_MIN_LEN = 236;
+    static final int _DHCP_MAX_MTU = 1500;
+
+    // Magic cookie
+    static final int _MAGIC_COOKIE = 0x63825363;
+
+    /**
+     * If a DHCP datagram is malformed this Exception is thrown.
+     *
+     * It inherits from <tt>IllegalArgumentException</tt> and <tt>RuntimeException</tt>
+     * so it doesn't need to be explicitly caught.
+     *
+     * @author David Gräff
+     */
+    static class BadPacketException extends IllegalArgumentException {
+        private static final long serialVersionUID = 5866225879843384688L;
+
+        BadPacketException(String message) {
+            super(message);
+        }
+
+        BadPacketException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+    }
+
+    private byte op;
+    private Map<Byte, byte[]> options;
+
+    /**
+     * Constructor for the <tt>DHCPPacket</tt> class. Parses the given datagram.
+     */
+    public DHCPPacket(DatagramPacket datagram) throws BadPacketException, IOException {
+        this.op = BOOTREPLY;
+        this.options = new LinkedHashMap<Byte, byte[]>();
+
+        byte[] buffer = datagram.getData();
+        int offset = datagram.getOffset();
+        int length = datagram.getLength();
+
+        // absolute minimum size for a valid packet
+        if (length < _BOOTP_ABSOLUTE_MIN_LEN) {
+            throw new BadPacketException(
+                    "DHCP Packet too small (" + length + ") absolute minimum is " + _BOOTP_ABSOLUTE_MIN_LEN);
+        }
+        // maximum size for a valid DHCP packet
+        if (length > _DHCP_MAX_MTU) {
+            throw new BadPacketException("DHCP Packet too big (" + length + ") max MTU is " + _DHCP_MAX_MTU);
+        }
+
+        // turn buffer into a readable stream
+        ByteArrayInputStream inBStream = new ByteArrayInputStream(buffer, offset, length);
+        DataInputStream inStream = new DataInputStream(inBStream);
+
+        byte[] dummy = new byte[128];
+
+        // parse static part of packet
+        this.op = inStream.readByte();
+        inStream.readByte(); // read hardware type (ETHERNET)
+        inStream.readByte(); // read hardware address length (6 bytes)
+        inStream.readByte(); // read hops
+        inStream.readInt(); // read transaction id
+        inStream.readShort(); // read secsonds elapsed
+        inStream.readShort(); // read flags
+        inStream.readFully(dummy, 0, 4); // ciaddr
+        inStream.readFully(dummy, 0, 4); // yiaddr
+        inStream.readFully(dummy, 0, 4); // siaddr
+        inStream.readFully(dummy, 0, 4); // giaddr
+        inStream.readFully(dummy, 0, 16); // chaddr
+        inStream.readFully(dummy, 0, 64); // sname
+        inStream.readFully(dummy, 0, 128); // file
+
+        // check for DHCP MAGIC_COOKIE
+        inBStream.mark(4); // read ahead 4 bytes
+        if (inStream.readInt() != _MAGIC_COOKIE) {
+            throw new BadPacketException("Packet seams to be truncated");
+        }
+
+        // DHCP Packet: parsing options
+        int type = 0;
+
+        while (true) {
+            int r = inBStream.read();
+            if (r < 0) {
+                break;
+            } // EOF
+
+            type = (byte) r;
+
+            if (type == DHO_PAD) {
+                continue;
+            } // skip Padding
+            if (type == DHO_END) {
+                break;
+            } // break if end of options
+
+            r = inBStream.read();
+            if (r < 0) {
+                break;
+            } // EOF
+
+            int len = Math.min(r, inBStream.available());
+            byte[] unit_opt = new byte[len];
+            inBStream.read(unit_opt);
+
+            this.options.put((byte) type, unit_opt);
+        }
+        if (type != DHO_END) {
+            throw new BadPacketException("Packet seams to be truncated");
+        }
+    }
+
+    /**
+     * Returns the op field (Message op code).
+     *
+     *
+     * @return the op field.
+     */
+    public byte getOp() {
+        return this.op;
+    }
+
+    /**
+     * Return the DHCP Option Type.
+     *
+     * <p>
+     * This is a short-cut for <tt>getOptionAsByte(DHO_DHCP_MESSAGE_TYPE)</tt>.
+     *
+     * @return option type, of <tt>null</tt> if not present.
+     */
+    public Byte getDHCPMessageType() {
+        byte[] opt = options.get(DHO_DHCP_MESSAGE_TYPE);
+        if (opt == null) {
+            return null;
+        }
+        if (opt.length != 1) {
+            throw new BadPacketException(
+                    "option " + DHO_DHCP_MESSAGE_TYPE + " is wrong size:" + opt.length + " should be 1");
+        }
+        return opt[0];
+    }
+
+    /**
+     * Returns the requested IP address of a BOOTREQUEST packet.
+     */
+    InetAddress getRequestedIPAddress() throws IllegalArgumentException, UnknownHostException {
+        byte[] opt = options.get(DHO_DHCP_REQUESTED_ADDRESS);
+        if (opt == null) {
+            return null;
+        }
+        if (opt.length != 4) {
+            throw new BadPacketException(
+                    "option " + DHO_DHCP_REQUESTED_ADDRESS + " is wrong size:" + opt.length + " should be 4");
+        }
+        return InetAddress.getByAddress(opt);
+    }
+}

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/ReceiveDHCPRequestPackets.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/ReceiveDHCPRequestPackets.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.network.service.dhcp;
 
 import java.io.IOException;
@@ -55,9 +63,7 @@ public class ReceiveDHCPRequestPackets extends Thread {
             }
             try {
                 instance.join(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            } catch (InterruptedException e) { }
             instance.interrupt();
             instance.dsocket = null;
         }
@@ -114,7 +120,6 @@ public class ReceiveDHCPRequestPackets extends Thread {
                 return;
             }
             logger.error(e.getLocalizedMessage());
-            e.printStackTrace();
         }
     }
 

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/ReceiveDHCPRequestPackets.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/dhcp/ReceiveDHCPRequestPackets.java
@@ -1,0 +1,124 @@
+package org.openhab.binding.network.service.dhcp;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.openhab.binding.network.service.StateUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A singleton UDP Receiver class. StateUpdate objects can register and unregister.
+ * If the first one is registered and there is no singleton instance, an instance will be created and the
+ * receiver thread will be started. If the last StateUpdate is removed, the thread will be stopped
+ * after the receive socket is closed. This instance listens to the UDP port 67 and will call
+ * StateUpdate.newState(0) for the address that is registered and matches the DHO_DHCP_REQUESTED_ADDRESS address field.
+ *
+ * @author David Graeff <david.graeff@web.de>
+ */
+public class ReceiveDHCPRequestPackets extends Thread {
+    private byte[] buffer = new byte[1024];
+    private DatagramSocket dsocket = new DatagramSocket(null);
+    private DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+    private boolean willbeclosed = false;
+    private Logger logger = LoggerFactory.getLogger(ReceiveDHCPRequestPackets.class);
+    private static ReceiveDHCPRequestPackets instance;
+    private static Map<String, StateUpdate> registeredListeners = new TreeMap<>();
+
+    public static synchronized void register(String hostAddress, StateUpdate receiveParseSimpleUDP)
+            throws SocketException {
+        if (instance == null) {
+            instance = new ReceiveDHCPRequestPackets();
+            instance.start();
+        }
+        registeredListeners.put(hostAddress, receiveParseSimpleUDP);
+    }
+
+    public static void unregister(String hostAddress) {
+        synchronized (registeredListeners) {
+            registeredListeners.remove(hostAddress);
+            if (!registeredListeners.isEmpty()) {
+                return;
+            }
+        }
+
+        if (instance != null && instance.isAlive()) {
+            instance.willbeclosed = true;
+            if (instance.dsocket != null) {
+                instance.dsocket.close();
+            }
+            try {
+                instance.join(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            instance.interrupt();
+            instance.dsocket = null;
+        }
+        instance = null;
+    }
+
+    ReceiveDHCPRequestPackets() throws SocketException {
+        dsocket.setReuseAddress(true);
+        dsocket.setBroadcast(true);
+        dsocket.bind(new InetSocketAddress(67));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("DHCP request packet listener online");
+            while (!willbeclosed) {
+                packet.setLength(buffer.length);
+                dsocket.receive(packet);
+
+                DHCPPacket request;
+                try {
+                    request = new DHCPPacket(packet);
+                } catch (Exception e) {
+                    continue;
+                }
+
+                if (request.getOp() != DHCPPacket.BOOTREQUEST) {
+                    continue; // skipping non BOOTREQUEST message types
+                }
+
+                Byte dhcpMessageType = request.getDHCPMessageType();
+
+                if (dhcpMessageType == null || dhcpMessageType != DHCPPacket.DHCPREQUEST) {
+                    continue; // skipping non DHCPREQUEST message types
+                }
+
+                InetAddress requestedAddress = request.getRequestedIPAddress();
+                if (requestedAddress == null) {
+                    logger.error("DHCPREQUEST field is missing");
+                    continue;
+                }
+                String requestedAddressStr = requestedAddress.getHostAddress();
+                StateUpdate receiver = registeredListeners.get(requestedAddressStr);
+                if (receiver != null) {
+                    logger.info("DHCP request for registered address: " + requestedAddressStr);
+                    receiver.newState(0);
+                } else {
+                    logger.info("DHCP request for unknown address: " + requestedAddressStr);
+                }
+            }
+        } catch (IOException e) {
+            if (willbeclosed) {
+                return;
+            }
+            logger.error(e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
+    public DatagramSocket getSocket() {
+        return dsocket;
+    }
+}


### PR DESCRIPTION
This pull request consists of two commits. One refactors a little bit. The other adds functionality.

## Refactor network binding
 * Move all network utilitiy functionality to network/service/NetworkUtils.java
 * Remove some indirections. The discovery service does not need anything from NetworkService
   and is on its own now. It also uses both Ping.checkVitality and NetworkUtils.nativePing. Especially
   on Windows Ping.checkVitality does not work that good.
 * Add comment to network/service/StateUpdate.java
 * NetworkHandler.java: Do not use generic Exception handlers while reading configuration parameters.
   If a wrong value or value type is provided for a parameter (e.g. a string for PARAMETER_RETRY etc),
   it is the right behaviour to not handle that exception *silently* and let Openhab update the thing
   with INITIALIZATION_ERROR instead.
 * NetworkHandler.java: use dispose() to call NetworkService.stopAutomaticRefresh
 * NetworkService: Remove discovery parts. Remove utility functions. Basically it provides:
   - startAutomaticRefresh(...)
   - stopAutomaticRefresh()
   - updateDeviceState()

## DHCP listen
Add optional dhcp listen functionality. If a network device (say smartphone) reregister to a network,
it will send a DHCPREQUEST with its old IP address. We listen for that packet and set the state
of the corresponding thing to ONLINE. This is much more faster ("instant") than waiting for the periodic
ping to succeed and an almost universal solution for IPv4 networks where DHCP is often used in those
scenarios.

 * Add relevant information to readme.md
 * Add service/dhcp/DHCPPacket.java: For marshalling a dhcp packet.
 * Add service/dhcp/ReceiveDHCPRequestPackets.java: For receiving and listening to dhcp traffic.

## Related functionality and improvements
For IPv6 we should also listen to ICMP IPv6 Neighbor Discovery messages.

Signed-off-by: David Gräff <david.graeff@web.de>