### PR TITLE
ZWave implement protection command class

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
@@ -41,12 +41,12 @@ public class ZWaveProtectionConverterTest {
         ZWaveThingChannel channel = createChannel(Type.PROTECTION_LOCAL.name());
 
         ZWaveCommandClassValueEvent event = new ZWaveCommandClassValueEvent(0, 0, CommandClass.PROTECTION,
-                LocalProtectionType.Sequence, Type.PROTECTION_LOCAL);
+                LocalProtectionType.SEQUENCE, Type.PROTECTION_LOCAL);
 
         State state = converter.handleEvent(channel, event);
 
         assertEquals(state.getClass(), DecimalType.class);
-        assertEquals(((DecimalType) state).intValue(), LocalProtectionType.Sequence.getKey());
+        assertEquals(((DecimalType) state).intValue(), LocalProtectionType.SEQUENCE.ordinal());
     }
 
     @Test
@@ -55,12 +55,12 @@ public class ZWaveProtectionConverterTest {
         ZWaveThingChannel channel = createChannel(Type.PROTECTION_RF.name());
 
         ZWaveCommandClassValueEvent event = new ZWaveCommandClassValueEvent(0, 0, CommandClass.PROTECTION,
-                RfProtectionType.NoRFResponse, Type.PROTECTION_RF);
+                RfProtectionType.NORFRESPONSE, Type.PROTECTION_RF);
 
         State state = converter.handleEvent(channel, event);
 
         assertEquals(state.getClass(), DecimalType.class);
-        assertEquals(((DecimalType) state).intValue(), RfProtectionType.NoRFResponse.getKey());
+        assertEquals(((DecimalType) state).intValue(), RfProtectionType.NORFRESPONSE.ordinal());
     }
 
 }

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
+import org.openhab.binding.zwave.internal.converter.ZWaveProtectionConverter;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.LocalProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.RfProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.Type;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+
+public class ZWaveProtectionConverterTest {
+    final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+
+    private ZWaveThingChannel createChannel(String type) {
+        Map<String, String> args = new HashMap<String, String>();
+        args.put("type", type);
+        return new ZWaveThingChannel(null, uid, DataType.DecimalType, CommandClass.PROTECTION.toString(), 0, args);
+    }
+
+    @Test
+    public void LocalProtectionEvent() {
+        ZWaveProtectionConverter converter = new ZWaveProtectionConverter(null);
+        ZWaveThingChannel channel = createChannel(Type.PROTECTION_LOCAL.name());
+
+        ZWaveCommandClassValueEvent event = new ZWaveCommandClassValueEvent(0, 0, CommandClass.PROTECTION,
+                LocalProtectionType.Sequence, Type.PROTECTION_LOCAL);
+
+        State state = converter.handleEvent(channel, event);
+
+        assertEquals(state.getClass(), DecimalType.class);
+        assertEquals(((DecimalType) state).intValue(), LocalProtectionType.Sequence.getKey());
+    }
+
+    @Test
+    public void RFProtectionEvent() {
+        ZWaveProtectionConverter converter = new ZWaveProtectionConverter(null);
+        ZWaveThingChannel channel = createChannel(Type.PROTECTION_RF.name());
+
+        ZWaveCommandClassValueEvent event = new ZWaveCommandClassValueEvent(0, 0, CommandClass.PROTECTION,
+                RfProtectionType.NoRFResponse, Type.PROTECTION_RF);
+
+        State state = converter.handleEvent(channel, event);
+
+        assertEquals(state.getClass(), DecimalType.class);
+        assertEquals(((DecimalType) state).intValue(), RfProtectionType.NoRFResponse.getKey());
+    }
+
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveCommandClassTest.java
@@ -46,9 +46,10 @@ public class ZWaveCommandClassTest {
      * It expects at least one response event.
      *
      * @param packetData byte array containing the full Z-Wave frame
+     * @param version commandclass version
      * @return List of ZWaveEvent(s)
      */
-    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData) {
+    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData, int version) {
         SerialMessage msg = new SerialMessage(packetData);
 
         // Check the packet is not corrupted and is a command class request
@@ -66,6 +67,7 @@ public class ZWaveCommandClassTest {
         // Get the command class and process the response
         try {
             ZWaveCommandClass cls = ZWaveCommandClass.getInstance(msg.getMessagePayloadByte(3), node, controller);
+            cls.setVersion(version);
             assertNotNull(cls);
             cls.handleApplicationCommandRequest(msg, 4, 0);
         } catch (ZWaveSerialMessageException e) {
@@ -78,6 +80,21 @@ public class ZWaveCommandClassTest {
 
         // Return all the notifications....
         return argument.getAllValues();
+    }
+
+    /**
+     * Helper class to create everything we need to test a command class message.
+     *
+     * We pass in the data, and the expected command class. This method creates the class, checks it's the right one,
+     * processes the message and gets the response events.
+     *
+     * It expects at least one response event.
+     *
+     * @param packetData byte array containing the full Z-Wave frame
+     * @return List of ZWaveEvent(s)
+     */
+    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData) {
+        return processCommandClassMessage(packetData, 0);
     }
 
     ZWaveCommandClass getCommandClass(CommandClass cls) {

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveProtectionCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveProtectionCommandClassTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.LocalProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.RfProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.Type;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
+
+/**
+ * Test cases for {@link ZWaveProtectionCommandClass}.
+ *
+ * @author Jorg de Jong
+ */
+public class ZWaveProtectionCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void reportProtection() {
+        byte[] packetData = { 0x01, 0x0A, 0x00, 0x04, 0x00, 0x0A, 0x04, 0x75, 0x03, 0x00, 0x00, (byte) 0x89 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData, 2);
+
+        assertEquals(events.size(), 2);
+
+        ZWaveCommandClassValueEvent localEvent = (ZWaveCommandClassValueEvent) events.get(0);
+
+        assertEquals(localEvent.getCommandClass(), CommandClass.PROTECTION);
+        assertEquals(localEvent.getEndpoint(), 0);
+        assertEquals(localEvent.getType(), Type.PROTECTION_LOCAL);
+        assertEquals(localEvent.getValue(), LocalProtectionType.Unprotected);
+
+        ZWaveCommandClassValueEvent rfEvent = (ZWaveCommandClassValueEvent) events.get(1);
+
+        assertEquals(rfEvent.getCommandClass(), CommandClass.PROTECTION);
+        assertEquals(rfEvent.getEndpoint(), 0);
+        assertEquals(rfEvent.getType(), Type.PROTECTION_RF);
+        assertEquals(rfEvent.getValue(), RfProtectionType.Unprotected);
+    }
+
+    @Test
+    public void setProtection() {
+        ZWaveProtectionCommandClass cls = (ZWaveProtectionCommandClass) getCommandClass(CommandClass.PROTECTION);
+        cls.setVersion(cls.getMaxVersion());
+
+        byte[] expectedResponse = { 99, 4, 117, 1, 1, 2 };
+        SerialMessage msg = cls.setValueMessage(LocalProtectionType.Sequence, RfProtectionType.NoRFResponse);
+
+        assertTrue(Arrays.equals(msg.getMessagePayload(), expectedResponse));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveProtectionCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveProtectionCommandClassTest.java
@@ -43,14 +43,14 @@ public class ZWaveProtectionCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(localEvent.getCommandClass(), CommandClass.PROTECTION);
         assertEquals(localEvent.getEndpoint(), 0);
         assertEquals(localEvent.getType(), Type.PROTECTION_LOCAL);
-        assertEquals(localEvent.getValue(), LocalProtectionType.Unprotected);
+        assertEquals(localEvent.getValue(), LocalProtectionType.UNPROTECTED);
 
         ZWaveCommandClassValueEvent rfEvent = (ZWaveCommandClassValueEvent) events.get(1);
 
         assertEquals(rfEvent.getCommandClass(), CommandClass.PROTECTION);
         assertEquals(rfEvent.getEndpoint(), 0);
         assertEquals(rfEvent.getType(), Type.PROTECTION_RF);
-        assertEquals(rfEvent.getValue(), RfProtectionType.Unprotected);
+        assertEquals(rfEvent.getValue(), RfProtectionType.UNPROTECTED);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class ZWaveProtectionCommandClassTest extends ZWaveCommandClassTest {
         cls.setVersion(cls.getMaxVersion());
 
         byte[] expectedResponse = { 99, 4, 117, 1, 1, 2 };
-        SerialMessage msg = cls.setValueMessage(LocalProtectionType.Sequence, RfProtectionType.NoRFResponse);
+        SerialMessage msg = cls.setValueMessage(LocalProtectionType.SEQUENCE, RfProtectionType.NORFRESPONSE);
 
         assertTrue(Arrays.equals(msg.getMessagePayload(), expectedResponse));
     }

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_channels.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_channels.xml
@@ -589,4 +589,35 @@
         </config-description>
     </channel-type>
     
+    <!-- Local Protection Channel -->
+    <channel-type id="protection_local" advanced="true">
+        <item-type>Number</item-type>
+        <label>Local Protection Mode</label>
+        <description>Sets the local protection mode
+        </description>
+        <state>
+            <options>
+                <option value="0">Unprotected</option>
+                <option value="1">Protection by sequence</option>
+                <option value="2">No operation possible</option>
+            </options>
+        </state>
+    </channel-type>
+
+    <!-- Rf Protection Channel -->
+    <channel-type id="protection_rf" advanced="true">
+        <item-type>Number</item-type>
+        <label>Rf Protection Mode</label>
+        <description>Sets the rf protection mode
+        </description>
+        <state>
+            <options>
+                <option value="0">Unprotected</option>
+                <option value="1">No RF control</option>
+                <option value="2">No RF response at all</option>
+            </options>
+        </state>
+    </channel-type>
+
+    
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -56,6 +56,7 @@ public abstract class ZWaveCommandClassConverter {
         temp.put(CommandClass.DOOR_LOCK, ZWaveDoorLockConverter.class);
         temp.put(CommandClass.METER, ZWaveMeterConverter.class);
         temp.put(CommandClass.METER_TBL_MONITOR, ZWaveMeterTblMonitorConverter.class);
+        temp.put(CommandClass.PROTECTION, ZWaveProtectionConverter.class);
         temp.put(CommandClass.SCENE_ACTIVATION, ZWaveSceneActivationConverter.class);
         temp.put(CommandClass.SENSOR_ALARM, ZWaveAlarmSensorConverter.class);
         temp.put(CommandClass.SENSOR_BINARY, ZWaveBinarySensorConverter.class);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveProtectionConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveProtectionConverter.java
@@ -64,6 +64,10 @@ public class ZWaveProtectionConverter extends ZWaveCommandClassConverter {
         ZWaveProtectionCommandClass commandClass = (ZWaveProtectionCommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.PROTECTION, channel.getEndpoint());
 
+        if (commandClass == null) {
+            return null;
+        }
+
         SerialMessage serialMessage = null;
 
         if (type != null) {
@@ -87,9 +91,7 @@ public class ZWaveProtectionConverter extends ZWaveCommandClassConverter {
                             commandClass.setValueMessage(null, RfProtectionType.values()[value]), commandClass,
                             channel.getEndpoint());
                 }
-
             }
-
         }
 
         if (serialMessage == null) {

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveProtectionConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveProtectionConverter.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.LocalProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.RfProtectionType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveProtectionCommandClass.Type;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ZWaveProtectionConverter class. Converters between binding items and the Z-Wave API for protection.
+ *
+ * @author Jorg de Jong
+ */
+public class ZWaveProtectionConverter extends ZWaveCommandClassConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveProtectionConverter.class);
+
+    /**
+     * Constructor. Creates a new instance of the {@link ZWaveConverterBase} class.
+     *
+     */
+    public ZWaveProtectionConverter(ZWaveControllerHandler controller) {
+        super(controller);
+    }
+
+    @Override
+    public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
+        String type = channel.getArguments().get("type");
+
+        // Don't trigger event if this item is bound to another type
+        if (type != null && !event.getType().equals(Type.valueOf(type))) {
+            return null;
+        }
+
+        Enum<?> e = (Enum<?>) event.getValue();
+        return new DecimalType(e.ordinal());
+    }
+
+    @Override
+    public List<SerialMessage> receiveCommand(ZWaveThingChannel channel, ZWaveNode node, Command command) {
+        String type = channel.getArguments().get("type");
+
+        ZWaveProtectionCommandClass commandClass = (ZWaveProtectionCommandClass) node
+                .resolveCommandClass(ZWaveCommandClass.CommandClass.PROTECTION, channel.getEndpoint());
+
+        SerialMessage serialMessage = null;
+
+        if (type != null) {
+            if (Type.PROTECTION_LOCAL.name().equals(type)) {
+                logger.debug("NODE {}: Local Protection command received for {}", node.getNodeId(), command.toString());
+
+                int value = ((DecimalType) command).intValue();
+                if (value >= 0 && value < LocalProtectionType.values().length) {
+                    serialMessage = node.encapsulate(
+                            commandClass.setValueMessage(LocalProtectionType.values()[value], null), commandClass,
+                            channel.getEndpoint());
+                }
+
+            }
+            if (Type.PROTECTION_RF.name().equals(type)) {
+                logger.debug("NODE {}: rf Protection command received for {}", node.getNodeId(), command.toString());
+
+                int value = ((DecimalType) command).intValue();
+                if (value >= 0 && value < RfProtectionType.values().length) {
+                    serialMessage = node.encapsulate(
+                            commandClass.setValueMessage(null, RfProtectionType.values()[value]), commandClass,
+                            channel.getEndpoint());
+                }
+
+            }
+
+        }
+
+        if (serialMessage == null) {
+            logger.warn("NODE {}: Generating message failed for command class = {}, endpoint = {}", node.getNodeId(),
+                    commandClass.getCommandClass().getLabel(), channel.getEndpoint());
+            return null;
+        }
+
+        logger.debug("NODE {}: Sending Message: {}", node.getNodeId(), serialMessage);
+        List<SerialMessage> messages = new ArrayList<SerialMessage>();
+        messages.add(serialMessage);
+
+        // Request an update so that OH knows when the protection settings has changed.
+        serialMessage = node.encapsulate(commandClass.getValueMessage(), commandClass, channel.getEndpoint());
+
+        if (serialMessage != null) {
+            messages.add(serialMessage);
+        }
+
+        return messages;
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveProtectionCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveProtectionCommandClass.java
@@ -8,11 +8,20 @@
  */
 package org.openhab.binding.zwave.internal.protocol.commandclass;
 
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,16 +32,46 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * Handles the protection command class.
  *
  * @author Chris Jackson
+ * @author Jorg de Jong
  */
 @XStreamAlias("protectionCommandClass")
-public class ZWaveProtectionCommandClass extends ZWaveCommandClass {
+public class ZWaveProtectionCommandClass extends ZWaveCommandClass
+        implements ZWaveCommandClassInitialization, ZWaveCommandClassDynamicState, ZWaveGetCommands {
 
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveProtectionCommandClass.class);
 
-    private static final int PROTECTION_SET = 1;
-    private static final int PROTECTION_GET = 2;
-    private static final int PROTECTION_REPORT = 3;
+    private static final int MAX_SUPPORTED_VERSION = 2;
+
+    public static final int PROTECTION_SET = 1;
+    public static final int PROTECTION_GET = 2;
+    public static final int PROTECTION_REPORT = 3;
+
+    // Version 2
+    public static final int PROTECTION_SUPPORTED_GET = 0x04;
+    public static final int PROTECTION_SUPPORTED_REPORT = 0x05;
+    public static final int PROTECTION_EXCLUSIVECONTROL_SET = 0x06;
+    public static final int PROTECTION_EXCLUSIVECONTROL_GET = 0x07;
+    public static final int PROTECTION_EXCLUSIVECONTROL_REPORT = 0x08;
+    public static final int PROTECTION_TIMEOUT_SET = 0x09;
+    public static final int PROTECTION_TIMEOUT_GET = 0x0a;
+    public static final int PROTECTION_TIMEOUT_REPORT = 0x0b;
+
+    // PROTECTION_SUPPORTED_REPORT
+    private static final int TIMEOUT_BITMASK = 0x01;
+    private static final int EXCLUSIVE_CONTROL_BITMASK = 0x02;
+
+    @XStreamOmitField
+    private boolean supportedInitialised = false;
+
+    @XStreamOmitField
+    private boolean dynamicDone = false;
+
+    @XStreamOmitField
+    private LocalProtectionType currentLocalMode;
+
+    private List<LocalProtectionType> localModes = new ArrayList<>();
+    private List<RfProtectionType> rfModes = new ArrayList<>();
 
     /**
      * Creates a new instance of the ZWaveProtectionCommandClass class.
@@ -55,6 +94,14 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass {
 
     /**
      * {@inheritDoc}
+     */
+    @Override
+    public int getMaxVersion() {
+        return MAX_SUPPORTED_VERSION;
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @throws ZWaveSerialMessageException
      */
@@ -64,10 +111,243 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass {
         logger.debug("NODE {}: Received protection command (v{})", this.getNode().getNodeId(), this.getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
+            case PROTECTION_REPORT:
+                int localMode = serialMessage.getMessagePayloadByte(offset + 1) & 0x0f;
+
+                if (localMode < LocalProtectionType.values().length) {
+                    this.currentLocalMode = LocalProtectionType.values()[localMode];
+                    ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(),
+                            endpoint, getCommandClass(), this.currentLocalMode, Type.PROTECTION_LOCAL);
+                    this.getController().notifyEventListeners(zEvent);
+                }
+                if (getVersion() > 1) {
+                    int rfMode = serialMessage.getMessagePayloadByte(offset + 2) & 0x0f;
+                    if (rfMode < RfProtectionType.values().length) {
+                        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(),
+                                endpoint, getCommandClass(), RfProtectionType.values()[rfMode], Type.PROTECTION_RF);
+                        this.getController().notifyEventListeners(zEvent);
+                    }
+                    logger.debug("NODE {}: Received protection report local:{} rf:{}", getNode().getNodeId(),
+                            LocalProtectionType.values()[localMode], RfProtectionType.values()[rfMode]);
+                } else {
+                    logger.debug("NODE {}: Received protection report local:{}", getNode().getNodeId(),
+                            LocalProtectionType.values()[localMode]);
+                }
+
+                dynamicDone = true;
+                break;
+            case PROTECTION_SUPPORTED_REPORT:
+                boolean exclusive = ((serialMessage.getMessagePayloadByte(offset + 1)
+                        & EXCLUSIVE_CONTROL_BITMASK) != 0);
+                boolean timeout = ((serialMessage.getMessagePayloadByte(offset + 1) & TIMEOUT_BITMASK) != 0);
+
+                int localStateMask = (serialMessage.getMessagePayloadByte(offset + 2)
+                        | serialMessage.getMessagePayloadByte(offset + 3) << 8);
+                int rfStateMask = (serialMessage.getMessagePayloadByte(offset + 4)
+                        | serialMessage.getMessagePayloadByte(offset + 5) << 8);
+
+                LocalProtectionType localTypes[] = LocalProtectionType.values();
+                for (int i = 0; i < localTypes.length; i++) {
+                    if ((localStateMask >> i & 0x01) > 0) {
+                        localModes.add(localTypes[i]);
+                    }
+                }
+                RfProtectionType rfTypes[] = RfProtectionType.values();
+                for (int i = 0; i < rfTypes.length; i++) {
+                    if ((rfStateMask >> i & 0x01) > 0) {
+                        rfModes.add(rfTypes[i]);
+                    }
+                }
+
+                logger.debug(
+                        "NODE {}: Received protection supported report Exclusive({}), Timeout({}},  Local states={}, RF states={}",
+                        getNode().getNodeId(), exclusive ? "supported" : "Not supported",
+                        timeout ? "supported" : "Not supported", localModes, rfModes);
+                supportedInitialised = true;
+                break;
+
             default:
                 logger.warn(String.format("NODE %d: Unsupported Command %d for command class %s (0x%02X).",
                         this.getNode().getNodeId(), command, this.getCommandClass().getLabel(),
                         this.getCommandClass().getKey()));
+        }
+    }
+
+    /**
+     * Gets a SerialMessage with the PROTECTION_SUPPORTED_GET command
+     *
+     * @return the serial message, or null if the supported command is not supported.
+     */
+    public SerialMessage getSupportedMessage() {
+        if (getVersion() == 1) {
+            logger.debug("NODE {}: PROTECTION_SUPPORTED_GET not supported for V1", getNode().getNodeId());
+            return null;
+        }
+
+        logger.debug("NODE {}: Creating new message for command PROTECTION_SUPPORTED_GET", getNode().getNodeId());
+
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(getNode().getNodeId());
+        outputData.write(2);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(PROTECTION_SUPPORTED_GET);
+
+        result.setMessagePayload(outputData.toByteArray());
+        return result;
+    }
+
+    /**
+     * Gets a SerialMessage with the PROTECTION_GET command
+     *
+     * @return the serial message, or null if the supported command is not supported.
+     */
+    @Override
+    public SerialMessage getValueMessage() {
+        logger.debug("NODE {}: Creating new message for command PROTECTION_GET", getNode().getNodeId());
+
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(getNode().getNodeId());
+        outputData.write(2);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(PROTECTION_GET);
+
+        result.setMessagePayload(outputData.toByteArray());
+        return result;
+    }
+
+    /**
+     * Gets a SerialMessage with the PROTECTION_SET command
+     *
+     * @return the serial message, or null if the supported command is not supported.
+     */
+    public SerialMessage setValueMessage(LocalProtectionType localMode, RfProtectionType rfMode) {
+        logger.debug("NODE {}: Creating new message for command PROTECTION_SET", getNode().getNodeId());
+
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.Set);
+
+        LocalProtectionType newLocalMode = localMode != null ? localMode : currentLocalMode;
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        if (getVersion() < 2 || rfMode == null) {
+            outputData.write(getNode().getNodeId());
+            outputData.write(3);
+            outputData.write(getCommandClass().getKey());
+            outputData.write(PROTECTION_SET);
+            outputData.write(newLocalMode.getKey());
+        } else {
+            outputData.write(getNode().getNodeId());
+            outputData.write(4);
+            outputData.write(getCommandClass().getKey());
+            outputData.write(PROTECTION_SET);
+            outputData.write(newLocalMode.getKey());
+            outputData.write(rfMode.getKey());
+
+        }
+        result.setMessagePayload(outputData.toByteArray());
+        return result;
+    }
+
+    @Override
+    public Collection<SerialMessage> initialize(boolean refresh) {
+        ArrayList<SerialMessage> result = new ArrayList<>();
+        if (getVersion() < 2) {
+            return result;
+        }
+
+        if (refresh == true || supportedInitialised == false) {
+            result.add(getSupportedMessage());
+        }
+        return result;
+    }
+
+    @Override
+    public Collection<SerialMessage> getDynamicValues(boolean refresh) {
+        ArrayList<SerialMessage> result = new ArrayList<>();
+        if (refresh == true || dynamicDone == false) {
+            result.add(getValueMessage());
+        }
+
+        return result;
+    }
+
+    /**
+     * Reported type of protection.
+     */
+    public enum Type {
+        PROTECTION_LOCAL,
+        PROTECTION_RF
+    }
+
+    /**
+     * Z-Wave LocalProtectionType enumeration. The LocalProtection type indicates the type of local protection that is
+     * reported.
+     *
+     * @author Jorg de Jong
+     */
+    @XStreamAlias("localProtection")
+    public enum LocalProtectionType {
+        Unprotected("Unprotected"),
+        Sequence("Protection by sequence"),
+        Protected("No operation possible");
+
+        private String label;
+
+        private LocalProtectionType(String label) {
+            this.label = label;
+        }
+
+        /**
+         * @return the key
+         */
+        public int getKey() {
+            return this.ordinal();
+        }
+
+        /**
+         * @return the label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+    }
+
+    /**
+     * Z-Wave RfProtectionType enumeration. The RfProtection type indicates the type of RF protection that is reported.
+     *
+     * @author Jorg de Jong
+     */
+    @XStreamAlias("rfProtection")
+    public enum RfProtectionType {
+        Unprotected("Unprotected"),
+        NoRFControl("No RF control"),
+        NoRFResponse("No RF response at all");
+
+        private String label;
+
+        private RfProtectionType(String label) {
+            this.label = label;
+        }
+
+        /**
+         * @return the key
+         */
+        public int getKey() {
+            return this.ordinal();
+        }
+
+        /**
+         * @return the label
+         */
+        public String getLabel() {
+            return label;
         }
     }
 }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveProtectionCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveProtectionCommandClass.java
@@ -108,24 +108,24 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug("NODE {}: Received protection command (v{})", this.getNode().getNodeId(), this.getVersion());
+        logger.debug("NODE {}: Received PROTECTION command V{}", getNode().getNodeId(), getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case PROTECTION_REPORT:
                 int localMode = serialMessage.getMessagePayloadByte(offset + 1) & 0x0f;
 
                 if (localMode < LocalProtectionType.values().length) {
-                    this.currentLocalMode = LocalProtectionType.values()[localMode];
+                    currentLocalMode = LocalProtectionType.values()[localMode];
                     ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(),
-                            endpoint, getCommandClass(), this.currentLocalMode, Type.PROTECTION_LOCAL);
-                    this.getController().notifyEventListeners(zEvent);
+                            endpoint, getCommandClass(), currentLocalMode, Type.PROTECTION_LOCAL);
+                    getController().notifyEventListeners(zEvent);
                 }
                 if (getVersion() > 1) {
                     int rfMode = serialMessage.getMessagePayloadByte(offset + 2) & 0x0f;
                     if (rfMode < RfProtectionType.values().length) {
                         ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(),
                                 endpoint, getCommandClass(), RfProtectionType.values()[rfMode], Type.PROTECTION_RF);
-                        this.getController().notifyEventListeners(zEvent);
+                        getController().notifyEventListeners(zEvent);
                     }
                     logger.debug("NODE {}: Received protection report local:{} rf:{}", getNode().getNodeId(),
                             LocalProtectionType.values()[localMode], RfProtectionType.values()[rfMode]);
@@ -168,8 +168,7 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass
 
             default:
                 logger.warn(String.format("NODE %d: Unsupported Command %d for command class %s (0x%02X).",
-                        this.getNode().getNodeId(), command, this.getCommandClass().getLabel(),
-                        this.getCommandClass().getKey()));
+                        getNode().getNodeId(), command, getCommandClass().getLabel(), getCommandClass().getKey()));
         }
     }
 
@@ -240,14 +239,14 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass
             outputData.write(3);
             outputData.write(getCommandClass().getKey());
             outputData.write(PROTECTION_SET);
-            outputData.write(newLocalMode.getKey());
+            outputData.write(newLocalMode.ordinal());
         } else {
             outputData.write(getNode().getNodeId());
             outputData.write(4);
             outputData.write(getCommandClass().getKey());
             outputData.write(PROTECTION_SET);
-            outputData.write(newLocalMode.getKey());
-            outputData.write(rfMode.getKey());
+            outputData.write(newLocalMode.ordinal());
+            outputData.write(rfMode.ordinal());
 
         }
         result.setMessagePayload(outputData.toByteArray());
@@ -293,30 +292,9 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass
      */
     @XStreamAlias("localProtection")
     public enum LocalProtectionType {
-        Unprotected("Unprotected"),
-        Sequence("Protection by sequence"),
-        Protected("No operation possible");
-
-        private String label;
-
-        private LocalProtectionType(String label) {
-            this.label = label;
-        }
-
-        /**
-         * @return the key
-         */
-        public int getKey() {
-            return this.ordinal();
-        }
-
-        /**
-         * @return the label
-         */
-        public String getLabel() {
-            return label;
-        }
-
+        UNPROTECTED,
+        SEQUENCE,
+        PROTECTED;
     }
 
     /**
@@ -326,28 +304,8 @@ public class ZWaveProtectionCommandClass extends ZWaveCommandClass
      */
     @XStreamAlias("rfProtection")
     public enum RfProtectionType {
-        Unprotected("Unprotected"),
-        NoRFControl("No RF control"),
-        NoRFResponse("No RF response at all");
-
-        private String label;
-
-        private RfProtectionType(String label) {
-            this.label = label;
-        }
-
-        /**
-         * @return the key
-         */
-        public int getKey() {
-            return this.ordinal();
-        }
-
-        /**
-         * @return the label
-         */
-        public String getLabel() {
-            return label;
-        }
+        UNPROTECTED,
+        NORFCONTROL,
+        NORFRESPONSE;
     }
 }


### PR DESCRIPTION
including converter, channel definition and unit tests.

Example  thing channel config:  
```
     <channel id="protection_local" typeId="protection_local">
        <label>Local Protection</label>
        <properties>
          <property name="binding:*:DecimalType">PROTECTION;type=PROTECTION_LOCAL</property>
        </properties>
      </channel>
      <channel id="protection_rf" typeId="protection_rf">
        <label>Rf Protection</label>
        <properties>
          <property name="binding:*:DecimalType">PROTECTION;type=PROTECTION_RF</property>
        </properties>
      </channel>
 ```
Where protection_rf is only supported by CC version 2 


Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)