### PR TITLE
Zwave inclusion refactor

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
@@ -134,7 +134,28 @@
                     <option value="-232323">send</option>
                 </options>
             </parameter>
-            
+
+            <parameter name="inclusion_mode" type="integer" groupName="network">
+                <label>Inclusion Mode</label>
+                <description>
+                    <![CDATA[Set the controller inclusion mode<br/>
+<h1>Low Power Inclusion</h1>
+In this mode, the device to be included must be brought close to the controller – normally the device must be within a meter or so of the controller.  Low Power Inclusion may be required for some older devices.
+<h1>High Power Inclusion</h1>
+In this mode, the controller and the device will use their nominal RF power, so they can be included into the network anywhere so long as the device can directly communicate with the controller. This would normally mean the device can be within 10 to 15m of the controller, however this will depend on the environment and it could require a shorter distance.
+<h1>Network Wide Inclusion</h1>
+In this mode, the controller uses high power, but also other devices within the network can route the inclusion messages within the mesh network. This means that devices can be included in their final location even if they are not in direct communication with the controller. This mode will only work when the routing devices also support NWI – generally this can be considered when the devices are Z-Wave Plus compatible.
+                    ]]>
+                </description>
+                <advanced>true</advanced>
+                <default>2</default>
+                <options>
+                    <option value="0">Low Power Inclusion</option>
+                    <option value="1">High Power Inclusion</option>
+                    <option value="2">Network Wide Inclusion</option>
+                </options>
+            </parameter>
+
             <parameter name="security_networkkey" type="text" groupName="network">
                 <label>Network Security Key</label>
                 <description>Set the network security key</description>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -33,6 +33,7 @@ public class ZWaveBindingConstants {
     public final static String CONFIGURATION_SUC = "controller_suc";
     public final static String CONFIGURATION_NETWORKKEY = "security_networkkey";
     public final static String CONFIGURATION_HEALTIME = "heal_time";
+    public final static String CONFIGURATION_INCLUSION_MODE = "inclusion_mode";
 
     public final static String CONFIGURATION_SWITCHALLMODE = "switchall_mode";
     public final static String CONFIGURATION_WAKEUPNODE = "wakeup_node";

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -469,16 +469,17 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         }
         ZWaveNode node = controller.getNode(nodeId);
         if (node == null) {
+            logger.error("NODE {}: Can't be found!", nodeId);
             return false;
         }
 
         // Only set the HEAL stage if the node is in DONE state
         if (node.getNodeInitStage() != ZWaveNodeInitStage.DONE) {
+            logger.debug("NODE {}: Can't start heal when device initialisation is not complete", nodeId);
             return false;
         }
 
-        node.setNodeStage(ZWaveNodeInitStage.HEAL);
-
+        node.setNodeStage(ZWaveNodeInitStage.HEAL_START);
         return true;
     }
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -279,7 +279,14 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         if (controller == null) {
             return;
         }
-        controller.requestAddNodesStart();
+
+        int inclusionMode = 2;
+        Object param = getConfig().get(CONFIGURATION_INCLUSION_MODE);
+        if (param instanceof BigDecimal && param != null) {
+            inclusionMode = ((BigDecimal) param).intValue();
+        }
+
+        controller.requestAddNodesStart(inclusionMode);
     }
 
     public void stopDeviceDiscovery() {

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Basic;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
@@ -457,8 +458,8 @@ public class ZWaveController {
             // Place nodes in the local ZWave Controller
             controller.zwaveNodes.putIfAbsent(nodeId, node);
 
-            // If we loaded from file, then we need to add this to the discovery since we bypass the initial discovery
-            // phases
+            // If we loaded from file, then we need to add this to the discovery
+            // since we bypass the initial discovery phases
             if (serializedOk == true) {
                 ZWaveEvent zEvent = new ZWaveInitializationStateEvent(node.getNodeId(),
                         ZWaveNodeInitStage.DISCOVERY_COMPLETE);
@@ -536,7 +537,7 @@ public class ZWaveController {
      */
     public void notifyEventListeners(ZWaveEvent event) {
         logger.debug("Notifying event listeners: {}", event.getClass().getSimpleName());
-        ArrayList<ZWaveEventListener> copy = new ArrayList<ZWaveEventListener>(this.zwaveEventListeners);
+        ArrayList<ZWaveEventListener> copy = new ArrayList<ZWaveEventListener>(zwaveEventListeners);
         for (ZWaveEventListener listener : copy) {
             listener.ZWaveIncomingEvent(event);
         }
@@ -546,19 +547,87 @@ public class ZWaveController {
             ZWaveInclusionEvent incEvent = (ZWaveInclusionEvent) event;
             switch (incEvent.getEvent()) {
                 case IncludeSlaveFound:
-                    // Use IncludeSlaveFound since security based devices need the
-                    // initial exchange to take place immediately or they will time out
+                    // When a device is found we get the IncludeSlaveFound notification.
+                    // Here we need to end inclusion.
+                    requestAddNodesStop();
                     logger.debug("NODE {}: Including node.", incEvent.getNodeId());
+
                     // First make sure this isn't an existing node
                     if (getNode(incEvent.getNodeId()) != null) {
                         logger.debug("NODE {}: Newly included node already exists - not initialising.",
                                 incEvent.getNodeId());
                         break;
                     }
-                    this.lastIncludeSlaveFoundEvent = incEvent;
-                    // Initialise the new node
-                    addNode(incEvent.getNodeId());
+
+                    // TODO: This can be removed once the key is added to the security class directly
+                    // TODO: a few lines below.
+                    lastIncludeSlaveFoundEvent = incEvent;
+
+                    // Create a new node
+                    ZWaveNode newNode = new ZWaveNode(homeId, incEvent.getNodeId(), this);
+
+                    // Add the device class
+                    ZWaveDeviceClass deviceClass = newNode.getDeviceClass();
+                    deviceClass.setBasicDeviceClass(incEvent.getBasic());
+                    deviceClass.setGenericDeviceClass(incEvent.getGeneric());
+                    deviceClass.setSpecificDeviceClass(incEvent.getSpecific());
+
+                    // If we have the NIF as part of the inclusion, use it
+                    // TODO: This code now appears in multiple places - consolidate into the node
+                    for (CommandClass commandClass : incEvent.getCommandClasses()) {
+                        ZWaveCommandClass zwaveCommandClass = ZWaveCommandClass.getInstance(commandClass.getKey(),
+                                newNode, this);
+                        if (zwaveCommandClass != null) {
+                            logger.debug("NODE {}: Inclusion is adding command class {}.", incEvent.getNodeId(),
+                                    commandClass);
+                            // TODO: Add the network key to the security class
+                            if (commandClass == CommandClass.SECURITY) {
+                                // ((ZWaveSecurityCommandClass)zwaveCommandClass).setRealNetworkKey(hexString);
+                            }
+                            newNode.addCommandClass(zwaveCommandClass);
+                        }
+                    }
+
+                    // Place nodes in the local ZWave Controller
+                    zwaveNodes.putIfAbsent(incEvent.getNodeId(), newNode);
                     break;
+
+                case IncludeDone:
+                    // Kick off the initialisation.
+                    // Since the node is awake, we jump straight into the initialisation sequence
+                    // without some of the initial stages like PING that are designed to detect if
+                    // the device is responding.
+                    // This is primarily designed to speed up the secure inclusion but is valid for all.
+                    // TODO: There's an assumption here that the whole NIF is provided with the inclusion method
+                    // -- we might want to keep an eye on this in case it's incorrect!
+                    ZWaveNode node = getNode(incEvent.getNodeId());
+                    if (node == null) {
+                        logger.debug("NODE {}: Newly included node doesn't exist - initialising from start.",
+                                incEvent.getNodeId());
+                        // Add the node using addNode()
+                        // This seems to happen if we exclude the node, then add it back in.
+                        // We don't get the IncludeSlaveFound notification, just the IncludeDone notification.
+                        addNode(incEvent.getNodeId());
+                        break;
+                    }
+
+                    // If this node is already initialising, then do nothing.
+                    // This might happen if a node is re-added even when we are aware of it
+                    if (node.getNodeInitStage() != ZWaveNodeInitStage.EMPTYNODE) {
+                        logger.debug("NODE {}: Newly included node already initialising at {}", incEvent.getNodeId(),
+                                node.getNodeInitStage());
+                        break;
+                    }
+
+                    // Start initialisation...
+                    // If we just included this through the IncludeSlaveFound, then we'll already know the device class
+                    if (node.getDeviceClass().getBasicDeviceClass() != Basic.NOT_KNOWN) {
+                        node.initialiseNode(ZWaveNodeInitStage.INCLUSION_START);
+                    } else {
+                        node.initialiseNode(ZWaveNodeInitStage.EMPTYNODE);
+                    }
+                    break;
+
                 case ExcludeDone:
                     logger.debug("NODE {}: Excluding node.", incEvent.getNodeId());
                     // Remove the node from the controller
@@ -566,7 +635,7 @@ public class ZWaveController {
                         logger.debug("NODE {}: Excluding node that doesn't exist.", incEvent.getNodeId());
                         break;
                     }
-                    this.zwaveNodes.remove(incEvent.getNodeId());
+                    zwaveNodes.remove(incEvent.getNodeId());
 
                     // Remove the XML file
                     ZWaveNodeSerializer nodeSerializer = new ZWaveNodeSerializer();
@@ -722,7 +791,7 @@ public class ZWaveController {
      *
      */
     public void requestNodeNeighborUpdate(int nodeId) {
-        this.enqueue(new RequestNodeNeighborUpdateMessageClass().doRequest(nodeId));
+        enqueue(new RequestNodeNeighborUpdateMessageClass().doRequest(nodeId));
     }
 
     /**
@@ -770,7 +839,7 @@ public class ZWaveController {
      *
      */
     public void requestAddNodesStop() {
-        this.enqueue(new AddNodeMessageClass().doRequestStop());
+        enqueue(new AddNodeMessageClass().doRequestStop());
         logger.debug("ZWave controller end inclusion");
     }
 
@@ -779,7 +848,7 @@ public class ZWaveController {
      *
      */
     public void requestRemoveNodesStart() {
-        this.enqueue(new RemoveNodeMessageClass().doRequestStart(true));
+        enqueue(new RemoveNodeMessageClass().doRequestStart(true));
         logger.debug("ZWave controller start exclusion");
     }
 
@@ -788,7 +857,7 @@ public class ZWaveController {
      *
      */
     public void requestRemoveNodesStop() {
-        this.enqueue(new RemoveNodeMessageClass().doRequestStop());
+        enqueue(new RemoveNodeMessageClass().doRequestStop());
         logger.debug("ZWave controller end exclusion");
     }
 
@@ -805,7 +874,7 @@ public class ZWaveController {
     public void requestSoftReset() {
         SerialMessage msg = new SerialApiSoftResetMessageClass().doRequest();
         msg.attempts = 1;
-        this.enqueue(msg);
+        enqueue(msg);
         logger.debug("ZWave controller soft reset");
     }
 
@@ -822,11 +891,11 @@ public class ZWaveController {
 
         SerialMessage msg = new ControllerSetDefaultMessageClass().doRequest();
         msg.attempts = 1;
-        this.enqueue(msg);
+        enqueue(msg);
 
         // Clear all the nodes and we'll reinitialise
-        this.zwaveNodes.clear();
-        this.enqueue(new SerialApiGetInitDataMessageClass().doRequest());
+        zwaveNodes.clear();
+        enqueue(new SerialApiGetInitDataMessageClass().doRequest());
         logger.debug("ZWave controller hard reset");
     }
 
@@ -837,7 +906,7 @@ public class ZWaveController {
      *            The address of the node to check
      */
     public void requestIsFailedNode(int nodeId) {
-        this.enqueue(new IsFailedNodeMessageClass().doRequest(nodeId));
+        enqueue(new IsFailedNodeMessageClass().doRequest(nodeId));
     }
 
     /**
@@ -848,7 +917,7 @@ public class ZWaveController {
      *            The address of the node to remove
      */
     public void requestRemoveFailedNode(int nodeId) {
-        this.enqueue(new RemoveFailedNodeMessageClass().doRequest(nodeId));
+        enqueue(new RemoveFailedNodeMessageClass().doRequest(nodeId));
     }
 
     /**
@@ -858,7 +927,7 @@ public class ZWaveController {
      *            The address of the node to set failed
      */
     public void requestSetFailedNode(int nodeId) {
-        this.enqueue(new ReplaceFailedNodeMessageClass().doRequest(nodeId));
+        enqueue(new ReplaceFailedNodeMessageClass().doRequest(nodeId));
     }
 
     /**
@@ -868,7 +937,7 @@ public class ZWaveController {
      * @param nodeId
      */
     public void requestDeleteAllReturnRoutes(int nodeId) {
-        this.enqueue(new DeleteReturnRouteMessageClass().doRequest(nodeId));
+        enqueue(new DeleteReturnRouteMessageClass().doRequest(nodeId));
     }
 
     /**
@@ -880,7 +949,7 @@ public class ZWaveController {
      *            Destination node
      */
     public void requestAssignReturnRoute(int nodeId, int destinationId) {
-        this.enqueue(new AssignReturnRouteMessageClass().doRequest(nodeId, destinationId, getCallbackId()));
+        enqueue(new AssignReturnRouteMessageClass().doRequest(nodeId, destinationId, getCallbackId()));
     }
 
     /**
@@ -891,7 +960,7 @@ public class ZWaveController {
      *            Source node
      */
     public void requestAssignSucReturnRoute(int nodeId) {
-        this.enqueue(new AssignSucReturnRouteMessageClass().doRequest(nodeId, getCallbackId()));
+        enqueue(new AssignSucReturnRouteMessageClass().doRequest(nodeId, getCallbackId()));
     }
 
     /**
@@ -951,7 +1020,7 @@ public class ZWaveController {
         synchronized (zwaveEventListeners) {
             // First, check if this listener is already registered
             if (zwaveEventListeners.contains(eventListener)) {
-                logger.debug("Event Listerener {} already registered", eventListener);
+                logger.debug("Event Listener {} already registered", eventListener);
                 return;
             }
             zwaveEventListeners.add(eventListener);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -728,11 +728,41 @@ public class ZWaveController {
     /**
      * Puts the controller into inclusion mode to add new nodes
      *
+     * @param inclusionMode the mode to use for inclusion.
+     *            <br>
+     *            0=Low Power Inclusion
+     *            <br>
+     *            1=High Power Inclusion
+     *            <br>
+     *            2=Network Wide Inclusion
+     *
      */
-    public void requestAddNodesStart() {
-        this.enqueue(new AddNodeMessageClass().doRequestStart(true,
-                hasApiCapability(SerialMessageClass.ExploreRequestInclusion)));
-        logger.debug("ZWave controller start inclusion");
+    public void requestAddNodesStart(int inclusionMode) {
+        logger.debug("ZWave controller start inclusion - mode {}", inclusionMode);
+
+        // Check if the stick supports NWI - if not, revert to HPI
+        if (inclusionMode == 2 && hasApiCapability(SerialMessageClass.ExploreRequestInclusion) == false) {
+            inclusionMode = 1;
+        }
+
+        boolean highPower;
+        boolean networkWide;
+        switch (inclusionMode) {
+            case 0:
+                highPower = false;
+                networkWide = false;
+                break;
+            case 1:
+                highPower = true;
+                networkWide = false;
+                break;
+            default:
+                highPower = true;
+                networkWide = true;
+                break;
+        }
+
+        enqueue(new AddNodeMessageClass().doRequestStart(highPower, networkWide));
     }
 
     /**

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -143,7 +143,7 @@ public class ZWaveNode {
         // Create the initialisation advancer and tell it we've loaded from file
         nodeInitStageAdvancer = new ZWaveNodeInitStageAdvancer(this, controller);
         nodeInitStageAdvancer.setRestoredFromConfigfile();
-        nodeInitStageAdvancer.setCurrentStage(ZWaveNodeInitStage.EMPTYNODE);
+        nodeInitStageAdvancer.startInitialisation(ZWaveNodeInitStage.EMPTYNODE);
     }
 
     /**
@@ -369,7 +369,7 @@ public class ZWaveNode {
      * @param nodeStage the nodeStage to set
      */
     public void setNodeStage(ZWaveNodeInitStage nodeStage) {
-        nodeInitStageAdvancer.setCurrentStage(nodeStage);
+        nodeInitStageAdvancer.startInitialisation(nodeStage);
     }
 
     /**
@@ -460,7 +460,7 @@ public class ZWaveNode {
     public void resetResendCount() {
         resendCount = 0;
         if (nodeInitStageAdvancer.isInitializationComplete() && isDead() == false) {
-            nodeInitStageAdvancer.setCurrentStage(ZWaveNodeInitStage.DONE);
+            nodeInitStageAdvancer.startInitialisation(ZWaveNodeInitStage.DONE);
         }
     }
 
@@ -587,6 +587,10 @@ public class ZWaveNode {
      */
     public void initialiseNode() {
         nodeInitStageAdvancer.startInitialisation();
+    }
+
+    public void initialiseNode(ZWaveNodeInitStage startStage) {
+        nodeInitStageAdvancer.startInitialisation(startStage);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClass.java
@@ -818,7 +818,7 @@ public abstract class ZWaveSecurityCommandClass extends ZWaveCommandClass {
     void setupNetworkKey(boolean useSchemeZero) {
         logger.info("NODE {}: setupNetworkKey useSchemeZero={}", getNode().getNodeId(), useSchemeZero);
         if (useSchemeZero) {
-            logger.info("NODE {}: Using Scheme0 Network Key for Key Exchange since we are in inclusion mode.)",
+            logger.info("NODE {}: Using Scheme0 Network Key for Key Exchange since we are in inclusion mode.",
                     getNode().getNodeId());
             // Scheme0 network key is a key of all zeros
             networkKey = new SecretKeySpec(new byte[16], AES);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClassWithInitialization.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClassWithInitialization.java
@@ -173,8 +173,8 @@ public class ZWaveSecurityCommandClassWithInitialization extends ZWaveSecurityCo
                 int schemes = serialMessage.getMessagePayloadByte(offset + 1);
                 logger.debug("NODE {}: Received Security Scheme Report: ", this.getNode().getNodeId(), schemes);
                 if (schemes == SECURITY_SCHEME_ZERO) {
-                    // Since we've agreed on a scheme for which to exchange our key, we now send our NetworkKey to the
-                    // device
+                    // Since we've agreed on a scheme for which to exchange our key
+                    // we now send our NetworkKey to the device
                     logger.debug("NODE {}: Security scheme agreed.", this.getNode().getNodeId());
                     // create the NetworkKey Packet
                     SerialMessage networkKeyMessage = new SerialMessage(this.getNode().getNodeId(),
@@ -264,20 +264,12 @@ public class ZWaveSecurityCommandClassWithInitialization extends ZWaveSecurityCo
                 super.handleApplicationCommandRequest(serialMessage, offset, endpoint);
                 return;
 
-            case SECURITY_NETWORK_KEY_SET: // we shouldn't get a NetworkKeySet from a node if we are the controller as
-                                           // we send it out to the Devices
-            case SECURITY_MESSAGE_ENCAP: // SECURITY_MESSAGE_ENCAP should be caught and handled in {@link
-                                         // ApplicationCommandMessageClass}
-            case SECURITY_MESSAGE_ENCAP_NONCE_GET: // SECURITY_MESSAGE_ENCAP_NONCE_GET should be caught and handled in
-                                                   // {@link ApplicationCommandMessageClass}
-                logger.info("NODE {}: Received {} from node but we shouldn't have gotten it.",
-                        this.getNode().getNodeId(), commandToString(command));
-                return;
             default:
                 logger.warn(String.format(
                         "NODE %d: Unsupported Command 0x%02X for command class %s (0x%02X) for message %s.",
                         this.getNode().getNodeId(), command, this.getCommandClass().getLabel(),
                         this.getCommandClass().getKey(), serialMessage));
+                break;
         }
     }
 
@@ -470,6 +462,7 @@ public class ZWaveSecurityCommandClassWithInitialization extends ZWaveSecurityCo
         super.checkInit();
     }
 
+    // TODO: Move this to main security class
     @Override
     boolean checkRealNetworkKeyLoaded() {
         if (realNetworkKey == null) {
@@ -479,6 +472,7 @@ public class ZWaveSecurityCommandClassWithInitialization extends ZWaveSecurityCo
                 errorMessage += keyException.getMessage();
             }
             // logger.error(errorMessage, keyException);
+            // TODO: Split this into the initialisation handler
             if (inclusionStateTracker != null) {
                 inclusionStateTracker.setErrorState(errorMessage);
             }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInclusionEvent.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInclusionEvent.java
@@ -8,7 +8,14 @@
  */
 package org.openhab.binding.zwave.internal.protocol.event;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Basic;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Generic;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Specific;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 
 /**
  * This event signals a node being included or excluded into the network.
@@ -16,8 +23,12 @@ import java.util.Date;
  * @author Chris Jackson
  */
 public class ZWaveInclusionEvent extends ZWaveEvent {
-    Type type;
+    private Type type;
     private final Date includedAt;
+    List<CommandClass> commandClasses = new ArrayList<CommandClass>();
+    Basic basic = Basic.NOT_KNOWN;
+    Generic generic = Generic.NOT_KNOWN;
+    Specific specific = Specific.NOT_USED;
 
     /**
      * Constructor. Creates a new instance of the ZWaveInclusionEvent
@@ -25,16 +36,27 @@ public class ZWaveInclusionEvent extends ZWaveEvent {
      *
      * @param nodeId the nodeId of the event.
      */
+    public ZWaveInclusionEvent(Type type) {
+        super(255);
+        this.includedAt = new Date();
+        this.type = type;
+    }
+
     public ZWaveInclusionEvent(Type type, int nodeId) {
         super(nodeId);
         this.includedAt = new Date();
         this.type = type;
     }
 
-    public ZWaveInclusionEvent(Type type) {
-        super(255);
+    public ZWaveInclusionEvent(Type type, int nodeId, Basic basic, Generic generic, Specific specific,
+            List<CommandClass> commandClasses) {
+        super(nodeId);
         this.includedAt = new Date();
         this.type = type;
+        this.basic = basic;
+        this.generic = generic;
+        this.specific = specific;
+        this.commandClasses.addAll(commandClasses);
     }
 
     public Date getIncludedAt() {
@@ -43,6 +65,22 @@ public class ZWaveInclusionEvent extends ZWaveEvent {
 
     public Type getEvent() {
         return type;
+    }
+
+    public Basic getBasic() {
+        return basic;
+    }
+
+    public Generic getGeneric() {
+        return generic;
+    }
+
+    public Specific getSpecific() {
+        return specific;
+    }
+
+    public List<CommandClass> getCommandClasses() {
+        return commandClasses;
     }
 
     public enum Type {

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -8,94 +8,57 @@
  */
 package org.openhab.binding.zwave.internal.protocol.initialization;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * Node Stage Enumeration for node initialisation.
+ * Node Stage Enumeration for node initialisation sequence.
+ * The initialisation will be performed in the order of the enum definitions.
  *
  * @author Chris Jackson
- * @author Brian Crosby
  */
 public enum ZWaveNodeInitStage {
-    EMPTYNODE(0, true),
-    PROTOINFO(1, true),
-    INIT_NEIGHBORS(2, true),
-    FAILED_CHECK(3, true),
-    WAIT(4, true),
-    PING(5, true),
-    DETAILS(6, true),
-    MANUFACTURER(7, true),
-    SECURITY_REPORT(8, true),
-    APP_VERSION(9, true),
-    DISCOVERY_COMPLETE(10, true),
-    VERSION(11, true),
-    ENDPOINTS(12, true),
-    UPDATE_DATABASE(13, true),
-    STATIC_VALUES(14, true),
-    ASSOCIATIONS(15, false),
-    SET_WAKEUP(16, false),
-    SET_ASSOCIATION(17, false),
-    STATIC_END(18, false),
+    EMPTYNODE(true),
+    PROTOINFO(true),
+    INIT_NEIGHBORS(true),
+    FAILED_CHECK(true),
+    WAIT(true),
+    PING(true),
+    DETAILS(true),
+
+    // States below form the main part of the initialisation
+    // For newly included devices, we start here
+    INCLUSION_START(true),
+    IDENTIFY_NODE(true),
+    SECURITY_REPORT(true),
+    MANUFACTURER(true),
+    APP_VERSION(true),
+    DISCOVERY_COMPLETE(true),
+    VERSION(true),
+    ENDPOINTS(true),
+    UPDATE_DATABASE(true),
+    STATIC_VALUES(true),
+    ASSOCIATIONS(false),
+    SET_WAKEUP(false),
+    SET_ASSOCIATION(false),
+    STATIC_END(false),
 
     // States below are not restored from the configuration files
-    SESSION_START(19, false),
-    GET_CONFIGURATION(20, false),
-    DYNAMIC_VALUES(21, false),
-    DYNAMIC_END(22, false),
+    SESSION_START(false),
+    GET_CONFIGURATION(false),
+    DYNAMIC_VALUES(false),
+    DYNAMIC_END(false),
 
     // States below are performed during initialisation, but also during heal
-    HEAL(23, false),
-    DELETE_ROUTES(24, false),
-    SUC_ROUTE(25, false),
-    RETURN_ROUTES(26, false),
-    NEIGHBORS(27, true),
+    HEAL_START(false),
+    DELETE_ROUTES(false),
+    SUC_ROUTE(false),
+    RETURN_ROUTES(false),
+    NEIGHBORS(false),
 
-    DONE(28, false);
+    DONE(false);
 
-    private int stage;
     private boolean mandatory;
 
-    /**
-     * A mapping between the integer code and its corresponding
-     * Node Stage to facilitate lookup by code.
-     */
-    private static Map<Integer, ZWaveNodeInitStage> codeToNodeStageMapping;
-
-    private ZWaveNodeInitStage(int s, boolean m) {
-        stage = s;
-        mandatory = m;
-    }
-
-    private static void initMapping() {
-        codeToNodeStageMapping = new HashMap<Integer, ZWaveNodeInitStage>();
-        for (ZWaveNodeInitStage s : values()) {
-            codeToNodeStageMapping.put(s.stage, s);
-        }
-    }
-
-    /**
-     * Get the stage protocol number.
-     *
-     * @return number
-     */
-    public int getStage() {
-        return this.stage;
-    }
-
-    /**
-     * Lookup function based on the command class code.
-     * Returns null if there is no command class with code i
-     *
-     * @param i the code to lookup
-     * @return enumeration value of the command class.
-     */
-    public static ZWaveNodeInitStage getNodeStage(int i) {
-        if (codeToNodeStageMapping == null) {
-            initMapping();
-        }
-
-        return codeToNodeStageMapping.get(i);
+    private ZWaveNodeInitStage(boolean manditory) {
+        this.mandatory = manditory;
     }
 
     /**
@@ -104,9 +67,9 @@ public enum ZWaveNodeInitStage {
      * @return the next stage
      */
     public ZWaveNodeInitStage getNextStage() {
-        for (ZWaveNodeInitStage s : values()) {
-            if (s.stage == this.stage + 1) {
-                return s;
+        for (ZWaveNodeInitStage stage : values()) {
+            if (stage.ordinal() == this.ordinal() + 1) {
+                return stage;
             }
         }
 
@@ -119,7 +82,7 @@ public enum ZWaveNodeInitStage {
      * @return true if static stages complete
      */
     public boolean isStaticComplete() {
-        if (stage > SESSION_START.stage) {
+        if (ordinal() > SESSION_START.ordinal()) {
             return true;
         }
         return false;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -1010,7 +1010,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                     return;
 
                 case SESSION_START:
-                case HEAL:
+                case HEAL_START:
                     // This is a 'do nothing' state.
                     // It's used as a marker within the NodeStage class to indicate
                     // where to start initialisation under specific situations.

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -143,7 +143,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
     ThingType thingType = null;
 
     private Date queryStageTimeStamp;
-    private ZWaveNodeInitStage currentStage;
+    private ZWaveNodeInitStage currentStage = ZWaveNodeInitStage.EMPTYNODE;
 
     /**
      * Used only by {@link ZWaveNodeInitStage#SECURITY_REPORT}
@@ -162,6 +162,9 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
         this.node = node;
         this.controller = controller;
 
+        // Create the timer
+        timer = new Timer();
+
         // Initialise the message queue
         msgQueue = new ArrayBlockingQueue<SerialMessage>(MAX_BUFFFER_LEN, true);
     }
@@ -170,13 +173,21 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
      * Starts the initialisation from the beginning.
      */
     public void startInitialisation() {
+        startInitialisation(ZWaveNodeInitStage.EMPTYNODE);
+    }
+
+    /**
+     * Start the initialisation from a specific stage
+     *
+     * @param startStage
+     */
+    public void startInitialisation(ZWaveNodeInitStage startStage) {
+        logger.debug("NODE {}: Starting initialisation from {}", node.getNodeId(), startStage);
+
         // Reset the state variables
-        currentStage = ZWaveNodeInitStage.EMPTYNODE;
+        currentStage = startStage;
         queryStageTimeStamp = Calendar.getInstance().getTime();
         retryTimer = BACKOFF_TIMER_START;
-
-        // Create the timer and timer task
-        timer = new Timer();
 
         wakeupCount = 0;
 
@@ -270,8 +281,8 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
             return;
         }
 
-        logger.debug("NODE {}: Node advancer - {}: queue length({}), free to send({})", node.getNodeId(),
-                currentStage.toString(), msgQueue.size(), freeToSend);
+        logger.debug("NODE {}: Node advancer - {}: queue length({}), free to send({})", node.getNodeId(), currentStage,
+                msgQueue.size(), freeToSend);
 
         // If this is a battery node, and we exceed the wakeup count without advancing the stage, then reset.
         if (wakeupCount >= 3) {
@@ -310,8 +321,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                 retryCount++;
                 if (retryCount > MAX_RETRIES) {
                     retryCount = 0;
-                    logger.error("NODE {}: Node advancer: Retries exceeded at {}", node.getNodeId(),
-                            currentStage.toString());
+                    logger.error("NODE {}: Node advancer: Retries exceeded at {}", node.getNodeId(), currentStage);
                     if (currentStage.isStageMandatory() == false) {
                         // If the current stage is not mandatory, then we skip forward to the next
                         // stage.
@@ -328,8 +338,8 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                 }
             }
 
-            logger.debug("NODE {}: Node advancer: loop - {} try {}: stageAdvanced({})", node.getNodeId(),
-                    currentStage.toString(), retryCount, stageAdvanced);
+            logger.debug("NODE {}: Node advancer: loop - {} try {}: stageAdvanced({})", node.getNodeId(), currentStage,
+                    retryCount, stageAdvanced);
 
             switch (currentStage) {
                 case EMPTYNODE:
@@ -347,7 +357,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                     break;
 
                 case INIT_NEIGHBORS:
-                    // If the incoming frame is the IdentifyNode, then we continue
+                    // If the incoming frame is the GetRoutingInfo, then we continue
                     if (eventClass == SerialMessageClass.GetRoutingInfo) {
                         break;
                     }
@@ -367,7 +377,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                         break;
                     }
 
-                    // If the incoming frame is the IdentifyNode, then we continue
+                    // If the incoming frame is the IsFailedNodeID, then we continue
                     if (eventClass == SerialMessageClass.IsFailedNodeID) {
                         break;
                     }
@@ -394,7 +404,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                     }
 
                     // If it's not listening, and not awake,
-                    // we'll wait a while before progressing with initialisation.
+                    // then wait a while before progressing with initialisation.
                     logger.debug("NODE {}: Node advancer: WAIT - Still waiting!", node.getNodeId());
                     return;
 
@@ -428,6 +438,17 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                         addToQueue(msg);
                     }
                     break;
+
+                case IDENTIFY_NODE:
+                    // If the incoming frame is the IdentifyNode, then we continue
+                    if (eventClass == SerialMessageClass.IdentifyNode) {
+                        break;
+                    }
+
+                    logger.debug("NODE {}: Node advancer: PROTOINFO - send IdentifyNode", node.getNodeId());
+                    addToQueue(new IdentifyNodeMessageClass().doRequest(node.getNodeId()));
+                    break;
+
                 case SECURITY_REPORT:
                     // For devices that use security. When invoked during secure inclusion, this
                     // method will go through all steps to give the device our zwave:networkKey from
@@ -997,7 +1018,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
 
                 default:
                     logger.debug("NODE {}: Node advancer: Unknown node state {} encountered.", node.getNodeId(),
-                            currentStage.toString().toString());
+                            currentStage);
                     break;
             }
 
@@ -1013,7 +1034,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                 // Reset the backoff timer
                 retryTimer = BACKOFF_TIMER_START;
 
-                logger.debug("NODE {}: Node advancer - advancing to {}", node.getNodeId(), currentStage.toString());
+                logger.debug("NODE {}: Node advancer - advancing to {}", node.getNodeId(), currentStage);
 
                 // Notify listeners
                 ZWaveEvent zEvent = new ZWaveInitializationStateEvent(node.getNodeId(), currentStage);
@@ -1084,15 +1105,11 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
     /**
      * Sets the current node stage
      */
-    public void setCurrentStage(ZWaveNodeInitStage newStage) {
+    private void setCurrentStage(ZWaveNodeInitStage newStage) {
         currentStage = newStage;
 
         // Remember the time so we can handle retries and keep users informed
         queryStageTimeStamp = Calendar.getInstance().getTime();
-
-        // Set an event callback so we get notification of events
-        // We do this again here in case this is part of a HEAL
-        controller.addEventListener(this);
     }
 
     /**
@@ -1168,7 +1185,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                 case DeleteReturnRoute:
                 case IsFailedNodeID:
                     logger.debug("NODE {}: Node advancer - {}: Transaction complete ({}:{}) success({})",
-                            node.getNodeId(), currentStage.toString(), serialMessage.getMessageClass(),
+                            node.getNodeId(), currentStage, serialMessage.getMessageClass(),
                             serialMessage.getMessageType(), completeEvent.getState());
 
                     // If this frame was successfully sent, then handle the stage advancer
@@ -1258,7 +1275,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
 
             // Timer has triggered, so log it!
             logger.debug("NODE {}: Stage {}. Initialisation retry timer triggered. Increased to {}", node.getNodeId(),
-                    currentStage.toString(), retryTimer);
+                    currentStage, retryTimer);
 
             // Kickstart comms - clear the queue and run the advancer
             msgQueue.clear();

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/security/ZWaveSecureInclusionStateTracker.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/security/ZWaveSecureInclusionStateTracker.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSecurityCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSecurityCommandClassWithInitialization;
 import org.openhab.binding.zwave.internal.protocol.initialization.ZWaveNodeInitStageAdvancer;
@@ -93,11 +93,13 @@ public class ZWaveSecureInclusionStateTracker {
             // Commands absent from EXPECTED_COMMAND_ORDER_LIST are always ok
             return true;
         }
+
         // Going back to the first step (zero index) is always OK // TODO: DB is it really?
         if (INIT_COMMAND_ORDER_LIST.indexOf(newStep) > 0) {
             // We have to verify where we are at
             int currentIndex = INIT_COMMAND_ORDER_LIST.indexOf(currentStep);
             int newIndex = INIT_COMMAND_ORDER_LIST.indexOf(newStep);
+
             // Accept one message back or the same message(device resending last reply) in addition to the normal one
             // message ahead
             if (newIndex != currentIndex && newIndex - currentIndex > 1) {
@@ -157,7 +159,7 @@ public class ZWaveSecureInclusionStateTracker {
             logger.debug("NODE {}: in InclusionStateTracker.getNextRequest() time left for reply: {}ms, returning {}",
                     node.getNodeId(), (System.currentTimeMillis() - waitForReplyTimeout), nextRequestMessage);
             if (System.currentTimeMillis() > waitForReplyTimeout) {
-                // waited too long for a reply, secure inclusion failed
+                // Waited too long for a reply, secure inclusion failed
                 setErrorState(WAIT_TIME_MILLIS + "ms passed since last request was sent, secure inclusion failed.");
                 return null;
             }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -8,9 +8,17 @@
  */
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Basic;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Generic;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Specific;
 import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveInclusionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,20 +31,20 @@ import org.slf4j.LoggerFactory;
 public class AddNodeMessageClass extends ZWaveCommandProcessor {
     private static final Logger logger = LoggerFactory.getLogger(AddNodeMessageClass.class);
 
-    private final int ADD_NODE_ANY = 0x01;
-    private final int ADD_NODE_CONTROLLER = 0x02;
-    private final int ADD_NODE_SLAVE = 0x03;
-    private final int ADD_NODE_EXISTING = 0x04;
-    private final int ADD_NODE_STOP = 0x05;
-    private final int ADD_NODE_STOP_FAILED = 0x06;
+    private final int ADD_NODE_ANY = 1;
+    private final int ADD_NODE_CONTROLLER = 2;
+    private final int ADD_NODE_SLAVE = 3;
+    private final int ADD_NODE_EXISTING = 4;
+    private final int ADD_NODE_STOP = 5;
+    private final int ADD_NODE_STOP_FAILED = 6;
 
-    private final int ADD_NODE_STATUS_LEARN_READY = 0x01;
-    private final int ADD_NODE_STATUS_NODE_FOUND = 0x02;
-    private final int ADD_NODE_STATUS_ADDING_SLAVE = 0x03;
-    private final int ADD_NODE_STATUS_ADDING_CONTROLLER = 0x04;
-    private final int ADD_NODE_STATUS_PROTOCOL_DONE = 0x05;
-    private final int ADD_NODE_STATUS_DONE = 0x06;
-    private final int ADD_NODE_STATUS_FAILED = 0x07;
+    private final int ADD_NODE_STATUS_LEARN_READY = 1;
+    private final int ADD_NODE_STATUS_NODE_FOUND = 2;
+    private final int ADD_NODE_STATUS_ADDING_SLAVE = 3;
+    private final int ADD_NODE_STATUS_ADDING_CONTROLLER = 4;
+    private final int ADD_NODE_STATUS_PROTOCOL_DONE = 5;
+    private final int ADD_NODE_STATUS_DONE = 6;
+    private final int ADD_NODE_STATUS_FAILED = 7;
 
     private final int OPTION_HIGH_POWER = 0x80;
     private final int OPTION_NETWORK_WIDE = 0x40;
@@ -48,15 +56,19 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
         SerialMessage newMessage = new SerialMessage(SerialMessage.SerialMessageClass.AddNodeToNetwork,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.AddNodeToNetwork,
                 SerialMessage.SerialMessagePriority.High);
-        byte[] newPayload = { (byte) ADD_NODE_ANY, (byte) 255 };
+        byte command = ADD_NODE_ANY;
         if (highPower == true) {
-            newPayload[0] |= OPTION_HIGH_POWER;
+            command |= OPTION_HIGH_POWER;
         }
         if (networkWide == true) {
-            newPayload[0] |= OPTION_NETWORK_WIDE;
+            command |= OPTION_NETWORK_WIDE;
         }
 
-        newMessage.setMessagePayload(newPayload);
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(command);
+        outputData.write(255); // TODO: This should use the callbackId
+        newMessage.setMessagePayload(outputData.toByteArray());
+
         return newMessage;
     }
 
@@ -67,9 +79,12 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
         SerialMessage newMessage = new SerialMessage(SerialMessage.SerialMessageClass.AddNodeToNetwork,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.AddNodeToNetwork,
                 SerialMessage.SerialMessagePriority.High);
-        byte[] newPayload = { (byte) ADD_NODE_STOP };
 
-        newMessage.setMessagePayload(newPayload);
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(ADD_NODE_STOP);
+        outputData.write(255); // TODO: This should use the callbackId
+        newMessage.setMessagePayload(outputData.toByteArray());
+
         return newMessage;
     }
 
@@ -87,8 +102,35 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
                     break;
                 case ADD_NODE_STATUS_ADDING_SLAVE:
                     logger.debug("NODE {}: Adding slave.", incomingMessage.getMessagePayloadByte(2));
-                    zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.IncludeSlaveFound,
-                            incomingMessage.getMessagePayloadByte(2)));
+
+                    int length = incomingMessage.getMessagePayloadByte(3);
+
+                    Basic basic = Basic.getBasic(incomingMessage.getMessagePayloadByte(4));
+                    Generic generic = Generic.getGeneric(incomingMessage.getMessagePayloadByte(5));
+                    Specific specific = Specific.getSpecific(generic, incomingMessage.getMessagePayloadByte(6));
+
+                    List<CommandClass> commandClasses = new ArrayList<CommandClass>();
+
+                    for (int i = 7; i < length + 4; i++) {
+                        int data = incomingMessage.getMessagePayloadByte(i);
+
+                        CommandClass commandClass = CommandClass.getCommandClass(data);
+                        if (commandClass == null) {
+                            continue;
+                        }
+
+                        // Check if this is the control marker
+                        if (commandClass == CommandClass.MARK) {
+                            // TODO: Implement control command classes
+                            break;
+                        }
+
+                        commandClasses.add(commandClass);
+                    }
+
+                    ZWaveInclusionEvent event = new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.IncludeSlaveFound,
+                            incomingMessage.getMessagePayloadByte(2), basic, generic, specific, commandClasses);
+                    zController.notifyEventListeners(event);
                     break;
                 case ADD_NODE_STATUS_ADDING_CONTROLLER:
                     logger.debug("NODE {}: Adding controller.", incomingMessage.getMessagePayloadByte(2));

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
@@ -92,8 +92,6 @@ public class ApplicationUpdateMessageClass extends ZWaveCommandProcessor {
                     for (int i = 6; i < length + 3; i++) {
                         int data = incomingMessage.getMessagePayloadByte(i);
 
-                        logger.trace(String.format("NODE %d: Command class 0x%02X is supported.", nodeId, data));
-
                         CommandClass commandClass = CommandClass.getCommandClass(data);
                         if (commandClass == null) {
                             logger.trace(String.format("NODE %d: Command class 0x%02X is not known.", nodeId, data));

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
@@ -8,9 +8,11 @@
  */
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
+import java.io.ByteArrayOutputStream;
+
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveInclusionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,17 +25,17 @@ import org.slf4j.LoggerFactory;
 public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
     private static final Logger logger = LoggerFactory.getLogger(RemoveNodeMessageClass.class);
 
-    private final int REMOVE_NODE_ANY = 0x01;
-    private final int REMOVE_NODE_CONTROLLER = 0x02;
-    private final int REMOVE_NODE_SLAVE = 0x03;
-    private final int REMOVE_NODE_STOP = 0x05;
+    private final int REMOVE_NODE_ANY = 1;
+    private final int REMOVE_NODE_CONTROLLER = 2;
+    private final int REMOVE_NODE_SLAVE = 3;
+    private final int REMOVE_NODE_STOP = 5;
 
-    private final int REMOVE_NODE_STATUS_LEARN_READY = 0x01;
-    private final int REMOVE_NODE_STATUS_NODE_FOUND = 0x02;
-    private final int REMOVE_NODE_STATUS_REMOVING_SLAVE = 0x03;
-    private final int REMOVE_NODE_STATUS_REMOVING_CONTROLLER = 0x04;
-    private final int REMOVE_NODE_STATUS_DONE = 0x06;
-    private final int REMOVE_NODE_STATUS_FAILED = 0x07;
+    private final int REMOVE_NODE_STATUS_LEARN_READY = 1;
+    private final int REMOVE_NODE_STATUS_NODE_FOUND = 2;
+    private final int REMOVE_NODE_STATUS_REMOVING_SLAVE = 3;
+    private final int REMOVE_NODE_STATUS_REMOVING_CONTROLLER = 4;
+    private final int REMOVE_NODE_STATUS_DONE = 6;
+    private final int REMOVE_NODE_STATUS_FAILED = 7;
 
     public SerialMessage doRequestStart(boolean highPower) {
         logger.debug("Setting controller into EXCLUSION mode.");
@@ -42,9 +44,12 @@ public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
         SerialMessage newMessage = new SerialMessage(SerialMessage.SerialMessageClass.RemoveNodeFromNetwork,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.RemoveNodeFromNetwork,
                 SerialMessage.SerialMessagePriority.High);
-        byte[] newPayload = { (byte) REMOVE_NODE_ANY, (byte) 255 };
 
-        newMessage.setMessagePayload(newPayload);
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(REMOVE_NODE_ANY);
+        outputData.write(255); // TODO: This should use the callbackId
+        newMessage.setMessagePayload(outputData.toByteArray());
+
         return newMessage;
     }
 
@@ -55,9 +60,12 @@ public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
         SerialMessage newMessage = new SerialMessage(SerialMessage.SerialMessageClass.RemoveNodeFromNetwork,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.RemoveNodeFromNetwork,
                 SerialMessage.SerialMessagePriority.High);
-        byte[] newPayload = { (byte) REMOVE_NODE_STOP };
 
-        newMessage.setMessagePayload(newPayload);
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(REMOVE_NODE_STOP);
+        outputData.write(255); // TODO: This should use the callbackId
+        newMessage.setMessagePayload(outputData.toByteArray());
+
         return newMessage;
     }
 
@@ -83,9 +91,12 @@ public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
                         ZWaveInclusionEvent.Type.ExcludeControllerFound, incomingMessage.getMessagePayloadByte(2)));
                 break;
             case REMOVE_NODE_STATUS_DONE:
-                logger.debug("NODE {}: Removed from network.", incomingMessage.getMessagePayloadByte(2));
-                zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.ExcludeDone,
-                        incomingMessage.getMessagePayloadByte(2)));
+                if (incomingMessage.getMessagePayloadByte(2) != 0) {
+                    logger.debug("NODE {}: Removed from network.", incomingMessage.getMessagePayloadByte(2));
+                    zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.ExcludeDone,
+                            incomingMessage.getMessagePayloadByte(2)));
+                }
+                logger.debug("Remove Node: Done.");
                 break;
             case REMOVE_NODE_STATUS_FAILED:
                 logger.debug("Remove Node: Failed.");

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
@@ -12,10 +12,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNodeState;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
@@ -36,6 +36,9 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
         logger.trace("Handle Message Send Data Response");
         if (incomingMessage.getMessagePayloadByte(0) != 0x00) {
             logger.debug("NODE {}: Sent Data successfully placed on stack.", lastSentMessage.getMessageNode());
+
+            // This response is our controller ACK
+            lastSentMessage.setAckRecieved();
         } else {
             // This is an error. This means that the transaction is complete!
             // Set the flag, and return false.
@@ -78,9 +81,6 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
                     node.getNodeId());
             return false;
         }
-
-        // This response is our controller ACK
-        lastSentMessage.setAckRecieved();
 
         switch (status) {
             case COMPLETE_OK:

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
@@ -70,11 +70,10 @@ public abstract class ZWaveCommandProcessor {
         // This is used for multi-stage transactions to ensure we get all parts of the
         // transaction before completing.
         if (lastSentMessage == null || lastSentMessage.isAckPending()) {
-            logger.trace("Checking transaction complete: Message has Ack Pending: {}", lastSentMessage);
-            // Return until we get the ack, then come back and compare. This is necessary since, per ZWaveSendThread, we
-            // sometimes
-            // get the response before the ack. See ZWaveSendThreadcomment starting with "A transaction consists of (up
-            // to) 4 parts"
+            logger.debug("Checking transaction complete: Message has Ack Pending: {}", lastSentMessage);
+            // Return until we get the ack, then come back and compare. This is necessary since, per ZWaveSendThread,
+            // we sometimes get the response before the ack. See ZWaveSendThreadcomment starting with "A transaction
+            // consists of (up to) 4 parts"
             return;
         }
 
@@ -90,7 +89,7 @@ public abstract class ZWaveCommandProcessor {
             }
             final SerialMessage incomingMessage = entry.getValue();
             logger.debug("Checking transaction complete: Recv {}", incomingMessage.toString());
-            final boolean ignoreTransmissionCompleteMismatch = false; // TODO: chagne
+            final boolean ignoreTransmissionCompleteMismatch = false; // TODO: change
             if (incomingMessage.getMessageClass() == lastSentMessage.getExpectedReply()
                     && !incomingMessage.isTransactionCanceled()) {
                 logger.debug(


### PR DESCRIPTION
This refactors the initialisation sequences when a node is included into the network. Information from the AddNode message is used to bypass the initial stages which significantly improves the speed at which nodes complete initialisation once initially included into the network.

This should help speed up battery device inclusion as initialisation starts immediately, and also reduces delays which may contribute to failures in secure inclusion.