### PR TITLE
Zwave add missing XStreamAlias

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
@@ -435,6 +435,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
      *
      * @author Chris Jackson
      */
+    @XStreamAlias("setpoint")
     private class Setpoint {
         SetpointType setpointType;
         boolean initialised = false;


### PR DESCRIPTION
Setpoint in ZWaveThermostatSetpointCommandClass seems to be missing a
@XStreamAlias annotation.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)