### PR TITLE
#112 MAX! Binding Tests - groovy test does not compile

### DIFF
--- a/addons/binding/org.openhab.binding.max.test/pom.xml
+++ b/addons/binding/org.openhab.binding.max.test/pom.xml
@@ -2,25 +2,46 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-		 <groupId>org.openhab.binding</groupId>
+	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.max.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<name>MAX! Binding Tests</name>
 
 	<parent>
-		 <groupId>org.openhab.binding</groupId>
+		<groupId>org.openhab.binding</groupId>
 		<artifactId>pom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
-
-    <properties>
-        <bundle.symbolicName>org.openhab.binding.max.test</bundle.symbolicName>
-        <bundle.namespace>org.openhab.binding.max.test</bundle.namespace>
-    </properties>
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.max.test</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.max.test</bundle.namespace>
+		<groovy.eclipse.compiler.version>2.8.0-01</groovy.eclipse.compiler.version>
+        <groovy.eclipse.batch.version>2.1.5-03</groovy.eclipse.batch.version>
+	</properties>
 	
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>0.24.0</version>
+				<configuration>
+					<compilerId>groovy-eclipse-compiler</compilerId>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-eclipse-compiler</artifactId>
+						<version>${groovy.eclipse.compiler.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-eclipse-batch</artifactId>
+						<version>${groovy.eclipse.batch.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>

--- a/addons/binding/org.openhab.binding.max.test/src/test/groovy/org/openhab/binding/max/test/MaxBridgeHandlerOSGiTest.groovy
+++ b/addons/binding/org.openhab.binding.max.test/src/test/groovy/org/openhab/binding/max/test/MaxBridgeHandlerOSGiTest.groovy
@@ -52,8 +52,8 @@ class MaxBridgeHandlerOSGiTest extends OSGiTest {
         assertThat maxBridgeHandler, is(nullValue())
 
         Configuration configuration = new Configuration().with {
-            put(MaxBinding.SERIAL_NUMBER, "KEQ0565026")
-            put(MaxBinding.IP_ADDRESS, "192.168.3.100")
+            put(MaxBinding.PROPERTY_SERIAL_NUMBER, "KEQ0565026")
+            put(MaxBinding.PROPERTY_IP_ADDRESS, "192.168.3.100")
             it
         }
 
@@ -64,6 +64,7 @@ class MaxBridgeHandlerOSGiTest extends OSGiTest {
         Bridge maxBridge = managedThingProvider.createThing(
                 BRIDGE_THING_TYPE_UID,
                 cubeUid,
+                null,
                 null, configuration)
 
         assertThat maxBridge, is(notNullValue())


### PR DESCRIPTION
Please see for reference my comment in #112 

Groovy-eclipse-compiler is added to tycho-compiler-plugin configuration.
Now the .groovy test is detected from Maven. Few constants name are
updated, because the test failed with the old names.

Signed-off-by: Svilen Valkanov <svilenvul@gmail.com> (github: svilenvul)