### PR TITLE
MAX Binding: Use workspace JDK instead of 1.7.

### DIFF
--- a/addons/binding/org.openhab.binding.max/.classpath
+++ b/addons/binding/org.openhab.binding.max/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>


### PR DESCRIPTION
Signed-off-by: Sebastian Janzen <sebastian@janzen.it>

I got compile errors because the MAX Binding project did not reference the Workspace JRE. It took JRE 1.7, but MAX Code uses 1.8 features.