### PR TITLE
Zwave: add support for the Meter Tbl Monitor Command Class

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterTblMonitorConverterTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterTblMonitorConverterTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
+import org.openhab.binding.zwave.internal.converter.ZWaveMeterTblMonitorConverter;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass.MeterTblMonitorScale;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass.MeterTblMonitorType;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+
+public class ZWaveMeterTblMonitorConverterTest {
+    final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+
+    private ZWaveThingChannel createChannel(String type) {
+        Map<String, String> args = new HashMap<String, String>();
+        args.put("type", type);
+        return new ZWaveThingChannel(uid, DataType.DecimalType, CommandClass.METER_TBL_MONITOR.toString(), 0, args);
+    }
+
+    private ZWaveCommandClassValueEvent createEvent(MeterTblMonitorType type, MeterTblMonitorScale scale,
+            BigDecimal value) {
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ZWaveNode node = Mockito.mock(ZWaveNode.class);
+        ZWaveEndpoint endpoint = Mockito.mock(ZWaveEndpoint.class);
+        ZWaveMeterTblMonitorCommandClass cls = new ZWaveMeterTblMonitorCommandClass(node, controller, endpoint);
+
+        return cls.new ZWaveMeterTblMonitorValueEvent(1, 0, type, scale, value);
+    }
+
+    @Test
+    public void EventElectric() {
+        ZWaveMeterTblMonitorConverter converter = new ZWaveMeterTblMonitorConverter();
+        ZWaveThingChannel channel = createChannel(MeterTblMonitorScale.TE_KWh.toString());
+        BigDecimal value = new BigDecimal("3.3");
+
+        ZWaveCommandClassValueEvent event = createEvent(
+                ZWaveMeterTblMonitorCommandClass.MeterTblMonitorType.TWIN_ELECTRIC,
+                ZWaveMeterTblMonitorCommandClass.MeterTblMonitorScale.TE_KWh, value);
+
+        State state = converter.handleEvent(channel, event);
+
+        assertEquals(state.getClass(), DecimalType.class);
+        assertEquals(((DecimalType) state).toBigDecimal(), value);
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClassTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass.ZWaveMeterTblMonitorValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
+
+/**
+ * Test cases for {@link ZWaveMeterTblMonitorCommandClass}.
+ *
+ * @author Jorg de Jong - Initial version
+ */
+public class ZWaveMeterTblMonitorCommandClassTest {
+
+    @Test
+    public void Gas_Cubic_Meters() {
+
+        byte[] initData = { 0x01, 0x13, 0x00, 0x04, 0x00, 0x07, 0x0D, 0x3D, 0x06, 0x42, 0x01, 0x03, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0x99 };
+
+        byte[] packetData = { 0x01, 0x26, 0x00, 0x04, 0x00, 0x07, 0x18, 0x3D, 0x0D, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+                0x00, 0x01, 0x01, 0x01, 0x1B, 0x19, 0x60, 0x00, 0x00, 0x02, 0x6C, 0x68, 0x00, 0x00, 0x00, 0x00, -107 };
+
+        List<ZWaveEvent> events = processCommandClassMessages(
+                Arrays.asList(new SerialMessage(initData), new SerialMessage(packetData)));
+
+        assertEquals(events.size(), 1);
+
+        ZWaveMeterTblMonitorValueEvent event = (ZWaveMeterTblMonitorValueEvent) events.get(0);
+
+        assertEquals(event.getCommandClass(), CommandClass.METER_TBL_MONITOR);
+        assertEquals(event.getMeterScale(), ZWaveMeterTblMonitorCommandClass.MeterTblMonitorScale.G_Cubic_Meters);
+        assertEquals(event.getMeterType(), ZWaveMeterTblMonitorCommandClass.MeterTblMonitorType.GAS);
+        assertEquals(event.getValue(), new BigDecimal("0.620"));
+    }
+
+    protected List<ZWaveEvent> processCommandClassMessages(List<SerialMessage> msgs) {
+
+        // Mock the controller so we can get any events
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ArgumentCaptor<ZWaveEvent> argument = ArgumentCaptor.forClass(ZWaveEvent.class);
+        Mockito.doNothing().when(controller).notifyEventListeners(argument.capture());
+        ZWaveNode node = Mockito.mock(ZWaveNode.class);
+        ZWaveCommandClass cls = null;
+
+        for (SerialMessage msg : msgs) {
+
+            // Check the packet is not corrupted and is a command class request
+            assertEquals(true, msg.isValid);
+            assertEquals(SerialMessageType.Request, msg.getMessageType());
+            assertEquals(SerialMessageClass.ApplicationCommandHandler, msg.getMessageClass());
+
+            // Get the command class and process the response
+            try {
+                if (cls == null) {
+                    cls = ZWaveCommandClass.getInstance(msg.getMessagePayloadByte(3), node, controller);
+                    assertNotNull(cls);
+                } else {
+                    // ensure a 2nd msg uses the same command class
+                    assertEquals(cls.getCommandClass().getKey(), msg.getMessagePayloadByte(3));
+                }
+                cls.handleApplicationCommandRequest(msg, 4, 0);
+            } catch (ZWaveSerialMessageException e) {
+                fail("Out of bounds exception processing data");
+            }
+        }
+        // Check that we received a response
+        assertNotNull(argument.getAllValues());
+        assertNotEquals(argument.getAllValues().size(), 0);
+
+        // Return all the notifications....
+        return argument.getAllValues();
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -51,6 +51,7 @@ public abstract class ZWaveCommandClassConverter {
         temp.put(CommandClass.CONFIGURATION, ZWaveConfigurationConverter.class);
         temp.put(CommandClass.DOOR_LOCK, ZWaveDoorLockConverter.class);
         temp.put(CommandClass.METER, ZWaveMeterConverter.class);
+        temp.put(CommandClass.METER_TBL_MONITOR, ZWaveMeterTblMonitorConverter.class);
         temp.put(CommandClass.SCENE_ACTIVATION, ZWaveSceneActivationConverter.class);
         temp.put(CommandClass.SENSOR_ALARM, ZWaveAlarmSensorConverter.class);
         temp.put(CommandClass.SENSOR_BINARY, ZWaveBinarySensorConverter.class);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterTblMonitorConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterTblMonitorConverter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass.MeterTblMonitorScale;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterTblMonitorCommandClass.ZWaveMeterTblMonitorValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ZWaveMeterTblMonitorConverter class. Converter for communication with the {@link ZWaveMeterTblMonitorCommandClass}.
+ * Implements polling of the sensor status and receiving of sensor events.
+ *
+ * @author Jorg de Jong
+ */
+public class ZWaveMeterTblMonitorConverter extends ZWaveCommandClassConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveMeterTblMonitorConverter.class);
+
+    /**
+     * Constructor. Creates a new instance of the {@link ZWaveMeterTblMonitorConverter} class.
+     *
+     * @param controller the {@link ZWaveController} to use for sending messages.
+     */
+    public ZWaveMeterTblMonitorConverter() {
+        super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<SerialMessage> executeRefresh(ZWaveThingChannel channel, ZWaveNode node) {
+        ZWaveMeterTblMonitorCommandClass commandClass = (ZWaveMeterTblMonitorCommandClass) node
+                .resolveCommandClass(ZWaveCommandClass.CommandClass.METER_TBL_MONITOR, channel.getEndpoint());
+        if (commandClass == null) {
+            return null;
+        }
+
+        logger.debug("NODE {}: Generating poll message for {}, endpoint {}", node.getNodeId(),
+                commandClass.getCommandClass().getLabel(), channel.getEndpoint());
+
+        List<SerialMessage> response = new ArrayList<SerialMessage>();
+
+        for (SerialMessage msg : commandClass.getDynamicValues(true)) {
+            response.add(node.encapsulate(msg, commandClass, channel.getEndpoint()));
+        }
+        return response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
+        String meterScale = channel.getArguments().get("type");
+        ZWaveMeterTblMonitorValueEvent meterEvent = (ZWaveMeterTblMonitorValueEvent) event;
+
+        // Don't trigger event if this item is bound to another sensor type
+        if (meterScale != null && MeterTblMonitorScale.getMeterScale(meterScale) != meterEvent.getMeterScale()) {
+            logger.debug("Not the right scale {} <> {}", meterScale, meterEvent.getMeterScale());
+            return null;
+        }
+
+        BigDecimal val = (BigDecimal) event.getValue();
+
+        return new DecimalType(val);
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -402,7 +402,7 @@ public abstract class ZWaveCommandClass {
         ZIP_ADV_CLIENT(0x34, "ZIP_ADV_CLIENT", null),
         METER_PULSE(0x35, "METER_PULSE", null),
         METER_TBL_CONFIG(0x3C, "METER_TBL_CONFIG", null),
-        METER_TBL_MONITOR(0x3D, "METER_TBL_MONITOR", null),
+        METER_TBL_MONITOR(0x3D, "METER_TBL_MONITOR", ZWaveMeterTblMonitorCommandClass.class),
         METER_TBL_PUSH(0x3E, "METER_TBL_PUSH", null),
         THERMOSTAT_HEATING(0x38, "THERMOSTAT_HEATING", null),
         THERMOSTAT_MODE(0x40, "THERMOSTAT_MODE", ZWaveThermostatModeCommandClass.class),

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClass.java
@@ -1,0 +1,565 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.protocol.commandclass;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
+/**
+ * Handles the Meter Tbl Monitor Command command class.
+ *
+ * @author Jorg de Jong
+ */
+@XStreamAlias("meterTblMonitorCommandClass")
+public class ZWaveMeterTblMonitorCommandClass extends ZWaveCommandClass
+        implements ZWaveCommandClassInitialization, ZWaveCommandClassDynamicState {
+
+    @XStreamOmitField
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveMeterTblMonitorCommandClass.class);
+
+    private static final byte METER_TBL_TABLE_ID_GET = 0x03;
+    private static final byte METER_TBL_TABLE_ID_REPORT = 0x04;
+    private static final byte METER_TBL_TABLE_CAPABILITY_GET = 0x05;
+    private static final byte METER_TBL_REPORT = 0x06;
+    private static final byte METER_TBL_CURRENT_DATA_GET = 0x0C;
+    private static final byte METER_TBL_CURRENT_DATA_REPORT = 0x0D;
+
+    // unsuported private static final byte METER_TBL_STATUS_REPORT = 0x0B;
+    // unsuported private static final byte METER_TBL_STATUS_DATE_GET = 0x0A;
+    // unsuported private static final byte METER_TBL_STATUS_DEPTH_GET = 0x09;
+    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_GET = 0x07;
+    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_REPORT = 0x08;
+    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_GET = 0x0E;
+    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_REPORT = 0x0F;;
+    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_GET = 0x01;
+    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_REPORT = 0x02;
+
+    @XStreamOmitField
+    private boolean initialiseDone = false;
+    @XStreamOmitField
+    private boolean dynamicDone = false;
+
+    private MeterTblMonitorType meterType;
+    private String tableName;
+    private int rateType;
+    private int dataset;
+
+    /**
+     * Creates a new instance of the ZWaveMeterTblMonitorCommandClass class.
+     *
+     * @param node
+     *            the node this command class belongs to
+     * @param controller
+     *            the controller to use
+     * @param endpoint
+     *            the endpoint this Command class belongs to
+     */
+    public ZWaveMeterTblMonitorCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
+        super(node, controller, endpoint);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommandClass getCommandClass() {
+        return CommandClass.METER_TBL_MONITOR;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ZWaveSerialMessageException
+     */
+    @Override
+    public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpointId)
+            throws ZWaveSerialMessageException {
+        logger.debug("NODE {}: Received Meter Tbl Monitor Request", this.getNode().getNodeId());
+        int command = serialMessage.getMessagePayloadByte(offset);
+        switch (command) {
+            case METER_TBL_CURRENT_DATA_REPORT:
+                handleDataReport(serialMessage, offset, endpointId);
+                break;
+            case METER_TBL_TABLE_ID_REPORT:
+                handleTableIdReport(serialMessage, offset, endpointId);
+                break;
+            case METER_TBL_REPORT:
+                handleReport(serialMessage, offset, endpointId);
+                break;
+            default:
+                logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command,
+                        getCommandClass().getLabel(), getCommandClass().getKey()));
+
+        }
+    }
+
+    private void handleTableIdReport(SerialMessage serialMessage, int offset, int endpointId)
+            throws ZWaveSerialMessageException {
+        logger.debug("NODE {}: Received Meter Tbl Monitor Table ID Report", this.getNode().getNodeId());
+        int numBytes = serialMessage.getMessagePayloadByte(offset + 1) & 0x1F;
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        // Check for null terminations - ignore anything after the first null
+        for (int c = 0; c < numBytes; c++) {
+            if (serialMessage.getMessagePayloadByte(c + offset + 2) > 32
+                    && serialMessage.getMessagePayloadByte(c + offset + 2) < 127) {
+                baos.write((byte) (serialMessage.getMessagePayloadByte(c + offset + 2)));
+            }
+        }
+        String name;
+
+        try {
+            name = new String(baos.toByteArray(), "ASCII");
+        } catch (UnsupportedEncodingException e) {
+            name = "unsupported";
+        }
+        tableName = name;
+        logger.debug("NODE {}: table name: {}", this.getNode().getNodeId(), name);
+    }
+
+    private void handleReport(SerialMessage serialMessage, int offset, int endpointId)
+            throws ZWaveSerialMessageException {
+        logger.debug("NODE {}: Received Meter Tbl Monitor Report", this.getNode().getNodeId());
+        int meterType = serialMessage.getMessagePayloadByte(offset + 1) & 0x3F;
+        int rateType = (serialMessage.getMessagePayloadByte(offset + 1) & 0xC0) >> 6;
+        int properties = serialMessage.getMessagePayloadByte(offset + 2);
+        int datasetSupported = extractValue(serialMessage.getMessagePayload(), offset + 3, 3);
+        int datasetSupportedHistory = extractValue(serialMessage.getMessagePayload(), offset + 6, 3);
+        int dataSupportedHistory = extractValue(serialMessage.getMessagePayload(), offset + 9, 3);
+
+        logger.debug("NODE {}: meterType              : {} {}", this.getNode().getNodeId(), meterType,
+                MeterTblMonitorType.getMeterType(meterType));
+        logger.debug("NODE {}: rateType               : {}", this.getNode().getNodeId(), rateType);
+        logger.debug("NODE {}: properties             : {}", this.getNode().getNodeId(), properties);
+        logger.debug("NODE {}: datasetSupported       : {}", this.getNode().getNodeId(), datasetSupported);
+        logger.debug("NODE {}: datasetSupportedHistory: {}", this.getNode().getNodeId(), datasetSupportedHistory);
+        logger.debug("NODE {}: dataSupportedHistory   : {}", this.getNode().getNodeId(), dataSupportedHistory);
+
+        this.meterType = MeterTblMonitorType.getMeterType(meterType);
+        this.rateType = rateType;
+        this.dataset = datasetSupported;
+
+        initialiseDone = true;
+    }
+
+    private void handleDataReport(SerialMessage serialMessage, int offset, int endpointId)
+            throws ZWaveSerialMessageException {
+        logger.debug("NODE {}: Received Meter Tbl Monitor Data Report", this.getNode().getNodeId());
+        int numReports = serialMessage.getMessagePayloadByte(offset + 1);
+        int rateType = serialMessage.getMessagePayloadByte(offset + 2) & 0x03;
+        boolean operatingStatus = (serialMessage.getMessagePayloadByte(offset + 2) & 0x80) > 0;
+
+        int dataset = extractValue(serialMessage.getMessagePayload(), offset + 3, 3);
+        int year = extractValue(serialMessage.getMessagePayload(), offset + 6, 2);
+        int month = serialMessage.getMessagePayloadByte(offset + 8);
+        int day = serialMessage.getMessagePayloadByte(offset + 9);
+        int hour = serialMessage.getMessagePayloadByte(offset + 10);
+        int minutes = serialMessage.getMessagePayloadByte(offset + 11);
+        int seconds = serialMessage.getMessagePayloadByte(offset + 12);
+
+        int scaleIndex = serialMessage.getMessagePayloadByte(offset + 13) & 0x1F;
+        int presision = (serialMessage.getMessagePayloadByte(offset + 13) & 0xE0) >> 5;
+
+        int valueRaw = extractValue(serialMessage.getMessagePayload(), offset + 14, 4);
+
+        logger.trace("NODE {}: numReports:{}", this.getNode().getNodeId(), numReports);
+        logger.trace("NODE {}: rateType  :{}", this.getNode().getNodeId(), rateType);
+        logger.trace("NODE {}: operating :{}", this.getNode().getNodeId(), operatingStatus);
+        logger.trace("NODE {}: dataset   :{}", this.getNode().getNodeId(), dataset);
+        logger.trace(String.format("NODE %d: time      :%04d-%02d-%02d %02d:%02d:%02d", this.getNode().getNodeId(),
+                year, month, day, hour, minutes, seconds));
+
+        logger.trace("NODE {}: scale     :{}", this.getNode().getNodeId(), scaleIndex);
+        logger.trace("NODE {}: presision :{}", this.getNode().getNodeId(), presision);
+        logger.trace("NODE {}: value     :{}", this.getNode().getNodeId(), valueRaw);
+
+        MeterTblMonitorScale scale = MeterTblMonitorScale.getMeterScale(meterType, scaleIndex);
+        if (scale == null) {
+            logger.warn("NODE {}: Invalid meter scale {}", getNode().getNodeId(), scaleIndex);
+            return;
+        }
+
+        try {
+            BigDecimal value = new BigDecimal(valueRaw / Math.pow(10, presision)).setScale(presision,
+                    BigDecimal.ROUND_HALF_UP);
+            logger.debug("NODE {}: Meter Tbl Monitor: Type={}, Scale={}({}), Value={}, Dataset={}",
+                    getNode().getNodeId(), meterType.getLabel(), scale.getUnit(), scale.getScale(), value, dataset);
+
+            ZWaveMeterTblMonitorValueEvent zEvent = new ZWaveMeterTblMonitorValueEvent(getNode().getNodeId(),
+                    endpointId, meterType, scale, value);
+            this.getController().notifyEventListeners(zEvent);
+        } catch (NumberFormatException e) {
+            logger.error("NODE {}: Meter Tbl Monitor Value Error {}", getNode().getNodeId(), e);
+            return;
+        }
+
+        dynamicDone = true;
+    }
+
+    /**
+     * Gets a SerialMessage with the METER_TBL_CURRENT_DATA_GET command
+     *
+     * @return the serial message
+     */
+    public SerialMessage getCurrentData(int dataset) {
+        logger.debug("NODE {}: Creating new message for application command METER_TBL_CURRENT_DATA_GET",
+                getNode().getNodeId());
+        SerialMessage message = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(this.getNode().getNodeId());
+        outputData.write(5);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(METER_TBL_CURRENT_DATA_GET);
+        outputData.write(dataset >> 16);
+        outputData.write(dataset >> 8);
+        outputData.write(dataset);
+        message.setMessagePayload(outputData.toByteArray());
+
+        return message;
+    }
+
+    /**
+     * Gets a SerialMessage with the METER_TBL_TABLE_CAPABILITY_GET command
+     *
+     * @return the serial message
+     */
+    public SerialMessage getCapabilityGet() {
+        logger.debug("NODE {}: Creating new message for application command METER_TBL_TABLE_CAPABILITY_GET",
+                getNode().getNodeId());
+        SerialMessage message = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(this.getNode().getNodeId());
+        outputData.write(2);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(METER_TBL_TABLE_CAPABILITY_GET);
+        message.setMessagePayload(outputData.toByteArray());
+
+        return message;
+    }
+
+    /**
+     * Gets a SerialMessage with the METER_TBL_TABLE_ID_GET command
+     *
+     * @return the serial message
+     */
+    public SerialMessage getTableIDGet() {
+        logger.debug("NODE {}: Creating new message for application command METER_TBL_TABLE_ID_GET",
+                getNode().getNodeId());
+        SerialMessage message = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(this.getNode().getNodeId());
+        outputData.write(2);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(METER_TBL_TABLE_ID_GET);
+        message.setMessagePayload(outputData.toByteArray());
+
+        return message;
+    }
+
+    @Override
+    public Collection<SerialMessage> initialize(boolean refresh) {
+        ArrayList<SerialMessage> result = new ArrayList<SerialMessage>();
+        // If we're already initialized, then don't do it again unless we're refreshing
+        if (refresh == true || initialiseDone == false) {
+            result.add(getCapabilityGet());
+            result.add(getTableIDGet());
+        }
+        return result;
+    }
+
+    @Override
+    public Collection<SerialMessage> getDynamicValues(boolean refresh) {
+        ArrayList<SerialMessage> result = new ArrayList<SerialMessage>();
+
+        if (refresh == true || dynamicDone == false) {
+            result.add(getCurrentData(dataset));
+        }
+
+        return result;
+    }
+
+    /**
+     * Z-Wave MeterTblMonitorType enumeration. The meter type indicates the type of meter that is reported.
+     *
+     */
+    public enum MeterTblMonitorType {
+        UNKNOWN(0, "Unknown"),
+        ELECTRIC(1, "Electric"),
+        GAS(2, "Gas"),
+        WATER(3, "Water"),
+        TWIN_ELECTRIC(4, "Twin Electric");
+
+        /**
+         * A mapping between the integer code and its corresponding Meter type
+         * to facilitate lookup by code.
+         */
+        private static Map<Integer, MeterTblMonitorType> codeToMeterTypeMapping;
+
+        private int key;
+        private String label;
+
+        private MeterTblMonitorType(int key, String label) {
+            this.key = key;
+            this.label = label;
+        }
+
+        private static void initMapping() {
+            codeToMeterTypeMapping = new HashMap<Integer, MeterTblMonitorType>();
+            for (MeterTblMonitorType s : values()) {
+                codeToMeterTypeMapping.put(s.key, s);
+            }
+        }
+
+        /**
+         * Lookup function based on the meter type code. Returns null if the
+         * code does not exist.
+         *
+         * @param i
+         *            the code to lookup
+         * @return enumeration value of the meter type.
+         */
+        public static MeterTblMonitorType getMeterType(int i) {
+            if (codeToMeterTypeMapping == null) {
+                initMapping();
+            }
+
+            return codeToMeterTypeMapping.get(i);
+        }
+
+        /**
+         * @return the key
+         */
+        public int getKey() {
+            return key;
+        }
+
+        /**
+         * @return the label
+         */
+        public String getLabel() {
+            return label;
+        }
+    }
+
+    /**
+     * Z-Wave MeterScale enumeration. The meter scale indicates the meter scale that is reported.
+     *
+     */
+    @XStreamAlias("meterTblMonitorScale")
+    public enum MeterTblMonitorScale {
+        E_KWh(0, MeterTblMonitorType.ELECTRIC, "kWh", "Energy"),
+        E_KVAh(1, MeterTblMonitorType.ELECTRIC, "kVAh", "Energy"),
+        E_W(2, MeterTblMonitorType.ELECTRIC, "W", "Power"),
+        E_Pulses(3, MeterTblMonitorType.ELECTRIC, "Pulses", "Count"),
+        E_V(4, MeterTblMonitorType.ELECTRIC, "V", "Voltage"),
+        E_A(5, MeterTblMonitorType.ELECTRIC, "A", "Current"),
+        E_Power_Factor(6, MeterTblMonitorType.ELECTRIC, "Power Factor", "Power Factor"),
+        G_Cubic_Meters(0, MeterTblMonitorType.GAS, "Cubic Meters", "Volume"),
+        G_Cubic_Feet(1, MeterTblMonitorType.GAS, "Cubic Feet", "Volume"),
+        G_Pulses(3, MeterTblMonitorType.GAS, "Pulses", "Count"),
+        W_Cubic_Meters(0, MeterTblMonitorType.WATER, "Cubic Meters", "Volume"),
+        W_Cubic_Feet(1, MeterTblMonitorType.WATER, "Cubic Feet", "Volume"),
+        W_Gallons(2, MeterTblMonitorType.WATER, "US gallons", "Volume"),
+        W_Pulses(3, MeterTblMonitorType.WATER, "Pulses", "Count"),
+        TE_KWh(0, MeterTblMonitorType.TWIN_ELECTRIC, "kWh", "Energy"),
+        TE_KVAh(1, MeterTblMonitorType.TWIN_ELECTRIC, "kVAh", "Energy"),
+        TE_W(2, MeterTblMonitorType.TWIN_ELECTRIC, "W", "Power"),
+        TE_Pulses(3, MeterTblMonitorType.TWIN_ELECTRIC, "Pulses", "Count"),
+        TE_V(4, MeterTblMonitorType.TWIN_ELECTRIC, "V", "Voltage"),
+        TE_A(5, MeterTblMonitorType.TWIN_ELECTRIC, "A", "Current");
+
+        private final int scale;
+        private final MeterTblMonitorType meterType;
+        private final String unit;
+        private final String label;
+
+        /**
+         * A mapping between the integer code, Meter type and its corresponding Meter scale
+         * to facilitate lookup by code.
+         */
+        private static Map<MeterTblMonitorType, Map<Integer, MeterTblMonitorScale>> codeToMeterScaleMapping;
+
+        /**
+         * A mapping between the name,and its corresponding Meter scale to facilitate lookup by enumeration name.
+         */
+        private static Map<String, MeterTblMonitorScale> nameToMeterScaleMapping;
+
+        /**
+         * Constructor. Creates a new enumeration value.
+         *
+         * @param scale the scale number
+         * @param meterType the meter type
+         * @param unit the unit
+         * @param label the label.
+         */
+        private MeterTblMonitorScale(int scale, MeterTblMonitorType meterType, String unit, String label) {
+            this.scale = scale;
+            this.meterType = meterType;
+            this.unit = unit;
+            this.label = label;
+        }
+
+        private static void initMapping() {
+            codeToMeterScaleMapping = new HashMap<MeterTblMonitorType, Map<Integer, MeterTblMonitorScale>>();
+            nameToMeterScaleMapping = new HashMap<String, MeterTblMonitorScale>();
+            for (MeterTblMonitorScale s : values()) {
+                if (!codeToMeterScaleMapping.containsKey(s.getMeterType())) {
+                    codeToMeterScaleMapping.put(s.getMeterType(), new HashMap<Integer, MeterTblMonitorScale>());
+                }
+                codeToMeterScaleMapping.get(s.getMeterType()).put(s.getScale(), s);
+                nameToMeterScaleMapping.put(s.name().toLowerCase(), s);
+            }
+        }
+
+        /**
+         * Lookup function based on the meter type and code. Returns null if the code does not exist.
+         *
+         * @param meterType the meter type to use to lookup the scale
+         * @param i the code to lookup
+         * @return enumeration value of the meter scale.
+         */
+        public static MeterTblMonitorScale getMeterScale(MeterTblMonitorType meterType, int i) {
+            if (codeToMeterScaleMapping == null) {
+                initMapping();
+            }
+            if (!codeToMeterScaleMapping.containsKey(meterType)) {
+                return null;
+            }
+
+            return codeToMeterScaleMapping.get(meterType).get(i);
+        }
+
+        /**
+         * Lookup function based on the name. Returns null if the name does not exist.
+         *
+         * @param name the name to lookup
+         * @return enumeration value of the meter scale.
+         */
+        public static MeterTblMonitorScale getMeterScale(String name) {
+            if (nameToMeterScaleMapping == null) {
+                initMapping();
+            }
+
+            return nameToMeterScaleMapping.get(name.toLowerCase());
+        }
+
+        /**
+         * Returns the scale code.
+         *
+         * @return the scale code.
+         */
+        protected int getScale() {
+            return scale;
+        }
+
+        /**
+         * Returns the meter type.
+         *
+         * @return the meterType
+         */
+        protected MeterTblMonitorType getMeterType() {
+            return meterType;
+        }
+
+        /**
+         * Returns the unit as string.
+         *
+         * @return the unit
+         */
+        protected String getUnit() {
+            return unit;
+        }
+
+        /**
+         * Returns the label (category).
+         *
+         * @return the label
+         */
+        protected String getLabel() {
+            return label;
+        }
+
+    }
+
+    /**
+     * Z-Wave Meter tbl monitor value Event class. Indicates that a meter value changed.
+     *
+     */
+    public class ZWaveMeterTblMonitorValueEvent extends ZWaveCommandClassValueEvent {
+
+        private MeterTblMonitorType meterType;
+        private MeterTblMonitorScale meterScale;
+
+        /**
+         * Constructor. Creates a instance of the ZWaveMeterTblMonitorValueEvent class.
+         *
+         * @param nodeId
+         *            the nodeId of the event
+         * @param endpoint
+         *            the endpoint of the event.
+         * @param meterType
+         *            the meter type that triggered the event;
+         * @param meterType
+         *            the meter scale for the event;
+         * @param value
+         *            the value for the event.
+         */
+        public ZWaveMeterTblMonitorValueEvent(int nodeId, int endpoint, MeterTblMonitorType meterType,
+                MeterTblMonitorScale meterScale, Object value) {
+            super(nodeId, endpoint, CommandClass.METER_TBL_MONITOR, value);
+            this.meterType = meterType;
+            this.meterScale = meterScale;
+        }
+
+        /**
+         * Gets the meter type for this meter tbl monitor value event.
+         *
+         * @return the meter type for this meter tbl monitor value event.
+         */
+        public MeterTblMonitorType getMeterType() {
+            return meterType;
+        }
+
+        /**
+         * Gets the meter scale for this meter tbl monitor value event.
+         *
+         * @return the meter scale for this meter tbl monitor value event.
+         */
+        public MeterTblMonitorScale getMeterScale() {
+            return meterScale;
+        }
+
+    }
+}


### PR DESCRIPTION
Add support for the METER_TBL_CURRENT_DATA_REPORT message.
In this message the current meter value is reported.
The command class also supports historical data, this is not
supported (yet).


Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)