### PR TITLE
RFXCOM binding: fix binding initialization

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
@@ -80,6 +80,10 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
     public void dispose() {
         logger.debug("Handler disposed.");
 
+        for (DeviceMessageListener deviceStatusListener : deviceStatusListeners) {
+            unregisterDeviceStatusListener(deviceStatusListener);
+        }
+
         if (connector != null) {
             connector.removeEventListener(eventListener);
             connector.disconnect();
@@ -408,7 +412,8 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
         if (deviceStatusListener == null) {
             throw new IllegalArgumentException("It's not allowed to pass a null deviceStatusListener.");
         }
-        return deviceStatusListeners.add(deviceStatusListener);
+        return deviceStatusListeners.contains(deviceStatusListener) ? false
+                : deviceStatusListeners.add(deviceStatusListener);
     }
 
     public boolean unregisterDeviceStatusListener(DeviceMessageListener deviceStatusListener) {

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComHandler.java
@@ -15,11 +15,11 @@ import java.util.concurrent.ScheduledFuture;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -97,51 +97,37 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
      */
     @Override
     public void initialize() {
-        config = getConfigAs(RFXComDeviceConfiguration.class);
-        logger.debug("Initialized RFXCOM device handler for {}, deviceId={}, subType={}", getThing().getUID(),
-                config.deviceId, config.subType);
-
-        if (config.deviceId == null || config.subType == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Initialized RFXCOM device missing deviceId or subType");
-        }
-
-        initializeBridge(getBridge().getHandler(), getBridge());
+        logger.debug("Initializing thing {}", getThing().getUID());
+        initializeBridge((getBridge() == null) ? null : getBridge().getHandler(),
+                (getBridge() == null) ? null : getBridge().getStatus());
     }
 
     @Override
-    public void bridgeHandlerInitialized(ThingHandler thingHandler, Bridge bridge) {
-        initializeBridge(thingHandler, bridge);
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        logger.debug("bridgeStatusChanged {} for thing {}", bridgeStatusInfo, getThing().getUID());
+        initializeBridge((getBridge() == null) ? null : getBridge().getHandler(), bridgeStatusInfo.getStatus());
     }
 
-    private void initializeBridge(ThingHandler thingHandler, Bridge bridge) {
-        if (thingHandler != null && bridge != null) {
+    private void initializeBridge(ThingHandler thingHandler, ThingStatus bridgeStatus) {
+        logger.debug("initializeBridge {} for thing {}", bridgeStatus, getThing().getUID());
 
-            logger.debug("Bridge initialized");
+        config = getConfigAs(RFXComDeviceConfiguration.class);
+        if (config.deviceId == null || config.subType == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "RFXCOM device missing deviceId or subType");
+        } else if (thingHandler != null && bridgeStatus != null) {
 
             bridgeHandler = (RFXComBridgeHandler) thingHandler;
             bridgeHandler.registerDeviceStatusListener(this);
 
-            if (config.deviceId == null || config.subType == null) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "RFXCOM device missing deviceId or subType");
+            if (bridgeStatus == ThingStatus.ONLINE) {
+                updateStatus(ThingStatus.ONLINE);
             } else {
-                if (bridge.getStatus() == ThingStatus.ONLINE) {
-                    updateStatus(ThingStatus.ONLINE);
-                } else {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
-                }
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
             }
+        } else {
+            updateStatus(ThingStatus.OFFLINE);
         }
-    }
-
-    @Override
-    public void bridgeHandlerDisposed(ThingHandler thingHandler, Bridge bridge) {
-        logger.debug("Bridge disposed");
-        if (bridgeHandler != null) {
-            bridgeHandler.unregisterDeviceStatusListener(this);
-        }
-        bridgeHandler = null;
     }
 
     /*
@@ -152,6 +138,10 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
     @Override
     public void dispose() {
         logger.debug("Thing {} disposed.", getThing().getUID());
+        if (bridgeHandler != null) {
+            bridgeHandler.unregisterDeviceStatusListener(this);
+        }
+        bridgeHandler = null;
         super.dispose();
     }
 
@@ -163,7 +153,7 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                 RFXComBaseMessage msg = (RFXComBaseMessage) message;
                 String receivedId = packetTypeThingMap.get(msg.packetType).getId();
 
-                if (receivedId.equals(getThing().getUID().getThingTypeId())) {
+                if (receivedId.equals(getThing().getThingTypeUID().getId())) {
                     updateStatus(ThingStatus.ONLINE);
                     logger.debug("Received message from bridge: {} message: {}", bridge, message);
 


### PR DESCRIPTION
Avoid a Null Pointer Exception at initialization
Suppress depreciated methods bridgeHandlerInitialized and
bridgeHandlerDisposed
Avoid multiple listeners registered for the same thing
Replace use of depreciated method getThingTypeId

Signed-off-by: Laurent Garnier <lg.hc@free.fr>