### PR TITLE
Add binding event concept

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Bundle-Activator: org.openhab.binding.zwave.internal.ZWaveActivator
 Import-Package: com.google.common.collect,
+ com.google.gson;version="2.5.0",
  com.thoughtworks.xstream,
  com.thoughtworks.xstream.annotations,
  com.thoughtworks.xstream.converters,

--- a/addons/binding/org.openhab.binding.zwave/OSGI-INF/ConfigDescriptionRegistry.xml
+++ b/addons/binding/org.openhab.binding.zwave/OSGI-INF/ConfigDescriptionRegistry.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.zwave.ConfigDescription">
+   <implementation class="org.openhab.binding.zwave.internal.ZWaveConfigProvider"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.config.core.ConfigOptionProvider"/>
+      <provide interface="org.eclipse.smarthome.config.core.ConfigDescriptionProvider"/>
+   </service>
+   <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
+   <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
+   <reference bind="setConfigDescriptionRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry" name="ConfigDescriptionRegistry" policy="static" unbind="unsetConfigDescriptionRegistry"/>
+</scr:component>

--- a/addons/binding/org.openhab.binding.zwave/OSGI-INF/EventFactory.xml
+++ b/addons/binding/org.openhab.binding.zwave/OSGI-INF/EventFactory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.zwave.event.BindingEventFactory">
+   <implementation class="org.openhab.binding.zwave.event.BindingEventFactory"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.events.EventFactory"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.zwave/OSGI-INF/EventPublisher.xml
+++ b/addons/binding/org.openhab.binding.zwave/OSGI-INF/EventPublisher.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.zwave.internal.ZWaveEventPublisher">
+   <implementation class="org.openhab.binding.zwave.internal.ZWaveEventPublisher"/>
+   <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" 
+           name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
+</scr:component>

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEvent.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEvent.java
@@ -1,0 +1,16 @@
+package org.openhab.binding.zwave.event;
+
+import org.eclipse.smarthome.core.events.AbstractEvent;
+
+public class BindingEvent extends AbstractEvent {
+    public final static String TYPE = BindingEvent.class.getSimpleName();
+
+    public BindingEvent(String topic, String binding, String payload) {
+        super(topic, payload, binding);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventDTO.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventDTO.java
@@ -1,0 +1,20 @@
+package org.openhab.binding.zwave.event;
+
+/**
+ * Base BindingEvent data transfer object
+ *
+ * This can be extended by bindings to add binding specific information, but provides basic information to allow the UI
+ * to render a message the user without having to implement any binding specific processor.
+ *
+ * @author Chris Jackson - initial contribution
+ *
+ */
+public class BindingEventDTO {
+    BindingEventType type;
+    String message;
+
+    public BindingEventDTO(BindingEventType type, String message) {
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventFactory.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventFactory.java
@@ -1,0 +1,48 @@
+package org.openhab.binding.zwave.event;
+
+import java.util.Set;
+
+import org.eclipse.smarthome.core.events.AbstractEventFactory;
+import org.eclipse.smarthome.core.events.Event;
+
+import com.google.common.collect.Sets;
+
+public class BindingEventFactory extends AbstractEventFactory {
+    private static final String BINDING_EVENT_TOPIC = "smarthome/binding/{binding}/{entity}/{event}";
+
+    public BindingEventFactory(Set<String> supportedEventTypes) {
+        super(supportedEventTypes);
+    }
+
+    public BindingEventFactory() {
+        super(Sets.newHashSet(BindingEvent.TYPE));
+    }
+
+    @Override
+    protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
+        if (eventType.equals(BindingEvent.TYPE)) {
+            return new BindingEvent(topic, source, payload);
+        }
+
+        throw new IllegalArgumentException(
+                eventType + " not supported by " + BindingEventFactory.class.getSimpleName());
+    }
+
+    /**
+     *
+     * @param binding
+     * @param entity
+     * @param event
+     * @param properties
+     * @return
+     */
+    public static BindingEvent createBindingEvent(String binding, String entity, String event, BindingEventDTO dto) {
+        String topic = BINDING_EVENT_TOPIC;
+        topic = topic.replace("{binding}", binding);
+        topic = topic.replace("{entity}", entity);
+        topic = topic.replace("{event}", event);
+
+        String payload = serializePayload(dto);
+        return new BindingEvent(topic, binding, payload);
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventType.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/event/BindingEventType.java
@@ -1,0 +1,14 @@
+package org.openhab.binding.zwave.event;
+
+/**
+ * Enumeration used in {@link BindingEventDTO} to provide context to a message
+ *
+ * @author Chris Jackson - initial contribution
+ *
+ */
+public enum BindingEventType {
+    SUCCESS,
+    WARNING,
+    INFO,
+    ERROR
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -20,6 +20,8 @@ import java.util.Map.Entry;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -28,6 +30,10 @@ import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.zwave.ZWaveBindingConstants;
 import org.openhab.binding.zwave.discovery.ZWaveDiscoveryService;
+import org.openhab.binding.zwave.event.BindingEventDTO;
+import org.openhab.binding.zwave.event.BindingEventFactory;
+import org.openhab.binding.zwave.event.BindingEventType;
+import org.openhab.binding.zwave.internal.ZWaveEventPublisher;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEventListener;
@@ -332,6 +338,24 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
                         updateNeighbours();
                     }
                     break;
+                case AssignReturnRoute:
+                    break;
+                case AssignSucReturnRoute:
+                    break;
+                case AssociationUpdate:
+                    break;
+                case DeleteNode:
+                    break;
+                case DeleteReturnRoute:
+                    break;
+                case DeleteSucReturnRoute:
+                    break;
+                case FailedNode:
+                    // BindingEventFactory.createBindingEvent(ZWaveBindingConstants.BINDING_ID,
+                    // "node" + networkEvent.getNodeId(), networkEvent.getEvent().toString(), null);
+                    break;
+                case NodeNeighborUpdate:
+                    break;
                 default:
                     break;
             }
@@ -342,8 +366,28 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
             ZWaveInclusionEvent incEvent = (ZWaveInclusionEvent) event;
             switch (incEvent.getEvent()) {
                 case IncludeDone:
-                    discoveryService.deviceDiscovered(event.getNodeId());
-                default:
+                    // Ignore node 0 - this just indicates inclusion is finished
+                    if (incEvent.getNodeId() != 0) {
+                        discoveryService.deviceDiscovered(event.getNodeId());
+                    }
+                case ExcludeDone:
+                case ExcludeFail:
+                case ExcludeStart:
+                case IncludeStart:
+                case IncludeFail:
+                    EventPublisher ep = ZWaveEventPublisher.getEventPublisher();
+                    if (ep != null) {
+                        BindingEventDTO dto = new BindingEventDTO(BindingEventType.SUCCESS,
+                                "Z-Wave network inclusion/exclusion: " + incEvent.getEvent());
+                        Event notification = BindingEventFactory.createBindingEvent(ZWaveBindingConstants.BINDING_ID,
+                                "network", incEvent.getEvent().toString(), dto);
+                        ep.post(notification);
+                    }
+                    break;
+                case ExcludeControllerFound:
+                case ExcludeSlaveFound:
+                case IncludeControllerFound:
+                case IncludeSlaveFound:
                     break;
             }
         }

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveEventPublisher.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveEventPublisher.java
@@ -1,0 +1,19 @@
+package org.openhab.binding.zwave.internal;
+
+import org.eclipse.smarthome.core.events.EventPublisher;
+
+public class ZWaveEventPublisher {
+    private static EventPublisher eventPublisher;
+
+    public void setEventPublisher(EventPublisher eventPublisher) {
+        ZWaveEventPublisher.eventPublisher = eventPublisher;
+    }
+
+    public void unsetEventPublisher(EventPublisher eventPublisher) {
+        ZWaveEventPublisher.eventPublisher = null;
+    }
+
+    public static EventPublisher getEventPublisher() {
+        return eventPublisher;
+    }
+}

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -591,6 +591,11 @@ public class ZWaveController {
                     break;
 
                 case IncludeDone:
+                    // Ignore node 0 - this just indicates inclusion finished
+                    if (incEvent.getNodeId() == 0) {
+                        break;
+                    }
+
                     // Kick off the initialisation.
                     // Since the node is awake, we jump straight into the initialisation sequence
                     // without some of the initial stages like PING that are designed to detect if
@@ -627,6 +632,10 @@ public class ZWaveController {
                     break;
 
                 case ExcludeDone:
+                    // Ignore node 0 - this just indicates inclusion finished
+                    if (incEvent.getNodeId() == 0) {
+                        break;
+                    }
                     logger.debug("NODE {}: Excluding node.", incEvent.getNodeId());
                     // Remove the node from the controller
                     if (getNode(incEvent.getNodeId()) == null) {
@@ -1205,7 +1214,7 @@ public class ZWaveController {
 
     /**
      * Returns the secure inclusion mode
-     * 
+     *
      * @return
      *         0 ENTRY_CONTROL
      *         1 All Devices

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -142,12 +142,8 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
                     break;
                 case ADD_NODE_STATUS_DONE:
                     logger.debug("Add Node: Done.");
-                    // If the node ID is 0, ignore!
-                    if (incomingMessage.getMessagePayloadByte(2) > 0
-                            && incomingMessage.getMessagePayloadByte(2) <= 232) {
-                        zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.IncludeDone,
-                                incomingMessage.getMessagePayloadByte(2)));
-                    }
+                    zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.IncludeDone,
+                            incomingMessage.getMessagePayloadByte(2)));
                     break;
                 case ADD_NODE_STATUS_FAILED:
                     logger.debug("Add Node: Failed.");

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
@@ -91,11 +91,8 @@ public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
                         ZWaveInclusionEvent.Type.ExcludeControllerFound, incomingMessage.getMessagePayloadByte(2)));
                 break;
             case REMOVE_NODE_STATUS_DONE:
-                if (incomingMessage.getMessagePayloadByte(2) != 0) {
-                    logger.debug("NODE {}: Removed from network.", incomingMessage.getMessagePayloadByte(2));
-                    zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.ExcludeDone,
-                            incomingMessage.getMessagePayloadByte(2)));
-                }
+                zController.notifyEventListeners(new ZWaveInclusionEvent(ZWaveInclusionEvent.Type.ExcludeDone,
+                        incomingMessage.getMessagePayloadByte(2)));
                 logger.debug("Remove Node: Done.");
                 break;
             case REMOVE_NODE_STATUS_FAILED:


### PR DESCRIPTION
This allows bindings to send binding specific notifications to the user in a consistent way so that the UI can present this information without knowing anything about the binding.
The base notification provides a message type, and a message string. This could be overridden by bindings to add information that is specific to the binding, but provides basic information so that it can be presented as a growl/toast style notification without any specific implementation in the UI.

@kaikreuzer I've implemented this in the ZWave binding as I need this to provide user feedback for ZWave specific events (eg nodes excluded, controller feedback, replication...). It's implemented in a non-ZWave specific way with a view that it can be used by any binding and as such I would see if moving to ESH.

Are you happy with such a concept for ESH, and if so, can you suggest a bundle where this could be placed since there is no 'binding' specific bundle at the moment. I could move it there and we can discuss further if you would see changes... Depending on where this was implemented, the API could be exposed a little better to the developer - consider this a proof of concept and open for comment :)

Signed-off-by: Chris Jackson chris@cd-jackson.com
