### PR TITLE
ZWave version handling regression

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -160,8 +160,6 @@ public abstract class ZWaveCommandClass {
             logger.debug("NODE {}: Version = {}, version set. Enabling extra functionality.", getNode().getNodeId(),
                     version);
         }
-
-        this.version = version;
     }
 
     /**


### PR DESCRIPTION
The command class version is always set to the supported version by the
device. The intent is set the version not higher that the max supported
version by the CC.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)