### PR TITLE
RFXCOM fixes

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXrec433.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXrec433.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="RFXrec433">
 		<label>RFXrec433 USB 433.92MHz Receiver</label>
@@ -15,12 +13,15 @@
 			</parameter>
 			<parameter name="ignoreConfig" type="boolean">
 				<label>Skip transceiver configuration</label>
-				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message configurations are ignored.</description>
+				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is
+					preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message
+					configurations are ignored.</description>
 				<default>true</default>
 			</parameter>
 			<parameter name="setMode" type="text">
 				<label>RFXCOM transceiver mode</label>
-				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters (14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
+				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters
+					(14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
 			</parameter>
 			<parameter name="enableUndecoded" type="boolean">
 				<label>Undecoded messages</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXtrx315.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXtrx315.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="RFXtrx315">
 		<label>RFXtrx315 USB 315MHz Transceiver</label>
@@ -15,12 +13,15 @@
 			</parameter>
 			<parameter name="ignoreConfig" type="boolean">
 				<label>Skip transceiver configuration</label>
-				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message configurations are ignored.</description>
+				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is
+					preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message
+					configurations are ignored.</description>
 				<default>true</default>
 			</parameter>
 			<parameter name="setMode" type="text">
 				<label>RFXCOM transceiver mode</label>
-				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters (14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
+				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters
+					(14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
 			</parameter>
 			<parameter name="transceiverType" type="text">
 				<label>RFXCOM transceiver type</label>
@@ -46,7 +47,7 @@
 				<description>Enable X10 messages to RFXCOM transceiver.</description>
 				<default>false</default>
 			</parameter>
-			
+
 		</config-description>
 	</bridge-type>
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXtrx433.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/RFXtrx433.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
-	
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+
 	<bridge-type id="RFXtrx433">
 		<label>RFXtrx433E USB 433.92MHz Transceiver</label>
 		<description>This is an RFXCOM 433.92MHz transceiver bridge.</description>
@@ -15,12 +13,15 @@
 			</parameter>
 			<parameter name="ignoreConfig" type="boolean">
 				<label>Skip transceiver configuration</label>
-				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message configurations are ignored.</description>
+				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is
+					preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message
+					configurations are ignored.</description>
 				<default>true</default>
 			</parameter>
 			<parameter name="setMode" type="text">
 				<label>RFXCOM transceiver mode</label>
-				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters (14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
+				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters
+					(14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
 			</parameter>
 			<parameter name="enableUndecoded" type="boolean">
 				<label>Undecoded messages</label>
@@ -127,7 +128,7 @@
 				<description>Enable X10 messages to RFXCOM transceiver.</description>
 				<default>false</default>
 			</parameter>
-			
+
 		</config-description>
 	</bridge-type>
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/blinds1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/blinds1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/blinds1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/blinds1.xml
@@ -25,7 +25,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Id + unit code, separated by dot. Example 23455.1</description>
+				<description>Sensor Id + unit code, separated by dot. Example 23455.1</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/bridge.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="bridge">
 		<label>RFXCOM USB Transceiver</label>
@@ -15,12 +13,15 @@
 			</parameter>
 			<parameter name="ignoreConfig" type="boolean" required="true">
 				<label>Skip transceiver configuration</label>
-				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message configurations are ignored.</description>
+				<description>Fully skip and ignore RFXCOM transceiver configuration. Binding assume that RFXCOM transceiver is
+					preconfigured e.g. via RFXcom Manager. When this is enabled, both set mode command and individual message
+					configurations are ignored.</description>
 				<default>true</default>
 			</parameter>
 			<parameter name="setMode" type="text">
 				<label>RFXCOM transceiver mode</label>
-				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters (14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
+				<description>RFXCOM transceiver set mode command. Command should be in hexadecimal string format and 28 characters
+					(14 bytes) long. If set mode command is given, individual message configurations are ignored.</description>
 			</parameter>
 			<parameter name="transceiverType" type="text">
 				<label>RFXCOM transceiver type</label>
@@ -153,7 +154,7 @@
 				<description>Enable X10 messages to RFXCOM transceiver.</description>
 				<default>false</default>
 			</parameter>
-			
+
 		</config-description>
 	</bridge-type>
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/curtain1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/curtain1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/curtain1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/curtain1.xml
@@ -25,7 +25,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. House code + unit code, separated by dot. Example A.1</description>
+				<description>House code + unit code, separated by dot. Example A.1</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/energy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/energy.xml
@@ -25,6 +25,21 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 5693</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="ELEC2">CM119/160</option>
+                    <option value="ELEC3">CM180</option>
+                </options>
+            </parameter>
+        </config-description>
+
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/energy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/energy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -25,20 +24,20 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 5693</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="ELEC2">CM119/160</option>
-                    <option value="ELEC3">CM180</option>
-                </options>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 5693</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="ELEC2">CM119/160</option>
+					<option value="ELEC3">CM180</option>
+				</options>
+			</parameter>
+		</config-description>
 
 	</thing-type>
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/humidity.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/humidity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -22,20 +21,20 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 5693</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="HUM1">LaCrosse TX3</option>
-                    <option value="HUM2">LaCrosse WS2300</option>
-                </options>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 5693</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="HUM1">LaCrosse TX3</option>
+					<option value="HUM2">LaCrosse WS2300</option>
+				</options>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/humidity.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/humidity.xml
@@ -21,6 +21,21 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 5693</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="HUM1">LaCrosse TX3</option>
+                    <option value="HUM2">LaCrosse WS2300</option>
+                </options>
+            </parameter>
+        </config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting2.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting2.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting2.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting2.xml
@@ -24,16 +24,16 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Id + unit code, separated by dot. Example 8773718.10</description>
+				<description>Remote/switch/unit Id + unit code, separated by dot. Example 8773718.10</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>
 				<description>Specifies device sub type.</description>
 				<options>
 					<option value="AC">AC</option>
-					<option value="HomeEasy EU">HomeEasy EU</option>
+					<option value="HOME_EASY_EU">HomeEasy EU</option>
 					<option value="ANSLUT">ANSLUT</option>
-					<option value="Kambrook RF3672">Kambrook RF3672</option>
+					<option value="KAMBROOK">Kambrook RF3672</option>
 				</options>
 			</parameter>
 		</config-description>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting4.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting4.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
@@ -25,7 +25,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Id + unit code, separated by dot. Example 10001.1</description>
+				<description>Remote/switch/unit Id + unit code, separated by dot. Example 10001.1</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting6.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting6.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting6.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting6.xml
@@ -23,7 +23,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Id + group code + unit code, separated by dot. Example 100.A.1</description>
+				<description>Remote/switch/unit Id + group code + unit code, separated by dot. Example 100.A.1</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rain.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rain.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -21,26 +20,26 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
-		
+
 		<config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 56923</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="RAIN1">RGR126/682/918/928</option>
-                    <option value="RAIN2">PCR800</option>
-                    <option value="RAIN3">TFA</option>
-                    <option value="RAIN4">UPM RG700</option>
-                    <option value="RAIN5">WS2300</option>
-                    <option value="RAIN6">La Crosse TX5</option>
-                </options>
-            </parameter>
-        </config-description>
-		
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 56923</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="RAIN1">RGR126/682/918/928</option>
+					<option value="RAIN2">PCR800</option>
+					<option value="RAIN3">TFA</option>
+					<option value="RAIN4">UPM RG700</option>
+					<option value="RAIN5">WS2300</option>
+					<option value="RAIN6">La Crosse TX5</option>
+				</options>
+			</parameter>
+		</config-description>
+
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rain.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rain.xml
@@ -21,6 +21,26 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+		
+		<config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 56923</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="RAIN1">RGR126/682/918/928</option>
+                    <option value="RAIN2">PCR800</option>
+                    <option value="RAIN3">TFA</option>
+                    <option value="RAIN4">UPM RG700</option>
+                    <option value="RAIN5">WS2300</option>
+                    <option value="RAIN6">La Crosse TX5</option>
+                </options>
+            </parameter>
+        </config-description>
+		
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
@@ -23,7 +23,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Id + unit code, separated by dot. Example 100.1</description>
+				<description>Unit Id + unit code, separated by dot. Example 100.1</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/security1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/security1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/security1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/security1.xml
@@ -27,7 +27,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Example 10001</description>
+				<description>Remote/sensor Id. Example 10001</description>
 			</parameter>
 			<parameter name="subType" type="text" required="true">
 				<label>Sub Type</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperature.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperature.xml
@@ -20,6 +20,30 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 56923</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="TEMP1">THR128/138, THC138</option>
+                    <option value="TEMP2">THC238/268,THN132,THWR288,THRN122,THN122,AW129/131</option>
+                    <option value="TEMP3">THWR800</option>
+                    <option value="TEMP4">RTHN318</option>
+                    <option value="TEMP5">La Crosse TX2, TX3, TX4, TX17</option>
+                    <option value="TEMP6">TS15C. UPM temp only</option>
+                    <option value="TEMP7">Viking 02811, Proove TSS330, 311346</option>
+                    <option value="TEMP8">La Crosse WS2300</option>
+                    <option value="TEMP9">Rubicson</option>
+                    <option value="TEMP10">TFA 30.3133</option>
+                    <option value="TEMP11">WT0122</option>
+                </options>
+            </parameter>
+        </config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperature.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperature.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -21,29 +20,29 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 56923</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="TEMP1">THR128/138, THC138</option>
-                    <option value="TEMP2">THC238/268,THN132,THWR288,THRN122,THN122,AW129/131</option>
-                    <option value="TEMP3">THWR800</option>
-                    <option value="TEMP4">RTHN318</option>
-                    <option value="TEMP5">La Crosse TX2, TX3, TX4, TX17</option>
-                    <option value="TEMP6">TS15C. UPM temp only</option>
-                    <option value="TEMP7">Viking 02811, Proove TSS330, 311346</option>
-                    <option value="TEMP8">La Crosse WS2300</option>
-                    <option value="TEMP9">Rubicson</option>
-                    <option value="TEMP10">TFA 30.3133</option>
-                    <option value="TEMP11">WT0122</option>
-                </options>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 56923</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="TEMP1">THR128/138, THC138</option>
+					<option value="TEMP2">THC238/268,THN132,THWR288,THRN122,THN122,AW129/131</option>
+					<option value="TEMP3">THWR800</option>
+					<option value="TEMP4">RTHN318</option>
+					<option value="TEMP5">La Crosse TX2, TX3, TX4, TX17</option>
+					<option value="TEMP6">TS15C. UPM temp only</option>
+					<option value="TEMP7">Viking 02811, Proove TSS330, 311346</option>
+					<option value="TEMP8">La Crosse WS2300</option>
+					<option value="TEMP9">Rubicson</option>
+					<option value="TEMP10">TFA 30.3133</option>
+					<option value="TEMP11">WT0122</option>
+				</options>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -22,33 +21,33 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
-		
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 56923</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="TH1">THGN122/123, THGN132, THGR122/228/238/268</option>
-                    <option value="TH2">THGR810, THGN800</option>
-                    <option value="TH3">RTGR328</option>
-                    <option value="TH4">THGR328</option>
-                    <option value="TH5">WTGR800</option>
-                    <option value="TH6">THGR918/928, THGRN228, THGN500</option>
-                    <option value="TH7">TFA TS34C, Cresta</option>
-                    <option value="TH8">WT260,WT260H,WT440H,WT450,WT450H</option>
-                    <option value="TH9">Viking 02035,02038 (02035 has no humidity), Proove TSS320, 311501</option>
-                    <option value="TH10">Rubicson</option>
-                    <option value="TH11">EW109</option>
-                    <option value="TH12">Imagintronix/Opus XT300 Soil sensor</option>
-                    <option value="TH13">Alecto WS1700 and compatibles</option>
-                </options>
-            </parameter>
-        </config-description>
-		
+
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 56923</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="TH1">THGN122/123, THGN132, THGR122/228/238/268</option>
+					<option value="TH2">THGR810, THGN800</option>
+					<option value="TH3">RTGR328</option>
+					<option value="TH4">THGR328</option>
+					<option value="TH5">WTGR800</option>
+					<option value="TH6">THGR918/928, THGRN228, THGN500</option>
+					<option value="TH7">TFA TS34C, Cresta</option>
+					<option value="TH8">WT260,WT260H,WT440H,WT450,WT450H</option>
+					<option value="TH9">Viking 02035,02038 (02035 has no humidity), Proove TSS320, 311501</option>
+					<option value="TH10">Rubicson</option>
+					<option value="TH11">EW109</option>
+					<option value="TH12">Imagintronix/Opus XT300 Soil sensor</option>
+					<option value="TH13">Alecto WS1700 and compatibles</option>
+				</options>
+			</parameter>
+		</config-description>
+
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
@@ -22,6 +22,33 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+		
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 56923</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="TH1">THGN122/123, THGN132, THGR122/228/238/268</option>
+                    <option value="TH2">THGR810, THGN800</option>
+                    <option value="TH3">RTGR328</option>
+                    <option value="TH4">THGR328</option>
+                    <option value="TH5">WTGR800</option>
+                    <option value="TH6">THGR918/928, THGRN228, THGN500</option>
+                    <option value="TH7">TFA TS34C, Cresta</option>
+                    <option value="TH8">WT260,WT260H,WT440H,WT450,WT450H</option>
+                    <option value="TH9">Viking 02035,02038 (02035 has no humidity), Proove TSS320, 311501</option>
+                    <option value="TH10">Rubicson</option>
+                    <option value="TH11">EW109</option>
+                    <option value="TH12">Imagintronix/Opus XT300 Soil sensor</option>
+                    <option value="TH13">Alecto WS1700 and compatibles</option>
+                </options>
+            </parameter>
+        </config-description>
+		
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat1.xml
@@ -22,6 +22,21 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 56923</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="DIGIMAX">Digimax, TLX7506</option>
+                    <option value="DIGIMAX_SHORT">Digimax with short format (no set point)</option>
+                </options>
+            </parameter>
+        </config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat1.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -23,20 +22,20 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 56923</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="DIGIMAX">Digimax, TLX7506</option>
-                    <option value="DIGIMAX_SHORT">Digimax with short format (no set point)</option>
-                </options>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 56923</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="DIGIMAX">Digimax, TLX7506</option>
+					<option value="DIGIMAX_SHORT">Digimax with short format (no set point)</option>
+				</options>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/wind.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/wind.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="rfxcom"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -22,24 +21,24 @@
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
 
-        <config-description>
-            <parameter name="deviceId" type="text" required="true">
-                <label>Device Id</label>
-                <description>Sensor Id. Example 2983</description>
-            </parameter>
-            <parameter name="subType" type="text" required="true">
-                <label>Sub Type</label>
-                <description>Specifies device sub type.</description>
-                <options>
-                    <option value="WIND1">WTGR800</option>
-                    <option value="WIND2">WGR800</option>
-                    <option value="WIND3">STR918, WGR918, WGR928</option>
-                    <option value="WIND4">TFA</option>
-                    <option value="WIND5">UPM WDS500</option>
-                    <option value="WIND6">WS2300</option>
-                </options>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Sensor Id. Example 2983</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="WIND1">WTGR800</option>
+					<option value="WIND2">WGR800</option>
+					<option value="WIND3">STR918, WGR918, WGR928</option>
+					<option value="WIND4">TFA</option>
+					<option value="WIND5">UPM WDS500</option>
+					<option value="WIND6">WS2300</option>
+				</options>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/wind.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/wind.xml
@@ -21,6 +21,25 @@
 			<channel id="batteryLevel" typeId="system.battery-level" />
 			<channel id="lowBattery" typeId="system.low-battery" />
 		</channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 2983</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="WIND1">WTGR800</option>
+                    <option value="WIND2">WGR800</option>
+                    <option value="WIND3">STR918, WGR918, WGR928</option>
+                    <option value="WIND4">TFA</option>
+                    <option value="WIND5">UPM WDS500</option>
+                    <option value="WIND6">WS2300</option>
+                </options>
+            </parameter>
+        </config-description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
@@ -42,6 +42,8 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import gnu.io.NoSuchPortException;
+
 /**
  * {@link RFXComBridgeHandler} is the handler for a RFXCOM transceivers. All
  * {@link RFXComHandler}s use the {@link RFXComBridgeHandler} to execute the
@@ -204,6 +206,8 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                 connector.sendMessage(RFXComMessageFactory.CMD_START_RECEIVER);
                 updateStatus(ThingStatus.ONLINE);
             }
+        } catch (NoSuchPortException e) {
+            logger.error("Connection to RFXCOM transceiver failed: invalid port");
         } catch (Exception e) {
             logger.error("Connection to RFXCOM transceiver failed: {}", e.getMessage());
         } catch (UnsatisfiedLinkError e) {

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessage.java
@@ -30,8 +30,8 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
 
     public enum SubType {
         UNDEF(0),
-        LACROSSE_TX3(1),
-        LACROSSE_WS2300(2),
+        HUM1(1),
+        HUM2(2),
 
         UNKNOWN(255);
 
@@ -79,7 +79,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.LACROSSE_TX3;
+    public SubType subType = SubType.UNDEF;
     public int sensorId = 0;
     public byte humidity = 0;
     public HumidityStatus humidityStatus = HumidityStatus.NORMAL;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
@@ -39,6 +39,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
         AC(0),
         HOME_EASY_EU(1),
         ANSLUT(2),
+        KAMBROOK(3),
 
         UNKNOWN(255);
 
@@ -176,7 +177,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
 
     /**
      * Convert a 0-15 scale value to a percent type.
-     * 
+     *
      * @param pt
      *            percent type to convert
      * @return converted value 0-15
@@ -188,7 +189,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
 
     /**
      * Convert a 0-15 scale value to a percent type.
-     * 
+     *
      * @param pt
      *            percent type to convert
      * @return converted value 0-15

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
@@ -29,12 +29,12 @@ public class RFXComRainMessage extends RFXComBaseMessage {
 
     public enum SubType {
         UNDEF(0),
-        RGR126_682_918_928(1),
-        PCR800(2),
-        TFA(3),
-        UPM_RG700(4),
-        WS2300(5),
-        LA_CROSSE_TX5(6),
+        RAIN1(1),
+        RAIN2(2),
+        RAIN3(3),
+        RAIN4(4),
+        RAIN5(5),
+        RAIN6(6),
 
         UNKNOWN(255);
 
@@ -59,7 +59,7 @@ public class RFXComRainMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.RGR126_682_918_928;
+    public SubType subType = SubType.UNDEF;
     public int sensorId = 0;
     public double rainRate = 0;
     public double rainTotal = 0;
@@ -102,11 +102,11 @@ public class RFXComRainMessage extends RFXComBaseMessage {
         sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
 
         rainRate = (short) ((data[6] & 0xFF) << 8 | (data[7] & 0xFF));
-        if (subType == SubType.PCR800) {
+        if (subType == SubType.RAIN2) {
             rainRate *= 0.01;
         }
 
-        if (subType == SubType.LA_CROSSE_TX5) {
+        if (subType == SubType.RAIN6) {
             rainTotal = (short) ((data[10] & 0xFF)) * 0.266;
         } else {
             rainTotal = (short) ((data[8] & 0xFF) << 8 | (data[9] & 0xFF) << 8 | (data[10] & 0xFF)) * 0.1;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessage.java
@@ -30,16 +30,19 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
 
     public enum SubType {
         UNDEF(0),
-        THGN122_123_132_THGR122_228_238_268(1),
-        THGN800_THGR810(2),
-        RTGR328(3),
-        THGR328(4),
-        WTGR800(5),
-        THGR918_THGRN228_THGN50(6),
-        TFA_TS34C__CRESTA(7),
-        WT260_WT260H_WT440H_WT450_WT450H(8),
-        VIKING_02035_02038(9),
-        RUBICSON(10),
+        TH1(1),
+        TH2(2),
+        TH3(3),
+        TH4(4),
+        TH5(5),
+        TH6(6),
+        TH7(7),
+        TH8(8),
+        TH9(9),
+        TH10(10),
+        TH11(11),
+        TH12(12),
+        TH13(13),
 
         UNKNOWN(255);
 
@@ -87,7 +90,7 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.THGN122_123_132_THGR122_228_238_268;
+    public SubType subType = SubType.UNDEF;
     public int sensorId = 0;
     public double temperature = 0;
     public byte humidity = 0;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessage.java
@@ -28,16 +28,16 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
 
     public enum SubType {
         UNDEF(0),
-        THR128_138_THC138(1),
-        THC238_268_THN122_132_THWR288_THRN122_AW129_131(2),
-        THWR800(3),
-        RTHN318(4),
-        LACROSSE_TX2_TX3_TX4_TX17(5),
-        TS15C(6),
-        VIKING_02811(7),
-        LACROSSE_WS2300(8),
-        RUBICSON(9),
-        TFA_30_3133(10),
+        TEMP1(1),
+        TEMP2(2),
+        TEMP3(3),
+        TEMP4(4),
+        TEMP5(5),
+        TEMP6(6),
+        TEMP7(7),
+        TEMP8(8),
+        TEMP9(9),
+        TEMP10(10),
 
         UNKNOWN(255);
 
@@ -61,7 +61,7 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.THR128_138_THC138;
+    public SubType subType = SubType.UNDEF;
     public int sensorId = 0;
     public double temperature = 0;
     public byte signalLevel = 0;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1Message.java
@@ -31,8 +31,8 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 public class RFXComThermostat1Message extends RFXComBaseMessage {
 
     public enum SubType {
-        DIGIMAX_TLX7506(0),
-        DIGIMAX_SHORT_FORMAT(1),
+        DIGIMAX(0),
+        DIGIMAX_SHORT(1),
 
         UNKNOWN(255);
 
@@ -103,7 +103,7 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.DIGIMAX_TLX7506;
+    public SubType subType = SubType.DIGIMAX;
     public int sensorId = 0;
     public byte temperature = 0;
     public byte set = 0;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessage.java
@@ -29,12 +29,12 @@ public class RFXComWindMessage extends RFXComBaseMessage {
 
     public enum SubType {
         UNDEF(0),
-        WTGR800(1),
-        WGR800(2),
-        STR918_WGR918_WGR928(3),
-        TFA(4),
-        UPM_WDS500(5),
-        WS2300(6),
+        WIND1(1),
+        WIND2(2),
+        WIND3(3),
+        WIND4(4),
+        WIND5(5),
+        WIND6(6),
 
         UNKNOWN(255);
 
@@ -59,7 +59,7 @@ public class RFXComWindMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.WTGR800;
+    public SubType subType = SubType.UNDEF;
     public int sensorId = 0;
     public double windDirection = 0;
     public double windSpeed = 0;
@@ -112,7 +112,7 @@ public class RFXComWindMessage extends RFXComBaseMessage {
         byte[] data = new byte[16];
 
         data[0] = 0x10;
-        data[1] = RFXComBaseMessage.PacketType.RAIN.toByte();
+        data[1] = RFXComBaseMessage.PacketType.WIND.toByte();
         data[2] = subType.toByte();
         data[3] = seqNbr;
         data[4] = (byte) ((sensorId & 0xFF00) >> 8);


### PR DESCRIPTION
- Added missing mandatory parameters to config descriptions.
- Adapted sub type naming to be inline RFXCOM spec.
- Check if bridge is already initialized during sensor initialization. Should prevent sensor to stay stay in offline mode.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>