### PR TITLE
Zwave: add delete suc return route

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNetworkEvent.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNetworkEvent.java
@@ -12,7 +12,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
  * Network event signals that a network function has completed.
  * This is used to notify higher layers of network functions so they can be handled by (for example) a network heal
  * process.
- * 
+ *
  * @author Chris Jackson
  */
 public class ZWaveNetworkEvent extends ZWaveEvent {
@@ -21,7 +21,7 @@ public class ZWaveNetworkEvent extends ZWaveEvent {
 
     /**
      * Constructor. Creates a new instance of the ZWaveNetworkEvent class.
-     * 
+     *
      * @param nodeId the nodeId of the event.
      */
     public ZWaveNetworkEvent(Type type, int nodeId, State state) {
@@ -42,6 +42,7 @@ public class ZWaveNetworkEvent extends ZWaveEvent {
     public enum Type {
         AssignSucReturnRoute,
         AssignReturnRoute,
+        DeleteSucReturnRoute,
         DeleteReturnRoute,
         NodeNeighborUpdate,
         NodeRoutingInfo,

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -38,6 +38,8 @@ public enum ZWaveNodeInitStage {
     ASSOCIATIONS(false),
     SET_WAKEUP(false),
     SET_ASSOCIATION(false),
+    DELETE_SUC_ROUTES(false),
+    SUC_ROUTE(false),
     STATIC_END(false),
 
     // States below are not restored from the configuration files
@@ -49,8 +51,6 @@ public enum ZWaveNodeInitStage {
     // States below are performed during initialisation, but also during heal
     HEAL_START(false),
     DELETE_ROUTES(false),
-    DELETE_SUC_ROUTES(false),
-    SUC_ROUTE(false),
     RETURN_ROUTES(false),
     NEIGHBORS(false),
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -49,6 +49,7 @@ public enum ZWaveNodeInitStage {
     // States below are performed during initialisation, but also during heal
     HEAL_START(false),
     DELETE_ROUTES(false),
+    DELETE_SUC_ROUTES(false),
     SUC_ROUTE(false),
     RETURN_ROUTES(false),
     NEIGHBORS(false),

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -830,6 +830,36 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                     }
                     break;
 
+                case DELETE_SUC_ROUTES:
+                    // If the incoming frame is the DeleteSUCReturnRoute, then we continue
+                    if (eventClass == SerialMessageClass.DeleteSUCReturnRoute) {
+                        break;
+                    }
+
+                    // Only delete the route if this is not the controller and there is an SUC in the network
+                    if (node.getNodeId() != controller.getOwnNodeId() && controller.getSucId() != 0) {
+                        // Update the route to the controller
+                        logger.debug("NODE {}: Node advancer is deleting SUC return route.", node.getNodeId());
+                        addToQueue(new DeleteSucReturnRouteMessageClass().doRequest(node.getNodeId()));
+                        break;
+                    }
+                    break;
+
+                case SUC_ROUTE:
+                    if (eventClass == SerialMessageClass.AssignSucReturnRoute) {
+                        break;
+                    }
+
+                    // Only set the route if this is not the controller and there is an SUC in the network
+                    if (node.getNodeId() != controller.getOwnNodeId() && controller.getSucId() != 0) {
+                        // Update the route to the controller
+                        logger.debug("NODE {}: Node advancer is setting SUC route.", node.getNodeId());
+                        addToQueue(new AssignSucReturnRouteMessageClass().doRequest(node.getNodeId(),
+                                controller.getCallbackId()));
+                        break;
+                    }
+                    break;
+
                 case GET_CONFIGURATION:
                     ZWaveConfigurationCommandClass configurationCommandClass = (ZWaveConfigurationCommandClass) node
                             .getCommandClass(CommandClass.CONFIGURATION);
@@ -941,36 +971,6 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                         // Delete all the return routes for the node
                         logger.debug("NODE {}: Node advancer is deleting return routes.", node.getNodeId());
                         addToQueue(new DeleteReturnRouteMessageClass().doRequest(node.getNodeId()));
-                        break;
-                    }
-                    break;
-
-                case DELETE_SUC_ROUTES:
-                    // If the incoming frame is the DeleteSUCReturnRoute, then we continue
-                    if (eventClass == SerialMessageClass.DeleteSUCReturnRoute) {
-                        break;
-                    }
-
-                    // Only delete the route if this is not the controller and there is an SUC in the network
-                    if (node.getNodeId() != controller.getOwnNodeId() && controller.getSucId() != 0) {
-                        // Update the route to the controller
-                        logger.debug("NODE {}: Node advancer is deleting SUC return route.", node.getNodeId());
-                        addToQueue(new DeleteSucReturnRouteMessageClass().doRequest(node.getNodeId()));
-                        break;
-                    }
-                    break;
-
-                case SUC_ROUTE:
-                    if (eventClass == SerialMessageClass.AssignSucReturnRoute) {
-                        break;
-                    }
-
-                    // Only set the route if this is not the controller and there is an SUC in the network
-                    if (node.getNodeId() != controller.getOwnNodeId() && controller.getSucId() != 0) {
-                        // Update the route to the controller
-                        logger.debug("NODE {}: Node advancer is setting SUC route.", node.getNodeId());
-                        addToQueue(new AssignSucReturnRouteMessageClass().doRequest(node.getNodeId(),
-                                controller.getCallbackId()));
                         break;
                     }
                     break;

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/DeleteSucReturnRouteMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/DeleteSucReturnRouteMessageClass.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.protocol.serialmessage;
+
+import java.io.ByteArrayOutputStream;
+
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveNetworkEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class processes a serial message from the zwave controller
+ *
+ * @author Jorg de Jong
+ */
+public class DeleteSucReturnRouteMessageClass extends ZWaveCommandProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(DeleteSucReturnRouteMessageClass.class);
+
+    public SerialMessage doRequest(int nodeId) {
+        logger.debug("NODE {}: Deleting SUC return routes", nodeId);
+
+        // Queue the request
+        SerialMessage newMessage = new SerialMessage(SerialMessageClass.DeleteSUCReturnRoute, SerialMessageType.Request,
+                SerialMessageClass.DeleteSUCReturnRoute, SerialMessagePriority.High);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(nodeId);
+        newMessage.setMessagePayload(outputData.toByteArray());
+
+        return newMessage;
+    }
+
+    @Override
+    public boolean handleResponse(ZWaveController zController, SerialMessage lastSentMessage,
+            SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        int nodeId = lastSentMessage.getMessagePayloadByte(0);
+
+        logger.debug("NODE {}: Got DeleteSUCReturnRoute response.", nodeId);
+        if (incomingMessage.getMessagePayloadByte(0) != 0x00) {
+            lastSentMessage.setAckRecieved();
+            logger.debug("NODE {}: DeleteSUCReturnRoute command in progress.", nodeId);
+        } else {
+            logger.error("NODE {}: DeleteSUCReturnRoute command failed.", nodeId);
+            zController.notifyEventListeners(new ZWaveNetworkEvent(ZWaveNetworkEvent.Type.DeleteSucReturnRoute, nodeId,
+                    ZWaveNetworkEvent.State.Failure));
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean handleRequest(ZWaveController zController, SerialMessage lastSentMessage,
+            SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        int nodeId = lastSentMessage.getMessagePayloadByte(0);
+
+        logger.debug("NODE {}: Got DeleteSUCReturnRoute request.", nodeId);
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
+            logger.error("NODE {}: Delete SUC return routes failed.", nodeId);
+            zController.notifyEventListeners(new ZWaveNetworkEvent(ZWaveNetworkEvent.Type.DeleteSucReturnRoute, nodeId,
+                    ZWaveNetworkEvent.State.Failure));
+        } else {
+            zController.notifyEventListeners(new ZWaveNetworkEvent(ZWaveNetworkEvent.Type.DeleteSucReturnRoute, nodeId,
+                    ZWaveNetworkEvent.State.Success));
+        }
+
+        checkTransactionComplete(lastSentMessage, incomingMessage);
+
+        return true;
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
@@ -162,6 +162,8 @@ public abstract class ZWaveCommandProcessor {
             messageMap.put(SerialMessage.SerialMessageClass.AssignSucReturnRoute,
                     AssignSucReturnRouteMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.DeleteReturnRoute, DeleteReturnRouteMessageClass.class);
+            messageMap.put(SerialMessage.SerialMessageClass.DeleteSUCReturnRoute,
+                    DeleteSucReturnRouteMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.EnableSuc, EnableSucMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetRoutingInfo, GetRoutingInfoMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetVersion, GetVersionMessageClass.class);


### PR DESCRIPTION
Before setting the return routes, the routes are cleared. While the SUC return route where only set and never cleared. The SUC return route is now also deleted before being set.

This PR also fixes a bug where the nodestage advancer was hanging in state SUC_ROUTE. Due to a missing case in method ZWaveIncomingEvent.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)