### PR TITLE
ZWave rename device class garage_door to sensor_notification

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
@@ -233,7 +233,7 @@ public class ZWaveDeviceClass {
         STATIC_CONTROLLER(0x02, "Static Controller"),
         AV_CONTROL_POINT(0x03, "A/V Control Point"),
         DISPLAY(0x06, "Display"),
-        GARAGE_DOOR(0x07, "Garage Door"), // Need to change to NOTIFICATION_SENSOR
+        SENSOR_NOTIFICATION(0x07, "Sensor Notification"),
         THERMOSTAT(0x08, "Thermostat"),
         WINDOW_COVERING(0x09, "Window Covering"),
         REPEATER_SLAVE(0x0f, "Repeater Slave"),
@@ -316,7 +316,7 @@ public class ZWaveDeviceClass {
                     return new CommandClass[0];
                 case REMOTE_CONTROLLER:
                 case STATIC_CONTROLLER:
-                case GARAGE_DOOR:
+                case SENSOR_NOTIFICATION:
                 case REPEATER_SLAVE:
                 case TOGGLE_SWITCH:
                 case REMOTE_SWITCH:
@@ -437,7 +437,7 @@ public class ZWaveDeviceClass {
         ADVANCED_ENERGY_CONTROL(2, Generic.METER, "Advanced Energy Control"),
         WHOLE_HOME_METER_SIMPLE(3, Generic.METER, "Whole Home Meter Simple"),
 
-        SIMPLE_GARAGE_DOOR(1, Generic.GARAGE_DOOR, "Simple Garage Door"),
+        NOTIFICATION_SENSOR(1, Generic.SENSOR_NOTIFICATION, "Notification Sensor"),
 
         DOOR_LOCK(1, Generic.ENTRY_CONTROL, "Door Lock"),
         ADVANCED_DOOR_LOCK(2, Generic.ENTRY_CONTROL, "Advanced Door Lock"),


### PR DESCRIPTION
- rename generic GARAGE_DOOR to SENSOR_NOTIFICATION
- rename specific SIMPLE_GARAGE_DOOR to NOTIFICATION_SENSOR

I am not sure what the fall out will be. But if you think is not worth it, feel free to reject this PR. 

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)