### PR TITLE
sort chart series before sending them

### DIFF
--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ChartResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ChartResource.java
@@ -87,8 +87,9 @@ public class ChartResource implements RESTResource {
     private UriInfo uriInfo;
 
     public void addPersistenceService(PersistenceService service) {
-        if (service instanceof QueryablePersistenceService)
+        if (service instanceof QueryablePersistenceService) {
             persistenceServices.put(service.getName(), (QueryablePersistenceService) service);
+        }
     }
 
     public void removePersistenceService(PersistenceService service) {
@@ -112,8 +113,9 @@ public class ChartResource implements RESTResource {
     public Response getChartSeries(@Context HttpHeaders headers, @QueryParam("rrd") String itemName,
             @QueryParam("ds") String consFunction, @QueryParam("start") String start, @QueryParam("end") String end,
             @QueryParam("res") long resolution) {
-        if (logger.isDebugEnabled())
+        if (logger.isDebugEnabled()) {
             logger.debug("Received GET request at '{}' for rrd '{}'.", uriInfo.getPath(), itemName);
+        }
         String responseType = MediaType.APPLICATION_JSON;
 
         // RRD specific: no equivalent in PersistenceService known
@@ -127,8 +129,9 @@ public class ChartResource implements RESTResource {
         Date endTime = new Date();
         endTime.setTime(times[1] * 1000L);
 
-        if (itemName.endsWith(".rrd"))
+        if (itemName.endsWith(".rrd")) {
             itemName = itemName.substring(0, itemName.length() - 4);
+        }
         String[] parts = itemName.split(":");
         String service = "rrd4j";
 
@@ -241,8 +244,10 @@ public class ChartResource implements RESTResource {
     }
 
     private ArrayList<Object> convertToRrd(Map<Long, ArrayList<String>> data) {
+        // sort data by key
+        Map<Long, ArrayList<String>> treeMap = new TreeMap<Long, ArrayList<String>>(data);
         ArrayList<Object> rrd = new ArrayList<Object>();
-        for (Long time : data.keySet()) {
+        for (Long time : treeMap.keySet()) {
             Object[] entry = new Object[2];
             entry[0] = time;
             entry[1] = data.get(time);


### PR DESCRIPTION
The chart data wasn't ordered by time as needed by CometVisus chart engine. This fix orderes the data before sending it to the Visu.

Signed-off-by: Tobias Bräutigam <tbraeutigam@gmail.com> (github: peuter)