### PR TITLE
Z-Wave: Fix time zone inconsistencies inside Clock and TimeParameters

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClockCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClockCommandClassTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
@@ -57,8 +58,12 @@ public class ZWaveClockCommandClassTest extends ZWaveCommandClassTest {
     public void setTime() {
         ZWaveClockCommandClass cls = (ZWaveClockCommandClass) getCommandClass(CommandClass.CLOCK);
 
-        byte[] expectedResponse = { 99, 4, -127, 4, -127, 0 };
-        SerialMessage msg = cls.getSetMessage(new Date(0));
+        byte[] expectedResponse = { 99, 4, -127, 4, -128, 0 };
+
+        Calendar utc = Calendar.getInstance();
+        utc.setTimeZone(TimeZone.getTimeZone("UTC"));
+        utc.setTime(new Date(0));
+        SerialMessage msg = cls.getSetMessage(utc);
 
         assertTrue(Arrays.equals(msg.getMessagePayload(), expectedResponse));
 

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveTimeParametersCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveTimeParametersCommandClassTest.java
@@ -11,8 +11,10 @@ package org.openhab.binding.zwave.test.internal.protocol.commandclass;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
@@ -52,8 +54,12 @@ public class ZWaveTimeParametersCommandClassTest extends ZWaveCommandClassTest {
         ZWaveTimeParametersCommandClass cls = (ZWaveTimeParametersCommandClass) getCommandClass(
                 CommandClass.TIME_PARAMETERS);
 
-        byte[] expectedResponse = { 99, 9, -117, 1, 7, -78, 1, 1, 1, 0, 0 };
-        SerialMessage msg = cls.getSetMessage(new Date(0));
+        byte[] expectedResponse = { 99, 9, -117, 1, 7, -78, 1, 1, 0, 0, 0 };
+
+        Calendar utc = Calendar.getInstance();
+        utc.setTimeZone(TimeZone.getTimeZone("UTC"));
+        utc.setTime(new Date(0));
+        SerialMessage msg = cls.getSetMessage(utc);
 
         assertTrue(Arrays.equals(msg.getMessagePayload(), expectedResponse));
     }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveClockConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveClockConverter.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.zwave.internal.converter;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class ZWaveClockConverter extends ZWaveCommandClassConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(ZWaveClockConverter.class);
 
-    private Date lastClockUpdate = new Date();
+    private Calendar lastClockUpdate = Calendar.getInstance();
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveClockConverter} class.
@@ -83,7 +84,8 @@ public class ZWaveClockConverter extends ZWaveCommandClassConverter {
                 long clockOffset = Math.abs(nodeTime.getTime() - System.currentTimeMillis()) / 1000;
 
                 // If the clock is outside the offset, then update
-                if (clockOffset > offsetAllowed && lastClockUpdate.getTime() < (new Date().getTime() - 30000)) {
+                if (clockOffset > offsetAllowed
+                		&& lastClockUpdate.getTimeInMillis() < (Calendar.getInstance().getTimeInMillis() - 30000)) {
                     logger.debug("NODE {}: Clock was {} seconds off. Time will be updated.", event.getNodeId(),
                             clockOffset);
 
@@ -91,8 +93,8 @@ public class ZWaveClockConverter extends ZWaveCommandClassConverter {
                     ZWaveClockCommandClass commandClass = (ZWaveClockCommandClass) node
                             .resolveCommandClass(ZWaveCommandClass.CommandClass.CLOCK, channel.getEndpoint());
 
-                    SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(new Date()), commandClass,
-                            channel.getEndpoint());
+                    SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(Calendar.getInstance()),
+                    		commandClass, channel.getEndpoint());
                     if (serialMessage == null) {
                         logger.warn("Generating message failed for command class = {}, node = {}, endpoint = {}",
                                 commandClass.getCommandClass().getLabel(), node.getNodeId(), channel.getEndpoint());
@@ -103,7 +105,7 @@ public class ZWaveClockConverter extends ZWaveCommandClassConverter {
 
                     // We keep track of the last time we set the time to avoid a pathalogical loop if the time set
                     // doesn't work
-                    lastClockUpdate = new Date();
+                    lastClockUpdate = Calendar.getInstance();
 
                     // And request a read-back
                     serialMessage = node.encapsulate(commandClass.getValueMessage(), commandClass,
@@ -135,7 +137,7 @@ public class ZWaveClockConverter extends ZWaveCommandClassConverter {
         ZWaveClockCommandClass commandClass = (ZWaveClockCommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.CLOCK, channel.getEndpoint());
 
-        SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(new Date()), commandClass,
+        SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(Calendar.getInstance()), commandClass,
                 channel.getEndpoint());
         if (serialMessage == null) {
             logger.warn("Generating message failed for command class = {}, node = {}, endpoint = {}",

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveTimeParametersConverter.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveTimeParametersConverter.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.zwave.internal.converter;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -91,8 +92,8 @@ public class ZWaveTimeParametersConverter extends ZWaveCommandClassConverter {
                     ZWaveTimeParametersCommandClass commandClass = (ZWaveTimeParametersCommandClass) node
                             .resolveCommandClass(ZWaveCommandClass.CommandClass.TIME_PARAMETERS, channel.getEndpoint());
 
-                    SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(new Date()), commandClass,
-                            channel.getEndpoint());
+                    SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(Calendar.getInstance()),
+                            commandClass, channel.getEndpoint());
                     if (serialMessage == null) {
                         logger.warn("Generating message failed for command class = {}, node = {}, endpoint = {}",
                                 commandClass.getCommandClass().getLabel(), node.getNodeId(), channel.getEndpoint());
@@ -135,7 +136,7 @@ public class ZWaveTimeParametersConverter extends ZWaveCommandClassConverter {
         ZWaveTimeParametersCommandClass commandClass = (ZWaveTimeParametersCommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.TIME_PARAMETERS, channel.getEndpoint());
 
-        SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(new Date()), commandClass,
+        SerialMessage serialMessage = node.encapsulate(commandClass.getSetMessage(Calendar.getInstance()), commandClass,
                 channel.getEndpoint());
         if (serialMessage == null) {
             logger.warn("Generating message failed for command class = {}, node = {}, endpoint = {}",

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClockCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClockCommandClass.java
@@ -92,11 +92,8 @@ public class ZWaveClockCommandClass extends ZWaveCommandClass
      *
      * @return the serial message.
      */
-    public SerialMessage getSetMessage(Date date) {
+    public SerialMessage getSetMessage(Calendar cal) {
         logger.debug("NODE {}: Creating new message for command CLOCK_SET", getNode().getNodeId());
-
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(date);
 
         int day = cal.get(Calendar.DAY_OF_WEEK) == 1 ? 7 : cal.get(Calendar.DAY_OF_WEEK) - 1;
         int hour = cal.get(Calendar.HOUR_OF_DAY);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveTimeParametersCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveTimeParametersCommandClass.java
@@ -90,11 +90,8 @@ public class ZWaveTimeParametersCommandClass extends ZWaveCommandClass
      *
      * @return the serial message.
      */
-    public SerialMessage getSetMessage(Date date) {
+    public SerialMessage getSetMessage(Calendar cal) {
         logger.debug("NODE {}: Creating new message for command TIME_SET", getNode().getNodeId());
-
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(date);
 
         SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
                 SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.RealTime);


### PR DESCRIPTION
Modify getSetMessage to accept a Calendar object instead of a Date object so the timezone is not a factor when creating the message.

Fixes #907 
Signed-off-by: Trey Sheldon <glsheldo@gmail.com> (github: tsheldon)