### PR TITLE
Zwave add Network Wide Inclusion (NWI) support

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -585,6 +585,7 @@ public class SerialMessage {
         SendSucId(0x57, "SendSucId"),
         RequestNodeNeighborUpdateOptions(0x5a, "RequestNodeNeighborUpdateOptions"), // Allow options for request node
                                                                                     // neighbor update
+        ExploreRequestInclusion(0x5e, "ExploreRequestInclusion"), // Initiate a Network-Wide Inclusion process
         RequestNodeInfo(0x60, "RequestNodeInfo"), // Get info (supported command classes) for the specified node
         RemoveFailedNodeID(0x61, "RemoveFailedNodeID"), // Mark a specified node id as failed
         IsFailedNodeID(0x62, "IsFailedNodeID"), // Check to see if a specified node has failed

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -11,7 +11,9 @@ package org.openhab.binding.zwave.internal.protocol;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,6 +121,7 @@ public class ZWaveController {
     private int sucID = 0;
     private boolean softReset = false;
     private boolean masterController = true;
+    private Set<SerialMessageClass> apiCapabilities = new HashSet<>();
 
     private AtomicInteger timeOutCount = new AtomicInteger(0);
 
@@ -330,6 +333,7 @@ public class ZWaveController {
                 this.manufactureId = ((SerialApiGetCapabilitiesMessageClass) processor).getManufactureId();
                 this.deviceId = ((SerialApiGetCapabilitiesMessageClass) processor).getDeviceId();
                 this.deviceType = ((SerialApiGetCapabilitiesMessageClass) processor).getDeviceType();
+                this.apiCapabilities = ((SerialApiGetCapabilitiesMessageClass) processor).getApiCapabilities();
 
                 this.enqueue(new SerialApiGetInitDataMessageClass().doRequest());
                 break;
@@ -736,7 +740,8 @@ public class ZWaveController {
      *
      */
     public void requestAddNodesStart() {
-        this.enqueue(new AddNodeMessageClass().doRequestStart(true));
+        this.enqueue(new AddNodeMessageClass().doRequestStart(true,
+                hasApiCapability(SerialMessageClass.ExploreRequestInclusion)));
         logger.debug("ZWave controller start inclusion");
     }
 
@@ -1025,6 +1030,17 @@ public class ZWaveController {
      */
     public boolean isMasterController() {
         return masterController;
+    }
+
+    /**
+     * Checks if the serial API supports the given capability.
+     *
+     * @param capability
+     *            the capability to check
+     * @return true if the controller API support the capability
+     */
+    public boolean hasApiCapability(SerialMessageClass capability) {
+        return apiCapabilities.contains(capability);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -42,7 +42,7 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
     private final int OPTION_NETWORK_WIDE = 0x40;
 
     public SerialMessage doRequestStart(boolean highPower, boolean networkWide) {
-        logger.debug("Setting controller into INCLUSION mode.");
+        logger.debug("Setting controller into INCLUSION mode, highPower:{} networkWide:{}.", highPower, networkWide);
 
         // Queue the request
         SerialMessage newMessage = new SerialMessage(SerialMessage.SerialMessageClass.AddNodeToNetwork,

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -9,8 +9,8 @@
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveInclusionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,8 +39,9 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
     private final int ADD_NODE_STATUS_FAILED = 0x07;
 
     private final int OPTION_HIGH_POWER = 0x80;
+    private final int OPTION_NETWORK_WIDE = 0x40;
 
-    public SerialMessage doRequestStart(boolean highPower) {
+    public SerialMessage doRequestStart(boolean highPower, boolean networkWide) {
         logger.debug("Setting controller into INCLUSION mode.");
 
         // Queue the request
@@ -50,6 +51,9 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
         byte[] newPayload = { (byte) ADD_NODE_ANY, (byte) 255 };
         if (highPower == true) {
             newPayload[0] |= OPTION_HIGH_POWER;
+        }
+        if (networkWide == true) {
+            newPayload[0] |= OPTION_NETWORK_WIDE;
         }
 
         newMessage.setMessagePayload(newPayload);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetCapabilitiesMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetCapabilitiesMessageClass.java
@@ -8,14 +8,19 @@
  */
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * This class processes a serial message from the zwave controller
@@ -29,6 +34,8 @@ public class SerialApiGetCapabilitiesMessageClass extends ZWaveCommandProcessor 
     private int manufactureId = 0;
     private int deviceType = 0;
     private int deviceId = 0;
+
+    private Set<SerialMessage.SerialMessageClass> apiCapabilities = new HashSet<>();
 
     public SerialMessage doRequest() {
         return new SerialMessage(SerialMessageClass.SerialApiGetCapabilities, SerialMessageType.Request,
@@ -52,6 +59,7 @@ public class SerialApiGetCapabilitiesMessageClass extends ZWaveCommandProcessor 
         logger.debug(String.format("Device Type    = 0x%x", deviceType));
         logger.debug(String.format("Device ID      = 0x%x", deviceId));
 
+        apiCapabilities = new HashSet<>();
         // Print the list of messages supported by this controller
         for (int by = 8; by < incomingMessage.getMessagePayload().length; by++) {
             for (int bi = 0; bi < 8; bi++) {
@@ -62,6 +70,7 @@ public class SerialApiGetCapabilitiesMessageClass extends ZWaveCommandProcessor 
                         logger.debug(String.format("Supports: Unknown Class 0x%02x", ((by - 8) << 3) + bi + 1));
                     } else {
                         logger.debug("Supports: {}", msgClass.getLabel());
+                        apiCapabilities.add(msgClass);
                     }
                 }
             }
@@ -86,5 +95,9 @@ public class SerialApiGetCapabilitiesMessageClass extends ZWaveCommandProcessor 
 
     public int getDeviceId() {
         return deviceId;
+    }
+
+    public Set<SerialMessageClass> getApiCapabilities() {
+        return ImmutableSet.copyOf(apiCapabilities);
     }
 }


### PR DESCRIPTION
Enable NWI during node inclusion when the controller supports it.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)