### PR TITLE
Zwave add neighbor update to Heal stages

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -50,6 +50,8 @@ public enum ZWaveNodeInitStage {
 
     // States below are performed during initialisation, but also during heal
     HEAL_START(false),
+    WAIT_HEAL(true),
+    DISCOVER_NEIGHBORS(false),
     DELETE_ROUTES(false),
     RETURN_ROUTES(false),
     NEIGHBORS(false),


### PR DESCRIPTION
- start the healing by waiting for the node to wake up
- request a neighbor update when the node has zero neighbors

Last weekend I replaced my controller by a new one and had to rebuild by zwave network.
Most of the nodes I include via habmin, so both the nodes and the controller where on there final locations. This resulted in a situation where a lot of nodes did not have any neighbors. For most nodes this did not seem to have a negative effect. For others, known not to be in direct contact with the controller, it cause issues like up to 4 times receiving of the identical message. 
With the help of this PR some nodes discovered their neighbors at the first attempt, for others it took two or three attempts. 
  
Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)