### PR TITLE
Zwave: fix compile error on cloudbees build

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.zwave.test/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Import-Package: org.slf4j,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.mockito,
  org.osgi.service.device
 Require-Bundle: org.junit;bundle-version="4.11.0"
 Export-Package: org.openhab.binding.zwave.internal.protocol;x-internal:=true

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -41,6 +41,7 @@
     <module>org.openhab.binding.tesla</module>
     <module>org.openhab.binding.vitotronic</module>
     <module>org.openhab.binding.zwave</module>
+    <module>org.openhab.binding.zwave.test</module>
   </modules>
 
 </project>


### PR DESCRIPTION
This fixes the compile error on last nights build. Not sure if the pom update is desired?

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)