### PR TITLE
Removal of Command Classes which report version 0

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
@@ -123,9 +123,33 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
                     logger.info("NODE {}: Command Class {} has version 0!", getNode().getNodeId(),
                             commandClass.getLabel());
 
-                    // TODO: We should remove the class
-                    // For now, just set the version to 1 to avoid a loop on initialisation
-                    commandClassVersion = 1;
+                    // Do not remove mandatory generic command classes.
+                    for (CommandClass mandatoryCommandClass : getNode().getDeviceClass().getGenericDeviceClass()
+                            .getMandatoryCommandClasses()) {
+                        if (mandatoryCommandClass == commandClass) {
+                            commandClassVersion = 1;
+                            break;
+                        }
+                    }
+
+                    // Do not remove mandatory specific command classes.
+                    if (commandClassVersion == 0) {
+                        for (CommandClass mandatoryCommandClass : getNode().getDeviceClass().getSpecificDeviceClass()
+                                .getMandatoryCommandClasses()) {
+                            if (mandatoryCommandClass == commandClass) {
+                                commandClassVersion = 1;
+                                break;
+                            }
+                        }
+                    }
+
+                    // Remove other command classes.
+                    if (commandClassVersion == 0) {
+                        getNode().removeCommandClass(commandClass);
+                        logger.debug("NODE {}: Removed Command Class {}", getNode().getNodeId(),
+                                commandClass.getLabel());
+                        return;
+                    }
                 }
 
                 zwaveCommandClass.setVersion(commandClassVersion);


### PR DESCRIPTION
Remove Command Classes from the node, if the reported version for the
command class is 0). Do not remove command classes that are mandatory
because of the generic or specific device class.

Signed-off-by: Jan-Willem Spuij jw@spuij.nl (github: jspuij)