### PR TITLE
Fixed HomeKit updating of thermostat (#988)

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -170,13 +170,13 @@ class HomekitThermostatImpl extends AbstractTemperatureHomekitAccessoryImpl<Grou
                 break;
         }
         StringItem item = getGenericItem(heatingCoolingModeItemName);
-        item.setState(new StringType(modeString));
+        item.send(new StringType(modeString));
     }
 
     @Override
     public void setTargetTemperature(Double value) throws Exception {
         NumberItem item = getGenericItem(targetTemperatureItemName);
-        item.setState(new DecimalType(BigDecimal.valueOf(convertFromCelsius(value))));
+        item.send(new DecimalType(BigDecimal.valueOf(convertFromCelsius(value))));
     }
 
     @Override


### PR DESCRIPTION
Thermostat setters in HomeKit addon were using setState instead of send to push updates.

Signed-off-by: Andy Lintner <dev@beowulfe.com> (github: beowulfe)