### PR TITLE
YamahaReceiver: Support RefreshType handling

### DIFF
--- a/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
@@ -25,10 +25,10 @@
                 <label>Address</label>
                 <description>The address of the AVR to control.</description>
             </parameter>
-            <parameter name="REFRESH" type="integer" required="false">
+            <parameter name="REFRESH_IN_SEC" type="integer" required="false">
                 <label>Refresh interval</label>
-                <description>Refresh interval in minutes.</description>
-                <default>1</default>
+                <description>Refresh interval in seconds.</description>
+                <default>60</default>
                 <advanced>true</advanced>
             </parameter>
             <parameter name="RELVOLUMECHANGE" type="decimal" required="false">

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
@@ -36,7 +36,7 @@ public class YamahaReceiverBindingConstants {
 
     public static final CharSequence UPNP_MANUFACTURER = "YAMAHA";
 
-    public static final String CONFIG_REFRESH = "REFRESH";
+    public static final String CONFIG_REFRESH = "REFRESH_IN_SEC";
     public static final String CONFIG_HOST_NAME = "HOST";
     public static final String CONFIG_ZONE = "ZONE";
     public static final String CONFIG_RELVOLUMECHANGE = "RELVOLUMECHANGE";


### PR DESCRIPTION
Allow the user to specify a refreh rate in seconds rather than minutes with a refreh rate default of one minute

Signed-off-by: David Graeff <david.graeff@web.de>