### PR TITLE
Remove polling from multilevel_switch command to stop slider returning

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
@@ -174,7 +174,9 @@ public class ZWaveMultiLevelSwitchConverter extends ZWaveCommandClassConverter {
         messages.add(serialMessage);
 
         // Poll an update once we've sent the command
-        messages.add(node.encapsulate(commandClass.getValueMessage(), commandClass, channel.getEndpoint()));
+        // Don't poll immediately since some devices return the original value, and some the new value.
+        // This conflicts with OH that will move the slider immediately.
+        // messages.add(node.encapsulate(commandClass.getValueMessage(), commandClass, channel.getEndpoint()));
         return messages;
     }
 }


### PR DESCRIPTION
https://github.com/openhab/openhab2-addons/issues/794

Signed-off-by: Chris Jackson <chris@cd-jackson.com>