### PR TITLE
Support subclasses of expected Item in HomeKit

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -47,7 +47,7 @@ abstract class AbstractHomekitAccessoryImpl<T extends GenericItem> implements Ho
             baseItem = ((GroupItem) baseItem).getBaseItem();
         }
         if (expectedItemClass != taggedItem.getItem().getClass()
-                && expectedItemClass.isAssignableFrom(baseItem.getClass())) {
+                && !expectedItemClass.isAssignableFrom(baseItem.getClass())) {
             logger.error("Type " + taggedItem.getItem().getName() + " is a " + baseItem.getClass().getName()
                     + " instead of the expected " + expectedItemClass.getName());
         }


### PR DESCRIPTION
Accidental inversion of the check for a subclass of supported items prevented the subclasses from being recognized by the HomeKit binding. This had the effect of, for example, not allowing a ColorItem to be used for a Lighting accessory, even though ColorItem extends SwitchItem.

Fixes #1052

Signed-off-by: Andy Lintner <dev@beowulfe.com>