### PR TITLE
ZWave: ALARMv3 discover reported events

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
@@ -11,7 +11,9 @@ package org.openhab.binding.zwave.internal.protocol.commandclass;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
@@ -45,13 +47,22 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
     private static final int ALARM_GET = 0x04;
     private static final int ALARM_REPORT = 0x05;
+
+    // Version 2
     private static final int ALARM_SUPPORTED_GET = 0x07;
     private static final int ALARM_SUPPORTED_REPORT = 0x08;
+
+    // Version 3
+    private static final int ALARM_EVENTSUPPORTED_GET = 0x01;
+    private static final int ALARM_EVENTSUPPORTED_REPORT = 0x02;
 
     private final Map<AlarmType, Alarm> alarms = new HashMap<AlarmType, Alarm>();
 
     @XStreamOmitField
-    private boolean initialiseDone = false;
+    private boolean supportedInitialised = false;
+    @XStreamOmitField
+    private boolean eventsSupportedInitialised = false;
+
     @XStreamOmitField
     private boolean dynamicDone = false;
 
@@ -160,9 +171,30 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
                         getAlarm(index);
                     }
                 }
-
-                initialiseDone = true;
+                supportedInitialised = true;
                 break;
+            case ALARM_EVENTSUPPORTED_REPORT:
+                logger.debug("NODE {}: Process Alarm Event Supported Report", this.getNode().getNodeId());
+                int notificationType = serialMessage.getMessagePayloadByte(offset + 1);
+                numBytes = serialMessage.getMessagePayloadByte(offset + 2);
+                List<Integer> types = new ArrayList<>();
+                for (int i = 0; i < numBytes; ++i) {
+                    for (int bit = 0; bit < 8; ++bit) {
+                        if (((serialMessage.getMessagePayloadByte(offset + i + 3)) & (1 << bit)) == 0) {
+                            continue;
+                        }
+
+                        int index = (i << 3) + bit;
+                        types.add(index);
+                        getAlarm(notificationType).getReportedEvents().add(index);
+                    }
+                }
+                logger.debug("NODE {}: AlarmType: {} reported events -> {}", this.getNode().getNodeId(),
+                        AlarmType.getAlarmType(notificationType), types);
+
+                eventsSupportedInitialised = true;
+                break;
+
             default:
                 logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command,
                         getCommandClass().getLabel(), getCommandClass().getKey()));
@@ -227,6 +259,28 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
         byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
                 (byte) ALARM_SUPPORTED_GET };
         result.setMessagePayload(newPayload);
+        return result;
+    }
+
+    /**
+     * Gets a SerialMessage with the ALARM_EVENTSUPPORTED_GET command
+     *
+     * @return the serial message, or null if the supported command is not supported.
+     */
+    public SerialMessage getSupportedEventMessage(int index) {
+        if (getVersion() < 2) {
+            logger.debug("NODE {}: ALARM_EVENTSUPPORTED_GET not supported for V1-2", this.getNode().getNodeId());
+            return null;
+        }
+
+        logger.debug("NODE {}: Creating new message for command ALARM_EVENTSUPPORTED_GET", this.getNode().getNodeId());
+
+        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.High);
+        byte[] newPayload = { (byte) this.getNode().getNodeId(), 3, (byte) getCommandClass().getKey(),
+                (byte) ALARM_EVENTSUPPORTED_GET, (byte) index };
+        result.setMessagePayload(newPayload);
+
         return result;
     }
 
@@ -368,6 +422,8 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
         @XStreamOmitField
         boolean initialised = false;
 
+        List<Integer> reportedEvents = new ArrayList<>();
+
         public Alarm(AlarmType type) {
             alarmType = type;
         }
@@ -382,6 +438,10 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
         public boolean getInitialised() {
             return initialised;
+        }
+
+        public List<Integer> getReportedEvents() {
+            return reportedEvents;
         }
     }
 
@@ -440,11 +500,24 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
     @Override
     public Collection<SerialMessage> initialize(boolean refresh) {
         ArrayList<SerialMessage> result = new ArrayList<SerialMessage>();
-        if (refresh == true || alarms.isEmpty()) {
-            if (getVersion() > 1) {
-                result.add(getSupportedMessage());
+
+        if (refresh == true) {
+            supportedInitialised = false;
+            eventsSupportedInitialised = false;
+        }
+
+        if (getVersion() > 1 && supportedInitialised == false) {
+            result.add(getSupportedMessage());
+        }
+
+        if (getVersion() > 2 && eventsSupportedInitialised == false) {
+            for (Entry<AlarmType, Alarm> alarmEntry : alarms.entrySet()) {
+                if (alarmEntry.getValue().getReportedEvents().isEmpty()) {
+                    result.add(getSupportedEventMessage(alarmEntry.getKey().key));
+                }
             }
         }
+
         return result;
     }
 


### PR DESCRIPTION
The ALARMv3/NOTIFICATION commandclass can report what events are reported for each notification type. The node xml now has a new element **reportedEvents**.  

````
    ....
    <entry>
      <commandClass>ALARM</commandClass>
      <alarmCommandClass>
        <version>3</version>
        <instances>1</instances>
        <alarms>
          <entry>
            <alarmType>POWER_MANAGEMENT</alarmType>
            <alarmState>
              <alarmType>POWER_MANAGEMENT</alarmType>
              <reportedEvents>
                <int>4</int>
                <int>5</int>
                <int>6</int>
                <int>8</int>
                <int>9</int>
              </reportedEvents>
              <outer-class reference="../../../.."/>
            </alarmState>
          </entry>
          <entry>
            <alarmType>HEAT</alarmType>
            <alarmState>
              <alarmType>HEAT</alarmType>
              <reportedEvents>
                <int>2</int>
              </reportedEvents>
              <outer-class reference="../../../.."/>
            </alarmState>
          </entry>
          <entry>
            <alarmType>SYSTEM</alarmType>
            <alarmState>
              <alarmType>SYSTEM</alarmType>
              <reportedEvents>
                <int>1</int>
              </reportedEvents>
              <outer-class reference="../../../.."/>
            </alarmState>
          </entry>
        </alarms>
        <isGetSupported>true</isGetSupported>
      </alarmCommandClass>
    </entry>

````
We now know that this node reports the following Power notification events:

	4)Surge Detection
	5)Voltage Drop/Drift
	6)Over-current detected
	8)Over-load detected
	9)Load error

I would like the node xml to have meaningful names for the event types but that is maybe work for an other PR. 

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)