### PR TITLE
ZWave restore config provider products list

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/danfoss_014g0160_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/danfoss_014g0160_0_0.xml
@@ -7,7 +7,9 @@
 
   <thing-type id="danfoss_014g0160_00_000" listed="false">
     <label>014G0160 Z-Wave room sensor</label>
-    <description>Z-Wave room sensor</description>
+    <description><![CDATA[
+Z-Wave room sensor<br /><h2>Inclusion Information</h2><p>Push one time LED Button</p> <br /><h2>Exclusion Information</h2><p>Push one time LED Button</p> <br /><h2>Wakeup Information</h2><p>Any button (LED, Temp+ or Temp-)</p>
+    ]]></description>
 
     <!-- CHANNEL DEFINITIONS -->
     <channels>
@@ -43,6 +45,109 @@
       <property name="manufacturerId">0002</property>
       <property name="manufacturerRef">0003:8010</property>
     </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_2" type="integer" groupName="configuration"
+                 min="1" max="100">
+        <label>1: Temperature Report threshold</label>
+        <description><![CDATA[
+Range is from 0.1 to 10°C 1=0.1°C 100=10°C<br /><h1>Overview</h1><p>Default value 5 = 0.5 °C</p>
+        ]]></description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_2_2" type="integer" groupName="configuration"
+                 min="1" max="100">
+        <label>2: Set-point display resolution</label>
+        <description>range from 0.1 to 10°C 1=0.1°C 100=10°C</description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_3_2" type="integer" groupName="configuration"
+                 min="0" max="40">
+        <label>3: Min Set-point and override limit</label>
+        <description>from min 0°C to max setpoint override limit 0=0°C 40=40°C</description>
+        <default>12</default>
+      </parameter>
+
+      <parameter name="config_4_2" type="integer" groupName="configuration"
+                 min="0" max="40">
+        <label>4: Max Set-point and override limit</label>
+        <description>from min setpoint override limit to max 40°C 0=0°C 40=40°C</description>
+        <default>28</default>
+      </parameter>
+
+      <parameter name="config_5_4" type="integer" groupName="configuration"
+                 min="0" max="65535">
+        <label>5: LED Flash period</label>
+        <description>0 to 65535 seconds</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_6_1" type="integer" groupName="configuration">
+        <label>6: Set-point control function</label>
+        <description>0=Disabled 1=Enabled</description>
+        <default>1</default>
+        <options>
+          <option value="0">disabled</option>
+          <option value="1">enabled</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_7_1" type="integer" groupName="configuration">
+        <label>7: Temporarily override scheduler</label>
+        <description>0=Disabled 1=Enabled</description>
+        <default>1</default>
+        <options>
+          <option value="0">disabled</option>
+          <option value="1">enabled</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_8_1" type="integer" groupName="configuration">
+        <label>8: Set-point type in Thermostat_Setpoint_Reports</label>
+        <description>1=Heating 2=Cooling 10=Auto Changeover</description>
+        <default>1</default>
+        <options>
+          <option value="1">Heating</option>
+          <option value="2">Cooling</option>
+          <option value="10">Auto-Changeover</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_9_2" type="integer" groupName="configuration"
+                 min="1" max="5">
+        <label>9: LED on time</label>
+        <description>1=100ms 5=500ms</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_10_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>10: Number of LED flashes (duration)</label>
+        <description>0 to 255</description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_11_1" type="integer" groupName="configuration">
+        <label>11: LED color</label>
+        <description>1=Green 2=Red</description>
+        <default>1</default>
+        <options>
+          <option value="1">Green</option>
+          <option value="2">Red</option>
+        </options>
+      </parameter>
+
+    </config-description>
 
   </thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/leviton_vrp03_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/leviton_vrp03_0_0.xml
@@ -32,7 +32,37 @@
       <property name="modelId">VRP03</property>
       <property name="manufacturerId">001D</property>
       <property name="manufacturerRef">0202:030B</property>
+      <property name="commandClass:BASIC">setVersion=1</property>
+      <property name="commandClass:SWITCH_MULTILEVEL">setVersion=1</property>
+      <property name="commandClass:SWITCH_ALL">setVersion=1</property>
+      <property name="commandClass:SCENE_ACTIVATION">setVersion=1</property>
+      <property name="commandClass:SCENE_ACTUATOR_CONF">setVersion=1</property>
+      <property name="commandClass:MANUFACTURER_SPECIFIC">setVersion=1</property>
+      <property name="commandClass:POWERLEVEL">setVersion=1</property>
+      <property name="commandClass:NODE_NAMING">setVersion=1</property>
+      <property name="commandClass:HAIL">setVersion=1</property>
+      <property name="commandClass:ASSOCIATION">setVersion=1</property>
+      <property name="commandClass:VERSION">setVersion=1</property>
+      <property name="commandClass:MANUFACTURER_PROPRIETARY">setVersion=1</property>
+      <property name="commandClass:MARK">setVersion=1</property>
+      <property name="defaultAssociations">1</property>
     </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Group 1</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
 
   </thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/leviton_vrs05_0_0.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/leviton_vrs05_0_0.xml
@@ -43,7 +43,7 @@
       <property name="commandClass:ASSOCIATION">setVersion=1</property>
       <property name="commandClass:VERSION">setVersion=1</property>
       <property name="commandClass:MANUFACTURER_PROPRIETARY">setVersion=1</property>
-      <property name="defaultAssociations">1</property>
+      <property name="defaultAssociations">1,2</property>
     </properties>
 
     <!-- CONFIGURATION DESCRIPTIONS -->
@@ -57,6 +57,11 @@
 
       <parameter name="group_1" type="text" groupName="association" multiple="true">
         <label>1: Group 1</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Group 2</label>
         <multipleLimit>5</multipleLimit>
       </parameter>
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/discovery/ZWaveDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/discovery/ZWaveDiscoveryService.java
@@ -172,7 +172,7 @@ public class ZWaveDiscoveryService extends AbstractDiscoveryService {
             if (product == null) {
                 continue;
             }
-            logger.debug("Checking {}", product.getThingTypeUID());
+            logger.debug("NODE {}: Checking {}", node.getNodeId(), product.getThingTypeUID());
             if (product.match(node) == true) {
                 foundProduct = product;
                 break;
@@ -188,7 +188,7 @@ public class ZWaveDiscoveryService extends AbstractDiscoveryService {
         // If we didn't find the product, then add the unknown thing
         String label = String.format("Z-Wave Node %d", node.getNodeId());
         if (foundProduct == null) {
-            logger.warn("NODE {}: Device could not be resolved to a thingType! {}:{}:{}::{}", node.getNodeId(),
+            logger.warn("NODE {}: Device discovery could not resolve to a thingType! {}:{}:{}::{}", node.getNodeId(),
                     String.format("%04X", node.getManufacturer()), String.format("%04X", node.getDeviceType()),
                     String.format("%04X", node.getDeviceId()), node.getApplicationVersion());
 
@@ -197,6 +197,8 @@ public class ZWaveDiscoveryService extends AbstractDiscoveryService {
                         node.getDeviceId(), node.getApplicationVersion());
             }
         } else {
+            logger.debug("NODE {}: Device discovery resolved to thingType {}", foundProduct.getThingTypeUID());
+
             // And create the new thing
             ThingType thingType = ZWaveConfigProvider.getThingType(foundProduct.getThingTypeUID());
             label += String.format(": %s", thingType.getLabel());

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -402,7 +402,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
 
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
-        logger.debug("NODE {}: Controller status changed.", nodeId, bridgeStatusInfo.getStatus());
+        logger.debug("NODE {}: Controller status changed to {}.", nodeId, bridgeStatusInfo.getStatus());
 
         if (bridgeStatusInfo.getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE);

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActivator.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActivator.java
@@ -15,8 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bundle activator to register the zwve service providers
- * 
+ * Bundle activator to register the zwave service providers
+ *
  * @author Chris Jackson
  */
 public final class ZWaveActivator implements BundleActivator {
@@ -25,27 +25,23 @@ public final class ZWaveActivator implements BundleActivator {
 
     private static BundleContext context;
 
-    // private ZWaveConfigProvider configProvider;
-
     /**
      * Called whenever the OSGi framework starts our bundle
-     * 
+     *
      * @param bc the bundle's execution context within the framework
      */
+    @Override
     public void start(BundleContext bc) throws Exception {
         context = bc;
-        logger.debug("ZWave binding started. Version {}", ZWaveActivator.getVersion());
-
-        // configProvider = new ZWaveConfigProvider();
-        // bc.registerService(ConfigDescriptionProvider.class.getName(), configProvider, new Hashtable<String,
-        // Object>());
+        logger.debug("Z-Wave binding started. Version {}", ZWaveActivator.getVersion());
     }
 
     /**
      * Called whenever the OSGi framework stops our bundle
-     * 
+     *
      * @param bc the bundle's execution context within the framework
      */
+    @Override
     public void stop(BundleContext bc) throws Exception {
         context = null;
         logger.debug("ZWave binding stopped.");
@@ -53,7 +49,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Returns the bundle context of this bundle
-     * 
+     *
      * @return the bundle context
      */
     public static BundleContext getContext() {
@@ -62,7 +58,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Returns the current version of the bundle.
-     * 
+     *
      * @return the current version of the bundle.
      */
     public static Version getVersion() {

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableSet;
 
 public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOptionProvider {
-    private final Logger logger = LoggerFactory.getLogger(ZWaveConfigProvider.class);
+    private final static Logger logger = LoggerFactory.getLogger(ZWaveConfigProvider.class);
 
     private static ThingRegistry thingRegistry;
     private static ThingTypeRegistry thingTypeRegistry;
@@ -304,6 +304,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                 Map<String, String> thingProperties = thingType.getProperties();
 
                 if (thingProperties.get(ZWaveBindingConstants.PROPERTY_XML_REFERENCES) == null) {
+                    logger.debug("ZWave product {} has no references!", thingType.getUID());
                     continue;
                 }
 
@@ -313,6 +314,8 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                     Integer type;
                     Integer id = null;
                     if (values.length != 2) {
+                        logger.debug("ZWave product {} has invalid references! '{}'", thingType.getUID(),
+                                thingProperties.get(ZWaveBindingConstants.PROPERTY_XML_REFERENCES));
                         continue;
                     }
 
@@ -326,22 +329,21 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                             Integer.parseInt(thingProperties.get(ZWaveBindingConstants.PROPERTY_XML_MANUFACTURER), 16),
                             type, id, versionMin, versionMax));
                 }
-
             }
         }
     }
 
     public static synchronized List<ZWaveProduct> getProductIndex() {
-        // if (productIndex.size() == 0) {
-        initialiseZWaveThings();
-        // }
+        if (productIndex.size() == 0) {
+            initialiseZWaveThings();
+        }
         return productIndex;
     }
 
     public static Set<ThingTypeUID> getSupportedThingTypes() {
-        // if (zwaveThingTypeUIDList.size() == 0) {
-        initialiseZWaveThings();
-        // }
+        if (zwaveThingTypeUIDList.size() == 0) {
+            initialiseZWaveThings();
+        }
         return zwaveThingTypeUIDList;
     }
 


### PR DESCRIPTION
This restores the generation of a single list of products that is created the first time the list is requested.
This was disabled before the XML startup sequence issue was resolved.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>