### PR TITLE
CV backend: Fix error handling for non existing config files

### DIFF
--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
@@ -216,7 +216,10 @@ public class CometVisuServlet extends HttpServlet {
 
                     return;
                 } else {
-                    throw new ServletException("Sitemap '" + matcher.group(1) + "' could not be found");
+                    logger.debug("Config file not found. Neither as normal config ('{}') nor as sitemap ('{}.sitemap')",
+                            requestedFile, matcher.group(2));
+                    resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
                 }
             }
         }


### PR DESCRIPTION
If cometVisu is requesting a non existing config file, the backend will throw an error instead of properly returning 404. This breaks the error handling in CV.

@peuter Please review.

Signed-off-by: Florian Schirmer <jolt@tuxbox.org> (github: joltcoke)