### PR TITLE
Netatmo javax.net

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
@@ -24,7 +24,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ javax.net,
+ javax.net.ssl
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.netatmo,
  org.openhab.binding.netatmo.handler


### PR DESCRIPTION
Fix for issue #1070 

Add missing javax.net packages for the NetAtmo API client.

Signed off by: Alan Alberghini <alan@iooota.com> (github: IOOOTAlan)