### PR TITLE
NPE that was preventing things from getting initiallized

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -481,15 +481,21 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
             ZWaveSwitchAllCommandClass switchallCommandClass = (ZWaveSwitchAllCommandClass) node
                     .getCommandClass(CommandClass.SWITCH_ALL);
             if (switchallCommandClass != null) {
-                config.put(ZWaveBindingConstants.CONFIGURATION_SWITCHALLMODE, switchallCommandClass.getMode());
+                if (switchallCommandClass.getMode() != null) {
+                    config.put(ZWaveBindingConstants.CONFIGURATION_SWITCHALLMODE, switchallCommandClass.getMode());
+                }
             }
 
             // Process NODE_NAMING
             ZWaveNodeNamingCommandClass nodenamingCommandClass = (ZWaveNodeNamingCommandClass) node
                     .getCommandClass(CommandClass.NODE_NAMING);
             if (nodenamingCommandClass != null) {
-                config.put(ZWaveBindingConstants.CONFIGURATION_NODELOCATION, nodenamingCommandClass.getLocation());
-                config.put(ZWaveBindingConstants.CONFIGURATION_NODENAME, nodenamingCommandClass.getName());
+                if (nodenamingCommandClass.getLocation() != null) {
+                    config.put(ZWaveBindingConstants.CONFIGURATION_NODELOCATION, nodenamingCommandClass.getLocation());
+                }
+                if (nodenamingCommandClass.getName() != null) {
+                    config.put(ZWaveBindingConstants.CONFIGURATION_NODENAME, nodenamingCommandClass.getName());
+                }
             }
 
             // Only update if configuration has changed


### PR DESCRIPTION
Using OH2 offline 2.0.0.201605280102.

When adding certain ZWave devices I hit this exception that leaves the thing in a not initialized state.

> 2016-05-29 09:35:47.678 [ERROR] [ome.core.thing.internal.ThingManager] - Exception occured during notification of thing 'zwave:device:a8c8fd8d:node3' about bridge initialization at 'org.openhab.binding.zwave.handler.ZWaveThingHandler@ebc66a': null
java.lang.NullPointerException
at org.openhab.binding.zwave.handler.ZWaveThingHandler.bridgeStatusChanged(ZWaveThingHandler.java:500)[188:org.openhab.binding.zwave:2.0.0.201605280102]
at org.openhab.binding.zwave.handler.ZWaveThingHandler.bridgeHandlerInitialized(ZWaveThingHandler.java:395)[188:org.openhab.binding.zwave:2.0.0.201605280102]
at org.eclipse.smarthome.core.thing.internal.ThingManager$8.run(ThingManager.java:750)[102:org.eclipse.smarthome.core.thing:0.8.0.201605191852]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)[:1.8.0_65]
at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_65]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)[:1.8.0_65]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)[:1.8.0_65]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_65]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_65]
at java.lang.Thread.run(Thread.java:745)[:1.8.0_65]

This other exception also appears in the logs

> Caused by: java.lang.NullPointerException
at org.openhab.binding.zwave.handler.ZWaveThingHandler.bridgeStatusChanged(ZWaveThingHandler.java:500)[188:org.openhab.binding.zwave:2.0.0.201605280102]
at org.openhab.binding.zwave.handler.ZWaveThingHandler.initialize(ZWaveThingHandler.java:140)[188:org.openhab.binding.zwave:2.0.0.201605280102]
at org.eclipse.smarthome.core.thing.internal.ThingManager$7$1.call(ThingManager.java:687)[102:org.eclipse.smarthome.core.thing:0.8.0.201605191852]
at org.eclipse.smarthome.core.thing.internal.ThingManager$7$1.call(ThingManager.java:1)[102:org.eclipse.smarthome.core.thing:0.8.0.201605191852]
at org.eclipse.smarthome.core.common.SafeMethodCaller$CallableWrapper.call(SafeMethodCaller.java:170)[96:org.eclipse.smarthome.core:0.8.0.201605191852]
at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_65]
... 3 more

Thanks,
Gaston