### PR TITLE
ZWave initialisation order to improve secure inclusion

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -27,8 +27,8 @@ public enum ZWaveNodeInitStage {
     // For newly included devices, we start here
     INCLUSION_START(true),
     IDENTIFY_NODE(true),
-    SECURITY_REPORT(true),
     MANUFACTURER(true),
+    SECURITY_REPORT(true),
     APP_VERSION(true),
     DISCOVERY_COMPLETE(true),
     VERSION(true),


### PR DESCRIPTION
It seems that secure inclusion can fail sometimes. At least on my Yale lock, the controller seems to return NO_ACK very quickly for a few requests after the inclusion is finished and performing the manufacturer request first seems to help.
This might be a temporary fix - let's see.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>