### PR TITLE
ZWave fix locking issue

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -55,7 +55,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
     private static Set<ThingTypeUID> zwaveThingTypeUIDList = new HashSet<ThingTypeUID>();
     private static List<ZWaveProduct> productIndex = new ArrayList<ZWaveProduct>();
 
-    private static Object productIndexLock = new Object();
+    private static final Object productIndexLock = new Object();
 
     // The following is a list of classes that are controllable.
     // This is used to filter endpoints so that when we display a list of nodes/endpoints

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -55,6 +55,8 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
     private static Set<ThingTypeUID> zwaveThingTypeUIDList = new HashSet<ThingTypeUID>();
     private static List<ZWaveProduct> productIndex = new ArrayList<ZWaveProduct>();
 
+    private static Object productIndexLock = new Object();
+
     // The following is a list of classes that are controllable.
     // This is used to filter endpoints so that when we display a list of nodes/endpoints
     // for configuring associations, we only list endpoints that are useful
@@ -279,7 +281,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
             return;
         }
 
-        synchronized (productIndex) {
+        synchronized (productIndexLock) {
             zwaveThingTypeUIDList = new HashSet<ThingTypeUID>();
             productIndex = new ArrayList<ZWaveProduct>();
 


### PR DESCRIPTION
The synchronized block was using productIndex which was also set inside the synchronized block. Other threads will now use the new value causing the synchronized block to have no effect.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)