### PR TITLE
Zwave device updates

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/everspring_se812_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/everspring_se812_0_0.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+  <thing-type id="everspring_se812_00_000">
+    <label>SE812 Indoor Siren</label>
+    <description>Indoor Siren</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="switch_binary" typeId="switch_binary">
+        <label>Siren</label>
+        <properties>
+          <property name="binding:*:OnOffType">SWITCH_BINARY,BASIC</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Everspring</property>
+      <property name="model">SE812</property>
+      <property name="manufacturerId">0060</property>
+      <property name="manufacturerRef">000C:0001</property>
+      <property name="DefaultAssociations">1</property>
+    </properties>
+
+    <config-description>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association"  multiple="true">
+        <label>1: Alarm notifications</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgd211_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgd211_0_0.xml
@@ -25,7 +25,7 @@
       <property name="model">FGD211</property>
       <property name="manufacturerId">010F</property>
       <property name="manufacturerRef">0100:0104,0100:0106,0100:0107,0100:0109,0100:100A,0100:300A</property>
-      <property name="versionMax">1.8</property>
+      <property name="versionMax">1.9</property>
       <property name="DefaultAssociations">3</property>
     </properties>
 


### PR DESCRIPTION
Two small updates to the device database:

- Fibaro FGD211 application version 1.9
- Added Everspring SE812 Indoor Siren

Of course tested on my own network.