### PR TITLE
Zwave: add zwave.test to maven build

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.zwave.test/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Openhab ZWave Binding Tests
 Bundle-SymbolicName: org.openhab.binding.zwave.test;singleton:=true
 Bundle-Version: 2.0.0.qualifier
+Bundle-ClassPath: .,lib/mockito-all-1.10.19.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Openhab
 Fragment-Host: org.openhab.binding.zwave

--- a/addons/binding/org.openhab.binding.zwave.test/build.properties
+++ b/addons/binding/org.openhab.binding.zwave.test/build.properties
@@ -3,4 +3,6 @@ source.. = src/test/groovy,\
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               src/
+               src/,\
+               lib/mockito-all-1.10.19.jar
+

--- a/addons/binding/org.openhab.binding.zwave.test/pom.xml
+++ b/addons/binding/org.openhab.binding.zwave.test/pom.xml
@@ -13,14 +13,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
-		</dependency>
-	</dependencies>
-
 	<properties>
 		<bundle.symbolicName>org.openhab.binding.zwave.test</bundle.symbolicName>
 		<bundle.namespace>org.openhab.binding.zwave.test</bundle.namespace>

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -44,6 +44,7 @@
     <module>org.openhab.binding.vitotronic</module>
     <module>org.openhab.binding.yamahareceiver</module>
     <module>org.openhab.binding.zwave</module>
+    <module>org.openhab.binding.zwave.test</module>
   </modules>
 
 </project>


### PR DESCRIPTION
This fixes the compile error on last nights build. 

(2nd attempt)

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)