### PR TITLE
DSC Alarm: Serial Connection Fix, other minor fixes, and one feature addition.

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -9,7 +8,7 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
-            <bridge-type-ref id="tcpserver" />
+			<bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Keypad</label>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
@@ -9,6 +9,7 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
+            <bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Keypad</label>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/panel.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/panel.xml
@@ -9,6 +9,7 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
+            <bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Panel</label>
@@ -124,7 +125,7 @@
 	</channel-type>
 
 	<channel-type id="panel_command">
-		<item-type>String</item-type>
+		<item-type>Number</item-type>
 		<label>Panel Command</label>
 		<description>Send Command</description>
 		<state pattern="%d">

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/partition.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/partition.xml
@@ -9,6 +9,7 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
+            <bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Partition</label>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/tcpserverbridge.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/tcpserverbridge.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="dscalarm"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+
+	<bridge-type id="tcpserver">
+		<label>TCP Server</label>
+		<description>This bridge represents a TCP Server
+			Ethernet interface.</description>
+
+		<channels>
+			<channel id="bridge_reset" typeId="reset">
+				<label>Reset TCP Server</label>
+				<description>Resets the TCP Server</description>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="ipAddress" type="text" required="true">
+				<context>network_address</context>
+				<label>IP Address</label>
+				<description>The IP address of the TCP Server.</description>
+			</parameter>
+
+			<parameter name="port" type="integer" required="true">
+				<label>Port</label>
+				<description>The TCP port to the TCP Server.</description>
+			</parameter>
+
+			<parameter name="connectionTimeout" type="integer" required="false">
+				<label>Connection Timeout</label>
+				<description>TCP Socket Connection Timeout (milliseconds).</description>
+				<default>5000</default>
+			</parameter>
+
+			<parameter name="pollPeriod" type="integer" required="false" min="1" max="15">
+				<label>Poll Period</label>
+				<description>The Poll Period (minutes).</description>
+				<default>1</default>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<channel-type id="reset">
+		<item-type>Switch</item-type>
+		<label>Reset</label>
+		<description>Reset Switch</description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/zone.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/zone.xml
@@ -9,6 +9,7 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
+            <bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Zone</label>

--- a/addons/binding/org.openhab.binding.dscalarm/README.md
+++ b/addons/binding/org.openhab.binding.dscalarm/README.md
@@ -12,12 +12,13 @@ This binding supports the following thing types
 
 <table>
 <tr><td><b>Thing</b></td><td><b>Thing Type</b></td><td><b>Description</b></td></tr>
-<tr><td>EnvisalinkBridge</td><td>Bridge</td><td>The EyezOn Envisalink 3/2DS interface.</td></tr>
-<tr><td>IT100Bridge</td><td>Bridge</td><td>The DSC IT-100 RS-232 interface.</td></tr>
-<tr><td>Panel</td><td>Thing</td><td>The basic representation of the DSC Alarm System.</td></tr>
-<tr><td>Partition</td><td>Thing</td><td>Represents a controllable area within a DSC Alarm system.</td></tr>
-<tr><td>Zone</td><td>Thing</td><td>Represents a physical device such as a door, window, or motion sensor.</td></tr>
-<tr><td>Keypad</td><td>Thing</td><td>Represents the central administrative unit.</td></tr>
+<tr><td>envisalink</td><td>Bridge</td><td>The EyezOn Envisalink 3/2DS interface.</td></tr>
+<tr><td>it100</td><td>Bridge</td><td>The DSC IT-100 RS-232 interface.</td></tr>
+<tr><td>tcpserver</td><td>Bridge</td><td>The DSC IT-100 TCP Server network interface.</td></tr>
+<tr><td>panel</td><td>Thing</td><td>The basic representation of the DSC Alarm System.</td></tr>
+<tr><td>partition</td><td>Thing</td><td>Represents a controllable area within a DSC Alarm system.</td></tr>
+<tr><td>zone</td><td>Thing</td><td>Represents a physical device such as a door, window, or motion sensor.</td></tr>
+<tr><td>keypad</td><td>Thing</td><td>Represents the central administrative unit.</td></tr>
 </table>
 
 ## Binding Configuration
@@ -26,7 +27,7 @@ There are essentially no overall binding configuration settings that need to be 
 
 ## Discovery
 
-The DSC Alarm binding incorporates several discovery modes in order to find DSC Alarm devices.  First, there is the Envisalink bridge discovery mode which performs a network query for any Envisalink adapters and adds them to the discovery inbox.  Second, there is The IT-100 bridge discovery mode which will find the serial ports attached to the OpenHAB machine and add them to the discovery inbox, which allows the choosing of the port corresponding to the IT-100 bridge.  Third, after a bridge is discovered and available to OpenHAB, the binding will attempt to discover DSC Alarm devices and add them to the discovery inbox.
+The DSC Alarm binding incorporates several discovery modes in order to find DSC Alarm systems.  First, there is the Envisalink bridge discovery mode which performs a network query for any Envisalink adapters and adds them to the discovery inbox.  Second, there is The IT-100 bridge discovery mode which will search serial ports for any  IT-100 adapters and add them to the discovery inbox.  Third, after a bridge is discovered and available to OpenHAB, the binding will attempt to discover DSC Alarm devices and add them to the discovery inbox.  The TCP Server bridge does not implement bridge discovery but will utilize device discovery once it is online.  
 
 ## Thing Configuration
 
@@ -34,18 +35,19 @@ DSC Alarm things can be configured either through the online configuration utili
 
 <table>
 	<tr><td><b>Thing</b></td><td><b>Configuration Parameters</b></td></tr>	
-	<tr><td>EnvisalinkBridge</td><td><table><tr><td><b>ipAddress</b> - IP address for the Envisalink adapter - Required.</td></tr><tr><td><b>port</b> - TCP port for the Envisalink adapter - Not Required - default = 4025.</td></tr><tr><td><b>password</b> - Password to login to the Envisalink bridge - Not Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the Envisalink bridge - Not Required - default=1.</td></tr></table></td></tr>
-	<tr><td>IT100Bridge</td><td><table><tr><td><b>serialPort</b> - Serial port for the IT-100s bridge - Required.</td></tr><tr><td><b>baud</b> - Baud rate of the IT-100 bridge - Not Required - default = 9600.</td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the IT-100 bridge - Not Required - default=1.</td></tr></table></td></tr>
-	<tr><td>Panel</td><td><table><tr><td><b>userCode</b> - User code for the DSC alarm panel - Not Required.</td></tr><tr><td><b>suppressAcknowledgementMsgs</b> - Suppress the display of acknowledgement messages when received - Not Required - default = false.</td></tr></table></td></tr>
-	<tr><td>Partition</td><td><b>partitionNumber</b> - Partition number (1-8) - Required.</td></tr>
-	<tr><td>Zone</td><td><table><tr><td><b>partitionNumber</b> - Partition number (1-8) - Not Required - default=1.</td></tr><tr><td><b>zoneNumber</b> - Zone number (1-64) - Required.</td></tr></table></td></tr>
-	<tr><td>Keypad</td><td>No parameters</td></tr>
+	<tr><td>envisalink</td><td><table><tr><td><b>ipAddress</b> - IP address for the Envisalink adapter - Required.</td></tr><tr><td><b>port</b> - TCP port for the Envisalink adapter - Not Required - default = 4025.</td></tr><tr><td><b>password</b> - Password to login to the Envisalink bridge - Not Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the Envisalink bridge - Not Required - default=1.</td></tr></table></td></tr>
+	<tr><td>it100</td><td><table><tr><td><b>serialPort</b> - Serial port for the IT-100s bridge - Required.</td></tr><tr><td><b>baud</b> - Baud rate of the IT-100 bridge - Not Required - default = 9600.</td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the IT-100 bridge - Not Required - default=1.</td></tr></table></td></tr>
+    <tr><td>tcpserver</td><td><table><tr><td><b>ipAddress</b> - IP address for the TCP Server - Required.</td></tr><tr><td><b>port</b> - TCP port for the TCP Server - Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the TCP Server bridge - Not Required - default=1.</td></tr></table></td></tr>
+    <tr><td>panel</td><td><table><tr><td><b>userCode</b> - User code for the DSC alarm panel - Not Required.</td></tr><tr><td><b>suppressAcknowledgementMsgs</b> - Suppress the display of acknowledgement messages when received - Not Required - default = false.</td></tr></table></td></tr>
+	<tr><td>partition</td><td><b>partitionNumber</b> - Partition number (1-8) - Required.</td></tr>
+	<tr><td>zone</td><td><table><tr><td><b>partitionNumber</b> - Partition number (1-8) - Not Required - default=1.</td></tr><tr><td><b>zoneNumber</b> - Zone number (1-64) - Required.</td></tr></table></td></tr>
+	<tr><td>keypad</td><td>No parameters</td></tr>
 </table>
 
-Here is an example 'dscalarm.thing' file:
+The binding can be configured manually if discovery is not used.  A thing configuration file in the format 'bindingName.thing' would need to be created, and placed in the 'conf/things' folder.  Here is an example of a thing configuration file called 'dscalarm.thing':
 
 ```
-Bridge dscalarm:envisalinkbridge:tcpbridge [ ipAddress="192.168.0.100" ]
+Bridge dscalarm:envisalink:mybridge [ ipAddress="192.168.0.100" ]
 {
 	Thing panel panel
 	Thing partition partition1 [ partitionNumber=1 ]
@@ -71,7 +73,7 @@ DSC Alarm things support a variety of channels as seen below in the following ta
 
 <table>
     <tr><td><b>Channel</b></td><td><b>Item Type</b></td><td><b>Description</b></td></tr>
-    <tr><td>bridge_connection</td><td>Switch</td><td>Bridge connection status.</td></tr>
+    <tr><td>bridge_reset</td><td>Switch</td><td>Reset the bridge connection.</td></tr>
     <tr><td>panel_message</td><td>String</td><td>Event messages received from the DSC Alarm system.</td></tr>
     <tr><td>panel_system_error</td><td>String</td><td>DSC Alarm system error.</td></tr>
     <tr><td>panel_trouble_message</td><td>String</td><td>Displays any trouble messages the panel might send.</td></tr>
@@ -162,7 +164,7 @@ DSC Alarm things support a variety of channels as seen below in the following ta
 
 ## Full Example
 
-The following is an example of an item file (dscalarm.item):
+The following is an example of an item file (dscalarm.items):
 
 ```
 Group DSCAlarm
@@ -171,319 +173,416 @@ Group DSCAlarmPartitions (DSCAlarm)
 Group DSCAlarmZones (DSCAlarm)
 Group DSCAlarmKeypads (DSCAlarm)
 
+/* Groups By Device Type */
+Group:Contact:OR(OPEN, CLOSED) DSCAlarmDoorWindow <door>
+Group:Contact:OR(OPEN, CLOSED) DSCAlarmMotion <motionDetector>
+Group:Contact:OR(OPEN, CLOSED) DSCAlarmSmoke <smokeDetector>
+
 /* DSC Alarm Items */
 
-Switch BRIDGE_CONNECTION {channel="dscalarm:envisalinkbridge:tcpbridge:bridge_connection"}
+Switch BRIDGE_CONNECTION {channel="dscalarm:envisalink:192_168_0_100:bridge_reset"}
 
 /* DSC Alarm Panel Items */
-Number PANEL_COMMAND "Panel Commands" (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_command"}
-String PANEL_MESSAGE "Panel Message: [%s]" (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_message"}
-String PANEL_SYSTEM_ERROR "Panel System Error: [%s]" <"shield-1"> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_system_error"}
+String PANEL_MESSAGE "Panel Message: [%s]" (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_message"}
+Number PANEL_COMMAND "Panel Commands" (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_command"}
+String PANEL_SYSTEM_ERROR "Panel System Error: [%s]" (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_system_error"}
 
-String PANEL_TROUBLE_MESSAGE "Panel Trouble Message: [%s]" <"shield-1"> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_trouble_message"}
-Switch PANEL_TROUBLE_LED "Panel Trouble LED" <warning> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_trouble_led"}
-Switch PANEL_SERVICE_REQUIRED <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_service_required"}
-Switch PANEL_AC_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_ac_trouble"}
-Switch PANEL_TELEPHONE_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_telephone_trouble"}
-Switch PANEL_FTC_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_ftc_trouble"}
-Switch PANEL_ZONE_FAULT <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_zone_fault"}
-Switch PANEL_ZONE_TAMPER <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_zone_tamper"}
-Switch PANEL_ZONE_LOW_BATTERY <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_zone_low_battery"}
-Switch PANEL_TIME_LOSS <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_time_loss"}
+String PANEL_TROUBLE_MESSAGE "Panel Trouble Message: [%s]" <"shieldGreen"> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_trouble_message"}
+Switch PANEL_TROUBLE_LED "Panel Trouble LED" <warning> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_trouble_led"}
+Switch PANEL_SERVICE_REQUIRED <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_service_required"}
+Switch PANEL_AC_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_ac_trouble"}
+Switch PANEL_TELEPHONE_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_telephone_trouble"}
+Switch PANEL_FTC_TROUBLE <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_ftc_trouble"}
+Switch PANEL_ZONE_FAULT <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_zone_fault"}
+Switch PANEL_ZONE_TAMPER <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_zone_tamper"}
+Switch PANEL_ZONE_LOW_BATTERY <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_zone_low_battery"}
+Switch PANEL_TIME_LOSS <yellowLED> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_time_loss"}
 
-DateTime PANEL_TIME "Panel Time [%1$tA, %1$tm/%1$td/%1$tY %1tT]" <calendar> (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_time"}
-Switch PANEL_TIME_STAMP (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_time_stamp"}
-Switch PANEL_TIME_BROADCAST (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_time_broadcast"}
+DateTime PANEL_TIME "Panel Time [%1$tA, %1$tm/%1$td/%1$tY %1tT]" <calendar> (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_time"}
+Switch PANEL_TIME_STAMP (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_time_stamp"}
+Switch PANEL_TIME_BROADCAST (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_time_broadcast"}
 
-Switch PANEL_FIRE_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_fire_key_alarm"}
-Switch PANEL_PANIC_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_panic_key_alarm"}
-Switch PANEL_AUX_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_aux_key_alarm"}
-Switch PANEL_AUX_INPUT_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:tcpbridge:panel:panel_aux_input_alarm"}
+Switch PANEL_FIRE_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_fire_key_alarm"}
+Switch PANEL_PANIC_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_panic_key_alarm"}
+Switch PANEL_AUX_KEY_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_aux_key_alarm"}
+Switch PANEL_AUX_INPUT_ALARM (DSCAlarmPanel) {channel="dscalarm:panel:192_168_0_100:panel:panel_aux_input_alarm"}
 
 /* DSC Alarm Partition Items */
-String PARTITION1_STATUS "Partition 1 Status: [%s]" (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_status"}
-Number PARTITION1_ARM_MODE (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_arm_mode"}
-String PARTITION1_OPENING_CLOSING_MODE "Partition 1 Opening/Closing Mode: [%s]" (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition_opening_closing_mode"}
-
-Switch PARTITION1_ARMED (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_armed"}
-Switch PARTITION1_ENTRY_DELAY (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_entry_delay"}
-Switch PARTITION1_EXIT_DELAY (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_exit_delay"}
-Switch PARTITION1_IN_ALARM (DSCAlarmPartitions) {channel="dscalarm:partition:tcpbridge:partition1:partition_in_alarm"}
+String PARTITION1_STATUS "Partition 1 Status: [%s]" (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_status"}
+Number PARTITION1_ARM_MODE "Partition 1 Arm Mode: [%d]" (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_arm_mode"}
+Switch PARTITION1_ARMED (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_armed"}
+Switch PARTITION1_ENTRY_DELAY (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_entry_delay"}
+Switch PARTITION1_EXIT_DELAY (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_exit_delay"}
+Switch PARTITION1_IN_ALARM (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_in_alarm"}
+String PARTITION1_OPENING_CLOSING_MODE "Opening/Closing Mode: [%s]" (DSCAlarmPartitions) {channel="dscalarm:partition:192_168_0_100:partition1:partition_opening_closing_mode"}
 
 /* DSC Alarm Zones Items */
-Contact ZONE1_STATUS "Tamper Switch" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_status"}
-Switch ZONE1_BYPASS_MODE "Tamper Switch Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_bypass_mode"}
-String ZONE1_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_message"}
-Switch ZONE1_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_in_alarm"}
-Switch ZONE1_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_tamper"}
-Switch ZONE1_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_fault"}
-Switch ZONE1_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone1:zone_tripped"}
+Contact ZONE1_STATUS "Tamper Switch (Zone 1)" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_status"}
+String ZONE1_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_message"}
+Switch ZONE1_BYPASS_MODE "Tamper Switch Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_bypass_mode"}
+Switch ZONE1_IN_ALARM "Zone 1 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_in_alarm"}
+Switch ZONE1_TAMPER "Zone 1 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_tamper"}
+Switch ZONE1_FAULT "Zone 1 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_fault"}
+Switch ZONE1_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone1:zone_tripped"}
 
-Contact ZONE9_STATUS "Front Door Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_status"}
-Switch ZONE9_BYPASS_MODE "Front Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_bypass_mode"}
-String ZONE9_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_amessage"}
-Switch ZONE9_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_in_alarm"}
-Switch ZONE9_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_tamper"}
-Switch ZONE9_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_fault"}
-Switch ZONE9_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone9:zone_tripped"}
+Contact ZONE9_STATUS "Front Door Sensor (Zone 9)" <door> (DSCAlarmZones, FrontFoyer, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone9:zone_status"}
+String ZONE9_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_message"}
+Switch ZONE9_BYPASS_MODE "Front Door Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_bypass_mode"}
+Switch ZONE9_IN_ALARM "Zone 9 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_in_alarm"}
+Switch ZONE9_TAMPER "Zone 9 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_tamper"}
+Switch ZONE9_FAULT "Zone 9 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_fault"}
+Switch ZONE9_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone9:zone_tripped"}
 
-Contact ZONE10_STATUS "Deck Door Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_status"}
-Switch ZONE10_BYPASS_MODE "Deck Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_bypass_mode"}
-String ZONE10_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_message"}
-Switch ZONE10_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_in_alarm"}
-Switch ZONE10_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_tamper"}
-Switch ZONE10_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_fault"}
-Switch ZONE10_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone10:zone_tripped"}
+Contact ZONE10_STATUS "Deck Door Sensor (Zone 10)" <door> (DSCAlarmZones, FamilyRoom, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone10:zone_status"}
+String ZONE10_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_message"}
+Switch ZONE10_BYPASS_MODE "Deck Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_bypass_mode"}
+Switch ZONE10_IN_ALARM "Zone 10 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_in_alarm"}
+Switch ZONE10_TAMPER "Zone 10 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_tamper"}
+Switch ZONE10_FAULT "Zone 10 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_fault"}
+Switch ZONE10_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone10:zone_tripped"}
 
-Contact ZONE11_STATUS "Back Door Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_status"}
-Switch ZONE11_BYPASS_MODE "Back Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_bypass_mode"}
-String ZONE11_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_message"}
-Switch ZONE11_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_in_alarm"}
-Switch ZONE11_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_tamper"}
-Switch ZONE11_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_fault"}
-Switch ZONE11_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone11:zone_tripped"}
+Contact ZONE11_STATUS "Back Door Sensor (Zone 11)" <door> (DSCAlarmZones, UtilityRoom, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone11:zone_status"}
+String ZONE11_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_message"}
+Switch ZONE11_BYPASS_MODE "Back Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_bypass_mode"}
+Switch ZONE11_IN_ALARM "Zone 11 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_in_alarm"}
+Switch ZONE11_TAMPER "Zone 11 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_tamper"}
+Switch ZONE11_FAULT "Zone 11 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_fault"}
+Switch ZONE11_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone11:zone_tripped"}
 
-Contact ZONE12_STATUS "Side Door Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_status"}
-Switch ZONE12_BYPASS_MODE "Side Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_bypass_mode"}
-String ZONE12_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_message"}
-Switch ZONE12_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_in_alarm"}
-Switch ZONE12_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_tamper"}
-Switch ZONE12_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_fault"}
-Switch ZONE12_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone12:zone_tripped"}
+Contact ZONE12_STATUS "Side Door Sensor (Zone 12)" <door> (DSCAlarmZones, SideFoyer, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone12:zone_status"}
+String ZONE12_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_message"}
+Switch ZONE12_BYPASS_MODE "Side Door Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_bypass_mode"}
+Switch ZONE12_IN_ALARM "Zone 12 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_in_alarm"}
+Switch ZONE12_TAMPER "Zone 12 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_tamper"}
+Switch ZONE12_FAULT "Zone 12 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_fault"}
+Switch ZONE12_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone12:zone_tripped"}
 
-Contact ZONE13_STATUS "Garage Door 1 Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_status"}
-Switch ZONE13_BYPASS_MODE "Garage Door 1 Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_bypass_mode"}
-String ZONE13_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_message"}
-Switch ZONE13_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_in_alarm"}
-Switch ZONE13_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_tamper"}
-Switch ZONE13_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_fault"}
-Switch ZONE13_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone13:zone_tripped"}
+Contact ZONE13_STATUS "Garage Door 1 Sensor (Zone 13)" <door> (DSCAlarmZones, Garage, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone13:zone_status"}
+String ZONE13_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_message"}
+Switch ZONE13_BYPASS_MODE "Garage Door 1 Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_bypass_mode"}
+Switch ZONE13_IN_ALARM "Zone 13 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_in_alarm"}
+Switch ZONE13_TAMPER "Zone 13 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_tamper"}
+Switch ZONE13_FAULT "Zone 13 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_fault"}
+Switch ZONE13_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone13:zone_tripped"}
 
-Contact ZONE14_STATUS "Garage Door 2 Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_status"}
-Switch ZONE14_BYPASS_MODE "Garage Door 2 Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_bypass_mode"}
-String ZONE14_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_message"}
-Switch ZONE14_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_in_alarm"}
-Switch ZONE14_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_tamper"}
-Switch ZONE14_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_fault"}
-Switch ZONE14_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone14:zone_tripped"}
+Contact ZONE14_STATUS "Garage Door 2 Sensor (Zone 14)" <garagedoor> (DSCAlarmZones, Garage, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone14:zone_status"}
+String ZONE14_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_message"}
+Switch ZONE14_BYPASS_MODE "Garage Door 2 Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_bypass_mode"}
+Switch ZONE14_IN_ALARM "Zone 14 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_in_alarm"}
+Switch ZONE14_TAMPER "Zone 14 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_tamper"}
+Switch ZONE14_FAULT "Zone 14 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_fault"}
+Switch ZONE14_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone14:zone_tripped"}
 
-Contact ZONE15_STATUS "Garage Window Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_status"}
-Switch ZONE15_BYPASS_MODE "Garage Window Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_bypass_mode"}
-String ZONE15_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_message"}
-Switch ZONE15_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_in_alarm"}
-Switch ZONE15_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_tamper"}
-Switch ZONE15_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_fault"}
-Switch ZONE15_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone15:zone_tripped"}
+Contact ZONE15_STATUS "Garage Window Sensor (Zone 15)" (DSCAlarmZones, Garage, DSCAlarmDoorWindow) {channel="dscalarm:zone:192_168_0_100:zone15:zone_status"}
+String ZONE15_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_message"}
+Switch ZONE15_BYPASS_MODE "Garage Window Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_bypass_mode"}
+Switch ZONE15_IN_ALARM "Zone 15 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_in_alarm"}
+Switch ZONE15_TAMPER "Zone 15 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_tamper"}
+Switch ZONE15_FAULT "Zone 15 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_fault"}
+Switch ZONE15_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone15:zone_tripped"}
 
-Contact ZONE21_STATUS "Family Room Motion Sensor" (DSCAlarmZones,  FamilyRoom) {channel="dscalarm:zone:tcpbridge:zone21:zone_status"}
-Switch ZONE21_BYPASS_MODE "Family Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_bypass_mode"}
-String ZONE21_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_message"}
-Switch ZONE21_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_in_alarm"}
-Switch ZONE21_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_tamper"}
-Switch ZONE21_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_fault"}
-Switch ZONE21_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone21:zone_tripped"}
+Contact ZONE21_STATUS "Family Room Motion Sensor (Zone 21)" <motionDetector> (DSCAlarmZones,  FamilyRoom, DSCAlarmMotion) {channel="dscalarm:zone:192_168_0_100:zone21:zone_status"}
+String ZONE21_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_message"}
+Switch ZONE21_BYPASS_MODE "Family Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_bypass_mode"}
+Switch ZONE21_IN_ALARM "Zone 21 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_in_alarm"}
+Switch ZONE21_TAMPER "Zone 21 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_tamper"}
+Switch ZONE21_FAULT "Zone 21 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_fault"}
+Switch ZONE21_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone21:zone_tripped"}
 
-Contact ZONE22_STATUS "Office Motion Sensor" (DSCAlarmZones,  Office) {channel="dscalarm:zone:tcpbridge:zone22:zone_status"}
-Switch ZONE22_BYPASS_MODE "Office Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_bypass_mode"}
-String ZONE22_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_message"}
-Switch ZONE22_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_in_alarm"}
-Switch ZONE22_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_tamper"}
-Switch ZONE22_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_fault"}
-Switch ZONE22_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone22:zone_tripped"}
+Contact ZONE22_STATUS "Office Motion Sensor (Zone 22)" <motionDetector> (DSCAlarmZones,  Office, DSCAlarmMotion) {channel="dscalarm:zone:192_168_0_100:zone22:zone_status"}
+String ZONE22_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_message"}
+Switch ZONE22_BYPASS_MODE "Office Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_bypass_mode"}
+Switch ZONE22_IN_ALARM "Zone 22 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_in_alarm"}
+Switch ZONE22_TAMPER "Zone 22 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_tamper"}
+Switch ZONE22_FAULT "Zone 22 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_fault"}
+Switch ZONE22_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone22:zone_tripped"}
 
-Contact ZONE23_STATUS "Dining Room Motion Sensor" (DSCAlarmZones,  DiningRoom) {channel="dscalarm:zone:tcpbridge:zone23:zone_status"}
-Switch ZONE23_BYPASS_MODE "Dining Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_bypass_mode"}
-String ZONE23_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_message"}
-Switch ZONE23_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_in_alarm"}
-Switch ZONE23_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_tamper"}
-Switch ZONE23_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_fault"}
-Switch ZONE23_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone23:zone_tripped"}
+Contact ZONE23_STATUS "Dining Room Motion Sensor (Zone 23)" <motionDetector> (DSCAlarmZones, DiningRoom, DSCAlarmMotion) {channel="dscalarm:zone:192_168_0_100:zone23:zone_status"}
+String ZONE23_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_message"}
+Switch ZONE23_BYPASS_MODE "Dining Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_bypass_mode"}
+Switch ZONE23_IN_ALARM "Zone 23 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_in_alarm"}
+Switch ZONE23_TAMPER "Zone 23 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_tamper"}
+Switch ZONE23_FAULT "Zone 23 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_fault"}
+Switch ZONE23_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone23:zone_tripped"}
 
-Contact ZONE24_STATUS "Living Room Motion Sensor" (DSCAlarmZones,  LivingRoom) {channel="dscalarm:zone:tcpbridge:zone24:zone_status"}
-Switch ZONE24_BYPASS_MODE "Living Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_bypass_mode"}
-String ZONE24_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_message"}
-Switch ZONE24_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_in_alarm"}
-Switch ZONE24_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_tamper"}
-Switch ZONE24_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_fault"}
-Switch ZONE24_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone24:zone_tripped"}
+Contact ZONE24_STATUS "Living Room Motion Sensor (Zone 24)" <motionDetector> (DSCAlarmZones,  LivingRoom, DSCAlarmMotion) {channel="dscalarm:zone:192_168_0_100:zone24:zone_status"}
+String ZONE24_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_message"}
+Switch ZONE24_BYPASS_MODE "Living Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_bypass_mode"}
+Switch ZONE24_IN_ALARM "Zone 24 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_in_alarm"}
+Switch ZONE24_TAMPER "Zone 24 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_tamper"}
+Switch ZONE24_FAULT "Zone 24 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_fault"}
+Switch ZONE24_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone24:zone_tripped"}
 
-Contact ZONE25_STATUS "Utility Room Motion Sensor" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_status"}
-Switch ZONE25_BYPASS_MODE "Utility Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_bypass_mode"}
-String ZONE25_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_message"}
-Switch ZONE25_IN_ALARM (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_in_alarm"}
-Switch ZONE25_TAMPER (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_tamper"}
-Switch ZONE25_FAULT (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_fault"}
-Switch ZONE25_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:tcpbridge:zone25:zone_tripped"}
+Contact ZONE25_STATUS "Utility Room Motion Sensor (Zone 25)" <motionDetector> (DSCAlarmZones,  UtilityRoom, DSCAlarmMotion) {channel="dscalarm:zone:192_168_0_100:zone25:zone_status"}
+String ZONE25_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_message"}
+Switch ZONE25_BYPASS_MODE "Utility Room Motion Sensor Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_bypass_mode"}
+Switch ZONE25_IN_ALARM "Zone 25 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_in_alarm"}
+Switch ZONE25_TAMPER "Zone 25 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_tamper"}
+Switch ZONE25_FAULT "Zone 25 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_fault"}
+Switch ZONE25_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone25:zone_tripped"}
+
+Contact ZONE51_STATUS "Utility Room Smoke Detector (Zone 51)" <smokeDetector> (DSCAlarmZones,  UtilityRoom, DSCAlarmSmoke) {channel="dscalarm:zone:192_168_0_100:zone51:zone_status"}
+String ZONE51_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_message"}
+Switch ZONE51_BYPASS_MODE "Utility Room Smoke Detector Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_bypass_mode"}
+Switch ZONE51_IN_ALARM "Zone 51 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_in_alarm"}
+Switch ZONE51_TAMPER "Zone 51 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_tamper"}
+Switch ZONE51_FAULT "Zone 51 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_fault"}
+Switch ZONE51_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone51:zone_tripped"}
+
+Contact ZONE52_STATUS "Dining Room Smoke Detector (Zone 52)" <smokeDetector> (DSCAlarmZones, DiningRoom, DSCAlarmSmoke) {channel="dscalarm:zone:192_168_0_100:zone52:zone_status"}
+String ZONE52_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_message"}
+Switch ZONE52_BYPASS_MODE "Dining Room Smoke Detector Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_bypass_mode"}
+Switch ZONE52_IN_ALARM "Zone 52 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_in_alarm"}
+Switch ZONE52_TAMPER "Zone 52 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_tamper"}
+Switch ZONE52_FAULT "Zone 52 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_fault"}
+Switch ZONE52_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone52:zone_tripped"}
+
+Contact ZONE53_STATUS "Front Foyer Smoke Detector (Zone 53)" <smokeDetector> (DSCAlarmZones, FrontFoyer, DSCAlarmSmoke) {channel="dscalarm:zone:192_168_0_100:zone53:zone_status"}
+String ZONE53_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_message"}
+Switch ZONE53_BYPASS_MODE "Front Foyer Smoke Detector Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_bypass_mode"}
+Switch ZONE53_IN_ALARM "Zone 53 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_in_alarm"}
+Switch ZONE53_TAMPER "Zone 53 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_tamper"}
+Switch ZONE53_FAULT "Zone 53 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_fault"}
+Switch ZONE53_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone53:zone_tripped"}
+
+Contact ZONE54_STATUS "Upstairs Hall Smoke Detector (Zone 54)" <smokeDetector> (DSCAlarmZones, UpstairsHall, DSCAlarmSmoke) {channel="dscalarm:zone:192_168_0_100:zone54:zone_status"}
+String ZONE54_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_message"}
+Switch ZONE54_BYPASS_MODE "Upstairs Hall Smoke Detector Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_bypass_mode"}
+Switch ZONE54_IN_ALARM "Zone 54 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_in_alarm"}
+Switch ZONE54_TAMPER "Zone 54 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_tamper"}
+Switch ZONE54_FAULT "Zone 54 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_fault"}
+Switch ZONE54_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone54:zone_tripped"}
+
+Contact ZONE55_STATUS "Master Bedroom Smoke Detector (Zone 55)" <smokeDetector> (DSCAlarmZones, Bedroom, DSCAlarmSmoke) {channel="dscalarm:zone:192_168_0_100:zone55:zone_status"}
+String ZONE55_MESSAGE "Zone Message: [%s]" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_message"}
+Switch ZONE55_BYPASS_MODE "Master Bedroom Smoke Detector Bypass Mode" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_bypass_mode"}
+Switch ZONE55_IN_ALARM "Zone 55 Alarm Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_in_alarm"}
+Switch ZONE55_TAMPER "Zone 55 Tamper Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_tamper"}
+Switch ZONE55_FAULT "Zone 55 Fault Condition" (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_fault"}
+Switch ZONE55_TRIPPED (DSCAlarmZones) {channel="dscalarm:zone:192_168_0_100:zone55:zone_tripped"}
 
 /* DSC Alarm Keypad Items */
-Number KEYPAD_READY_LED "Ready LED Status: [%d]" <readyLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_ready_led"}
-Number KEYPAD_ARMED_LED "Armed LED Status: [%d]" <armedLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_armed_led"}
-Number KEYPAD_MEMORY_LED "Memory LED Status: [%d]" <memoryLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_memory_led"}
-Number KEYPAD_BYPASS_LED "Bypass LED Status: [%d]" <bypassLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_bypass_led"}
-Number KEYPAD_TROUBLE_LED "Trouble LED Status: [%d]" <trouble> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_trouble_led"}
-Number KEYPAD_PROGRAM_LED "Program LED Status: [%d]" <programLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_program_led"}
-Number KEYPAD_FIRE_LED "Fire LED Status: [%d]" <fireLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_fire_led"}
-Number KEYPAD_BACKLIGHT_LED "Backlight LED Status: [%d]" <backlightLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_backlight_led"}
-Number KEYPAD_AC_LED "AC LED Status: [%d]" <acLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:tcpbridge:keypad:keypad_ac_led"}
+Number KEYPAD_READY_LED "Ready LED Status" <readyLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_ready_led"}
+Number KEYPAD_ARMED_LED "Armed LED Status" <armedLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_armed_led"}
+Number KEYPAD_MEMORY_LED "Memory LED Status" <memoryLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_memory_led"}
+Number KEYPAD_BYPASS_LED "Bypass LED Status" <bypassLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_bypass_led"}
+Number KEYPAD_TROUBLE_LED "Trouble LED Status" <troubleLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_trouble_led"}
+Number KEYPAD_PROGRAM_LED "Program LED Status" <programLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_program_led"}
+Number KEYPAD_FIRE_LED "Fire LED Status" <fireLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_fire_led"}
+Number KEYPAD_BACKLIGHT_LED "Backlight LED Status" <backlightLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_backlight_led"}
+Number KEYPAD_AC_LED "AC LED Status" <acLED> (DSCAlarmKeypads) {channel="dscalarm:keypad:192_168_0_100:keypad:keypad_ac_led"}
 ```
 
 Here is an example sitemap:
 
 ```
-Frame label="Alarm System" {
-	Text label="DSC Alarm System" icon="MyImages/DSC" {
-		Frame label="Panel" {
-			Switch item=PANEL_CONNECTION label="Panel Connection" mappings=[1="Connected", 0="Disconnected"]
-			Text item=PANEL_MESSAGE icon="MyImages/arrow_down"
-			Selection item=PANEL_COMMAND icon="MyImages/arrow_up" mappings=[0="Poll", 1="Status Report", 2="Labels Request (Serial Only)", 8="Dump Zone Timers (TCP Only)", 10="Set Time/Date", 200="Send User Code"]
-			Text item=PANEL_TIME {
-				Switch item=PANEL_TIME_STAMP label="Panel Time Stamp"
-				Switch item=PANEL_TIME_BROADCAST label="Panel Time Broadcast"
-			}
-			
-			Text item=PANEL_SYSTEM_ERROR icon="MyImages/system-error"
-							
-			Text item=PANEL_TROUBLE_LED label="Panel Trouble Condition" {
-				Text item=PANEL_TROUBLE_MESSAGE icon="shield-0"
-				Text item=PANEL_SERVICE_REQUIRED label="Service Required"
-				Text item=PANEL_AC_TROUBLE label="AC Trouble"
-				Text item=PANEL_TELEPHONE_TROUBLE label="Telephone Line Trouble"
-				Text item=PANEL_FTC_TROUBLE label="Failed to Communicate Trouble"
-				Text item=PANEL_ZONE_FAULT label="Zone Fault"
-				Text item=PANEL_ZONE_TAMPER label="Zone Tamper"
-				Text item=PANEL_ZONE_LOW_BATTERY label="Zone Low Battery"
-				Text item=PANEL_TIME_LOSS label="Panel Time Loss"					
-			}
-		}
+    Frame label="Alarm System" {
+        Text label="DSC Alarm System" icon="DSC" {
+            Frame label="Panel" {
+                Switch item=BRIDGE_CONNECTION label="Panel Connection" mappings=[ON="Connected", OFF="Disconnected"]
+                Text item=PANEL_MESSAGE icon="returnpipe"
+                Selection item=PANEL_COMMAND icon="flowpipe" mappings=[0="Poll", 1="Status Report", 2="Labels Request (Serial Only)", 8="Dump Zone Timers (TCP Only)", 10="Set Time/Date", 200="Send User Code"]
+                Text item=PANEL_TIME {
+                    Switch item=PANEL_TIME_STAMP label="Panel Time Stamp"
+                    Switch item=PANEL_TIME_BROADCAST label="Panel Time Broadcast"
+                }
+                
+                Text item=PANEL_SYSTEM_ERROR icon="systemError"
+                                
+                Text item=PANEL_TROUBLE_LED label="Panel Trouble Condition" {
+                    Text item=PANEL_TROUBLE_MESSAGE icon="shieldRed"
+                    Text item=PANEL_SERVICE_REQUIRED label="Service Required"
+                    Text item=PANEL_AC_TROUBLE label="AC Trouble"
+                    Text item=PANEL_TELEPHONE_TROUBLE label="Telephone Line Trouble"
+                    Text item=PANEL_FTC_TROUBLE label="Failed to Communicate Trouble"
+                    Text item=PANEL_ZONE_FAULT label="Zone Fault"
+                    Text item=PANEL_ZONE_TAMPER label="Zone Tamper"
+                    Text item=PANEL_ZONE_LOW_BATTERY label="Zone Low Battery"
+                    Text item=PANEL_TIME_LOSS label="Panel Time Loss"                   
+                }
+            }
 
-		Frame label="Partitions" {
-				Text item=PARTITION1_STATUS icon="shield-1" {
-					Switch item=PARTITION1_ARM_MODE label="Partition 1 Arm Options" icon="shield-1" mappings=[0="Disarm", 1="Away", 2="Stay", 3="Zero"]
-					Text item=PARTITION1_OPENING_CLOSING_MODE icon="shield-1"
-				}
-		}
+            Frame label="Partitions" {
+                Text item=PARTITION1_STATUS icon="shieldGreen" {
+                    Switch item=PARTITION1_ARM_MODE label="Partition 1 Arm Options" icon="shieldGreen" mappings=[0="Disarm", 1="Away", 2="Stay", 3="No Entry Delay", 4="With User Code"]
+                    Text item=PARTITION1_OPENING_CLOSING_MODE icon="shieldGreen"
+                }
+            }
 
-		Frame label="Keypad" {
-			Text label="Keypad LED Status" icon="MyImages/DSCKeypad" {
-				Text item=KEYPAD_READY_LED label="Ready LED Status"
-				Text item=KEYPAD_ARMED_LED label="Armed LED Status"
-				Text item=KEYPAD_MEMORY_LED label="Memory LED Status"
-				Text item=KEYPAD_BYPASS_LED label="Bypass LED Status"
-				Text item=KEYPAD_TROUBLE_LED label="Trouble LED Status"
-				Text item=KEYPAD_PROGRAM_LED label="Program LED Status"
-				Text item=KEYPAD_FIRE_LED label="Fire LED Status"
-				Text item=KEYPAD_BACKLIGHT_LED label="Backlight LED Status"
-				Text item=KEYPAD_AC_LED label="AC LED Status"
-			}
-		}
+            Frame label="Keypad" {
+                Text label="Keypad LED Status" icon="DSCKeypad" {
+                    Text item=KEYPAD_READY_LED label="Ready LED Status"
+                    Text item=KEYPAD_ARMED_LED label="Armed LED Status"
+                    Text item=KEYPAD_MEMORY_LED label="Memory LED Status"
+                    Text item=KEYPAD_BYPASS_LED label="Bypass LED Status"
+                    Text item=KEYPAD_TROUBLE_LED label="Trouble LED Status"
+                    Text item=KEYPAD_PROGRAM_LED label="Program LED Status"
+                    Text item=KEYPAD_FIRE_LED label="Fire LED Status"
+                    Text item=KEYPAD_BACKLIGHT_LED label="Backlight LED Status"
+                    Text item=KEYPAD_AC_LED label="AC LED Status"
+                }
+            }
 
-		Frame label="Zones" {
-			Text item=ZONE1_GENERAL_STATUS {
-				Switch item=ZONE1_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE1_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE1_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE1_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
+            Frame label="Zones" {
+                Text label="All Zones" icon="ZoneAlarm" {
+                    Text item=ZONE1_STATUS {
+                        Switch item=ZONE1_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE1_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE1_TAMPER icon="statusWarning"
+                            Switch item=ZONE1_FAULT icon="statusWarning"
+                        }
+                    }
 
-			Text item=ZONE9_GENERAL_STATUS {
-				Switch item=ZONE9_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE9_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE9_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE9_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE10_GENERAL_STATUS {
-				Switch item=ZONE10_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE10_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE10_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE10_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE11_GENERAL_STATUS {
-				Switch item=ZONE11_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE11_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE11_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE11_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE12_GENERAL_STATUS {
-				Switch item=ZONE12_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE12_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE12_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE12_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE13_GENERAL_STATUS {
-				Switch item=ZONE13_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE13_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE13_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE13_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE14_GENERAL_STATUS {
-				Switch item=ZONE14_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE14_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE14_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE14_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE15_GENERAL_STATUS {
-				Switch item=ZONE15_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE15_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE15_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE15_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE21_GENERAL_STATUS {
-				Switch item=ZONE21_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE21_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE21_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE21_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE22_GENERAL_STATUS {
-				Switch item=ZONE22_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE22_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE22_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE22_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE23_GENERAL_STATUS {
-				Switch item=ZONE23_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE23_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE23_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE23_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE24_GENERAL_STATUS {
-				Switch item=ZONE24_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE24_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE24_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE24_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-			Text item=ZONE25_GENERAL_STATUS {
-				Switch item=ZONE25_BYPASS_MODE icon="MyImages/Zone-Alarm" mappings=[0="Armed", 1="Bypassed"]
-				Frame label="Other Status:" {
-					Text item=ZONE25_ALARM_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE25_FAULT_STATUS icon="MyImages/Status-warning"
-					Text item=ZONE25_TAMPER_STATUS icon="MyImages/Status-warning"
-				}
-			}
-		}
-	}
-}
+                    Text item=ZONE9_STATUS {
+                        Switch item=ZONE9_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE9_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE9_TAMPER icon="statusWarning"
+                            Switch item=ZONE9_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE10_STATUS {
+                        Switch item=ZONE10_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE10_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE10_TAMPER icon="statusWarning"
+                            Switch item=ZONE10_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE11_STATUS {
+                        Switch item=ZONE11_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE11_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE11_TAMPER icon="statusWarning"
+                            Switch item=ZONE11_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE12_STATUS {
+                        Switch item=ZONE12_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE12_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE12_TAMPER icon="statusWarning"
+                            Switch item=ZONE12_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE13_STATUS {
+                        Switch item=ZONE13_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE13_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE13_TAMPER icon="statusWarning"
+                            Switch item=ZONE13_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE14_STATUS {
+                        Switch item=ZONE14_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE14_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE14_TAMPER icon="statusWarning"
+                            Switch item=ZONE14_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE15_STATUS {
+                        Switch item=ZONE15_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE15_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE15_TAMPER icon="statusWarning"
+                            Switch item=ZONE15_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE21_STATUS {
+                        Switch item=ZONE21_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE21_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE21_TAMPER icon="statusWarning"
+                            Switch item=ZONE21_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE22_STATUS {
+                        Switch item=ZONE22_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE22_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE22_TAMPER icon="statusWarning"
+                            Switch item=ZONE22_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE23_STATUS {
+                        Switch item=ZONE23_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE23_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE23_TAMPER icon="statusWarning"
+                            Switch item=ZONE23_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE24_STATUS {
+                        Switch item=ZONE24_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE24_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE24_TAMPER icon="statusWarning"
+                            Switch item=ZONE24_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE25_STATUS {
+                        Switch item=ZONE25_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE25_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE25_TAMPER icon="statusWarning"
+                            Switch item=ZONE25_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE51_STATUS {
+                        Switch item=ZONE51_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE51_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE51_TAMPER icon="statusWarning"
+                            Switch item=ZONE51_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE52_STATUS {
+                        Switch item=ZONE52_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE52_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE52_TAMPER icon="statusWarning"
+                            Switch item=ZONE52_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE53_STATUS {
+                        Switch item=ZONE53_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE53_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE53_TAMPER icon="statusWarning"
+                            Switch item=ZONE53_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE54_STATUS {
+                        Switch item=ZONE54_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE54_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE54_TAMPER icon="statusWarning"
+                            Switch item=ZONE54_FAULT icon="statusWarning"
+                        }
+                    }
+                    Text item=ZONE55_STATUS {
+                        Switch item=ZONE55_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Frame label="Other Status:" {
+                            Switch item=ZONE55_IN_ALARM icon="statusWarning"
+                            Switch item=ZONE55_TAMPER icon="statusWarning"
+                            Switch item=ZONE55_FAULT icon="statusWarning"
+                        }
+                    }
+                }
+                
+                Group item=DSCAlarmDoorWindow label="Door/Window Sensors"
+                Group item=DSCAlarmMotion label="Motion Sensors"
+                Group item=DSCAlarmSmoke label="Smoke Detectors"
+                
+            }
+        }
+    }
 ```
+
+##Change Log
+
+###OpenHAB 2.0.0 Beta 1
+
+* Initial commit of the DSC Alarm Binding. ([#324](https://github.com/openhab/openhab2-addons/pull/324))

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
@@ -27,6 +27,7 @@ public class DSCAlarmBindingConstants {
     // List of bridge device types
     public static final String ENVISALINK_BRIDGE = "envisalink";
     public static final String IT100_BRIDGE = "it100";
+    public static final String TCPSERVER_BRIDGE = "tcpserver";
 
     // List of DSC Alarm device types
     public static final String PANEL = "panel";
@@ -37,6 +38,7 @@ public class DSCAlarmBindingConstants {
     // List of all Bridge Thing Type UIDs
     public final static ThingTypeUID ENVISALINKBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, ENVISALINK_BRIDGE);
     public final static ThingTypeUID IT100BRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, IT100_BRIDGE);
+    public final static ThingTypeUID TCPSERVERBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, TCPSERVER_BRIDGE);
 
     // List of all DSC Alarm Thing Type UIDs
     public final static ThingTypeUID PANEL_THING_TYPE = new ThingTypeUID(BINDING_ID, PANEL);
@@ -47,7 +49,6 @@ public class DSCAlarmBindingConstants {
     // List of all Channel IDs
     public final static String BRIDGE_RESET = "bridge_reset";
 
-    public final static String PANEL_CONNECTION = "panel_connection";
     public final static String PANEL_MESSAGE = "panel_message";
     public final static String PANEL_COMMAND = "panel_command";
     public final static String PANEL_SYSTEM_ERROR = "panel_system_error";
@@ -98,9 +99,9 @@ public class DSCAlarmBindingConstants {
     public final static String KEYPAD_AC_LED = "keypad_ac_led";
 
     // Set of all supported Thing Type UIDs
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(ENVISALINKBRIDGE_THING_TYPE, IT100BRIDGE_THING_TYPE, PANEL_THING_TYPE, PARTITION_THING_TYPE, ZONE_THING_TYPE, KEYPAD_THING_TYPE);
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(ENVISALINKBRIDGE_THING_TYPE, IT100BRIDGE_THING_TYPE, TCPSERVERBRIDGE_THING_TYPE, PANEL_THING_TYPE, PARTITION_THING_TYPE, ZONE_THING_TYPE, KEYPAD_THING_TYPE);
 
     // Set of all supported Bridge Type UIDs
-    public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS = ImmutableSet.of(ENVISALINKBRIDGE_THING_TYPE, IT100BRIDGE_THING_TYPE);
+    public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS = ImmutableSet.of(ENVISALINKBRIDGE_THING_TYPE, IT100BRIDGE_THING_TYPE, TCPSERVERBRIDGE_THING_TYPE);
 
 }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/EnvisalinkBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/EnvisalinkBridgeConfiguration.java
@@ -9,7 +9,8 @@
 package org.openhab.binding.dscalarm.config;
 
 /**
- * Configuration class for the EyezOn Envisalink 3/2DS Ethernet TCP interface bridge, used to connect to the DSC Alarm system.
+ * Configuration class for the EyezOn Envisalink 3/2DS Ethernet TCP interface bridge, used to connect to the DSC Alarm
+ * system.
  * 
  * @author Russell Stephens - Initial contribution
  */

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/IT100BridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/IT100BridgeConfiguration.java
@@ -22,7 +22,8 @@ public class IT100BridgeConfiguration {
     public static final String POLL_PERIOD = "pollPeriod";
 
     /**
-     * DSC IT100 port name for a serial connection. Valid values are e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.
+     * DSC IT100 port name for a serial connection. Valid values are e.g. COM1 for Windows and /dev/ttyS0 or
+     * /dev/ttyUSB0 for Linux.
      */
     public String serialPort;
 

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/TCPServerBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/TCPServerBridgeConfiguration.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dscalarm.config;
+
+/**
+ * Configuration class for the TCP Server bridge, used to connect to the DSC Alarm system.
+ *
+ * @author Russell Stephens - Initial contribution
+ */
+
+public class TCPServerBridgeConfiguration {
+
+    // TCP Server Bridge Thing constants
+    public static final String IP_ADDRESS = "ipAddress";
+    public static final String PORT = "port";
+    public static final String PASSWORD = "password";
+    public static final String CONNECTION_TIMEOUT = "connectionTimeout";
+    public static final String POLL_PERIOD = "pollPeriod";
+
+    /**
+     * The IP address of the TCP Server
+     */
+    public String ipAddress;
+
+    /**
+     * The port number of the TCP Server
+     */
+    public Integer port;
+
+    /**
+     * The Socket connection timeout for the TCP Server
+     */
+    public Integer connectionTimeout;
+
+    /**
+     * The Panel Poll Period. Can be set in range 1-15 minutes. Default is 1 minute;
+     */
+    public Integer pollPeriod;
+}

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmProtocol.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmProtocol.java
@@ -9,12 +9,11 @@
 package org.openhab.binding.dscalarm.handler;
 
 /**
- * Enum class for the different bridge types.
+ * Enum class for the different DSC Alarm Protocol types.
  *
  * @author Russell Stephens - Initial Contribution
  */
-public enum DSCAlarmBridgeType {
-    Envisalink,
-    IT100,
-    TCPServer;
+public enum DSCAlarmProtocol {
+    ENVISALINK_TPI,
+    IT100_API;
 }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/IT100BridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/IT100BridgeHandler.java
@@ -47,7 +47,7 @@ public class IT100BridgeHandler extends DSCAlarmBaseBridgeHandler implements Ser
      * @param bridge
      */
     public IT100BridgeHandler(Bridge bridge) {
-        super(bridge, DSCAlarmBridgeType.IT100);
+        super(bridge, DSCAlarmBridgeType.IT100, DSCAlarmProtocol.IT100_API);
     }
 
     private String serialPortName = "";

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
@@ -13,6 +13,7 @@ import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.*;
 import java.util.EventObject;
 
 import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -86,8 +87,7 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
                     break;
                 case PANEL_COMMAND:
                     state = properties.getSystemCommand();
-                    str = String.valueOf(state);
-                    updateState(channelUID, new StringType(str));
+                    updateState(channelUID, new DecimalType(state));
                     break;
                 case PANEL_TROUBLE_MESSAGE:
                     str = properties.getTroubleMessage();

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
@@ -198,7 +198,10 @@ public class PartitionThingHandler extends DSCAlarmBaseThingHandler {
         DSCAlarmMessage apiMessage = dscAlarmEvent.getDSCAlarmMessage();
         DSCAlarmCode apiCode = DSCAlarmCode.getDSCAlarmCodeValue(apiMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
         ChannelUID channelUID = null;
-        int state = 0; /* 0=None, 1=User Closing, 2=Special Closing, 3=Partial Closing, 4=User Opening, 5=Special Opening */
+        int state = 0; /*
+                        * 0=None, 1=User Closing, 2=Special Closing, 3=Partial Closing, 4=User Opening, 5=Special
+                        * Opening
+                        */
 
         String strStatus = apiMessage.getMessageInfo(DSCAlarmMessageInfoType.NAME);
 
@@ -266,7 +269,10 @@ public class PartitionThingHandler extends DSCAlarmBaseThingHandler {
                         updateProperties(channelUID, 0, "");
                         updateChannel(channelUID);
 
-                        /* arm mode:0=disarmed, 1=away armed, 2=stay armed, 3=away no delay, 4=stay no delay, 5=with user code */
+                        /*
+                         * arm mode:0=disarmed, 1=away armed, 2=stay armed, 3=away no delay, 4=stay no delay, 5=with
+                         * user code
+                         */
                         int armMode = Integer.parseInt(apiMode) + 1;
                         channelUID = new ChannelUID(getThing().getUID(), PARTITION_ARM_MODE);
                         updateProperties(channelUID, armMode, "");

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/TCPServerBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/TCPServerBridgeHandler.java
@@ -20,27 +20,27 @@ import java.net.UnknownHostException;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ThingStatus;
-import org.openhab.binding.dscalarm.config.EnvisalinkBridgeConfiguration;
+import org.openhab.binding.dscalarm.config.TCPServerBridgeConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The bridge handler for the EyezOn Envisalink 3/2DS Ethernet interface.
+ * The bridge handler for a TCP Server to connect to a DSC IT100 RS232 Serial interface over a network.
  *
  * @author Russell Stephens - Initial Contribution
  */
 
-public class EnvisalinkBridgeHandler extends DSCAlarmBaseBridgeHandler {
+public class TCPServerBridgeHandler extends DSCAlarmBaseBridgeHandler {
 
-    private Logger logger = LoggerFactory.getLogger(EnvisalinkBridgeHandler.class);
+    private Logger logger = LoggerFactory.getLogger(TCPServerBridgeHandler.class);
 
     /**
      * Constructor.
      *
      * @param bridge
      */
-    public EnvisalinkBridgeHandler(Bridge bridge) {
-        super(bridge, DSCAlarmBridgeType.Envisalink, DSCAlarmProtocol.ENVISALINK_TPI);
+    public TCPServerBridgeHandler(Bridge bridge) {
+        super(bridge, DSCAlarmBridgeType.TCPServer, DSCAlarmProtocol.IT100_API);
     }
 
     // Variables for TCP connection.
@@ -53,15 +53,14 @@ public class EnvisalinkBridgeHandler extends DSCAlarmBaseBridgeHandler {
 
     @Override
     public void initialize() {
-        logger.debug("Initializing the Envisalink Bridge handler.");
+        logger.debug("Initializing the TCP Server Bridge handler.");
 
-        EnvisalinkBridgeConfiguration configuration = getConfigAs(EnvisalinkBridgeConfiguration.class);
+        TCPServerBridgeConfiguration configuration = getConfigAs(TCPServerBridgeConfiguration.class);
 
         ipAddress = configuration.ipAddress;
 
         if (configuration.ipAddress != null) {
             tcpPort = configuration.port.intValue();
-            setPassword(configuration.password);
             connectionTimeout = configuration.connectionTimeout.intValue();
             pollPeriod = configuration.pollPeriod.intValue();
 
@@ -71,7 +70,7 @@ public class EnvisalinkBridgeHandler extends DSCAlarmBaseBridgeHandler {
                 this.pollPeriod = 1;
             }
 
-            logger.debug("Envisalink Bridge Handler Initialized");
+            logger.debug("TCP Server Bridge Handler Initialized");
             logger.debug("   IP Address:         {},", ipAddress);
             logger.debug("   Port:               {},", tcpPort);
             logger.debug("   Password:           {},", getPassword());

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmCode.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmCode.java
@@ -202,7 +202,8 @@ public enum DSCAlarmCode {
     }
 
     /**
-     * Lookup function to return the DSCAlarmCode value based on the string code. Returns 'UnknownCode' if the string code is not found.
+     * Lookup function to return the DSCAlarmCode value based on the string code. Returns 'UnknownCode' if the string
+     * code is not found.
      *
      * @param code
      * @return enum value

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmProperties.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmProperties.java
@@ -41,7 +41,10 @@ public class DSCAlarmProperties {
 
     private int generalState = 0;
     private String generalStateDescription = "";
-    private int armState = 0; /* partition:0=disarmed, 1=away armed, 2=stay armed, 3=away no delay, 4=stay no delay, 5=with user code; zone:0=Armed, 1=Bypassed*/
+    private int armState = 0; /*
+                               * partition:0=disarmed, 1=away armed, 2=stay armed, 3=away no delay, 4=stay no delay,
+                               * 5=with user code; zone:0=Armed, 1=Bypassed
+                               */
     private String armStateDescription = "";
     private int alarmState = 0;
     private String alarmStateDescription = "";
@@ -49,32 +52,37 @@ public class DSCAlarmProperties {
     private String tamperStateDescription = "";
     private int faultState = 0;
     private String faultStateDescription = "";
-    private int openingClosingState = 0; /* 0=None, 1=User Closing, 2=Special Closing, 3=Partial Closing, 4=User Opening, 5=Special Opening */
+    private int openingClosingState = 0; /*
+                                          * 0=None, 1=User Closing, 2=Special Closing, 3=Partial Closing, 4=User
+                                          * Opening, 5=Special Opening
+                                          */
     private String openingClosingStateDescription = "";
 
     /**
-     * Bitwise representation of a zones state: bit0=General State (0-Closed, 1-Open), bit1=Arm State (0-Armed, 1-Bypassed), bit2=Alarm State (0-No Alarm, 1-Alarm), bit3=Tamper State (0-No Tamper, 1-Tamper), bit4=Fault State (0-No Fault, 1-Fault).
+     * Bitwise representation of a zones state: bit0=General State (0-Closed, 1-Open), bit1=Arm State (0-Armed,
+     * 1-Bypassed), bit2=Alarm State (0-No Alarm, 1-Alarm), bit3=Tamper State (0-No Tamper, 1-Tamper), bit4=Fault State
+     * (0-No Fault, 1-Fault).
      */
     private int zoneBitState = 0;
 
     private String ledStates[] = { "Off", "On", "Flashing" };
-    private int readyLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int readyLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String readyLEDStateDescription = "Off";
-    private int armedLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int armedLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String armedLEDStateDescription = "Off";
-    private int memoryLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int memoryLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String memoryLEDStateDescription = "Off";
-    private int bypassLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int bypassLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String bypassLEDStateDescription = "Off";
-    private int troubleLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int troubleLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String troubleLEDStateDescription = "Off";
-    private int programLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int programLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String programLEDStateDescription = "Off";
-    private int fireLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int fireLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String fireLEDStateDescription = "Off";
-    private int backlightLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int backlightLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String backlightLEDStateDescription = "Off";
-    private int acLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
+    private int acLEDState = 0; /* 0=Off, 1=On, 2=Flashing */
     private String acLEDStateDescription = "Off";
 
     private String troubleMessage = "";

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
@@ -35,6 +35,7 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
     private final static Logger logger = LoggerFactory.getLogger(DSCAlarmBridgeDiscovery.class);
 
     private long refreshInterval = 600;
+    private long intialDelay = 30;
     private ScheduledFuture<?> envisalinkBridgeDiscoveryJob;
     private ScheduledFuture<?> it100BridgeDiscoveryJob;
     private EnvisalinkBridgeDiscovery envisalinkBridgeDiscovery = new EnvisalinkBridgeDiscovery(this);
@@ -63,11 +64,15 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
     protected void startBackgroundDiscovery() {
         logger.debug("Start DSC Alarm Bridge background discovery");
         if (envisalinkBridgeDiscoveryJob == null || envisalinkBridgeDiscoveryJob.isCancelled()) {
-            envisalinkBridgeDiscoveryJob = scheduler.scheduleAtFixedRate(envisalinkBridgeDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
+            envisalinkBridgeDiscoveryJob = scheduler.scheduleAtFixedRate(envisalinkBridgeDiscoveryRunnable, intialDelay,
+                    refreshInterval, TimeUnit.SECONDS);
         }
+
         if (it100BridgeDiscoveryJob == null || it100BridgeDiscoveryJob.isCancelled()) {
-            it100BridgeDiscoveryJob = scheduler.scheduleAtFixedRate(it100BridgeDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
+            it100BridgeDiscoveryJob = scheduler.scheduleAtFixedRate(it100BridgeDiscoveryRunnable, intialDelay,
+                    refreshInterval, TimeUnit.SECONDS);
         }
+
     }
 
     @Override
@@ -156,7 +161,8 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
 
             if (thingUID != null) {
 
-                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("DSC IT-100 Bridge - " + port).build();
+                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                        .withLabel("DSC IT-100 Bridge - " + port).build();
                 thingDiscovered(result);
 
                 logger.trace("addBridge(): '{}' was added to Smarthome inbox.", result.getThingUID());

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
@@ -64,13 +64,11 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
     protected void startBackgroundDiscovery() {
         logger.debug("Start DSC Alarm Bridge background discovery");
         if (envisalinkBridgeDiscoveryJob == null || envisalinkBridgeDiscoveryJob.isCancelled()) {
-            envisalinkBridgeDiscoveryJob = scheduler.scheduleAtFixedRate(envisalinkBridgeDiscoveryRunnable, intialDelay,
-                    refreshInterval, TimeUnit.SECONDS);
+            envisalinkBridgeDiscoveryJob = scheduler.scheduleAtFixedRate(envisalinkBridgeDiscoveryRunnable, intialDelay, refreshInterval, TimeUnit.SECONDS);
         }
 
         if (it100BridgeDiscoveryJob == null || it100BridgeDiscoveryJob.isCancelled()) {
-            it100BridgeDiscoveryJob = scheduler.scheduleAtFixedRate(it100BridgeDiscoveryRunnable, intialDelay,
-                    refreshInterval, TimeUnit.SECONDS);
+            it100BridgeDiscoveryJob = scheduler.scheduleAtFixedRate(it100BridgeDiscoveryRunnable, intialDelay, refreshInterval, TimeUnit.SECONDS);
         }
 
     }
@@ -161,8 +159,7 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
 
             if (thingUID != null) {
 
-                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                        .withLabel("DSC IT-100 Bridge - " + port).build();
+                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("DSC IT-100 Bridge - " + port).build();
                 thingDiscovered(result);
 
                 logger.trace("addBridge(): '{}' was added to Smarthome inbox.", result.getThingUID());

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
@@ -61,7 +61,8 @@ public class EnvisalinkBridgeDiscovery {
         try {
             InetAddress localHost = InetAddress.getLocalHost();
             NetworkInterface networkInterface = NetworkInterface.getByInetAddress(localHost);
-            subnetUtils = new SubnetUtils(localHost.getHostAddress() + "/" + networkInterface.getInterfaceAddresses().get(0).getNetworkPrefixLength());
+            subnetUtils = new SubnetUtils(localHost.getHostAddress() + "/"
+                    + networkInterface.getInterfaceAddresses().get(0).getNetworkPrefixLength());
             subnetInfo = subnetUtils.getInfo();
             lowIP = convertIPToNumber(subnetInfo.getLowAddress());
             highIP = convertIPToNumber(subnetInfo.getHighAddress());
@@ -73,8 +74,10 @@ public class EnvisalinkBridgeDiscovery {
             return;
         }
 
-        logger.debug("   Local IP Address: {} - {}", subnetInfo.getAddress(), convertIPToNumber(subnetInfo.getAddress()));
-        logger.debug("   Subnet:           {} - {}", subnetInfo.getNetworkAddress(), convertIPToNumber(subnetInfo.getNetworkAddress()));
+        logger.debug("   Local IP Address: {} - {}", subnetInfo.getAddress(),
+                convertIPToNumber(subnetInfo.getAddress()));
+        logger.debug("   Subnet:           {} - {}", subnetInfo.getNetworkAddress(),
+                convertIPToNumber(subnetInfo.getNetworkAddress()));
         logger.debug("   Network Prefix:   {}", subnetInfo.getCidrSignature().split("/")[1]);
         logger.debug("   Network Mask:     {}", subnetInfo.getNetmask());
         logger.debug("   Low IP:           {}", convertNumberToIP(lowIP));
@@ -94,10 +97,11 @@ public class EnvisalinkBridgeDiscovery {
                     try (BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
                         message = input.readLine();
                     } catch (SocketTimeoutException e) {
-                        logger.error("discoverBridge(): No Message Read from Socket at [{}] - {}", ipAddress, e.getMessage());
+                        logger.debug("discoverBridge(): No Message Read from Socket at [{}] - {}", ipAddress,
+                                e.getMessage());
                         continue;
                     } catch (Exception e) {
-                        logger.error("discoverBridge(): Exception Reading from Socket! {}", e.toString());
+                        logger.debug("discoverBridge(): Exception Reading from Socket! {}", e.toString());
                         continue;
                     }
 
@@ -105,17 +109,18 @@ public class EnvisalinkBridgeDiscovery {
                         logger.debug("discoverBridge(): Bridge Found - [{}]!  Message - '{}'", ipAddress, message);
                         dscAlarmBridgeDiscovery.addEnvisalinkBridge(ipAddress);
                     } else {
-                        logger.debug("discoverBridge(): No Response from Connection -  [{}]!  Message - '{}'", ipAddress, message);
+                        logger.debug("discoverBridge(): No Response from Connection -  [{}]!  Message - '{}'",
+                                ipAddress, message);
                     }
                 }
             } catch (IllegalArgumentException e) {
-                logger.error("discoverBridge(): Illegal Argument Exception - {}", e.toString());
+                logger.debug("discoverBridge(): Illegal Argument Exception - {}", e.toString());
             } catch (SocketTimeoutException e) {
                 logger.trace("discoverBridge(): No Connection on Port 4025! [{}]", ipAddress);
             } catch (SocketException e) {
-                logger.error("discoverBridge(): Socket Exception! [{}] - {}", ipAddress, e.toString());
+                logger.debug("discoverBridge(): Socket Exception! [{}] - {}", ipAddress, e.toString());
             } catch (IOException e) {
-                logger.error("discoverBridge(): IO Exception! [{}] - {}", ipAddress, e.toString());
+                logger.debug("discoverBridge(): IO Exception! [{}] - {}", ipAddress, e.toString());
             }
         }
     }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
@@ -61,8 +61,7 @@ public class EnvisalinkBridgeDiscovery {
         try {
             InetAddress localHost = InetAddress.getLocalHost();
             NetworkInterface networkInterface = NetworkInterface.getByInetAddress(localHost);
-            subnetUtils = new SubnetUtils(localHost.getHostAddress() + "/"
-                    + networkInterface.getInterfaceAddresses().get(0).getNetworkPrefixLength());
+            subnetUtils = new SubnetUtils(localHost.getHostAddress() + "/" + networkInterface.getInterfaceAddresses().get(0).getNetworkPrefixLength());
             subnetInfo = subnetUtils.getInfo();
             lowIP = convertIPToNumber(subnetInfo.getLowAddress());
             highIP = convertIPToNumber(subnetInfo.getHighAddress());
@@ -74,10 +73,8 @@ public class EnvisalinkBridgeDiscovery {
             return;
         }
 
-        logger.debug("   Local IP Address: {} - {}", subnetInfo.getAddress(),
-                convertIPToNumber(subnetInfo.getAddress()));
-        logger.debug("   Subnet:           {} - {}", subnetInfo.getNetworkAddress(),
-                convertIPToNumber(subnetInfo.getNetworkAddress()));
+        logger.debug("   Local IP Address: {} - {}", subnetInfo.getAddress(), convertIPToNumber(subnetInfo.getAddress()));
+        logger.debug("   Subnet:           {} - {}", subnetInfo.getNetworkAddress(), convertIPToNumber(subnetInfo.getNetworkAddress()));
         logger.debug("   Network Prefix:   {}", subnetInfo.getCidrSignature().split("/")[1]);
         logger.debug("   Network Mask:     {}", subnetInfo.getNetmask());
         logger.debug("   Low IP:           {}", convertNumberToIP(lowIP));
@@ -97,8 +94,7 @@ public class EnvisalinkBridgeDiscovery {
                     try (BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
                         message = input.readLine();
                     } catch (SocketTimeoutException e) {
-                        logger.debug("discoverBridge(): No Message Read from Socket at [{}] - {}", ipAddress,
-                                e.getMessage());
+                        logger.debug("discoverBridge(): No Message Read from Socket at [{}] - {}", ipAddress, e.getMessage());
                         continue;
                     } catch (Exception e) {
                         logger.debug("discoverBridge(): Exception Reading from Socket! {}", e.toString());
@@ -109,8 +105,7 @@ public class EnvisalinkBridgeDiscovery {
                         logger.debug("discoverBridge(): Bridge Found - [{}]!  Message - '{}'", ipAddress, message);
                         dscAlarmBridgeDiscovery.addEnvisalinkBridge(ipAddress);
                     } else {
-                        logger.debug("discoverBridge(): No Response from Connection -  [{}]!  Message - '{}'",
-                                ipAddress, message);
+                        logger.debug("discoverBridge(): No Response from Connection -  [{}]!  Message - '{}'", ipAddress, message);
                     }
                 }
             } catch (IllegalArgumentException e) {

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/IT100BridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/IT100BridgeDiscovery.java
@@ -81,7 +81,7 @@ public class IT100BridgeDiscovery {
                     try {
                         message = serialInput.readLine();
                     } catch (IOException e) {
-                        logger.error("discoverBridge(): No Message Read from Serial Port '{}'", portIdentifier.getName());
+                        logger.debug("discoverBridge(): No Message Read from Serial Port '{}'", portIdentifier.getName());
                         continue;
                     }
 
@@ -93,13 +93,13 @@ public class IT100BridgeDiscovery {
                     }
 
                 } catch (UnsupportedCommOperationException e) {
-                    logger.error("discoverBridge(): Unsupported Comm Operation Exception: ", e);
+                    logger.debug("discoverBridge(): Unsupported Comm Operation Exception - '{}': {}", portIdentifier.getName(), e.toString());
                 } catch (PortInUseException e) {
-                    logger.error("discoverBridge(): Port in Use Exception: ", e);
+                    logger.debug("discoverBridge(): Port in Use Exception - '{}': {}", portIdentifier.getName(), e.toString());
                 } catch (UnsupportedEncodingException e) {
-                    logger.error("discoverBridge(): Unsupported Encoding Exception: ", e);
+                    logger.debug("discoverBridge(): Unsupported Encoding Exception - '{}': {}", portIdentifier.getName(), e.toString());
                 } catch (IOException e) {
-                    logger.error("discoverBridge(): IO Exception: ", e);
+                    logger.debug("discoverBridge(): IO Exception - '{}': ", portIdentifier.getName(), e.toString());
                 } finally {
                     if (serialInput != null) {
                         IOUtils.closeQuietly(serialInput);

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/factory/DSCAlarmHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/factory/DSCAlarmHandlerFactory.java
@@ -8,25 +8,12 @@
  */
 package org.openhab.binding.dscalarm.internal.factory;
 
-import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.*;
+import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.SUPPORTED_THING_TYPES_UIDS;
 
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 
-import org.openhab.binding.dscalarm.DSCAlarmBindingConstants;
-import org.openhab.binding.dscalarm.config.*;
-import org.openhab.binding.dscalarm.handler.DSCAlarmBaseBridgeHandler;
-import org.openhab.binding.dscalarm.handler.EnvisalinkBridgeHandler;
-import org.openhab.binding.dscalarm.handler.IT100BridgeHandler;
-import org.openhab.binding.dscalarm.handler.PanelThingHandler;
-import org.openhab.binding.dscalarm.handler.PartitionThingHandler;
-import org.openhab.binding.dscalarm.handler.ZoneThingHandler;
-import org.openhab.binding.dscalarm.handler.KeypadThingHandler;
-import org.openhab.binding.dscalarm.internal.discovery.DSCAlarmDiscoveryService;
-import org.osgi.framework.ServiceRegistration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Bridge;
@@ -35,10 +22,28 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.dscalarm.DSCAlarmBindingConstants;
+import org.openhab.binding.dscalarm.config.DSCAlarmPartitionConfiguration;
+import org.openhab.binding.dscalarm.config.DSCAlarmZoneConfiguration;
+import org.openhab.binding.dscalarm.config.EnvisalinkBridgeConfiguration;
+import org.openhab.binding.dscalarm.config.IT100BridgeConfiguration;
+import org.openhab.binding.dscalarm.config.TCPServerBridgeConfiguration;
+import org.openhab.binding.dscalarm.handler.DSCAlarmBaseBridgeHandler;
+import org.openhab.binding.dscalarm.handler.EnvisalinkBridgeHandler;
+import org.openhab.binding.dscalarm.handler.IT100BridgeHandler;
+import org.openhab.binding.dscalarm.handler.KeypadThingHandler;
+import org.openhab.binding.dscalarm.handler.PanelThingHandler;
+import org.openhab.binding.dscalarm.handler.PartitionThingHandler;
+import org.openhab.binding.dscalarm.handler.TCPServerBridgeHandler;
+import org.openhab.binding.dscalarm.handler.ZoneThingHandler;
+import org.openhab.binding.dscalarm.internal.discovery.DSCAlarmDiscoveryService;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link DSCAlarmHandlerFactory} is responsible for creating things and thing. handlers.
- * 
+ *
  * @author Russell Stephens - Initial Contribution
  */
 public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
@@ -57,6 +62,10 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
             ThingUID it100BridgeUID = getIT100BridgeThingUID(thingTypeUID, thingUID, configuration);
             logger.debug("createThing(): IT100_BRIDGE: Creating an '{}' type Thing - {}", thingTypeUID, it100BridgeUID.getId());
             return super.createThing(thingTypeUID, configuration, it100BridgeUID, null);
+        } else if (DSCAlarmBindingConstants.TCPSERVERBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            ThingUID tcpServerBridgeUID = getTCPServerBridgeThingUID(thingTypeUID, thingUID, configuration);
+            logger.debug("createThing(): TCP_SERVER_BRIDGE: Creating an '{}' type Thing - {}", thingTypeUID, tcpServerBridgeUID.getId());
+            return super.createThing(thingTypeUID, configuration, tcpServerBridgeUID, null);
         } else if (DSCAlarmBindingConstants.PANEL_THING_TYPE.equals(thingTypeUID)) {
             ThingUID panelThingUID = getDSCAlarmPanelUID(thingTypeUID, thingUID, configuration, bridgeUID);
             logger.debug("createThing(): PANEL_THING: Creating '{}' type Thing - {}", thingTypeUID, panelThingUID.getId());
@@ -85,7 +94,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the Envisalink Bridge Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -94,7 +103,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
     private ThingUID getEnvisalinkBridgeThingUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
         if (thingUID == null) {
             String ipAddress = (String) configuration.get(EnvisalinkBridgeConfiguration.IP_ADDRESS);
-            String bridgeID = ipAddress.replace('.', '-');
+            String bridgeID = ipAddress.replace('.', '_');
             thingUID = new ThingUID(thingTypeUID, bridgeID);
         }
         return thingUID;
@@ -102,7 +111,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the IT-100 Bridge Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -111,7 +120,25 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
     private ThingUID getIT100BridgeThingUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
         if (thingUID == null) {
             String serialPort = (String) configuration.get(IT100BridgeConfiguration.SERIAL_PORT);
-            String bridgeID = serialPort.replace('.', '-');
+            String bridgeID = serialPort.replace('.', '_');
+            thingUID = new ThingUID(thingTypeUID, bridgeID);
+        }
+        return thingUID;
+    }
+
+    /**
+     * Get the IT-100 Bridge Thing UID.
+     *
+     * @param thingTypeUID
+     * @param thingUID
+     * @param configuration
+     * @return thingUID
+     */
+    private ThingUID getTCPServerBridgeThingUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
+        if (thingUID == null) {
+            String ipAddress = (String) configuration.get(TCPServerBridgeConfiguration.IP_ADDRESS);
+            String port = (String) configuration.get(TCPServerBridgeConfiguration.PORT);
+            String bridgeID = ipAddress.replace('.', '_') + "_" + port;
             thingUID = new ThingUID(thingTypeUID, bridgeID);
         }
         return thingUID;
@@ -119,7 +146,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the Panel Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -136,7 +163,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the Partition Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -153,7 +180,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the Zone Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -170,7 +197,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Get the Keypad Thing UID.
-     * 
+     *
      * @param thingTypeUID
      * @param thingUID
      * @param configuration
@@ -187,7 +214,7 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Register the Thing Discovery Service for a bridge.
-     * 
+     *
      * @param dscAlarmBridgeHandler
      */
     private void registerDSCAlarmDiscoveryService(DSCAlarmBaseBridgeHandler dscAlarmBridgeHandler) {
@@ -209,12 +236,17 @@ public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
             EnvisalinkBridgeHandler handler = new EnvisalinkBridgeHandler((Bridge) thing);
             registerDSCAlarmDiscoveryService(handler);
             logger.debug("createHandler(): ENVISALINKBRIDGE_THING: ThingHandler created for {}", thingTypeUID);
-            return (EnvisalinkBridgeHandler) handler;
+            return handler;
         } else if (thingTypeUID.equals(DSCAlarmBindingConstants.IT100BRIDGE_THING_TYPE)) {
             IT100BridgeHandler handler = new IT100BridgeHandler((Bridge) thing);
             registerDSCAlarmDiscoveryService(handler);
             logger.debug("createHandler(): IT100BRIDGE_THING: ThingHandler created for {}", thingTypeUID);
-            return (IT100BridgeHandler) handler;
+            return handler;
+        } else if (thingTypeUID.equals(DSCAlarmBindingConstants.TCPSERVERBRIDGE_THING_TYPE)) {
+            TCPServerBridgeHandler handler = new TCPServerBridgeHandler((Bridge) thing);
+            registerDSCAlarmDiscoveryService(handler);
+            logger.debug("createHandler(): TCPSERVERBRIDGE_THING: ThingHandler created for {}", thingTypeUID);
+            return handler;
         } else if (thingTypeUID.equals(DSCAlarmBindingConstants.PANEL_THING_TYPE)) {
             logger.debug("createHandler(): PANEL_THING: ThingHandler created for {}", thingTypeUID);
             return new PanelThingHandler(thing);


### PR DESCRIPTION
This fixes a bug where the IT-100 bridge would not connect.  This was first described on the community site [here](https://community.openhab.org/t/dscalarm-binding-with-it100-serial-device-thing-stays-offline/9876).  The fix has been tested by the user and is working ([see here](https://community.openhab.org/t/dsc-binding-not-connecting-to-it-100/8510/11)).

Some minor fixes include:
1. The channel named `panel_command` was changed from type String to type Number.
2. Update of the README.md file.
3. Fixed a bug where the IT100 adapter requires a 6-digit user code instead of 4-digits.

Added a feature, that was added to the openHAB 1 binding, where connectivity to a DSC IT-100 can be done over a network through a TCP serial server.

Signed-off by: Russell Stephens <rsstephens@gmail.com> (github: @RSStephens)