### PR TITLE
Fix for WiFi LED controller Binding (see #496) 

### DIFF
--- a/addons/binding/org.openhab.binding.wifiled/.classpath
+++ b/addons/binding/org.openhab.binding.wifiled/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/addons/binding/org.openhab.binding.wifiled/.project
+++ b/addons/binding/org.openhab.binding.wifiled/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.wifiled</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="wifiled"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+	<name>WiFi LED Binding</name>
+	<description>Binding for WiFi LED devices. These are known as Magic Home RGBW LED, UFO LED, LED NET controller etc.</description>
+	<author>Osman Basha</author>
+
+</binding:binding>

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 
 	<name>WiFi LED Binding</name>
 	<description>Binding for WiFi LED devices. These are known as Magic Home RGBW LED, UFO LED, LED NET controller etc.</description>
-	<author>Osman Basha</author>
+	<author>Osman Basha, Patrick Hofmann</author>
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/i18n/wifiled_de.properties
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/i18n/wifiled_de.properties
@@ -1,0 +1,21 @@
+# binding
+binding.wifiled.name = WiFi LED Binding
+binding.wifiled.description = Binding für WiFi LED Geräte. Diese werden u.a. als Magic Home RGBW LED, UFO LED, LED NET controller etc.vertrieben.
+
+# thing types
+thing-type.wifiled.wifiled.label = WiFi LED
+thing-type.wifiled.wifiled.description = WiFi LED Gerät
+thing-type.config.wifiled.wifiled.ip.label = IP
+thing-type.config.wifiled.wifiled.ip.description = IP-Adresse oder Host-Name des Gerätes
+thing-type.config.wifiled.wifiled.port.label = Port
+thing-type.config.wifiled.wifiled.port.description = Genutzte Portnummer des Gerätes
+thing-type.config.wifiled.wifiled.pollingPeriod.label = Abfrageintervall
+thing-type.config.wifiled.wifiled.pollingPeriod.description = Daten-Abfrageintervall in Sek.
+thing-type.config.wifiled.wifiled.protocol.label = Protokoll
+thing-type.config.wifiled.wifiled.protocol.description = Das zur Kommunikation mit dem Gerät genutzte Protokoll
+
+# channel types
+channel-type.wifiled.colorType.label = Farbe
+channel-type.wifiled.white.label = Weiß
+channel-type.wifiled.program.label = Programm
+channel-type.wifiled.programSpeed.label = Programm-Geschwindigkeit

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/i18n/wifiled_de.properties
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/i18n/wifiled_de.properties
@@ -15,7 +15,8 @@ thing-type.config.wifiled.wifiled.protocol.label = Protokoll
 thing-type.config.wifiled.wifiled.protocol.description = Das zur Kommunikation mit dem Ger‰t genutzte Protokoll
 
 # channel types
-channel-type.wifiled.colorType.label = Farbe
+channel-type.wifiled.power.label = Einschalter
+channel-type.wifiled.color.label = Farbe
 channel-type.wifiled.white.label = Weiﬂ
 channel-type.wifiled.program.label = Programm
 channel-type.wifiled.programSpeed.label = Programm-Geschwindigkeit

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/thing/wifiled.xml
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/thing/wifiled.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="wifiled"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="wifiled">
+		<label>WiFi LED</label>
+		<description>WiFi LED Device</description>
+
+		<channels>
+			<channel id="color" typeId="color" />
+			<channel id="white" typeId="white" />
+			<channel id="program" typeId="program" />
+			<channel id="programSpeed" typeId="programSpeed" />
+		</channels>
+
+		<config-description>
+			<parameter name="ip" type="text" required="true">
+				<label>IP</label>
+				<description>IP address or host name of the WIFI LED Controller</description>
+				<default>192.168.178.25</default>
+			</parameter>
+			<parameter name="port" type="integer" required="false" min="1024"
+				max="49151">
+				<label>Port</label>
+				<description>Used Port of the device</description>
+				<default>5577</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="pollingPeriod" type="integer" required="false">
+				<label>Polling period</label>
+				<description>Polling period for refreshing the data in s</description>
+				<default>30</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="protocol" type="text" required="false">
+				<label>Device protocol</label>
+				<description>The protocol used for communication with the device</description>
+				<default>LD382A</default>
+				<options>
+					<option value="LD382A">LD382A</option>
+					<option value="LD382">LD382</option>
+				</options>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="color">
+		<item-type>Color</item-type>
+		<label>Color</label>
+		<category>ColorLight</category>
+	</channel-type>
+	<channel-type id="white" advanced="true">
+		<item-type>Dimmer</item-type>
+		<label>White</label>
+	</channel-type>
+	<channel-type id="program" advanced="true">
+		<item-type>String</item-type>
+		<label>Program</label>
+		<state readOnly="false">
+			<options>
+				<option value="97">NONE</option>
+				<option value="37">Seven Colors Cross Fade</option>
+				<option value="38">Red Gradual Change</option>
+				<option value="39">Green Gradual Change</option>
+				<option value="40">Blue Gradual Change</option>
+				<option value="41">Yellow Gradual Change</option>
+				<option value="42">Cyan Gradual Change</option>
+				<option value="43">Purple Gradual Change</option>
+				<option value="44">White Gradual Change</option>
+				<option value="45">Red,Green Cross Fade</option>
+				<option value="46">Red, Blue Cross Fade</option>
+				<option value="47">Green, Blue Cross Fade</option>
+				<option value="48">Seven Colors Strobe Flash</option>
+				<option value="49">Red Strobe Flash</option>
+				<option value="50">Green Strobe Flash</option>
+				<option value="51">Blue Strobe Flash</option>
+				<option value="52">Yellow Strobe Flash</option>
+				<option value="53">Cyan Strobe Flash</option>
+				<option value="54">Purple Strobe Flash</option>
+				<option value="55">White Strobe Flash</option>
+				<option value="56">Seven Colors Jumping Change</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="programSpeed" advanced="true">
+		<item-type>Dimmer</item-type>
+		<label>Program speed</label>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/thing/wifiled.xml
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/thing/wifiled.xml
@@ -9,6 +9,7 @@
 		<description>WiFi LED Device</description>
 
 		<channels>
+		    <channel id="power" typeId="power" />
 			<channel id="color" typeId="color" />
 			<channel id="white" typeId="white" />
 			<channel id="program" typeId="program" />
@@ -46,7 +47,12 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-
+	
+	<channel-type id="power">
+        <item-type>Switch</item-type>
+        <label>Power</label>
+        <category>Switch</category>
+    </channel-type>
 	<channel-type id="color">
 		<item-type>Color</item-type>
 		<label>Color</label>

--- a/addons/binding/org.openhab.binding.wifiled/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.wifiled/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: WiFiLED Binding
+Bundle-SymbolicName: org.openhab.binding.wifiled;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.types,
+ org.slf4j
+Service-Component: OSGI-INF/*
+Export-Package: org.openhab.binding.wifiled,
+ org.openhab.binding.wifiled.handler

--- a/addons/binding/org.openhab.binding.wifiled/OSGI-INF/WiFiLEDDiscovery.xml
+++ b/addons/binding/org.openhab.binding.wifiled/OSGI-INF/WiFiLEDDiscovery.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.wifiled.discovery.WiFiLEDDiscoveryService">
+
+   <implementation class="org.openhab.binding.wifiled.discovery.WiFiLEDDiscoveryService"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryService"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.wifiled/OSGI-INF/WiFiLEDHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.wifiled/OSGI-INF/WiFiLEDHandlerFactory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.wifiled.internal.WiFiLEDHandlerFactory">
+
+   <implementation class="org.openhab.binding.wifiled.internal.WiFiLEDHandlerFactory"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.wifiled/README.md
+++ b/addons/binding/org.openhab.binding.wifiled/README.md
@@ -1,0 +1,31 @@
+# WiFi LED Binding
+
+This Binding is used to control LED stripes connected by WiFi. These devices are sold with different names, i.e. Magic Home LED, UFO LED, LED NET controller, etc.  
+
+## Supported Things
+
+This Binding supports RGB(W) LED devices.
+
+## Discovery
+
+The LED WiFi Controllers are discovered by broadcast. The device has to be connected to the local network (i.e. by using the WiFi PBC connection method or the native App shipped with the device). For details please refer to the manual of the device. 
+
+## Binding Configuration
+
+No binding configuration required.
+
+## Thing Configuration
+
+Usually no manual configuration is required.
+If the automatic discovery does not work for some reason then the IP address and the port have to be set manually. Optionally, a refresh interval (in seconds) can be defined.
+The binding supports newer controllers also known as v3 or LD382A (default) and the older generation also known as LD382. As the two generations differ in their protocol it might be necessary to set the configuration appropriately.
+
+## Channels
+
+- **color** Color of the RGB LEDs expressed as values of hue, saturation and brightness
+- **white** The brightness of the (warm) white LEDs
+- **program** The program to be automatically run by the controller (i.e. color cross fade, strobe, etc.)
+- **programSpeed** The speed of the programm
+
+## Full example
+N/A

--- a/addons/binding/org.openhab.binding.wifiled/README.md
+++ b/addons/binding/org.openhab.binding.wifiled/README.md
@@ -22,6 +22,7 @@ The binding supports newer controllers also known as v3 or LD382A (default) and 
 
 ## Channels
 
+- **power** Power state of the RGB(W) device
 - **color** Color of the RGB LEDs expressed as values of hue, saturation and brightness
 - **white** The brightness of the (warm) white LEDs
 - **program** The program to be automatically run by the controller (i.e. color cross fade, strobe, etc.)

--- a/addons/binding/org.openhab.binding.wifiled/build.properties
+++ b/addons/binding/org.openhab.binding.wifiled/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/

--- a/addons/binding/org.openhab.binding.wifiled/pom.xml
+++ b/addons/binding/org.openhab.binding.wifiled/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.wifiled</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  
+  <name>WiFiLED Binding</name>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link WiFiLEDBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDBindingConstants {
+
+    public static final String BINDING_ID = "wifiled";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_WIFILED = new ThingTypeUID(BINDING_ID, "wifiled");
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WIFILED);
+
+    // List of all Channel IDs
+    public static final String CHANNEL_COLOR = "color";
+    public static final String CHANNEL_WHITE = "white";
+    public static final String CHANNEL_PROGRAM = "program";
+    public static final String CHANNEL_PROGRAM_SPEED = "programSpeed";
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
@@ -17,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Osman Basha - Initial contribution
+ * @author Patrick Hofmann - Introduce power state channel
  */
 public class WiFiLEDBindingConstants {
 
@@ -28,6 +29,7 @@ public class WiFiLEDBindingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WIFILED);
 
     // List of all Channel IDs
+    public static final String CHANNEL_POWER = "power";
     public static final String CHANNEL_COLOR = "color";
     public static final String CHANNEL_WHITE = "white";
     public static final String CHANNEL_PROGRAM = "program";

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/configuration/WiFiLEDConfig.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/configuration/WiFiLEDConfig.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.configuration;
+
+/**
+ * The {@link WiFiLEDConfig} class holds the configuration properties of the thing.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDConfig {
+
+    private String ip;
+    private Integer port;
+    private Integer pollingPeriod;
+    private String protocol;
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Integer getPollingPeriod() {
+        return pollingPeriod;
+    }
+
+    public void setPollingPeriod(Integer pollingPeriod) {
+        this.pollingPeriod = pollingPeriod;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/configuration/WiFiLEDConfig.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/configuration/WiFiLEDConfig.java
@@ -7,17 +7,20 @@
  */
 package org.openhab.binding.wifiled.configuration;
 
+import org.openhab.binding.wifiled.handler.WiFiLEDDriver.Protocol;
+
 /**
  * The {@link WiFiLEDConfig} class holds the configuration properties of the thing.
  *
  * @author Osman Basha - Initial contribution
+ * @author Patrick Hofmann - change type of protocol String -> Protocol
  */
 public class WiFiLEDConfig {
 
     private String ip;
     private Integer port;
     private Integer pollingPeriod;
-    private String protocol;
+    private Protocol protocol;
 
     public String getIp() {
         return ip;
@@ -43,11 +46,11 @@ public class WiFiLEDConfig {
         this.pollingPeriod = pollingPeriod;
     }
 
-    public String getProtocol() {
+    public Protocol getProtocol() {
         return protocol;
     }
 
-    public void setProtocol(String protocol) {
+    public void setProtocol(Protocol protocol) {
         this.protocol = protocol;
     }
 

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/discovery/WiFiLEDDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/discovery/WiFiLEDDiscoveryService.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.discovery;
+
+import static org.openhab.binding.wifiled.WiFiLEDBindingConstants.*;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketTimeoutException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.wifiled.handler.WiFiLEDDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WiFiLEDDiscoveryService} class implements a service
+ * for discovering supported WiFi LED Devices.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDDiscoveryService extends AbstractDiscoveryService {
+
+    private static final int DEFAULT_BROADCAST_PORT = 48899;
+
+    private Logger logger = LoggerFactory.getLogger(WiFiLEDDiscoveryService.class);
+
+    public WiFiLEDDiscoveryService() {
+        super(SUPPORTED_THING_TYPES_UIDS, 15, true);
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypes() {
+        return SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        logger.debug("Start WiFi LED background discovery");
+        scheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                discover();
+            }
+        }, 0, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void startScan() {
+        logger.debug("Start WiFi LED scan");
+        discover();
+    }
+
+    private synchronized void discover() {
+        logger.debug("Try to discover all WiFi LED devices");
+
+        try (DatagramSocket socket = new DatagramSocket()) {
+            socket.setBroadcast(true);
+            socket.setSoTimeout(5000);
+
+            InetAddress inetAddress = InetAddress.getByName("255.255.255.255");
+
+            // send discover
+            byte[] discover = "HF-A11ASSISTHREAD".getBytes();
+            DatagramPacket packet = new DatagramPacket(discover, discover.length, inetAddress, DEFAULT_BROADCAST_PORT);
+            socket.send(packet);
+            logger.debug("Disover message sent: '{}'", WiFiLEDDriver.bytesToHex(discover));
+
+            // wait for responses
+            while (true) {
+                byte[] rxbuf = new byte[256];
+                packet = new DatagramPacket(rxbuf, rxbuf.length);
+                try {
+                    socket.receive(packet);
+                } catch (SocketTimeoutException e) {
+                    break; // leave the endless loop
+                }
+
+                byte[] data = packet.getData();
+                String s = bytesToString(data);
+                logger.debug("Disover response received: '{}' [{}] ", s, WiFiLEDDriver.bytesToHex(data));
+
+                // 192.168.178.25,ACCF23489C9A,HF-LPB100-ZJ200
+                // ^-IP..........,^-MAC.......,^-HOSTNAME.....
+
+                String[] ss = s.split(",");
+                String ip = ss[0];
+                String mac = ss[1];
+                String name = ss[2];
+                logger.debug("Adding a new WiFi LED with IP '{}' and MAC '{}' to inbox", ip, mac);
+                Map<String, Object> properties = new HashMap<>();
+                properties.put("ip", ip);
+                properties.put("protocol", WiFiLEDDriver.Protocol.LD382A);
+                ThingUID uid = new ThingUID(THING_TYPE_WIFILED, mac);
+                if (uid != null) {
+                    DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                            .withLabel(name).build();
+                    thingDiscovered(result);
+                    logger.debug("Thing discovered '{}'", result);
+                }
+            }
+        } catch (IOException e) {
+            logger.debug("No WiFi LED device found. Diagnostic: {}", e.getMessage());
+            return;
+        }
+    }
+
+    private static final String bytesToString(byte[] bytes) {
+        String s = "";
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] == 0) {
+                break;
+            }
+            s += (char) (bytes[i] & 0xFF);
+        }
+
+        return s;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/LEDStateDTO.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/LEDStateDTO.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.handler;
+
+import java.awt.Color;
+import java.math.BigDecimal;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StringType;
+
+/**
+ * The {@link LEDStateDTO} class holds the data and the settings for a LED device (i.e. the selected colors, the running
+ * program, etc.).
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class LEDStateDTO extends HSBType {
+
+    private static final long serialVersionUID = 1L;
+
+    protected BigDecimal white;
+    protected StringType program;
+    protected BigDecimal programSpeed;
+
+    public LEDStateDTO(DecimalType hue, PercentType saturation, PercentType brightness, PercentType white,
+            StringType program, PercentType programSpeed) {
+        super(hue, saturation, brightness);
+        this.white = white.toBigDecimal();
+        this.program = program;
+        this.programSpeed = programSpeed.toBigDecimal();
+    }
+
+    public PercentType getWhite() {
+        return new PercentType(white);
+    }
+
+    public StringType getProgram() {
+        return new StringType(program.toString());
+    }
+
+    public PercentType getProgramSpeed() {
+        return new PercentType(programSpeed);
+    }
+
+    @Override
+    public String toString() {
+        return getHue() + "," + getSaturation() + "," + getBrightness() + "," + getWhite() + " [" + getProgram() + ","
+                + getProgramSpeed() + "]";
+    }
+
+    public static LEDStateDTO valueOf(int state, int program, int programSpeed, int red, int green, int blue,
+            int white) {
+
+        float[] hsv = new float[3];
+        Color.RGBtoHSB(red, green, blue, hsv);
+        long hue = (long) (hsv[0] * 360);
+        int saturation = (int) (hsv[1] * 100);
+        int brightness = (int) (hsv[2] * 100);
+        DecimalType h = new DecimalType(hue);
+        PercentType s = new PercentType(saturation);
+        // set Brightness to 0 if state is OFF
+        PercentType b = ((state & 0x01) == 0) ? PercentType.ZERO : new PercentType(brightness);
+        PercentType w = new PercentType(white / 255 * 100);
+
+        StringType p = new StringType(Integer.toString(program));
+        PercentType e = new PercentType(100 - (programSpeed / 0x1F * 100)); // Range: 0x00 .. 0x1F. Speed is inversed
+
+        return new LEDStateDTO(h, s, b, w, p, e);
+    }
+
+    public LEDStateDTO withColor(HSBType color) {
+        return new LEDStateDTO(color.getHue(), color.getSaturation(), color.getBrightness(), this.getWhite(),
+                this.getProgram(), this.getProgramSpeed());
+    }
+
+    public LEDStateDTO withBrightness(PercentType brightness) {
+        return new LEDStateDTO(this.getHue(), this.getSaturation(), brightness, this.getWhite(), this.getProgram(),
+                this.getProgramSpeed());
+    }
+
+    public LEDStateDTO withIncrementedBrightness(int step) {
+        int brightness = this.getBrightness().intValue();
+        brightness += step;
+        if (brightness > 100) {
+            brightness = 100;
+        } else if (brightness < 0) {
+            brightness = 0;
+        }
+
+        return withBrightness(new PercentType(brightness));
+    }
+
+    public LEDStateDTO withWhite(PercentType white) {
+        return new LEDStateDTO(this.getHue(), this.getSaturation(), this.getBrightness(), white, this.getProgram(),
+                this.getProgramSpeed());
+    }
+
+    public LEDStateDTO withIncrementedWhite(int step) {
+        int white = this.getWhite().intValue();
+        white += step;
+        if (white > 100) {
+            white = 100;
+        } else if (white < 0) {
+            white = 0;
+        }
+
+        return withWhite(new PercentType(white));
+    }
+
+    public LEDStateDTO withProgram(StringType program) {
+        return new LEDStateDTO(this.getHue(), this.getSaturation(), this.getBrightness(), this.getWhite(), program,
+                this.getProgramSpeed());
+    }
+
+    public LEDStateDTO withoutProgram() {
+        return withProgram(new StringType(String.valueOf(0x61)));
+    }
+
+    public LEDStateDTO withProgramSpeed(PercentType programSpeed) {
+        return new LEDStateDTO(this.getHue(), this.getSaturation(), this.getBrightness(), this.getWhite(),
+                this.getProgram(), programSpeed);
+    }
+
+    public LEDStateDTO withIncrementedProgramSpeed(int step) {
+        int programSpeed = this.getProgramSpeed().intValue();
+        programSpeed += step;
+        if (programSpeed > 100) {
+            programSpeed = 100;
+        } else if (programSpeed < 0) {
+            programSpeed = 0;
+        }
+
+        return withProgramSpeed(new PercentType(programSpeed));
+    }
+
+    public Color getColor() {
+        float hue = (float) this.getHue().intValue() / 360;
+        float saturation = (float) this.getSaturation().intValue() / 100;
+        float brightness = (float) this.getBrightness().intValue() / 100;
+        return new Color(Color.HSBtoRGB(hue, saturation, brightness));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDDriver.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.handler;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WiFiLEDDriver} class is responsible for the communication with the WiFi LED controller.
+ * It's used for sending color or program settings and also extracting the data out of the received telegrams.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDDriver {
+
+    public enum Protocol {
+        LD382,
+        LD382A;
+    }
+
+    private static final int DEFAULT_SOCKET_TIMEOUT = 5000;
+
+    public static final Integer DEFAULT_PORT = 5577;
+
+    private Logger logger = LoggerFactory.getLogger(WiFiLEDDriver.class);
+    private String host;
+    private int port;
+    private Protocol protocol;
+
+    public WiFiLEDDriver(String host, int port, Protocol protocol) {
+        this.host = host;
+        this.port = port;
+        this.protocol = protocol;
+    }
+
+    public synchronized LEDStateDTO getLEDState() throws IOException {
+        try (Socket socket = new Socket(host, port)) {
+            logger.debug("Connected to '{}'", socket);
+
+            socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT);
+
+            DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
+            DataInputStream inputStream = new DataInputStream(socket.getInputStream());
+
+            byte[] data = { (byte) 0x81, (byte) 0x8A, (byte) 0x8B, (byte) 0x96 };
+            outputStream.write(data);
+            logger.debug("Data sent: '{}'", bytesToHex(data));
+
+            byte[] statusBytes = new byte[14];
+            inputStream.readFully(statusBytes);
+            logger.debug("Data read: '{}'", bytesToHex(statusBytes));
+
+            // Example response (14 Bytes):
+            // 0x81 0x04 0x23 0x26 0x21 0x10 0x45 0x00 0x00 0x00 0x03 0x00 0x00 0x47
+            // ..........^--- On/Off.........R....G....B....WW..
+            // ...............^-- PGM...^---SPEED...............
+
+            int state = statusBytes[2] & 0xFF; // On/Off
+            int program = statusBytes[3] & 0xFF;
+            int programSpeed = statusBytes[5] & 0xFF;
+
+            int red = statusBytes[6] & 0xFF;
+            int green = statusBytes[7] & 0xFF;
+            int blue = statusBytes[8] & 0xFF;
+            int white = statusBytes[9] & 0xFF;
+            LEDStateDTO ledState = LEDStateDTO.valueOf(state, program, programSpeed, red, green, blue, white);
+
+            logger.debug("RGBW: {},{},{},{} -> LEDState: {}", red, green, blue, white, ledState);
+
+            Thread.sleep(100);
+            return ledState;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public synchronized void setColor(HSBType color) throws IOException {
+        logger.debug("Setting color to {}", color);
+
+        LEDStateDTO ledState = getLEDState().withColor(color).withoutProgram();
+        sendLEDData(ledState);
+    }
+
+    public synchronized void setBrightness(PercentType brightness) throws IOException {
+        logger.debug("Setting brightness to {}", brightness);
+
+        LEDStateDTO ledState = getLEDState().withBrightness(brightness).withoutProgram();
+        sendLEDData(ledState);
+    }
+
+    public synchronized void incBrightness(int step) throws IOException {
+        logger.debug("Changing brightness by {}", step);
+
+        LEDStateDTO ledState = getLEDState().withIncrementedBrightness(step).withoutProgram();
+        sendLEDData(ledState);
+    }
+
+    public synchronized void decBrightness(int step) throws IOException {
+        incBrightness(-step);
+    }
+
+    public synchronized void setWhite(PercentType white) throws IOException {
+        logger.debug("Setting (warm) white LED to {}", white);
+
+        LEDStateDTO ledState = getLEDState().withWhite(white).withoutProgram();
+        sendLEDData(ledState);
+    }
+
+    public synchronized void incWhite(int step) throws IOException {
+        logger.debug("Changing white by {}", step);
+
+        LEDStateDTO ledState = getLEDState().withIncrementedWhite(step).withoutProgram();
+        sendLEDData(ledState);
+    }
+
+    public synchronized void decWhite(int step) throws IOException {
+        incWhite(-step);
+    }
+
+    public synchronized void setOn() throws IOException {
+        logger.debug("Setting on");
+
+        byte[] data = { 0x71, 0x23 };
+        sendRaw(data);
+    }
+
+    public synchronized void setOff() throws IOException {
+        logger.debug("Setting off");
+
+        byte[] data = { 0x71, 0x24 };
+        sendRaw(data);
+    }
+
+    public synchronized void setProgram(StringType program) throws IOException {
+        logger.debug("Setting program '{}'", program);
+
+        LEDStateDTO ledState = getLEDState().withProgram(program);
+        sendLEDData(ledState);
+    }
+
+    public synchronized void setProgramSpeed(PercentType speed) throws IOException {
+        logger.debug("Setting program speed to {}", speed);
+
+        LEDStateDTO ledState = getLEDState().withProgramSpeed(speed);
+        if (speed.equals(PercentType.ZERO)) {
+            ledState = ledState.withoutProgram();
+        }
+        sendLEDData(ledState);
+    }
+
+    public synchronized void incProgramSpeed(int step) throws IOException {
+        logger.debug("Changing program speed by {}", step);
+
+        LEDStateDTO ledState = getLEDState().withIncrementedProgramSpeed(step);
+        sendLEDData(ledState);
+    }
+
+    public synchronized void decProgramSpeed(int step) throws IOException {
+        incProgramSpeed(-step);
+    }
+
+    private void sendLEDData(LEDStateDTO ledState) throws IOException {
+        logger.debug("Setting LED State to {}", ledState);
+
+        int program = Integer.valueOf(ledState.getProgram().toString());
+        if (program == 0x61) {
+            // "normal" program: set color etc.
+            byte r = (byte) (ledState.getColor().getRed() & 0xFF);
+            byte g = (byte) (ledState.getColor().getGreen() & 0xFF);
+            byte b = (byte) (ledState.getColor().getBlue() & 0xFF);
+            byte w = (byte) ((ledState.getWhite().intValue() * 255 / 100) & 0xFF);
+            byte[] bytes = new byte[] { 0x31, r, g, b, w, 0x00 };
+            sendRaw(bytes);
+        } else {
+            // program selected
+            byte p = (byte) (program & 0xFF);
+            byte s = (byte) (((100 - ledState.getProgramSpeed().intValue()) * 0x1F / 100) & 0xFF);
+            byte[] data = { 0x61, p, s };
+            sendRaw(data);
+        }
+    }
+
+    private void sendRaw(byte[] data) throws IOException {
+        byte[] dataWithCS;
+
+        // append 0x0F (if dev.type LD382A)
+        if (protocol.equals(Protocol.LD382A)) {
+            dataWithCS = new byte[data.length + 2];
+            dataWithCS[dataWithCS.length - 2] = 0x0F;
+        } else {
+            dataWithCS = new byte[data.length + 1];
+        }
+
+        // append checksum
+        System.arraycopy(data, 0, dataWithCS, 0, data.length);
+        int cs = 0;
+        for (int i = 0; i < dataWithCS.length - 1; i++) {
+            cs += dataWithCS[i];
+        }
+        cs = cs & 0xFF;
+        dataWithCS[dataWithCS.length - 1] = (byte) cs;
+
+        try (Socket socket = new Socket(host, port)) {
+            logger.debug("Connected to '{}'", socket);
+
+            socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT);
+
+            DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
+            outputStream.write(dataWithCS);
+            logger.debug("RAW data sent: '{}'", bytesToHex(dataWithCS));
+
+            Thread.sleep(100);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public static final String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            builder.append(String.format("%02x ", bytes[i]));
+        }
+        String string = builder.toString();
+        return string.substring(0, string.length() - 1);
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDHandler.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDHandler.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.handler;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.wifiled.WiFiLEDBindingConstants;
+import org.openhab.binding.wifiled.configuration.WiFiLEDConfig;
+import org.openhab.binding.wifiled.handler.WiFiLEDDriver.Protocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WiFiLEDHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDHandler extends BaseThingHandler {
+
+    private static final int INC_DEC_STEP = 10;
+
+    private Logger logger = LoggerFactory.getLogger(WiFiLEDHandler.class);
+    private WiFiLEDDriver driver;
+    private ScheduledFuture<?> pollingJob;
+
+    public WiFiLEDHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Initializing WiFiLED handler '{}'", getThing().getUID());
+
+        WiFiLEDConfig config = getConfigAs(WiFiLEDConfig.class);
+
+        int port = (config.getPort() == null) ? WiFiLEDDriver.DEFAULT_PORT : config.getPort();
+        driver = new WiFiLEDDriver(config.getIp(), port, Protocol.valueOf(config.getProtocol()));
+        try {
+            driver.getLEDState();
+
+            logger.debug("Found a WiFi LED device '{}'", getThing().getUID());
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, e.getMessage());
+            return;
+        }
+        updateStatus(ThingStatus.ONLINE);
+
+        int pollingPeriod = (config.getPollingPeriod() == null) ? 30 : config.getPollingPeriod();
+        pollingJob = scheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                update();
+            }
+        }, 0, pollingPeriod, TimeUnit.SECONDS);
+        logger.debug("Polling job scheduled to run every {} sec. for '{}'", pollingPeriod, getThing().getUID());
+    }
+
+    @Override
+    public void postInitialize() {
+        super.postInitialize();
+        update();
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("Disposing WiFiLED handler '{}'", getThing().getUID());
+
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+            pollingJob = null;
+        }
+        driver = null;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("Handle command '{}' for {}", command, channelUID);
+
+        try {
+            if (command == RefreshType.REFRESH) {
+                update();
+            } else if (channelUID.getId().equals(WiFiLEDBindingConstants.CHANNEL_COLOR)) {
+                handleColorCommand(command);
+            } else if (channelUID.getId().equals(WiFiLEDBindingConstants.CHANNEL_WHITE)) {
+                handleWhiteCommand(command);
+            } else if (channelUID.getId().equals(WiFiLEDBindingConstants.CHANNEL_PROGRAM)
+                    && (command instanceof StringType)) {
+                driver.setProgram((StringType) command);
+            } else if (channelUID.getId().equals(WiFiLEDBindingConstants.CHANNEL_PROGRAM_SPEED)) {
+                handleProgramSpeedCommand(command);
+            }
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    private void handleColorCommand(Command command) throws IOException {
+        if (command instanceof HSBType) {
+            driver.setColor((HSBType) command);
+        } else if (command instanceof PercentType) {
+            driver.setBrightness((PercentType) command);
+        } else if (command instanceof OnOffType) {
+            OnOffType onOffCommand = (OnOffType) command;
+            if (onOffCommand.equals(OnOffType.ON)) {
+                driver.setOn();
+            } else {
+                driver.setOff();
+            }
+        } else if (command instanceof IncreaseDecreaseType) {
+            IncreaseDecreaseType increaseDecreaseType = (IncreaseDecreaseType) command;
+            if (increaseDecreaseType.equals(IncreaseDecreaseType.INCREASE)) {
+                driver.incBrightness(INC_DEC_STEP);
+            } else {
+                driver.decBrightness(INC_DEC_STEP);
+            }
+        }
+    }
+
+    private void handleWhiteCommand(Command command) throws IOException {
+        if (command instanceof PercentType) {
+            driver.setWhite((PercentType) command);
+        } else if (command instanceof OnOffType) {
+            OnOffType onOffCommand = (OnOffType) command;
+            if (onOffCommand.equals(OnOffType.ON)) {
+                driver.setWhite(PercentType.HUNDRED);
+            } else {
+                driver.setWhite(PercentType.ZERO);
+            }
+        } else if (command instanceof IncreaseDecreaseType) {
+            IncreaseDecreaseType increaseDecreaseType = (IncreaseDecreaseType) command;
+            if (increaseDecreaseType.equals(IncreaseDecreaseType.INCREASE)) {
+                driver.incWhite(INC_DEC_STEP);
+            } else {
+                driver.decWhite(INC_DEC_STEP);
+            }
+        }
+    }
+
+    private void handleProgramSpeedCommand(Command command) throws IOException {
+        if (command instanceof PercentType) {
+            driver.setProgramSpeed((PercentType) command);
+        } else if (command instanceof OnOffType) {
+            OnOffType onOffCommand = (OnOffType) command;
+            if (onOffCommand.equals(OnOffType.ON)) {
+                driver.setProgramSpeed(PercentType.HUNDRED);
+            } else {
+                driver.setProgramSpeed(PercentType.ZERO);
+            }
+        } else if (command instanceof IncreaseDecreaseType) {
+            IncreaseDecreaseType increaseDecreaseType = (IncreaseDecreaseType) command;
+            if (increaseDecreaseType.equals(IncreaseDecreaseType.INCREASE)) {
+                driver.incProgramSpeed(INC_DEC_STEP);
+            } else {
+                driver.decProgramSpeed(INC_DEC_STEP);
+            }
+        }
+    }
+
+    private synchronized void update() {
+        logger.debug("Updating WiFiLED data '{}'", getThing().getUID());
+
+        try {
+            LEDStateDTO ledState = driver.getLEDState();
+            HSBType color = new HSBType(ledState.getHue(), ledState.getSaturation(), ledState.getBrightness());
+            updateState(WiFiLEDBindingConstants.CHANNEL_COLOR, color);
+            updateState(WiFiLEDBindingConstants.CHANNEL_WHITE, ledState.getWhite());
+            updateState(WiFiLEDBindingConstants.CHANNEL_PROGRAM, ledState.getProgram());
+            updateState(WiFiLEDBindingConstants.CHANNEL_PROGRAM_SPEED, ledState.getProgramSpeed());
+
+            if (getThing().getStatus().equals(ThingStatus.OFFLINE)) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/WiFiLEDHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/WiFiLEDHandlerFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wifiled.internal;
+
+import static org.openhab.binding.wifiled.WiFiLEDBindingConstants.THING_TYPE_WIFILED;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.wifiled.handler.WiFiLEDHandler;
+
+/**
+ * The {@link WiFiLEDHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class WiFiLEDHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WIFILED);
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(Thing thing) {
+
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(THING_TYPE_WIFILED)) {
+            return new WiFiLEDHandler(thing);
+        }
+
+        return null;
+    }
+
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -39,6 +39,7 @@
     <module>org.openhab.binding.squeezebox</module>
     <module>org.openhab.binding.tesla</module>
     <module>org.openhab.binding.vitotronic</module>
+    <module>org.openhab.binding.wifiled</module>
     <module>org.openhab.binding.zwave</module>
   </modules>
 


### PR DESCRIPTION
This makes WifiLEDBinding working again and resolves conflicts in #496.
It also improves the binding by introducing a new channel "power", that makes it possible to switch the LED off / on with leaving the brightness value untouched.
It also contains a few fixes with warm white LED channel.
Tested with a Magic UFO (a LD382A device)

It seems like that @xylo with #755 and I were fixing this binding at the same time.... :smile: 
How ever I still want hand my changes in, since its my first contributing ever :tada: