### PR TITLE
ZWave add tests for most command class message creation

### DIFF
--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
@@ -8,12 +8,15 @@
  */
 package org.openhab.binding.zwave.test.internal.protocol.commandclass;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.AlarmType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ZWaveAlarmValueEvent;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
@@ -41,6 +44,58 @@ public class ZWaveAlarmCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(event.getEndpoint(), 0);
         assertEquals(event.getAlarmType(), ZWaveAlarmCommandClass.AlarmType.SMOKE);
         assertEquals(event.getAlarmStatus(), 0xFF);
+    }
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveAlarmCommandClass cls = (ZWaveAlarmCommandClass) getCommandClass(CommandClass.ALARM);
+        SerialMessage msg;
+
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        assertNull(msg);
+
+        byte[] expectedResponseV2 = { 1, 9, 0, 19, 99, 2, 113, 7, 0, 0, -14 };
+        cls.setVersion(2);
+        msg = cls.getSupportedMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV2));
+    }
+
+    @Test
+    public void getSupportedEventMessage() {
+        ZWaveAlarmCommandClass cls = (ZWaveAlarmCommandClass) getCommandClass(CommandClass.ALARM);
+        SerialMessage msg;
+
+        cls.setVersion(1);
+        msg = cls.getSupportedEventMessage(1);
+        assertNull(msg);
+
+        byte[] expectedResponseV3 = { 1, 10, 0, 19, 99, 3, 113, 1, 1, 0, 0, -9 };
+        cls.setVersion(3);
+        msg = cls.getSupportedEventMessage(1);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV3));
+    }
+
+    @Test
+    public void getMessage() {
+        ZWaveAlarmCommandClass cls = (ZWaveAlarmCommandClass) getCommandClass(CommandClass.ALARM);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 113, 4, 6, 0, 0, -11 };
+        cls.setVersion(1);
+        msg = cls.getMessage(AlarmType.ACCESS_CONTROL);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+
+        byte[] expectedResponseV2 = { 1, 11, 0, 19, 99, 4, 113, 4, 0, 6, 0, 0, -13 };
+        cls.setVersion(2);
+        msg = cls.getMessage(AlarmType.ACCESS_CONTROL);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV2));
+
+        byte[] expectedResponseV3 = { 1, 12, 0, 19, 99, 5, 113, 4, 0, 6, 1, 0, 0, -12 };
+        cls.setVersion(3);
+        msg = cls.getMessage(AlarmType.ACCESS_CONTROL);
+        byte[] b = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV3));
     }
 
 }

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmSensorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmSensorCommandClassTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass.AlarmType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveAlarmSensorCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveAlarmSensorCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveAlarmSensorCommandClass cls = (ZWaveAlarmSensorCommandClass) getCommandClass(CommandClass.SENSOR_ALARM);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -100, 3, 0, 0, 27 };
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getMessage() {
+        ZWaveAlarmSensorCommandClass cls = (ZWaveAlarmSensorCommandClass) getCommandClass(CommandClass.SENSOR_ALARM);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -100, 1, 6, 0, 0, 29 };
+        cls.setVersion(1);
+        msg = cls.getMessage(AlarmType.ACCESS_CONTROL);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAssociationCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveAlarmSensorCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getAssociationMessage() {
+        ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -123, 2, 1, 0, 0, 0 };
+        cls.setVersion(1);
+        msg = cls.getAssociationMessage(1);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getGroupingsMessage() {
+        ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -123, 5, 0, 0, 4 };
+        cls.setVersion(1);
+        msg = cls.getGroupingsMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void removeAssociationMessage() {
+        ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 11, 0, 19, 99, 4, -123, 4, 1, 1, 0, 0, 1 };
+        cls.setVersion(1);
+        msg = cls.removeAssociationMessage(1, 1);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setAssociationMessage() {
+        ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 11, 0, 19, 99, 4, -123, 1, 1, 1, 0, 0, 4 };
+        cls.setVersion(1);
+        msg = cls.setAssociationMessage(1, 1);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBarrierOperatorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBarrierOperatorCommandClassTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBarrierOperatorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBarrierOperatorCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveBarrierOperatorCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveBarrierOperatorCommandClass cls = (ZWaveBarrierOperatorCommandClass) getCommandClass(
+                CommandClass.BARRIER_OPERATOR);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 102, 2, 0, 0, -32 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveBarrierOperatorCommandClass cls = (ZWaveBarrierOperatorCommandClass) getCommandClass(
+                CommandClass.BARRIER_OPERATOR);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 102, 1, -1, 0, 0, 30 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(77);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBasicCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBasicCommandClassTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBasicCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveBasicCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveBasicCommandClass cls = (ZWaveBasicCommandClass) getCommandClass(CommandClass.BASIC);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 32, 2, 0, 0, -90 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveBasicCommandClass cls = (ZWaveBasicCommandClass) getCommandClass(CommandClass.BASIC);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 32, 1, 34, 0, 0, -123 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(34);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBatteryCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveBatteryCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveBatteryCommandClass cls = (ZWaveBatteryCommandClass) getCommandClass(CommandClass.BATTERY);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -128, 2, 0, 0, 6 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBinarySensorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBinarySensorCommandClassTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBinarySensorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBinarySensorCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveBinarySensorCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveBinarySensorCommandClass cls = (ZWaveBinarySensorCommandClass) getCommandClass(CommandClass.SENSOR_BINARY);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 48, 2, 0, 0, -74 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBinarySwitchCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBinarySwitchCommandClassTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBinarySwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBinarySwitchCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveBinarySwitchCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveBinarySwitchCommandClass cls = (ZWaveBinarySwitchCommandClass) getCommandClass(CommandClass.SWITCH_BINARY);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 37, 2, 0, 0, -93 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveBinarySwitchCommandClass cls = (ZWaveBinarySwitchCommandClass) getCommandClass(CommandClass.SWITCH_BINARY);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 37, 1, -1, 0, 0, 93 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(33);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveCentralSceneCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveCentralSceneCommandClassTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCentralSceneCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+/**
+ * Test cases for {@link ZWaveBatteryCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveCentralSceneCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveCentralSceneCommandClass cls = (ZWaveCentralSceneCommandClass) getCommandClass(CommandClass.CENTRAL_SCENE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 91, 1, 0, 0, -34 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveConfigurationCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveConfigurationCommandClassTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveConfigurationParameter;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveConfigurationCommandClass;
+
+/**
+ * Test cases for {@link ZWaveConfigurationCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveConfigurationCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveConfigurationCommandClass cls = (ZWaveConfigurationCommandClass) getCommandClass(
+                CommandClass.CONFIGURATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 112, 5, 12, 0, 0, -1 };
+        cls.setVersion(1);
+        msg = cls.getConfigMessage(12);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveConfigurationCommandClass cls = (ZWaveConfigurationCommandClass) getCommandClass(
+                CommandClass.CONFIGURATION);
+        SerialMessage msg;
+
+        ZWaveConfigurationParameter parameter = new ZWaveConfigurationParameter(12, 34, 4);
+
+        byte[] expectedResponseV1 = { 1, 15, 0, 19, 99, 8, 112, 4, 12, 4, 0, 0, 0, 34, 0, 0, -42 };
+        cls.setVersion(1);
+        msg = cls.setConfigMessage(parameter);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveIndicatorCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveIndicatorCommandClassTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass;
+
+/**
+ * Test cases for {@link ZWaveIndicatorCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveIndicatorCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveIndicatorCommandClass cls = (ZWaveIndicatorCommandClass) getCommandClass(CommandClass.INDICATOR);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -121, 2, 0, 0, 1 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveIndicatorCommandClass cls = (ZWaveIndicatorCommandClass) getCommandClass(CommandClass.INDICATOR);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -121, 1, 34, 0, 0, 34 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(34);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveManufacturerSpecificCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveManufacturerSpecificCommandClassTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveManufacturerSpecificCommandClass;
+
+/**
+ * Test cases for {@link ZWaveManufacturerSpecificCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveManufacturerSpecificCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveManufacturerSpecificCommandClass cls = (ZWaveManufacturerSpecificCommandClass) getCommandClass(
+                CommandClass.MANUFACTURER_SPECIFIC);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 114, 4, 0, 0, -14 };
+        cls.setVersion(1);
+        msg = cls.getManufacturerSpecificMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterCommandClassTest.java
@@ -8,14 +8,19 @@
  */
 package org.openhab.binding.zwave.test.internal.protocol.commandclass;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterCommandClass.MeterScale;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterCommandClass.ZWaveMeterValueEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 
@@ -64,4 +69,51 @@ public class ZWaveMeterCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(event.getValue(), new BigDecimal("154.653"));
     }
 
+    @Test
+    public void setValueMessage() {
+        ZWaveMeterCommandClass cls = (ZWaveMeterCommandClass) getCommandClass(CommandClass.METER);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 50, 1, 0, 0, -73 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getResetMessage() {
+        ZWaveMeterCommandClass cls = (ZWaveMeterCommandClass) getCommandClass(CommandClass.METER);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 50, 5, 0, 0, -77 };
+        cls.setVersion(2);
+        Map<String, String> options = new HashMap<String, String>();
+        options.put("meterCanReset", "true");
+        cls.setOptions(options);
+        msg = cls.getResetMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveMeterCommandClass cls = (ZWaveMeterCommandClass) getCommandClass(CommandClass.METER);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 50, 3, 0, 0, -75 };
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getMessage() {
+        ZWaveMeterCommandClass cls = (ZWaveMeterCommandClass) getCommandClass(CommandClass.METER);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 50, 1, 0, 0, 0, -75 };
+        cls.setVersion(1);
+        msg = cls.getMessage(MeterScale.E_KWh);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
 }

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterPulseCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterPulseCommandClassTest.java
@@ -8,12 +8,15 @@
  */
 package org.openhab.binding.zwave.test.internal.protocol.commandclass;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMeterPulseCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 
@@ -25,7 +28,7 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 public class ZWaveMeterPulseCommandClassTest extends ZWaveCommandClassTest {
 
     @Test
-    public void reportTime() {
+    public void reportValue() {
         byte[] packetData = { 0x01, 0x0F, 0x00, 0x04, 0x00, 0x01, 0x07, (byte) 0x35, 0x05, 0x00, 0x01, 0x00, 0x00,
                 (byte) 0xC3 };
 
@@ -37,5 +40,16 @@ public class ZWaveMeterPulseCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(event.getCommandClass(), CommandClass.METER_PULSE);
         assertEquals(event.getEndpoint(), 0);
         assertEquals((int) event.getValue(), 65536);
+    }
+
+    @Test
+    public void getValueMessage() {
+        ZWaveMeterPulseCommandClass cls = (ZWaveMeterPulseCommandClass) getCommandClass(CommandClass.METER_PULSE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 53, 4, 0, 0, -75 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 }

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWavePowerLevelCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWavePowerLevelCommandClassTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWavePowerLevelCommandClass;
+
+/**
+ * Test cases for {@link ZWaveBasicCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWavePowerLevelCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWavePowerLevelCommandClass cls = (ZWavePowerLevelCommandClass) getCommandClass(CommandClass.POWERLEVEL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 115, 2, 0, 0, -11 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWavePowerLevelCommandClass cls = (ZWavePowerLevelCommandClass) getCommandClass(CommandClass.POWERLEVEL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 11, 0, 19, 99, 4, 115, 1, 1, 1, 0, 0, -14 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(1, 1);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveSwitchAllCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveSwitchAllCommandClassTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass.SwitchAllMode;
+
+/**
+ * Test cases for {@link ZWaveSwitchAllCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveSwitchAllCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveSwitchAllCommandClass cls = (ZWaveSwitchAllCommandClass) getCommandClass(CommandClass.SWITCH_ALL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 39, 2, 0, 0, -95 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveSwitchAllCommandClass cls = (ZWaveSwitchAllCommandClass) getCommandClass(CommandClass.SWITCH_ALL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, 39, 1, 2, 0, 0, -94 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(SwitchAllMode.SWITCH_ALL_INCLUDE_OFF_ONLY.ordinal());
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void allOnMessage() {
+        ZWaveSwitchAllCommandClass cls = (ZWaveSwitchAllCommandClass) getCommandClass(CommandClass.SWITCH_ALL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 39, 4, 0, 0, -89 };
+        cls.setVersion(1);
+        msg = cls.allOnMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void allOffMessage() {
+        ZWaveSwitchAllCommandClass cls = (ZWaveSwitchAllCommandClass) getCommandClass(CommandClass.SWITCH_ALL);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 39, 5, 0, 0, -90 };
+        cls.setVersion(1);
+        msg = cls.allOffMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClassTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveThermostatFanModeCommandClass;
+
+/**
+ * Test cases for {@link ZWaveBasicCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveThermostatFanModeCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveThermostatFanModeCommandClass cls = (ZWaveThermostatFanModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_FAN_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 68, 2, 0, 0, -62 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveThermostatFanModeCommandClass cls = (ZWaveThermostatFanModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_FAN_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 68, 4, 0, 0, -60 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(34);
+        // byte[] x = msg.getMessageBuffer();
+        // assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveThermostatFanModeCommandClass cls = (ZWaveThermostatFanModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_FAN_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 68, 4, 0, 0, -60 };
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatFanStateCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatFanStateCommandClassTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveThermostatFanStateCommandClass;
+
+/**
+ * Test cases for {@link ZWaveThermostatFanStateCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveThermostatFanStateCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveThermostatFanStateCommandClass cls = (ZWaveThermostatFanStateCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_FAN_STATE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 69, 2, 0, 0, -61 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatModeCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatModeCommandClassTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveThermostatModeCommandClass;
+
+/**
+ * Test cases for {@link ZWaveBasicCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveThermostatModeCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveThermostatModeCommandClass cls = (ZWaveThermostatModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 64, 2, 0, 0, -58 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveThermostatModeCommandClass cls = (ZWaveThermostatModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 64, 4, 0, 0, -64 };
+        cls.setVersion(1);
+        // msg = cls.setValueMessage(34);
+        // byte[] x = msg.getMessageBuffer();
+        // assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveThermostatModeCommandClass cls = (ZWaveThermostatModeCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_MODE);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 64, 4, 0, 0, -64 };
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClassTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveThermostatSetpointCommandClass;
+
+/**
+ * Test cases for {@link ZWaveThermostatSetpointCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveThermostatSetpointCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveThermostatSetpointCommandClass cls = (ZWaveThermostatSetpointCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_SETPOINT);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 67, 4, 0, 0, -61 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveThermostatSetpointCommandClass cls = (ZWaveThermostatSetpointCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_SETPOINT);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 67, 4, 0, 0, -61 };
+        cls.setVersion(1);
+        // msg = cls.setValueMessage(34);
+        // byte[] x = msg.getMessageBuffer();
+        // assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getSupportedMessage() {
+        ZWaveThermostatSetpointCommandClass cls = (ZWaveThermostatSetpointCommandClass) getCommandClass(
+                CommandClass.THERMOSTAT_SETPOINT);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, 67, 4, 0, 0, -61 };
+        cls.setVersion(1);
+        msg = cls.getSupportedMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveVersionCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveVersionCommandClassTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveVersionCommandClass;
+
+/**
+ * Test cases for {@link ZWaveVersionCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveVersionCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getVersionMessage() {
+        ZWaveVersionCommandClass cls = (ZWaveVersionCommandClass) getCommandClass(CommandClass.VERSION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -122, 17, 0, 0, 19 };
+        cls.setVersion(1);
+        msg = cls.getVersionMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveVersionCommandClass cls = (ZWaveVersionCommandClass) getCommandClass(CommandClass.VERSION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -122, 19, 113, 0, 0, 98 };
+        cls.setVersion(1);
+        msg = cls.getCommandClassVersionMessage(CommandClass.ALARM);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveWakeUpCommandClassTest.java
+++ b/addons/binding/org.openhab.binding.zwave.test/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveWakeUpCommandClassTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
+
+/**
+ * Test cases for {@link ZWaveWakeUpCommandClass}.
+ *
+ * @author Chris Jackson - Initial version
+ */
+public class ZWaveWakeUpCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getNoMoreInformationMessage() {
+        ZWaveWakeUpCommandClass cls = (ZWaveWakeUpCommandClass) getCommandClass(CommandClass.WAKE_UP);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -124, 8, 0, 0, 8 };
+        cls.setVersion(1);
+        msg = cls.getNoMoreInformationMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getIntervalMessage() {
+        ZWaveWakeUpCommandClass cls = (ZWaveWakeUpCommandClass) getCommandClass(CommandClass.WAKE_UP);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -124, 5, 0, 0, 5 };
+        cls.setVersion(1);
+        msg = cls.getIntervalMessage();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setInterval() {
+        ZWaveWakeUpCommandClass cls = (ZWaveWakeUpCommandClass) getCommandClass(CommandClass.WAKE_UP);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 13, 0, 19, 99, 6, -124, 4, 0, 38, -108, 0, 0, 0, -74 };
+        cls.setVersion(1);
+        msg = cls.setInterval(9876);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getIntervalCapabilitiesMessage() {
+        ZWaveWakeUpCommandClass cls = (ZWaveWakeUpCommandClass) getCommandClass(CommandClass.WAKE_UP);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -124, 9, 0, 0, 9 };
+        cls.setVersion(1);
+        msg = cls.getIntervalCapabilitiesMessage();
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
@@ -82,7 +82,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug("NODE {}: Received Sensor Alarm Request", this.getNode().getNodeId());
+        logger.debug("NODE {}: Received SENSOR_ALARM command V{}", getNode().getNodeId(), getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case SENSOR_ALARM_REPORT:
@@ -97,12 +97,12 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
                 if (alarm != null) {
                     alarm.setInitialised();
 
-                    logger.debug("NODE {}: Alarm Report: Source={}, Type={}({}), Value={}", this.getNode().getNodeId(),
+                    logger.debug("NODE {}: Alarm Report: Source={}, Type={}({}), Value={}", getNode().getNodeId(),
                             sourceNode, alarm.getAlarmType().getLabel(), alarmTypeCode, value);
 
-                    ZWaveAlarmSensorValueEvent zEvent = new ZWaveAlarmSensorValueEvent(this.getNode().getNodeId(),
-                            endpoint, alarm.getAlarmType(), value);
-                    this.getController().notifyEventListeners(zEvent);
+                    ZWaveAlarmSensorValueEvent zEvent = new ZWaveAlarmSensorValueEvent(getNode().getNodeId(), endpoint,
+                            alarm.getAlarmType(), value);
+                    getController().notifyEventListeners(zEvent);
                 }
                 break;
             case SENSOR_ALARM_SUPPORTED_REPORT:
@@ -198,13 +198,13 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
      */
     public SerialMessage getMessage(AlarmType alarmType) {
         if (isGetSupported == false) {
-            logger.debug("NODE {}: Node doesn't support get requests", this.getNode().getNodeId());
+            logger.debug("NODE {}: Node doesn't support get requests", getNode().getNodeId());
             return null;
         }
 
-        logger.debug("NODE {}: Creating new message for command SENSOR_ALARM_GET, type {}", this.getNode().getNodeId(),
+        logger.debug("NODE {}: Creating new message for command SENSOR_ALARM_GET, type {}", getNode().getNodeId(),
                 alarmType.getLabel());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
                 SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.Get);
         byte[] newPayload = { (byte) this.getNode().getNodeId(), 3, (byte) getCommandClass().getKey(),
                 (byte) SENSOR_ALARM_GET, (byte) alarmType.getKey() };
@@ -230,22 +230,9 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
         logger.debug("NODE {}: Creating new message for command SENSOR_ALARM_SUPPORTED_GET",
                 this.getNode().getNodeId());
 
-        if (this.getNode().getManufacturer() == 0x010F && this.getNode().getDeviceType() == 0x0501) {
-            logger.warn(
-                    "NODE {}: Detected Fibaro FGBS001 Universal Sensor - this device fails to respond to SENSOR_ALARM_GET and SENSOR_ALARM_SUPPORTED_GET.",
-                    this.getNode().getNodeId());
-            return null;
-        }
-        if (this.getNode().getManufacturer() == 0x010F && this.getNode().getDeviceType() == 0x0600) {
-            logger.warn(
-                    "NODE {}: Detected Fibaro FGWPE Wall Plug - this device fails to respond to SENSOR_ALARM_GET and SENSOR_ALARM_SUPPORTED_GET.",
-                    this.getNode().getNodeId());
-            return null;
-        }
-
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
                 SerialMessageType.Request, SerialMessageClass.ApplicationCommandHandler, SerialMessagePriority.High);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
+        byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
                 (byte) SENSOR_ALARM_SUPPORTED_GET };
         result.setMessagePayload(newPayload);
         return result;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBarrierOperatorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBarrierOperatorCommandClass.java
@@ -42,14 +42,14 @@ public class ZWaveBarrierOperatorCommandClass extends ZWaveCommandClass
 
     private static final Logger logger = LoggerFactory.getLogger(ZWaveBarrierOperatorCommandClass.class);
 
-    public static final int BARRIER_OPERATOR_SET = 0x01;
-    public static final int BARRIER_OPERATOR_GET = 0x02;
-    public static final int BARRIER_OPERATOR_REPORT = 0x03;
-    public static final int BARRIER_OPERATOR_SIGNAL_SUPPORTED_GET = 0x04;
-    public static final int BARRIER_OPERATOR_SIGNAL_SUPPORTED_REPORT = 0x05;
-    public static final int BARRIER_OPERATOR_SIGNAL_SET = 0x06;
-    public static final int BARRIER_OPERATOR_SIGNAL_GET = 0x07;
-    public static final int BARRIER_OPERATOR_SIGNAL_REPORT = 0x08;
+    public static final int BARRIER_OPERATOR_SET = 1;
+    public static final int BARRIER_OPERATOR_GET = 2;
+    public static final int BARRIER_OPERATOR_REPORT = 3;
+    public static final int BARRIER_OPERATOR_SIGNAL_SUPPORTED_GET = 4;
+    public static final int BARRIER_OPERATOR_SIGNAL_SUPPORTED_REPORT = 5;
+    public static final int BARRIER_OPERATOR_SIGNAL_SET = 6;
+    public static final int BARRIER_OPERATOR_SIGNAL_GET = 7;
+    public static final int BARRIER_OPERATOR_SIGNAL_REPORT = 8;
 
     @XStreamOmitField
     private boolean dynamicDone = false;
@@ -66,30 +66,29 @@ public class ZWaveBarrierOperatorCommandClass extends ZWaveCommandClass
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug("NODE {}: Received Barrier Operator Request", this.getNode().getNodeId());
+        logger.debug("NODE {}: Received BARRIER_OPERATOR command V{}", getNode().getNodeId(), getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case BARRIER_OPERATOR_REPORT:
                 logger.trace("Process Barrier Operator Report");
                 int value = serialMessage.getMessagePayloadByte(offset + 1);
-                logger.debug("NODE {}: Barrier Operator report, value = {}", this.getNode().getNodeId(), value);
+                logger.debug("NODE {}: Barrier Operator report, value = {}", getNode().getNodeId(), value);
 
-                ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(),
-                        endpoint, this.getCommandClass(), value,
-                        BarrierOperatorStateType.getBarrierOperatorStateType(value));
+                ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(), endpoint,
+                        getCommandClass(), value, BarrierOperatorStateType.getBarrierOperatorStateType(value));
 
                 this.getController().notifyEventListeners(zEvent);
                 break;
             default:
                 logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command,
-                        this.getCommandClass().getLabel(), this.getCommandClass().getKey()));
+                        getCommandClass().getLabel(), this.getCommandClass().getKey()));
         }
     }
 
     @Override
     public SerialMessage setValueMessage(int value) {
         logger.debug("NODE {}: Creating new message for application command BARRIER_OPERATOR_SET",
-                this.getNode().getNodeId());
+                getNode().getNodeId());
         SerialMessage message = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
                 SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.Set);
         ByteArrayOutputStream outputData = new ByteArrayOutputStream();

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCentralSceneCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCentralSceneCommandClass.java
@@ -74,7 +74,7 @@ public class ZWaveCentralSceneCommandClass extends ZWaveCommandClass
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug("NODE {}: Received central scene command (v{})", this.getNode().getNodeId(), this.getVersion());
+        logger.debug("NODE {}: Received CENTRAL_SCENE command V{}", getNode().getNodeId(), getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case SCENE_SET:

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterTblMonitorCommandClass.java
@@ -43,22 +43,22 @@ public class ZWaveMeterTblMonitorCommandClass extends ZWaveCommandClass
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveMeterTblMonitorCommandClass.class);
 
-    private static final byte METER_TBL_TABLE_ID_GET = 0x03;
-    private static final byte METER_TBL_TABLE_ID_REPORT = 0x04;
-    private static final byte METER_TBL_TABLE_CAPABILITY_GET = 0x05;
-    private static final byte METER_TBL_REPORT = 0x06;
-    private static final byte METER_TBL_CURRENT_DATA_GET = 0x0C;
-    private static final byte METER_TBL_CURRENT_DATA_REPORT = 0x0D;
+    private static final byte METER_TBL_TABLE_ID_GET = 3;
+    private static final byte METER_TBL_TABLE_ID_REPORT = 4;
+    private static final byte METER_TBL_TABLE_CAPABILITY_GET = 5;
+    private static final byte METER_TBL_REPORT = 6;
+    private static final byte METER_TBL_CURRENT_DATA_GET = 12;
+    private static final byte METER_TBL_CURRENT_DATA_REPORT = 13;
 
-    // unsuported private static final byte METER_TBL_STATUS_REPORT = 0x0B;
-    // unsuported private static final byte METER_TBL_STATUS_DATE_GET = 0x0A;
-    // unsuported private static final byte METER_TBL_STATUS_DEPTH_GET = 0x09;
-    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_GET = 0x07;
-    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_REPORT = 0x08;
-    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_GET = 0x0E;
-    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_REPORT = 0x0F;;
-    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_GET = 0x01;
-    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_REPORT = 0x02;
+    // unsuported private static final byte METER_TBL_STATUS_REPORT = 11;
+    // unsuported private static final byte METER_TBL_STATUS_DATE_GET = 10;
+    // unsuported private static final byte METER_TBL_STATUS_DEPTH_GET = 9;
+    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_GET = 7;
+    // unsuported private static final byte METER_TBL_STATUS_SUPPORTED_REPORT = 8;
+    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_GET = 14;
+    // unsuported private static final byte METER_TBL_HISTORICAL_DATA_REPORT = 15;
+    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_GET = 1;
+    // unsuported private static final byte METER_TBL_TABLE_POINT_ADM_NO_REPORT = 2;
 
     @XStreamOmitField
     private boolean initialiseDone = false;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -36,11 +36,11 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveSwitchAllCommandClass.class);
 
-    private static final int SWITCH_ALL_SET = 0x01;
-    private static final int SWITCH_ALL_GET = 0x02;
-    private static final int SWITCH_ALL_REPORT = 0x03;
-    private static final int SWITCH_ALL_ON = 0x04;
-    private static final int SWITCH_ALL_OFF = 0x05;
+    private static final int SWITCH_ALL_SET = 1;
+    private static final int SWITCH_ALL_GET = 2;
+    private static final int SWITCH_ALL_REPORT = 3;
+    private static final int SWITCH_ALL_ON = 4;
+    private static final int SWITCH_ALL_OFF = 5;
 
     public enum SwitchAllMode {
         SWITCH_ALL_EXCLUDED(0x00, "not included in either All On or All Off groups"),
@@ -121,20 +121,20 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug(String.format("Received Switch All Request for Node ID = %d", this.getNode().getNodeId()));
+        logger.debug("NODE {}: Received SWITCH_ALL command V{}", getNode().getNodeId());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case SWITCH_ALL_SET:
                 logger.debug("Switch All Set sent to the controller will be processed as Switch All Report");
-                this.processSwitchAllReport(serialMessage, offset, endpoint);
+                processSwitchAllReport(serialMessage, offset, endpoint);
                 break;
             case SWITCH_ALL_REPORT:
-                this.processSwitchAllReport(serialMessage, offset, endpoint);
+                processSwitchAllReport(serialMessage, offset, endpoint);
                 initialiseDone = true;
                 break;
             default:
                 logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command,
-                        this.getCommandClass().getLabel(), this.getCommandClass().getKey()));
+                        getCommandClass().getLabel(), getCommandClass().getKey()));
         }
     }
 
@@ -144,28 +144,28 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
         mode = SwitchAllMode.fromInteger(m);
 
         if (mode != null) {
-            logger.debug("NODE {}: Switch All report, {}.", this.getNode().getNodeId(), mode.getDescription());
+            logger.debug("NODE {}: Switch All report, {}.", getNode().getNodeId(), mode.getDescription());
         } else {
-            logger.debug("NODE {}: Switch All unsupported mode.", this.getNode().getNodeId());
+            logger.debug("NODE {}: Switch All unsupported mode.", getNode().getNodeId());
             return;
         }
 
-        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
+        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(), endpoint,
                 CommandClass.SWITCH_ALL, new Integer(m));
-        this.getController().notifyEventListeners(zEvent);
+        getController().notifyEventListeners(zEvent);
     }
 
     public SerialMessage getValueMessage() {
-        if (!this.isGetSupported) {
-            logger.debug("NODE {}: Node doesn't support get requests", this.getNode().getNodeId());
+        if (!isGetSupported) {
+            logger.debug("NODE {}: Node doesn't support get requests", getNode().getNodeId());
             return null;
         }
 
-        logger.debug("NODE {}: Creating new message for command SWITCH_ALL_GET", this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
+        logger.debug("NODE {}: Creating new message for command SWITCH_ALL_GET", getNode().getNodeId());
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.ApplicationCommandHandler,
                 SerialMessage.SerialMessagePriority.Get);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 2, (byte) this.getCommandClass().getKey(),
+        byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
                 (byte) SWITCH_ALL_GET };
         result.setMessagePayload(newPayload);
         return result;
@@ -183,17 +183,17 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
         mode = SwitchAllMode.fromInteger(newMode);
 
         if (mode != null) {
-            logger.debug("NODE {}: Switch All report, {}.", this.getNode().getNodeId(), mode.getDescription());
+            logger.debug("NODE {}: Switch All report, {}.", getNode().getNodeId(), mode.getDescription());
         } else {
-            logger.debug("NODE {}: Switch All unsupported mode.", this.getNode().getNodeId());
+            logger.debug("NODE {}: Switch All unsupported mode.", getNode().getNodeId());
             return null;
         }
 
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 3, (byte) this.getCommandClass().getKey(),
-                (byte) SWITCH_ALL_SET, (byte) newMode };
+        byte[] newPayload = { (byte) getNode().getNodeId(), 3, (byte) getCommandClass().getKey(), (byte) SWITCH_ALL_SET,
+                (byte) newMode };
 
         result.setMessagePayload(newPayload);
         return result;
@@ -205,11 +205,11 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
      * @return
      */
     public SerialMessage allOnMessage() {
-        logger.debug("NODE {}: Switch All - Creating All On message.", this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
+        logger.debug("NODE {}: Switch All - Creating All On message.", getNode().getNodeId());
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 2, (byte) this.getCommandClass().getKey(),
+        byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
                 (byte) SWITCH_ALL_ON };
         result.setMessagePayload(newPayload);
         return result;
@@ -221,11 +221,11 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
      * @return
      */
     public SerialMessage allOffMessage() {
-        logger.debug("NODE {}: Switch All - Creating All Off message.", this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
+        logger.debug("NODE {}: Switch All - Creating All Off message.", getNode().getNodeId());
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData,
                 SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = { (byte) this.getNode().getNodeId(), 2, (byte) this.getCommandClass().getKey(),
+        byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
                 (byte) SWITCH_ALL_OFF };
         result.setMessagePayload(newPayload);
         return result;
@@ -255,7 +255,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
         // If we're already initialized, then don't do it again unless we're
         // refreshing
         if (refresh == true || initialiseDone == false) {
-            result.add(this.getValueMessage());
+            result.add(getValueMessage());
         }
 
         return result;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
@@ -19,10 +19,10 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,11 +43,11 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveThermostatFanModeCommandClass.class);
 
-    private static final byte THERMOSTAT_FAN_MODE_SET = 0x1;
-    private static final byte THERMOSTAT_FAN_MODE_GET = 0x2;
-    private static final byte THERMOSTAT_FAN_MODE_REPORT = 0x3;
-    private static final byte THERMOSTAT_FAN_MODE_SUPPORTED_GET = 0x4;
-    private static final byte THERMOSTAT_FAN_MODE_SUPPORTED_REPORT = 0x5;
+    private static final byte THERMOSTAT_FAN_MODE_SET = 1;
+    private static final byte THERMOSTAT_FAN_MODE_GET = 2;
+    private static final byte THERMOSTAT_FAN_MODE_REPORT = 3;
+    private static final byte THERMOSTAT_FAN_MODE_SUPPORTED_GET = 4;
+    private static final byte THERMOSTAT_FAN_MODE_SUPPORTED_REPORT = 5;
 
     private final Set<FanModeType> fanModeTypes = new HashSet<FanModeType>();
 
@@ -87,13 +87,13 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @throws ZWaveSerialMessageException
      */
     @Override
     public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint)
             throws ZWaveSerialMessageException {
-        logger.debug("NODE {}: Received Thermostat Fan Mode Request", this.getNode().getNodeId());
+        logger.debug("NODE {}: Received THERMOSTAT_FAN_MODE command V{}", getNode().getNodeId(), getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
             case THERMOSTAT_FAN_MODE_SUPPORTED_REPORT:


### PR DESCRIPTION
Adds tests for most command classes that create messages prior to potential refactoring.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>