### PR TITLE
ZWave: MultiLevelSensor update to CCv7

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClassTest.java
@@ -42,6 +42,7 @@ public class ZWaveMultiLevelSensorCommandClassTest extends ZWaveCommandClassTest
         assertEquals(event.getEndpoint(), 0);
         assertEquals(event.getSensorType(), ZWaveMultiLevelSensorCommandClass.SensorType.LUMINANCE);
         assertEquals(event.getValue(), new BigDecimal("103"));
+        assertEquals(event.getSensorScale(), 1);
     }
 
     @Test
@@ -60,5 +61,6 @@ public class ZWaveMultiLevelSensorCommandClassTest extends ZWaveCommandClassTest
         assertEquals(event.getEndpoint(), 0);
         assertEquals(event.getSensorType(), ZWaveMultiLevelSensorCommandClass.SensorType.TEMPERATURE);
         assertEquals(event.getValue(), new BigDecimal("27.4"));
+        assertEquals(event.getSensorScale(), 0);
     }
 }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSensorConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSensorConverter.java
@@ -58,8 +58,17 @@ public class ZWaveMultiLevelSensorConverter extends ZWaveCommandClassConverter {
 
         logger.debug("NODE {}: Generating poll message for {}, endpoint {}", node.getNodeId(),
                 commandClass.getCommandClass().getLabel(), channel.getEndpoint());
-        SerialMessage serialMessage = node.encapsulate(commandClass.getValueMessage(), commandClass,
-                channel.getEndpoint());
+
+        String sensorType = channel.getArguments().get("type");
+
+        SerialMessage serialMessage;
+        if (sensorType != null) {
+            serialMessage = node.encapsulate(commandClass.getMessage(SensorType.valueOf(sensorType)), commandClass,
+                    channel.getEndpoint());
+        } else {
+            serialMessage = node.encapsulate(commandClass.getValueMessage(), commandClass, channel.getEndpoint());
+        }
+
         List<SerialMessage> response = new ArrayList<SerialMessage>(1);
         response.add(serialMessage);
         return response;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
@@ -236,12 +236,6 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
      * @return the serial message
      */
     public SerialMessage getMessage(SensorType sensorType) {
-        if (getVersion() < 5) {
-            logger.debug("NODE {}: command SENSOR_MULTI_LEVEL_GET sensorType not supprted for version:{}",
-                    this.getNode().getNodeId(), getVersion());
-            return null;
-        }
-
         if (isGetSupported == false) {
             logger.debug("NODE {}: Node doesn't support get requests for MULTI_LEVEL_SENSOR",
                     this.getNode().getNodeId());
@@ -253,12 +247,23 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
                 SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
 
         ByteArrayOutputStream outputData = new ByteArrayOutputStream();
-        outputData.write(getNode().getNodeId());
-        outputData.write(4);
-        outputData.write(getCommandClass().getKey());
-        outputData.write(SENSOR_MULTI_LEVEL_GET);
-        outputData.write(sensorType.getKey());
-        outputData.write(0); // first scale }
+        if (getVersion() < 5) {
+            // pre v5 does not have a sensortype argument, but since we
+            // used to use it, lets not break things and keep doing so....
+            outputData.write(getNode().getNodeId());
+            outputData.write(3);
+            outputData.write(getCommandClass().getKey());
+            outputData.write(SENSOR_MULTI_LEVEL_GET);
+            outputData.write(sensorType.getKey());
+        } else {
+            outputData.write(getNode().getNodeId());
+            outputData.write(4);
+            outputData.write(getCommandClass().getKey());
+            outputData.write(SENSOR_MULTI_LEVEL_GET);
+            outputData.write(sensorType.getKey());
+            outputData.write(0); // first scale }
+
+        }
         result.setMessagePayload(outputData.toByteArray());
         return result;
     }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.zwave.internal.protocol.commandclass;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,12 +44,16 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveMultiLevelSensorCommandClass.class);
-    private static final int MAX_SUPPORTED_VERSION = 5;
+    private static final int MAX_SUPPORTED_VERSION = 7;
 
     private static final int SENSOR_MULTI_LEVEL_SUPPORTED_GET = 0x01;
     private static final int SENSOR_MULTI_LEVEL_SUPPORTED_REPORT = 0x02;
     private static final int SENSOR_MULTI_LEVEL_GET = 0x04;
     private static final int SENSOR_MULTI_LEVEL_REPORT = 0x05;
+
+    // v5
+    public static final int SENSOR_MULTI_LEVEL_SUPPORTED_GET_SCALE = 0x03;
+    public static final int SENSOR_MULTI_LEVEL_SUPPORTED_SCALE_REPORT = 0x06;
 
     private final Map<SensorType, Sensor> sensors = new HashMap<SensorType, Sensor>();
 
@@ -231,6 +236,12 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
      * @return the serial message
      */
     public SerialMessage getMessage(SensorType sensorType) {
+        if (getVersion() < 5) {
+            logger.debug("NODE {}: command SENSOR_MULTI_LEVEL_GET sensorType not supprted for version:{}",
+                    this.getNode().getNodeId(), getVersion());
+            return null;
+        }
+
         if (isGetSupported == false) {
             logger.debug("NODE {}: Node doesn't support get requests for MULTI_LEVEL_SENSOR",
                     this.getNode().getNodeId());
@@ -240,9 +251,15 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
         logger.debug("NODE {}: Creating new message for command SENSOR_MULTI_LEVEL_GET", this.getNode().getNodeId());
         SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
                 SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 3, (byte) getCommandClass().getKey(),
-                (byte) SENSOR_MULTI_LEVEL_GET, (byte) sensorType.getKey() };
-        result.setMessagePayload(newPayload);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(getNode().getNodeId());
+        outputData.write(4);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(SENSOR_MULTI_LEVEL_GET);
+        outputData.write(sensorType.getKey());
+        outputData.write(0); // first scale }
+        result.setMessagePayload(outputData.toByteArray());
         return result;
     }
 
@@ -338,7 +355,27 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
         ELECTRICAL_CONDUCTIVITY(29, "ElectricalConductivity"),
         LOUDNESS(30, "Loudness"),
         MOISTURE(31, "Moisture"),
-        MAX_TYPE(32, "MaxType");
+        FREQUENCY(32, "Frequency"),
+        TIME(33, "Time"),
+        TARGET_TEMPERATURE(34, "Target Temperature"),
+        PARTICULATE_MATTER(35, "Particulate Matter"),
+        FORMALDEHYDE_LEVEL(36, "Formaldehyde Level"),
+        RADON_CONCENTRATION(37, "Radon Concentration"),
+        METHANE_DENSITY(38, "Methane Density"),
+        VOLATILE_ORGANIC_COMPOUND(39, "Volatile Organic Compound"),
+        CARBON_MONOXIDE(40, "Carbon Monoxide"),
+        SOIL_HUMIDITY(41, "Soil Humidity"),
+        SOIL_REACTIVITY(42, "Soil Reactivity"),
+        SOIL_SALINITY(43, "Soil Salinity"),
+        HEART_RATE(44, "Heart Rate"),
+        BLOOD_PRESSURE(45, "Blood Pressure"),
+        MUSCLE_MASS(46, "Muscle Mass"),
+        FAT_MASS(47, "Fat Mass"),
+        BONE_MASS(48, "Bone Mass"),
+        TOTAL_BODY_WATER(49, "Total Body Water"),
+        BASIC_METABOLIC_RATE(50, "Basic Metabolic Rate"),
+        BODY_MASS_INDEX(51, "Body Mass Index"),
+        MAX_TYPE(52, "MaxType");
 
         /**
          * A mapping between the integer code and its corresponding Sensor type to facilitate lookup by code.


### PR DESCRIPTION
- updated the supported version to 7
- added new v7 enum values
- update converter so executeRefresh uses the configured type
- fixed SENSOR_MULTI_LEVEL_GET for CC >4 (scale was missing)

FGMS001 has
```
     <property name="commandClass:SENSOR_MULTILEVEL">getSupported=false</property>
```
which is now not longer needed. 


Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)