### PR TITLE
ZWave: Allow configuration of inclusion type

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
@@ -134,7 +134,28 @@
                     <option value="-232323">send</option>
                 </options>
             </parameter>
-            
+
+            <parameter name="inclusion_mode" type="integer" groupName="network">
+                <label>Inclusion Mode</label>
+                <description>
+                    <![CDATA[Set the controller inclusion mode<br/>
+<h1>Low Power Inclusion</h1>
+In this mode, the device to be included must be brought close to the controller – normally the device must be within a meter or so of the controller.  Low Power Inclusion may be required for some older devices.
+<h1>High Power Inclusion</h1>
+In this mode, the controller and the device will use their nominal RF power, so they can be included into the network anywhere so long as the device can directly communicate with the controller. This would normally mean the device can be within 10 to 15m of the controller, however this will depend on the environment and it could require a shorter distance.
+<h1>Network Wide Inclusion</h1>
+In this mode, the controller uses high power, but also other devices within the network can route the inclusion messages within the mesh network. This means that devices can be included in their final location even if they are not in direct communication with the controller. This mode will only work when the routing devices also support NWI – generally this can be considered when the devices are Z-Wave Plus compatible.
+                    ]]>
+                </description>
+                <advanced>true</advanced>
+                <default>2</default>
+                <options>
+                    <option value="0">Low Power Inclusion</option>
+                    <option value="1">High Power Inclusion</option>
+                    <option value="2">Network Wide Inclusion</option>
+                </options>
+            </parameter>
+
             <parameter name="security_networkkey" type="text" groupName="network">
                 <label>Network Security Key</label>
                 <description>Set the network security key</description>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -33,6 +33,7 @@ public class ZWaveBindingConstants {
     public final static String CONFIGURATION_SUC = "controller_suc";
     public final static String CONFIGURATION_NETWORKKEY = "security_networkkey";
     public final static String CONFIGURATION_HEALTIME = "heal_time";
+    public final static String CONFIGURATION_INCLUSION_MODE = "inclusion_mode";
 
     public final static String CONFIGURATION_SWITCHALLMODE = "switchall_mode";
     public final static String CONFIGURATION_WAKEUPNODE = "wakeup_node";

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -287,7 +287,14 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         if (controller == null) {
             return;
         }
-        controller.requestAddNodesStart();
+
+        int inclusionMode = 2;
+        Object param = getConfig().get(CONFIGURATION_INCLUSION_MODE);
+        if (param instanceof BigDecimal && param != null) {
+            inclusionMode = ((BigDecimal) param).intValue();
+        }
+
+        controller.requestAddNodesStart(inclusionMode);
     }
 
     public void stopDeviceDiscovery() {

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -738,11 +738,41 @@ public class ZWaveController {
     /**
      * Puts the controller into inclusion mode to add new nodes
      *
+     * @param inclusionMode the mode to use for inclusion.
+     *            <br>
+     *            0=Low Power Inclusion
+     *            <br>
+     *            1=High Power Inclusion
+     *            <br>
+     *            2=Network Wide Inclusion
+     *
      */
-    public void requestAddNodesStart() {
-        this.enqueue(new AddNodeMessageClass().doRequestStart(true,
-                hasApiCapability(SerialMessageClass.ExploreRequestInclusion)));
-        logger.debug("ZWave controller start inclusion");
+    public void requestAddNodesStart(int inclusionMode) {
+        logger.debug("ZWave controller start inclusion - mode {}", inclusionMode);
+
+        // Check if the stick supports NWI - if not, revert to HPI
+        if (inclusionMode == 2 && hasApiCapability(SerialMessageClass.ExploreRequestInclusion) == false) {
+            inclusionMode = 1;
+        }
+
+        boolean highPower;
+        boolean networkWide;
+        switch (inclusionMode) {
+            case 0:
+                highPower = false;
+                networkWide = false;
+                break;
+            case 1:
+                highPower = true;
+                networkWide = false;
+                break;
+            default:
+                highPower = true;
+                networkWide = true;
+                break;
+        }
+
+        enqueue(new AddNodeMessageClass().doRequestStart(highPower, networkWide));
     }
 
     /**


### PR DESCRIPTION
This makes the inclusion mode configurable by the user.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>