### PR TITLE
ZWave: [WIP] enable FIBARO_FGRM_222 converter

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgrm222_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgrm222_0_0.xml
@@ -27,13 +27,13 @@
       <channel id="shutter_fgrm222" typeId="switch_dimmer">
         <label>Shutter (FGRM222)</label>
         <properties>
-          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=shutter</property>
+          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=shutter,invert=true</property>
         </properties>
       </channel>
       <channel id="lamella_fgrm222" typeId="switch_dimmer">
         <label>Lamella (FGRM222)</label>
         <properties>
-          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=lamella</property>
+          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=lamella,invert=true</property>
         </properties>
       </channel>
       <channel id="switch_binary" typeId="switch_binary">
@@ -68,7 +68,7 @@
         <default>255</default>
         <options>
           <option value="0">No protection. Roller Shutter responds to push buttons</option>
-          <option value="2">Local protection active. Roller Shutter does not respond to push butto</option>
+          <option value="2">Local protection active. Roller Shutter does not respond to push button</option>
         </options>
       </parameter>
 

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgrm222_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibaro_fgrm222_0_0.xml
@@ -24,6 +24,18 @@
           <property name="binding:*:DecimalType">SENSOR_MULTILEVEL;type=POWER</property>
         </properties>
       </channel>
+      <channel id="shutter_fgrm222" typeId="switch_dimmer">
+        <label>Shutter (FGRM222)</label>
+        <properties>
+          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=shutter</property>
+        </properties>
+      </channel>
+      <channel id="lamella_fgrm222" typeId="switch_dimmer">
+        <label>Lamella (FGRM222)</label>
+        <properties>
+          <property name="binding:*:PercentType">FIBARO_FGRM_222;type=lamella</property>
+        </properties>
+      </channel>
       <channel id="switch_binary" typeId="switch_binary">
         <label>Switch</label>
         <properties>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
@@ -102,6 +102,11 @@ public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
     public List<SerialMessage> receiveCommand(ZWaveThingChannel channel, ZWaveNode node, Command command) {
         FibaroFGRM222CommandClass commandClass = (FibaroFGRM222CommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.FIBARO_FGRM_222, channel.getEndpoint());
+        if (commandClass == null) {
+            logger.warn("NODE {}: Cannot resolve command class (endpoint: {}).", node.getNodeId(),
+                    channel.getEndpoint());
+            return null;
+        }
 
         logger.debug("NODE {}: receiveCommand()", node.getNodeId());
         SerialMessage serialMessage = null;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.zwave.internal.converter;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +20,6 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
-import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
@@ -36,9 +36,36 @@ import org.slf4j.LoggerFactory;
 public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(FibaroFGRM222Converter.class);
+    private static String INVERT = "invert";
 
     public FibaroFGRM222Converter(ZWaveControllerHandler controller) {
         super(controller);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T handleInvert(ZWaveThingChannel channel, T obj) {
+        final T rv;
+        if ("true".equalsIgnoreCase(channel.getArguments().get(INVERT))) {
+            if (obj instanceof PercentType) {
+                rv = (T) new PercentType(new BigDecimal(100).subtract(((PercentType) obj).toBigDecimal()));
+            } else if (obj instanceof DecimalType) {
+                rv = (T) new DecimalType(new BigDecimal(255).subtract(((DecimalType) obj).toBigDecimal()));
+            } else if (obj instanceof UpDownType) {
+                if (obj == UpDownType.UP) {
+                    rv = (T) UpDownType.DOWN;
+                } else if (obj == UpDownType.DOWN) {
+                    rv = (T) UpDownType.UP;
+                } else {
+                    rv = obj;
+                }
+            } else {
+                rv = obj;
+            }
+        } else {
+            rv = obj;
+        }
+        logger.debug("FibaroFGRM222: [{}={}] {} => {}", INVERT, channel.getArguments().get(INVERT), obj, rv);
+        return rv;
     }
 
     @Override
@@ -50,12 +77,25 @@ public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
             return null;
         }
 
-        State state = new DecimalType(((Integer) event.getValue()).intValue());
-        if (channel.getDataType() == DataType.DecimalType) {
-            state = new PercentType(100 - ((DecimalType) state).intValue());
+        logger.debug("FibaroFGRM222: channel data type: {}, event value: {}, event type: {}", channel.getDataType(),
+                event.getValue(), event.getType());
+
+        final Integer value = ((Integer) event.getValue()).intValue();
+
+        final State state;
+        switch (channel.getDataType()) {
+            case PercentType:
+                state = new PercentType(value);
+                break;
+            case DecimalType:
+                state = new DecimalType(value);
+                break;
+            default:
+                state = new DecimalType(value);
+                break;
         }
 
-        return state;
+        return handleInvert(channel, state);
     }
 
     @Override
@@ -64,33 +104,22 @@ public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.FIBARO_FGRM_222, channel.getEndpoint());
 
         logger.debug("NODE {}: receiveCommand()", node.getNodeId());
-        Command internalCommand = command;
         SerialMessage serialMessage = null;
 
-        if (internalCommand instanceof StopMoveType && (StopMoveType) internalCommand == StopMoveType.STOP) {
+        if (command instanceof StopMoveType && (StopMoveType) command == StopMoveType.STOP) {
             // Special handling for the STOP command
             serialMessage = commandClass.stopLevelChangeMessage(channel.getArguments().get("type"));
         } else {
             int value;
 
+            command = handleInvert(channel, command);
+
             if (command instanceof PercentType) {
-                if ("true".equalsIgnoreCase(channel.getArguments().get("invert_percent"))) {
-                    value = 100 - ((PercentType) command).intValue();
-                } else {
-                    value = ((PercentType) command).intValue();
-                }
-
+                value = ((PercentType) command).intValue();
+            } else if (command instanceof DecimalType) {
+                value = ((DecimalType) command).intValue();
             } else if (command instanceof UpDownType) {
-                if ("true".equalsIgnoreCase(channel.getArguments().get("invert_state"))) {
-                    if (command == UpDownType.UP) {
-                        command = UpDownType.DOWN;
-                    } else {
-                        command = UpDownType.UP;
-                    }
-                }
-
                 value = command != UpDownType.DOWN ? 0x63 : 0x00;
-
             } else {
                 logger.warn("NODE {}: No conversion for channel {}", node.getNodeId(), channel.getUID());
                 return null;
@@ -98,8 +127,8 @@ public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
             if (value == 0) {
                 value = 1;
             }
-            logger.trace("NODE {}: Converted command '{}' to value {} for item = {}, endpoint = {}.", node.getNodeId(),
-                    internalCommand.toString(), channel.getEndpoint());
+            logger.debug("NODE {}: Converted command '{}' to value {} for item = {}, endpoint = {}.", node.getNodeId(),
+                    command, channel.getEndpoint());
 
             serialMessage = commandClass.setValueMessage(value, channel.getArguments().get("type"));
         }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/FibaroFGRM222Converter.java
@@ -129,9 +129,10 @@ public class FibaroFGRM222Converter extends ZWaveCommandClassConverter {
                 logger.warn("NODE {}: No conversion for channel {}", node.getNodeId(), channel.getUID());
                 return null;
             }
-            if (value == 0) {
-                value = 1;
-            }
+
+            // if (value == 0) {
+            // value = 1;
+            // }
             logger.debug("NODE {}: Converted command '{}' to value {} for item = {}, endpoint = {}.", node.getNodeId(),
                     command, channel.getEndpoint());
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -54,6 +54,7 @@ public abstract class ZWaveCommandClassConverter {
         temp.put(CommandClass.COLOR, ZWaveColorConverter.class);
         temp.put(CommandClass.CONFIGURATION, ZWaveConfigurationConverter.class);
         temp.put(CommandClass.DOOR_LOCK, ZWaveDoorLockConverter.class);
+        temp.put(CommandClass.FIBARO_FGRM_222, FibaroFGRM222Converter.class);
         temp.put(CommandClass.METER, ZWaveMeterConverter.class);
         temp.put(CommandClass.METER_TBL_MONITOR, ZWaveMeterTblMonitorConverter.class);
         temp.put(CommandClass.PROTECTION, ZWaveProtectionConverter.class);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
@@ -60,6 +60,11 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
     }
 
     public SerialMessage setValueMessage(final int level, final String type) {
+        /*
+         * <blind %>: 0 to 99%, 0 = fully closed, 99% = fully opened
+         * <lamellas %>: 0 to 99%, 0 = vertical, 99% = horizontal
+         */
+
         logger.debug("NODE {}: Creating new message for application command FIBARO FGRM 222 set. type: {}. level {}.",
                 this.getNode().getNodeId(), type, level);
         SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
@@ -67,22 +72,41 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
                 SerialMessage.SerialMessagePriority.Set);
         byte[] newPayload;
         if (type.equalsIgnoreCase(FibaroFGRM222ValueType.Shutter.name())) {
+            final int levelInRange;
+            if (level >= 100) {
+                levelInRange = 99;
+            } else if (level < 0) {
+                levelInRange = 0;
+            } else {
+                levelInRange = level;
+            }
+
             newPayload = new byte[] { (byte) this.getNode().getNodeId(), // Node ID of Target Node
                     (byte) 8, // Number of payload Bytes following
                     (byte) 0x91, // 4 Magic Fibaro Bytes.
                     (byte) 0x1, (byte) 0xF, (byte) 0x26, (byte) 1, // set blind % (1 --> set, 2 ? , 3 report
                     (byte) 2, // set lamella
-                    (byte) level, // blind level
+                    (byte) levelInRange, // blind level
                     (byte) 0 // lamella level
             };
-        } else {
+        } else /* if (type.equalsIgnoreCase(FibaroFGRM222ValueType.Lamella.name())) */ {
+            final int levelInRange;
+            if (level >= 100) {
+                levelInRange = 99;
+            } else if (level < 0) {
+                levelInRange = 0;
+            } else {
+                levelInRange = level;
+            }
+
             newPayload = new byte[] { (byte) this.getNode().getNodeId(), (byte) 8, (byte) 0x91, (byte) 0x1, (byte) 0xF,
                     (byte) 0x26, (byte) 1, // set blind % (1 --> set, 2 ? , 3 report
                     (byte) 1, // set lamella
                     (byte) 0, // blind level
-                    (byte) level // lamella level
+                    (byte) levelInRange // lamella level
             };
         }
+
         result.setMessagePayload(newPayload);
         return result;
     }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
@@ -75,8 +75,8 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
             final int levelInRange;
             if (level >= 100) {
                 levelInRange = 99;
-            } else if (level < 0) {
-                levelInRange = 0;
+            } else if (level <= 0) {
+                levelInRange = 1;
             } else {
                 levelInRange = level;
             }
@@ -93,8 +93,8 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
             final int levelInRange;
             if (level >= 100) {
                 levelInRange = 99;
-            } else if (level < 0) {
-                levelInRange = 0;
+            } else if (level <= 0) {
+                levelInRange = 1;
             } else {
                 levelInRange = level;
             }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/proprietary/FibaroFGRM222CommandClass.java
@@ -9,10 +9,10 @@
 package org.openhab.binding.zwave.internal.protocol.commandclass.proprietary;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.slf4j.Logger;
@@ -109,7 +109,7 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
         // (byte) 15,
         // (byte) 38,
         // (byte) 1, // set blind % (1 --> set, 2 ? , 3 report
-        // (byte) 3, // set lamelle
+        // (byte) 3, // set lamella
         // (byte) 0, // blind level
         // (byte) 0 // lamella level
         // };
@@ -122,7 +122,7 @@ public class FibaroFGRM222CommandClass extends ZWaveCommandClass {
         // (byte) 15,
         // (byte) 38,
         // (byte) 3, // set blind % (1 --> set, 2 ? , 3 report
-        // (byte) 1, // set lamelle
+        // (byte) 1, // set lamella
         // (byte) 0, // blind level
         // (byte) 0 // lamella level
         // };


### PR DESCRIPTION
This PR should be a base for discussion.

@cdjackson I know that the thing XML files are generated by your database.

The following changes allows me to use the Fibaro FGRM222 proprietary manufacturer specific command class implementation to control the roller shutter.

Using that class (you already know) I can also set the lamella angle and not only the position of the blinds.

PercentType is perhaps not correct for angles of lamellas (they could be negative). But that is the XML and should not matter here.