### PR TITLE
Reporting node-id in the logs the common way.

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
@@ -214,7 +214,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
      */
     protected void processGroupingsReport(SerialMessage serialMessage, int offset) throws ZWaveSerialMessageException {
         maxGroups = serialMessage.getMessagePayloadByte(offset + 1);
-        logger.debug("NODE {}: processGroupingsReport number of groups {}", getNode().getNodeId(), maxGroups);
+        logger.debug("NODE{}: processGroupingsReport number of groups {}", getNode().getNodeId(), maxGroups);
 
         initialiseDone = true;
 


### PR DESCRIPTION
I just noted while looking at the logs that most of the time nodes are reported as ```NODE#:```. Commit d1920e1daf8354067f7098fb2d44d4c670bbe083 , which adds a missing node-id just breaks that convention.

Signed-off-by: Thomas Karl Pietrowski thopiekar@gmail.com (github: thopiekar)