### PR TITLE
switched to snapshot versions of ESH+OHC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>
-        <esh.version>0.8.0.b2</esh.version>
+        <esh.version>0.8.0-SNAPSHOT</esh.version>
         <shk.version>1.2</shk.version>
-        <ohc.version>2.0.0.b1</ohc.version>
+        <ohc.version>2.0.0.x</ohc.version>
         <ohdr.version>1.0.0</ohdr.version>
         <karaf.version>4.0.3</karaf.version>
         <karaf.maven.plugin.version>4.0.3</karaf.maven.plugin.version>
@@ -374,7 +374,7 @@
         <!-- openHAB core p2 repository -->
         <repository>
             <id>p2-openhab-core</id>
-            <url>https://dl.bintray.com/kaikreuzer/openhab-core/p2/${ohc.version}</url>
+            <url>https://dl.bintray.com/openhab/p2/openhab-core/${ohc.version}</url>
             <layout>p2</layout>
         </repository>
 


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>