### PR TITLE
Allow CurrentTemperature on HomeKit Thermostat

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -35,11 +35,12 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
 
     @Override
     public synchronized void added(Item item) {
-        HomekitTaggedItem taggedItem = new HomekitTaggedItem(item);
+        HomekitTaggedItem taggedItem = new HomekitTaggedItem(item, itemRegistry);
         if (taggedItem.isTagged()) {
             if (taggedItem.isRootDevice()) {
                 createRootDevice(taggedItem);
-            } else {
+            }
+            if (taggedItem.isCharacteristic()) {
                 createCharacteristic(taggedItem);
             }
         }
@@ -52,7 +53,7 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
 
     @Override
     public synchronized void removed(Item item) {
-        HomekitTaggedItem taggedItem = new HomekitTaggedItem(item);
+        HomekitTaggedItem taggedItem = new HomekitTaggedItem(item, itemRegistry);
         if (taggedItem.isTagged()) {
             accessoryRegistry.remove(taggedItem);
         }

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.library.items.DimmerItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,13 +33,15 @@ public class HomekitTaggedItem {
     private Logger logger = LoggerFactory.getLogger(HomekitTaggedItem.class);
     private final int id;
 
-    public HomekitTaggedItem(Item item) {
+    public HomekitTaggedItem(Item item, ItemRegistry itemRegistry) {
         this.item = item;
         for (String tag : item.getTags()) {
             if (item instanceof DimmerItem) {
                 tag = "Dimmable" + tag;
             }
-            homekitDeviceType = HomekitDeviceType.valueOfTag(tag);
+            if (!isMemberOfRootGroup(item, itemRegistry)) {
+                homekitDeviceType = HomekitDeviceType.valueOfTag(tag);
+            }
             if (homekitDeviceType == null) {
                 homekitCharacteristicType = HomekitCharacteristicType.valueOfTag(tag);
             }
@@ -64,6 +67,10 @@ public class HomekitTaggedItem {
 
     public boolean isRootDevice() {
         return homekitDeviceType != null;
+    }
+
+    public boolean isCharacteristic() {
+        return homekitCharacteristicType != null;
     }
 
     public Item getItem() {
@@ -95,5 +102,19 @@ public class HomekitTaggedItem {
             CREATED_ACCESSORY_IDS.put(id, item.getName());
         }
         return id;
+    }
+
+    private boolean isMemberOfRootGroup(Item item, ItemRegistry itemRegistry) {
+        for (String groupName : item.getGroupNames()) {
+            Item groupItem = itemRegistry.get(groupName);
+            if (groupItem != null) {
+                for (String groupTag : groupItem.getTags()) {
+                    if (HomekitDeviceType.valueOfTag(groupTag) != null) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
In the initial implementation, characteristics and accessories had their own unique naming convention. With the ESH ontology, CurrentTemperature became both an individual accessory and a characteristic of a Thermostat.

With this change, we look at the groups an item belongs to before deciding if it is an accessory or a characteristic - if a group is tagged with a recognized value, we treat the item as a characteristic.

Fixes #1053

Signed-off-by: Andy Lintner <dev@beowulfe.com>