### PR TITLE
MAX! improvements and issue fixes

### DIFF
--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/S_Command.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/S_Command.java
@@ -21,7 +21,9 @@ import org.openhab.binding.max.internal.device.ThermostatModeType;
  */
 public class S_Command extends CubeCommand {
 
-    private String baseString = "000440000000";
+    private String baseStringS = "000040000000"; // for single devices
+    private String baseStringG = "000440000000"; // for group/room devices
+
     private boolean[] bits = null;
 
     private String rfAddress = null;
@@ -83,6 +85,13 @@ public class S_Command extends CubeCommand {
      */
     @Override
     public String getCommandString() {
+
+        String baseString = "";
+        if (roomId == 0) {
+            baseString = baseStringS;
+        } else {
+            baseString = baseStringG;
+        }
 
         String commandString = baseString + rfAddress + Utils.toHex(roomId) + Utils.toHex(bits);
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Device.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Device.java
@@ -126,7 +126,7 @@ public abstract class Device {
         device.setLinkStatusError(bits2[6]);
         device.setBatteryLow(bits2[7]);
 
-        logger.trace("Device {} type {} L Message length: {} content: {}", rfAddress, device.getType().toString(),
+        logger.trace("Device {} ({}): L Message length: {} content: {}", rfAddress, device.getType().toString(),
                 raw.length, Utils.getHex(raw));
 
         // TODO move the device specific readings into the sub classes
@@ -145,7 +145,7 @@ public abstract class Device {
                 } else if (bits2[1] == true && bits2[0] == true) {
                     heatingThermostat.setMode(ThermostatModeType.BOOST);
                 } else {
-                    logger.debug("Device {}: Unknown mode", rfAddress);
+                    logger.debug("Device {} ({}): Unknown mode", rfAddress, device.getType().toString());
                 }
 
                 heatingThermostat.setValvePosition(raw[6] & 0xFF);
@@ -169,26 +169,29 @@ public abstract class Device {
                             && heatingThermostat.getMode() != ThermostatModeType.BOOST) {
                         actualTemp = (raw[8] & 0xFF) * 256 + (raw[9] & 0xFF);
                     } else {
-                        logger.debug("Device {}: No temperature reading in {} mode", rfAddress,
-                                heatingThermostat.getMode());
+                        logger.debug("Device {} ({}): No temperature reading in {} mode", rfAddress,
+                                device.getType().toString(), heatingThermostat.getMode());
                     }
                 }
-                logger.trace("Device {}: Actual Temperature : {}", rfAddress, (double) actualTemp / 10);
+                logger.debug("Device {} ({}): Actual Temperature : {}", rfAddress, device.getType().toString(),
+                        (double) actualTemp / 10);
                 heatingThermostat.setTemperatureActual((double) actualTemp / 10);
                 break;
             case EcoSwitch:
                 String eCoSwitchData = Utils.toHex(raw[3] & 0xFF, raw[4] & 0xFF, raw[5] & 0xFF);
-                logger.trace("EcoSwitch Device {} status bytes : {}", rfAddress, eCoSwitchData);
+                logger.trace("Device {} ({}): Status bytes : {}", rfAddress, device.getType().toString(),
+                        eCoSwitchData);
                 EcoSwitch ecoswitch = (EcoSwitch) device;
                 // xxxx xx10 = shutter open, xxxx xx00 = shutter closed
                 if (bits2[1] == true && bits2[0] == false) {
                     ecoswitch.setEcoMode(OnOffType.ON);
-                    logger.trace("Device {} status: ON", rfAddress);
+                    logger.trace("Device {} ({}): status: ON", rfAddress, device.getType().toString());
                 } else if (bits2[1] == false && bits2[0] == false) {
                     ecoswitch.setEcoMode(OnOffType.OFF);
-                    logger.trace("Device {} status: OFF", rfAddress);
+                    logger.trace("Device {} ({}): Status: OFF", rfAddress, device.getType().toString());
                 } else {
-                    logger.trace("Device {} status switch status Unknown (true-true)", rfAddress);
+                    logger.trace("Device {} ({}): Status switch status Unknown (true-true)", rfAddress,
+                            device.getType().toString());
                 }
                 break;
             case ShutterContact:
@@ -196,12 +199,13 @@ public abstract class Device {
                 // xxxx xx10 = shutter open, xxxx xx00 = shutter closed
                 if (bits2[1] == true && bits2[0] == false) {
                     shutterContact.setShutterState(OpenClosedType.OPEN);
-                    logger.trace("Device {} status: Open", rfAddress);
+                    logger.debug("Device {} ({}): Status: Open", rfAddress, device.getType().toString());
                 } else if (bits2[1] == false && bits2[0] == false) {
                     shutterContact.setShutterState(OpenClosedType.CLOSED);
-                    logger.trace("Device {} status: Closed", rfAddress);
+                    logger.debug("Device {} ({}): Status: Closed", rfAddress, device.getType().toString());
                 } else {
-                    logger.trace("Device {} status switch status Unknown (true-true)", rfAddress);
+                    logger.trace("Device {} ({}): Status switch status Unknown (true-true)", rfAddress,
+                            device.getType().toString());
                 }
 
                 break;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceConfiguration.java
@@ -38,23 +38,25 @@ public final class DeviceConfiguration {
 
     public static DeviceConfiguration create(DeviceInformation di) {
         DeviceConfiguration configuration = new DeviceConfiguration();
-        configuration.setValues(di.getRFAddress(), di.getDeviceType(), di.getSerialNumber(), di.getName());
+        configuration.setValues(di.getRFAddress(), di.getDeviceType(), di.getSerialNumber(), di.getRoomId(),
+                di.getName());
         return configuration;
     }
 
     public void setValues(C_Message message) {
-        setValues(message.getRFAddress(), message.getDeviceType(), message.getSerialNumber());
+        setValues(message.getRFAddress(), message.getDeviceType(), message.getSerialNumber(), message.getRoomID());
     }
 
-    private void setValues(String rfAddress, DeviceType deviceType, String serialNumber, String name) {
-        setValues(rfAddress, deviceType, serialNumber);
+    private void setValues(String rfAddress, DeviceType deviceType, String serialNumber, int roomId, String name) {
+        setValues(rfAddress, deviceType, serialNumber, roomId);
         this.name = name;
     }
 
-    private void setValues(String rfAddress, DeviceType deviceType, String serialNumber) {
+    private void setValues(String rfAddress, DeviceType deviceType, String serialNumber, int roomId) {
         this.rfAddress = rfAddress;
         this.deviceType = deviceType;
         this.serialNumber = serialNumber;
+        this.roomId = roomId;
     }
 
     public String getRFAddress() {

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -15,6 +15,7 @@ import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketTimeoutException;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,8 +126,9 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
                 bcReceipt.receive(receivePacket);
 
                 // We have a response
-                String message = new String(receivePacket.getData(), receivePacket.getOffset(),
-                        receivePacket.getLength());
+                byte[] messageBuf = Arrays.copyOfRange(receivePacket.getData(), receivePacket.getOffset(),
+                        receivePacket.getOffset() + receivePacket.getLength());
+                String message = new String(messageBuf);
                 logger.trace("Broadcast response from {} : {} '{}'", receivePacket.getAddress(), message.length(),
                         message);
 
@@ -140,14 +142,14 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
                     String rfAddress = "";
                     logger.debug("MAX! Cube found on network");
                     logger.debug("Found at  : {}", maxCubeIP);
-                    logger.debug("Cube State: {}", maxCubeState);
+                    logger.trace("Cube State: {}", maxCubeState);
                     logger.debug("Serial    : {}", serialNumber);
                     logger.trace("Msg Valid : {}", msgValidid);
                     logger.trace("Msg Type  : {}", requestType);
 
                     if (requestType.equals("I")) {
-                        rfAddress = Utils.getHex(message.substring(21, 24).getBytes()).replace(" ", "").toLowerCase();
-                        String firmwareVersion = Utils.getHex(message.substring(24, 26).getBytes()).replace(" ", ".");
+                        rfAddress = Utils.getHex(Arrays.copyOfRange(messageBuf, 21, 24)).replace(" ", "").toLowerCase();
+                        String firmwareVersion = Utils.getHex(Arrays.copyOfRange(messageBuf, 24, 26)).replace(" ", ".");
                         logger.debug("RF Address: {}", rfAddress);
                         logger.debug("Firmware  : {}", firmwareVersion);
                     }
@@ -163,8 +165,9 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
         } finally {
             // Close the port!
             try {
-                if (bcReceipt != null)
+                if (bcReceipt != null) {
                     bcReceipt.close();
+                }
             } catch (Exception e) {
                 logger.debug(e.toString());
             }
@@ -238,8 +241,9 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
             logger.debug("IO error during MAX! Cube discovery: {}", e.getMessage());
         } finally {
             try {
-                if (bcSend != null)
+                if (bcSend != null) {
                     bcSend.close();
+                }
             } catch (Exception e) {
                 // Ignore
             }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
@@ -34,6 +34,7 @@ public final class C_Message extends Message {
     private String rfAddress = null;
     private int length = 0;
     private DeviceType deviceType = null;
+    private int roomId = -1;
     private String serialNumber = null;
     private String tempComfort = null;
     private String tempEco = null;
@@ -77,13 +78,16 @@ public final class C_Message extends Message {
         }
 
         deviceType = DeviceType.create(data[4]);
+        roomId = data[5] & 0xFF;
 
         serialNumber = getSerialNumber(bytes);
         if (deviceType == DeviceType.HeatingThermostatPlus || deviceType == DeviceType.HeatingThermostat
-                || deviceType == DeviceType.WallMountedThermostat)
+                || deviceType == DeviceType.WallMountedThermostat) {
             parseHeatingThermostatData(bytes);
-        if (deviceType == DeviceType.EcoSwitch || deviceType == DeviceType.ShutterContact)
+        }
+        if (deviceType == DeviceType.EcoSwitch || deviceType == DeviceType.ShutterContact) {
             logger.trace("Device {} type {} Data:", rfAddress, deviceType.toString(), parseData(bytes));
+        }
     }
 
     private String getSerialNumber(byte[] bytes) {
@@ -103,8 +107,9 @@ public final class C_Message extends Message {
     }
 
     private String parseData(byte[] bytes) {
-        if (bytes.length <= 18)
+        if (bytes.length <= 18) {
             return "";
+        }
         try {
             int DataStart = 18;
             byte[] sn = new byte[bytes.length - DataStart];
@@ -209,15 +214,20 @@ public final class C_Message extends Message {
         return deviceType;
     }
 
+    public int getRoomID() {
+        return roomId;
+    }
+
     @Override
     public void debug(Logger logger) {
-        logger.trace("=== C_Message === ");
+        logger.debug("=== C_Message === ");
         logger.trace("\tRAW:                    {}", this.getPayload());
-        logger.trace("DeviceType:               {}", deviceType.toString());
-        logger.trace("SerialNumber:             {}", serialNumber);
-        logger.trace("RFAddress:                {}", rfAddress);
+        logger.debug("DeviceType:               {}", deviceType.toString());
+        logger.debug("SerialNumber:             {}", serialNumber);
+        logger.debug("RFAddress:                {}", rfAddress);
+        logger.debug("RoomID:                   {}", roomId);
         for (String key : properties.keySet()) {
-            logger.trace("{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
+            logger.debug("{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
         }
         logger.trace("ProgramData:          {}", programData);
     }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/H_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/H_Message.java
@@ -143,11 +143,11 @@ public final class H_Message extends Message {
 
     @Override
     public void debug(Logger logger) {
-        logger.trace("=== H_Message === ");
+        logger.debug("=== H_Message === ");
         logger.trace("\tRAW:            : {}", this.getPayload());
         logger.trace("\tReading Time    : {}", cal.getTime());
         for (String key : properties.keySet()) {
-            logger.trace("\t{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
+            logger.debug("\t{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
         }
     }
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/M_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/M_Message.java
@@ -39,7 +39,7 @@ public final class M_Message extends Message {
 
         String[] tokens = this.getPayload().split(Message.DELIMETER);
 
-        if (tokens.length > 1)
+        if (tokens.length > 1) {
             try {
                 byte[] bytes = Base64.decodeBase64(tokens[2].getBytes());
 
@@ -105,7 +105,7 @@ public final class M_Message extends Message {
                 logger.info("Unknown error parsing the M Message: {}", e.getMessage(), e);
                 logger.debug("\tRAW : {}", this.getPayload());
             }
-        else {
+        } else {
             logger.info("No rooms defined. Configure your Max! Cube");
             hasConfiguration = false;
         }
@@ -113,22 +113,22 @@ public final class M_Message extends Message {
 
     @Override
     public void debug(Logger logger) {
-        logger.trace("=== M_Message === ");
+        logger.debug("=== M_Message === ");
         if (hasConfiguration) {
             logger.trace("\tRAW : {}", this.getPayload());
             for (RoomInformation room : rooms) {
-                logger.trace("\t=== Rooms ===");
-                logger.trace("\tRoom Pos   : {}", room.getPosition());
-                logger.trace("\tRoom Name  : {}", room.getName());
-                logger.trace("\tRoom RF Adr: {}", room.getRFAddress());
+                logger.debug("\t=== Rooms ===");
+                logger.debug("\tRoom Pos   : {}", room.getPosition());
+                logger.debug("\tRoom Name  : {}", room.getName());
+                logger.debug("\tRoom RF Adr: {}", room.getRFAddress());
                 for (DeviceInformation device : devices) {
                     if (room.getPosition() == device.getRoomId()) {
-                        logger.trace("\t=== Devices ===");
-                        logger.trace("\tDevice Type    : {}", device.getDeviceType());
-                        logger.trace("\tDevice Name    : {}", device.getName());
-                        logger.trace("\tDevice Serialnr: {}", device.getSerialNumber());
-                        logger.trace("\tDevice RF Adr  : {}", device.getRFAddress());
-                        logger.trace("\tRoom Id        : {}", device.getRoomId());
+                        logger.debug("\t=== Devices ===");
+                        logger.debug("\tDevice Type    : {}", device.getDeviceType());
+                        logger.debug("\tDevice Name    : {}", device.getName());
+                        logger.debug("\tDevice Serialnr: {}", device.getSerialNumber());
+                        logger.debug("\tDevice RF Adr  : {}", device.getRFAddress());
+                        logger.debug("\tRoom Id        : {}", device.getRoomId());
                     }
                 }
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageProcessor.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageProcessor.java
@@ -164,8 +164,9 @@ public class MessageProcessor {
 
                 if (index + 1 == receivedLines.size()) {
                     String newLine = "";
-                    for (String curLine : receivedLines)
+                    for (String curLine : receivedLines) {
                         newLine += curLine;
+                    }
                     this.currentMessage = new M_Message(newLine);
                     result = true;
                 }


### PR DESCRIPTION
FIX: error on empty M processing
FIX: take room from C: msg so corrupted M: messages or devices
configured via fhem will not error 
FIX: temp sending for single thermostats not connected to a room
FIX: correct rf address for cubes during discovery
FIX: Double messages in TRACE level
FIX: Don't send command if it is null (e.g. device is not yet available)
Improve debug messages
Update logging levels

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>