### PR TITLE
CV backend: Fix auto configuration header

### DIFF
--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
@@ -683,8 +683,6 @@ public class CometVisuServlet extends HttpServlet {
             disposition = accept != null && accepts(accept, contentType) ? "inline" : "attachment";
         }
 
-        // Initialize response.
-        response.reset();
         response.setBufferSize(DEFAULT_BUFFER_SIZE);
         response.setHeader("Content-Disposition", disposition + ";filename=\"" + fileName + "\"");
         response.setHeader("Accept-Ranges", "bytes");


### PR DESCRIPTION
Resetting the response will remove the already added auto configuration headers.

@peuter Please review.

Signed-off-by: Florian Schirmer <jolt@tuxbox.org> (github: joltcoke)