### PR TITLE
ZWave add Secure Inclusion Mode configuration option

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/_controller_serial.xml
@@ -156,6 +156,25 @@ In this mode, the controller uses high power, but also other devices within the 
                 </options>
             </parameter>
 
+            <parameter name="security_inclusionmode" type="integer" groupName="network">
+                <label>Secure Inclusion Mode</label>
+                <description>
+                    <![CDATA[Sets the controller secure inclusion mode<br/>
+<h1>All Devices</h1>
+In this mode, all devices reporting the SECURITY command class will be securely included into the network.<br/>
+This may reduce the life of battery devices and slow down communications. For most devices, it is not necesary to include the device securely into the network since the same command classes can be used without security.
+<h1>Entry Control Devices</h1>
+In this mode, only <i>Entry Control Devices</i> such as locks will be securely included into the network.<br/>
+                    ]]>
+                </description>
+                <advanced>true</advanced>
+                <default>0</default>
+                <options>
+                    <option value="1">All Devices</option>
+                    <option value="0">Entry Control Devices</option>
+                </options>
+            </parameter>
+
             <parameter name="security_networkkey" type="text" groupName="network">
                 <label>Network Security Key</label>
                 <description>Set the network security key</description>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -31,6 +31,7 @@ public class ZWaveBindingConstants {
     public final static String CONFIGURATION_MASTER = "controller_master";
     public final static String CONFIGURATION_SUC = "controller_suc";
     public final static String CONFIGURATION_NETWORKKEY = "security_networkkey";
+    public final static String CONFIGURATION_SECUREINCLUSION = "security_inclusionmode";
     public final static String CONFIGURATION_HEALTIME = "heal_time";
     public final static String CONFIGURATION_INCLUSION_MODE = "inclusion_mode";
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -62,6 +62,7 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
     private Boolean isMaster;
     private Boolean isSUC;
     private String networkKey;
+    private Integer secureInclusionMode;
     private Integer healTime;
 
     public ZWaveControllerHandler(Bridge bridge) {
@@ -78,6 +79,13 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
             isMaster = (Boolean) param;
         } else {
             isMaster = true;
+        }
+
+        param = getConfig().get(CONFIGURATION_SECUREINCLUSION);
+        if (param instanceof BigDecimal && param != null) {
+            secureInclusionMode = ((BigDecimal) param).intValue();
+        } else {
+            secureInclusionMode = 0;
         }
 
         param = getConfig().get(CONFIGURATION_SUC);
@@ -129,6 +137,8 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         Map<String, String> config = new HashMap<String, String>();
         config.put("masterController", isMaster.toString());
         config.put("isSUC", isSUC ? "true" : "false");
+        config.put("secureInclusion", secureInclusionMode.toString());
+        config.put("networkKey", networkKey);
 
         // MAJOR BODGE
         // The security class uses a static member to set the key so for now

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -28,6 +28,7 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Generic;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Specific;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEventListener;
@@ -451,6 +452,26 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                     break;
 
                 case SECURITY_REPORT:
+                    // Check if we want to perform a secure inclusion...
+                    boolean doSecureInclusion = false;
+                    switch (controller.getSecureInclusionMode()) {
+                        default:
+                        case 0:
+                            // Only ENTRY_CONTROL
+                            if (node.getDeviceClass().getGenericDeviceClass() == Generic.ENTRY_CONTROL) {
+                                doSecureInclusion = true;
+                            }
+                            break;
+                        case 1:
+                            // All devices
+                            doSecureInclusion = true;
+                            break;
+                    }
+
+                    if (doSecureInclusion == false) {
+                        break;
+                    }
+
                     // For devices that use security. When invoked during secure inclusion, this
                     // method will go through all steps to give the device our zwave:networkKey from
                     // the config. This requires multiple steps as defined in


### PR DESCRIPTION
Adds an option to disable secure inclusion for devices other than locks. Using security classes  caries a large overhead and probably isn't necessary in many situations.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>