### PR TITLE
New binding for Sony Bravia TVs.

### DIFF
--- a/addons/binding/org.openhab.binding.sonytv/.classpath
+++ b/addons/binding/org.openhab.binding.sonytv/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/addons/binding/org.openhab.binding.sonytv/.project
+++ b/addons/binding/org.openhab.binding.sonytv/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.sonytv</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addons/binding/org.openhab.binding.sonytv/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.sonytv/ESH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="sonytv"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+    <name>SonyTV Binding</name>
+    <description>This is the binding for Sony Bravia TV.</description>
+    <author>Mikołaj Siedlarek</author>
+</binding:binding>

--- a/addons/binding/org.openhab.binding.sonytv/ESH-INF/i18n/sonytv_xx_XX.properties
+++ b/addons/binding/org.openhab.binding.sonytv/ESH-INF/i18n/sonytv_xx_XX.properties
@@ -1,0 +1,11 @@
+# binding
+binding.sonytv.name = <Your localized Binding name>
+binding.sonytv.description = <Your localized Binding description>
+
+# thing types
+thing-type.sonytv.sample.label = <Your localized Thing label>
+thing-type.sonytv.sample.description = <Your localized Thing description>
+
+# channel types
+channel-type.sonytv.sample-channel.label = <Your localized Channel label>
+channel-type.sonytv.sample-channel.description = <Your localized Channel description>

--- a/addons/binding/org.openhab.binding.sonytv/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.sonytv/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonytv"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+    <thing-type id="bravia">
+        <label>Sony Bravia TV</label>
+        <description>Represents a Sony Bravia TV.</description>
+        <channels>
+            <channel id="power" typeId="power"/>
+            <channel id="input" typeId="input"/>
+        </channels>
+        <config-description>
+            <parameter-group name="general">
+                <label>General</label>
+            </parameter-group>
+            <parameter-group name="authentication">
+                <label>Authentication</label>
+            </parameter-group>
+            <parameter name="udn" type="text" groupName="general" required="true">
+                <label>Unique Device Name</label>
+                <description>The UDN identifies the TV.</description>
+            </parameter>
+            <parameter name="apiUrl" type="text" groupName="general" required="true">
+                <label>API URL</label>
+                <description>An address of the Sony Scalar API for the TV.</description>
+            </parameter>
+            <parameter name="refresh" type="integer" groupName="general">
+                <label>Refresh interval</label>
+                <description>Specifies the refresh interval in seconds</description>
+                <default>5</default>
+            </parameter>
+            <parameter name="preSharedKey" type="text" groupName="authentication" required="true">
+                <label>Pre-shared Key</label>
+                <description>A pre-shared key set in TV's IP control settings.</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+    <channel-type id="power">
+        <item-type>Switch</item-type>
+        <label>Power</label>
+        <description>Power on/off the TV</description>
+    </channel-type>
+    <channel-type id="input">
+        <item-type>String</item-type>
+        <label>Input</label>
+        <description>Input source to show on the TV</description>
+    </channel-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.sonytv/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.sonytv/META-INF/MANIFEST.MF
@@ -1,0 +1,34 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: SonyTV Binding
+Bundle-SymbolicName: org.openhab.binding.sonytv;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: 
+ com.google.common.base,
+ com.google.common.collect,
+ com.google.gson,
+ javax.ws.rs,
+ javax.ws.rs.client,
+ javax.ws.rs.core,
+ org.apache.commons.net.util,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.types,
+ org.jupnp,
+ org.jupnp.model,
+ org.jupnp.model.meta,
+ org.jupnp.model.types,
+ org.openhab.binding.sonytv,
+ org.openhab.binding.sonytv.handler,
+ org.slf4j
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.sonytv,
+ org.openhab.binding.sonytv.handler

--- a/addons/binding/org.openhab.binding.sonytv/OSGI-INF/BraviaDiscovery.xml
+++ b/addons/binding/org.openhab.binding.sonytv/OSGI-INF/BraviaDiscovery.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.sonytv.discovery.bravia">
+   <implementation class="org.openhab.binding.sonytv.discovery.BraviaDiscoveryParticipant"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.sonytv/OSGI-INF/SonyTVHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.sonytv/OSGI-INF/SonyTVHandlerFactory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.sonytv.internal.SonyTVHandlerFactory">
+   <implementation class="org.openhab.binding.sonytv.internal.SonyTVHandlerFactory"/>
+   <reference bind="setDiscoveryServiceRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry" name="DiscoveryServiceRegistry" policy="static" unbind="unsetDiscoveryServiceRegistry"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.sonytv/build.properties
+++ b/addons/binding/org.openhab.binding.sonytv/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/

--- a/addons/binding/org.openhab.binding.sonytv/pom.xml
+++ b/addons/binding/org.openhab.binding.sonytv/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.sonytv</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+
+  <name>SonyTV Binding</name>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/SonyTVBindingConstants.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/SonyTVBindingConstants.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link SonyTVBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class SonyTVBindingConstants {
+
+    public static final String BINDING_ID = "sonytv";
+
+    public final static ThingTypeUID THING_TYPE_BRAVIA = new ThingTypeUID(BINDING_ID, "bravia");
+
+    public final static String CHANNEL_POWER = "power";
+    public final static String CHANNEL_INPUT = "input";
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/config/BraviaConfiguration.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/config/BraviaConfiguration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.config;
+
+/**
+ * The {@link BraviaConfiguration} class is a model of the binding's settings.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class BraviaConfiguration {
+
+    public static final String UDN = "udn";
+    public static final String API_URL = "apiUrl";
+    public static final String REFRESH = "refresh";
+    public static final String PRE_SHARED_KEY = "preSharedKey";
+
+    public String udn;
+    public String apiUrl;
+    public Integer refresh;
+    public String preSharedKey;
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/discovery/BraviaDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/discovery/BraviaDiscoveryParticipant.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.discovery;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.binding.sonytv.SonyTVBindingConstants;
+import org.openhab.binding.sonytv.config.BraviaConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/**
+ * The {@link BraviaDiscoveryParticipant} is responsible processing the
+ * results of searches for UPNP devices
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class BraviaDiscoveryParticipant implements UpnpDiscoveryParticipant {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DocumentBuilder documentBuilder;
+    private final XPathExpression baseUrlXpath;
+
+    public BraviaDiscoveryParticipant() {
+        try {
+            this.documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        } catch (final ParserConfigurationException exception) {
+            throw new AssertionError(exception);
+        }
+
+        final XPath xpath = XPathFactory.newInstance().newXPath();
+        try {
+            baseUrlXpath = xpath.compile("//*[local-name()='X_ScalarWebAPI_BaseURL']");
+        } catch (final XPathExpressionException exception) {
+            throw new AssertionError(exception);
+        }
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return Collections.singleton(SonyTVBindingConstants.THING_TYPE_BRAVIA);
+    }
+
+    @Override
+    public DiscoveryResult createResult(final RemoteDevice device) {
+        final ThingUID uid = getThingUID(device);
+        if (uid == null) {
+            return null;
+        }
+
+        final Document descriptor;
+        try {
+            descriptor = documentBuilder.parse(device.getIdentity().getDescriptorURL().toString());
+        } catch (final SAXException | IOException exception) {
+            logger.error("Could not parse UPnP descriptor.", exception);
+            return null;
+        }
+
+        final String apiUrl;
+        try {
+            apiUrl = (String) baseUrlXpath.evaluate(descriptor, XPathConstants.STRING);
+        } catch (final XPathExpressionException exception) {
+            logger.error("Could not extract base URL from UPnP descriptor.", exception);
+            return null;
+        }
+
+        final Map<String, Object> properties = new HashMap<>(2);
+        properties.put(BraviaConfiguration.UDN, device.getIdentity().getUdn().getIdentifierString());
+        properties.put(BraviaConfiguration.API_URL, apiUrl);
+        return DiscoveryResultBuilder.create(uid).withProperties(properties)
+                .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(BraviaConfiguration.UDN)
+                .build();
+    }
+
+    @Override
+    public ThingUID getThingUID(final RemoteDevice device) {
+        final String manufacturer;
+        final String model;
+        final String udn;
+        try {
+            manufacturer = device.getDetails().getManufacturerDetails().getManufacturer().toUpperCase();
+            model = device.getDetails().getModelDetails().getModelName().toUpperCase();
+            udn = device.getIdentity().getUdn().getIdentifierString();
+        } catch (final NullPointerException exception) {
+            return null;
+        }
+        if (manufacturer.contains("SONY") && model.startsWith("KDL-")) {
+            return new ThingUID(SonyTVBindingConstants.THING_TYPE_BRAVIA, udn);
+        }
+        return null;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/handler/SonyTVHandler.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/handler/SonyTVHandler.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.handler;
+
+import java.util.Collection;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryListener;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.sonytv.SonyTVBindingConstants;
+import org.openhab.binding.sonytv.config.BraviaConfiguration;
+import org.openhab.binding.sonytv.internal.ScalarApiClient;
+import org.openhab.binding.sonytv.internal.ScalarApiClient.Error;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * The {@link SonyTVHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class SonyTVHandler extends BaseThingHandler implements DiscoveryListener {
+
+    private static final int DEFAULT_REFRESH_INTERVAL = 5;
+
+    private final Runnable pollingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            try {
+                updateState();
+            } catch (final Exception exception) {
+                logger.error("Exception during poll.", exception);
+            }
+        }
+    };
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DiscoveryServiceRegistry discoveryServiceRegistry;
+
+    private ScalarApiClient api;
+    private ScheduledFuture<?> pollingJob;
+
+    public SonyTVHandler(final Thing thing, final DiscoveryServiceRegistry discoveryServiceRegistry) {
+        super(thing);
+        this.discoveryServiceRegistry = Preconditions.checkNotNull(discoveryServiceRegistry);
+    }
+
+    @Override
+    public void initialize() {
+        final BraviaConfiguration configuration = getConfig().as(BraviaConfiguration.class);
+
+        if (configuration.udn == null) {
+            logger.warn("Invalid configuration: missing UDN.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Invalid configuration: missing UDN.");
+            return;
+        }
+        if (configuration.apiUrl == null) {
+            logger.warn("Invalid configuration: missing API URL.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Invalid configuration: missing API URL.");
+            return;
+        }
+        if (configuration.preSharedKey == null) {
+            logger.warn("Invalid configuration: missing pre-shared key.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Invalid configuration: missing pre-shared key.");
+            return;
+        }
+
+        discoveryServiceRegistry.addDiscoveryListener(this);
+        connect();
+        super.initialize();
+    }
+
+    @Override
+    public void dispose() {
+        discoveryServiceRegistry.removeDiscoveryListener(this);
+        disconnect();
+        super.dispose();
+    }
+
+    @Override
+    public void thingDiscovered(final DiscoveryService source, final DiscoveryResult result) {
+        if (result.getThingUID().equals(this.getThing().getUID())) {
+            if (getThing().getConfiguration().get(BraviaConfiguration.UDN)
+                    .equals(result.getProperties().get(BraviaConfiguration.UDN))) {
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    connect();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void thingRemoved(final DiscoveryService source, final ThingUID thingUID) {
+        if (thingUID.equals(this.getThing().getUID())) {
+            updateStatus(ThingStatus.OFFLINE);
+        }
+    }
+
+    @Override
+    public void handleCommand(final ChannelUID channelUID, final Command command) {
+        if (getThing().getStatus() != ThingStatus.ONLINE) {
+            logger.warn("Ignoring command - not connected.");
+            return;
+        }
+        try {
+            switch (channelUID.getId()) {
+                case SonyTVBindingConstants.CHANNEL_POWER:
+                    api.setPower((OnOffType) command);
+                    break;
+                case SonyTVBindingConstants.CHANNEL_INPUT:
+                    api.setActiveInput((StringType) command);
+                    break;
+            }
+        } catch (final Error error) {
+            logger.error("Error while executing command.", error);
+        }
+    }
+
+    private void updateState() throws Error {
+        try {
+            final OnOffType power = api.getPower();
+            updateState(SonyTVBindingConstants.CHANNEL_POWER, power);
+            updateStatus(ThingStatus.ONLINE);
+            if (power.equals(OnOffType.ON)) {
+                updateState(SonyTVBindingConstants.CHANNEL_INPUT, api.getActiveInput());
+            }
+        } catch (final ScalarApiClient.Error error) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, error.getMessage());
+        }
+    }
+
+    private synchronized void connect() {
+        final BraviaConfiguration config = getConfig().as(BraviaConfiguration.class);
+        try {
+            api = new ScalarApiClient(config.apiUrl, config.preSharedKey);
+        } catch (final Error error) {
+            logger.error("Communication error.", error);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error.");
+            return;
+        }
+        updateStatus(ThingStatus.ONLINE);
+        if (pollingJob == null || pollingJob.isCancelled()) {
+            pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, 0,
+                    (config.refresh == null ? DEFAULT_REFRESH_INTERVAL : config.refresh), TimeUnit.SECONDS);
+        }
+    }
+
+    private synchronized void disconnect() {
+        if (pollingJob != null && !pollingJob.isCancelled()) {
+            pollingJob.cancel(true);
+            pollingJob = null;
+        }
+        updateStatus(ThingStatus.OFFLINE);
+    }
+
+    @Override
+    public Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
+            Collection<ThingTypeUID> thingTypeUIDs) {
+        return null;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/ScalarApiClient.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/ScalarApiClient.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.internal;
+
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * The {@link ScalarApiClient} is an abstraction over Sony Bravia's JSON-RPC API.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class ScalarApiClient {
+
+    private static final String PSK_HEADER = "X-Auth-PSK";
+
+    private Gson gson = new Gson();
+    private final Client client = ClientBuilder.newClient();
+    private WebTarget api;
+    private WebTarget system;
+    private WebTarget avContent;
+    private String preSharedKey;
+
+    public ScalarApiClient(final String baseURL, final String preSharedKey) throws Error {
+        this.api = client.target(Preconditions.checkNotNull(baseURL));
+        this.system = api.path("system");
+        this.avContent = api.path("avContent");
+        this.preSharedKey = Preconditions.checkNotNull(preSharedKey);
+        getPower();
+    }
+
+    public SystemInformation getSystemInformation() throws Error {
+        final JsonObject result = rpc(system, "getSystemInformation").get(0).getAsJsonObject();
+        final SystemInformation info = new SystemInformation();
+        info.setProduct(result.get("product").getAsString());
+        info.setRegion(result.get("region").getAsString());
+        info.setLanguage(result.get("language").getAsString());
+        info.setModel(result.get("model").getAsString());
+        info.setSerial(result.get("serial").getAsString());
+        info.setMac(result.get("macAddr").getAsString());
+        info.setName(result.get("name").getAsString());
+        info.setGeneration(result.get("generation").getAsString());
+        info.setArea(result.get("area").getAsString());
+        info.setCid(result.get("cid").getAsString());
+        return info;
+    }
+
+    public StringType getActiveInput() throws Error {
+        final JsonArray result = rpc(avContent, "getPlayingContentInfo");
+        if (result == null) {
+            return new StringType("");
+        } else {
+            return new StringType(result.get(0).getAsJsonObject().get("uri").getAsString());
+        }
+    }
+
+    public void setActiveInput(final StringType input) throws Error {
+        final JsonObject request = new JsonObject();
+        request.addProperty("uri", input.toString());
+        rpc(avContent, "setPlayContent", request);
+    }
+
+    public OnOffType getPower() throws Error {
+        final JsonArray result = rpc(system, "getPowerStatus");
+        if (result.get(0).getAsJsonObject().get("status").getAsString().equals("active")) {
+            return OnOffType.ON;
+        } else {
+            return OnOffType.OFF;
+        }
+    }
+
+    public void setPower(final OnOffType power) throws Error {
+        final JsonObject request = new JsonObject();
+        request.addProperty("status", power.equals(OnOffType.ON));
+        rpc(system, "setPowerStatus", request);
+    }
+
+    private JsonArray rpc(final WebTarget target, final String method, final JsonElement... arguments) throws Error {
+        final Invocation.Builder invocation = target.request(MediaType.APPLICATION_JSON_TYPE);
+        invocation.header(PSK_HEADER, preSharedKey);
+        final Response httpResponse;
+        try {
+            httpResponse = invocation.post(makeJsonRpcRequest(method, arguments));
+        } catch (final ProcessingException exception) {
+            if (exception.getCause() instanceof NoRouteToHostException
+                    || exception.getCause() instanceof ConnectException) {
+                throw new ConnectionError(exception.getCause());
+            } else {
+                throw exception;
+            }
+        }
+        final String responseText;
+        final JsonObject response;
+        if (httpResponse.hasEntity()) {
+            responseText = httpResponse.readEntity(String.class);
+            response = gson.fromJson(responseText, JsonObject.class);
+        } else {
+            responseText = null;
+            response = null;
+        }
+        if (httpResponse.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
+            if (response != null && response.has("result") && response.get("result").isJsonArray()) {
+                return response.getAsJsonArray("result");
+            } else {
+                return null;
+            }
+        } else {
+            throw new InvocationError(httpResponse.getStatusInfo(), responseText);
+        }
+    }
+
+    private Entity<String> makeJsonRpcRequest(final String method, final JsonElement... arguments) {
+        final JsonArray params = new JsonArray();
+        for (final JsonElement argument : arguments) {
+            params.add(argument);
+        }
+        final JsonObject request = new JsonObject();
+        request.addProperty("version", "1.0");
+        request.addProperty("id", 1);
+        request.addProperty("method", method);
+        request.add("params", params);
+        return Entity.entity(gson.toJson(request), MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    public static class Error extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public Error() {
+        }
+
+        public Error(final Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class ConnectionError extends Error {
+        private static final long serialVersionUID = 1L;
+
+        public ConnectionError(final Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class InvocationError extends Error {
+        private static final long serialVersionUID = 1L;
+
+        private final Response.StatusType status;
+        private final String response;
+
+        public InvocationError(final Response.StatusType status, final String response) {
+            this.status = Preconditions.checkNotNull(status);
+            this.response = response;
+        }
+
+        public Response.StatusType getStatus() {
+            return status;
+        }
+
+        public String getReason() {
+            return response;
+        }
+
+        @Override
+        public String getMessage() {
+            final StringBuilder messageBuilder = new StringBuilder("ScalarAPI error: ");
+            messageBuilder.append(status.toString());
+            if (response != null) {
+                messageBuilder.append(": ");
+                messageBuilder.append(response);
+            }
+            return messageBuilder.toString();
+        }
+
+    }
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/SonyTVHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/SonyTVHandlerFactory.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.internal;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.sonytv.SonyTVBindingConstants;
+import org.openhab.binding.sonytv.handler.SonyTVHandler;
+
+/**
+ * The {@link SonyTVHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class SonyTVHandlerFactory extends BaseThingHandlerFactory {
+
+    private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .singleton(SonyTVBindingConstants.THING_TYPE_BRAVIA);
+
+    private DiscoveryServiceRegistry discoveryServiceRegistry;
+
+    @Override
+    public boolean supportsThingType(final ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(final Thing thing) {
+        final ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        if (thingTypeUID.equals(SonyTVBindingConstants.THING_TYPE_BRAVIA)) {
+            return new SonyTVHandler(thing, discoveryServiceRegistry);
+        }
+        return null;
+    }
+
+    protected void setDiscoveryServiceRegistry(final DiscoveryServiceRegistry discoveryServiceRegistry) {
+        this.discoveryServiceRegistry = discoveryServiceRegistry;
+    }
+
+    protected void unsetDiscoveryServiceRegistry(final DiscoveryServiceRegistry discoveryServiceRegistry) {
+        this.discoveryServiceRegistry = null;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/SystemInformation.java
+++ b/addons/binding/org.openhab.binding.sonytv/src/main/java/org/openhab/binding/sonytv/internal/SystemInformation.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sonytv.internal;
+
+/**
+ * The {@link SystemInformation} is a model of device status information
+ * returned from Sony Bravia's API.
+ *
+ * @author Mikołaj Siedlarek - Initial contribution
+ */
+public class SystemInformation {
+
+    private String product;
+    private String region;
+    private String language;
+    private String model;
+    private String serial;
+    private String mac;
+    private String name;
+    private String generation;
+    private String area;
+    private String cid;
+
+    public String getProduct() {
+        return product;
+    }
+
+    public void setProduct(String product) {
+        this.product = product;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getSerial() {
+        return serial;
+    }
+
+    public void setSerial(String serial) {
+        this.serial = serial;
+    }
+
+    public String getMac() {
+        return mac;
+    }
+
+    public void setMac(String mac) {
+        this.mac = mac;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getGeneration() {
+        return generation;
+    }
+
+    public void setGeneration(String generation) {
+        this.generation = generation;
+    }
+
+    public String getArea() {
+        return area;
+    }
+
+    public void setArea(String area) {
+        this.area = area;
+    }
+
+    public String getCid() {
+        return cid;
+    }
+
+    public void setCid(String cid) {
+        this.cid = cid;
+    }
+
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -40,6 +40,7 @@
     <module>org.openhab.binding.tesla</module>
     <module>org.openhab.binding.vitotronic</module>
     <module>org.openhab.binding.zwave</module>
+    <module>org.openhab.binding.sonytv</module>
   </modules>
 
 </project>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -132,6 +132,12 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zwave/${project.version}</bundle>
     </feature>
 
+    <feature name="openhab-binding-sonytv" description="SonyTV Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-upnp</feature>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.sonytv/${project.version}</bundle>
+    </feature>
+
     <!-- misc -->
 
     <feature name="openhab-misc-myopenhab" description="my.openHAB" version="${project.version}">


### PR DESCRIPTION
This is a new binding for Sony Bravia TV's. The protocol was reverse-engineered from the official remote control app for iOS and works at least for the newest firmware on my TV (PKG2.704EUA).

The binding is fairly minimalistic at the moment, having only the particular things I needed (power and input source control), but some groundwork is done and the binding can easily be extended.

For those wishing to discover more about the Bravia's protocol I recommend POSTing this JSON `{"id": 1,  "method": "getMethodTypes", "params": ["1.0"], "version": "1.0"}` to `http://<your tv>/sony/system`. For some methods you'll need a `X-Auth-PSK` HTTP header with the pre-shared key you set in your TV's IP Control settings. I'm leaving this tip here for posterity. :)

At last - this is my first OpenHAB binding, and OpenHAB is a huge beast with a complicated architecture. Please review this PR carefully, because I might have made some stupid mistakes, especially around object lifetimes and initialization/deinitialization/discovery processes.

Signed-off-by: Mikołaj Siedlarek <mikolaj@siedlarek.pl> (github: msiedlarek)