### PR TITLE
RFXCom Documentation: Fix wording and typos. Alphabetise supported channel list.

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/README.md
+++ b/addons/binding/org.openhab.binding.rfxcom/README.md
@@ -1,8 +1,8 @@
 # RFXCOM Binding
 
-This binding integrates large number of sensors and actuators from several different manufactures throug the [RFXCOM transceivers](http://www.rfxcom.com).
+This binding integrates large number of sensors and actuators from several different manufactures through [RFXCOM transceivers](http://www.rfxcom.com).
 
-RFXCOM transceivers supports RF 433 Mhz protocols like: 
+RFXCOM transceivers support RF 433 Mhz protocols like: 
 * HomeEasy 
 * Cresta 
 * X10 
@@ -12,14 +12,14 @@ RFXCOM transceivers supports RF 433 Mhz protocols like:
 * PT2262
 * Oregon etc.
 
-See RFXtrx User Guide for the complete list of supported sensors and devices from [RFXCOM](http://www.rfxcom.com) and firmware update announcements.
+See the RFXtrx User Guide from [RFXCOM](http://www.rfxcom.com) for the complete list of supported sensors and devices as well as firmware update announcements.
 
 
 ## Supported Things
 
-Binding should support RFXtrx433E and RFXtrx315 transceivers and RFXrec433 receiver as bridge for accessing different sensors and actuators.
+This binding supports the RFXtrx433E and RFXtrx315 transceivers and the RFXrec433 receiver as bridges for accessing different sensors and actuators.
 
-RFXCOM binding currently supports following packet types:
+This binding currently supports following packet types:
 
 * Blinds1
 * Curtain1 
@@ -59,11 +59,11 @@ FTDI driver can be enabled by the following command
 sudo kextunload -b com.apple.driver.AppleUSBFTDI
 ```
 
-If you meet any problems with JD2XX or you don't want to disable FTDI driver on OS X, you can also configure RFXCOM transceivers/receivers manually.
+If you have any problems with JD2XX or you don't want to disable FTDI driver on OS X, you can also configure RFXCOM transceivers/receivers manually.
 
-After bridge is configured and transceiver receives message from any sensor and actuator, device is put in the Inbox. Because RFXCOM communication is one way protocol, receiver actuators can't be discovered automatically.
+After the bridge is configured and the transceiver receives a message from any sensor or actuator, the device is put in the Inbox. Because RFXCOM communication is a one way protocol, receiver actuators can't be discovered automatically.
 
-Both bridges and sensor/actuators are easy to configure from the Paper UI. However, a manual configuration looks (thing file) e.g. like
+Both bridges and sensor/actuators are easy to configure from the Paper UI. However, you can configure things manually in the thing file, for example:
 
 ```
 Bridge rfxcom:bridge:usb0 [ serialPort="/dev/tty.usbserial-06VVEG1Y" ] {
@@ -73,28 +73,28 @@ Bridge rfxcom:bridge:usb0 [ serialPort="/dev/tty.usbserial-06VVEG1Y" ] {
 
 ## Channels
 
-Currently supported  channels:
+This binding currently supports following channels:
 
 | Channel Type ID | Item Type    | Description  |
 |-----------------|------------------------|--------------|
+| batterylevel | Number | Battery level. |
 | command | Switch | Command channel. |
 | contact | Contact | Contact channel. |
 | dimminglevel | Dimmer | Dimming level channel. |
-| mood | Number | Mood channel. |
+| humidity | Number | Relative humidity level in percentages. |
+| humiditystatus | String | Current humidity status. |
+| instantamp | Number | Instant current in Amperes. |
+| instantpower | Number | Instant power consumption in Watts. |
 | status | String | Status channel. |
 | setpoint | Number | Requested temperature. |
+| mood | Number | Mood channel. |
 | motion | Switch | Motion detection sensor state. |
 | rainrate | Number | Rain fall rate in millimeters per hour. |
 | raintotal | Number | Total rain in millimeters. |
 | shutter | Rollershutter | Shutter channel. |
-| instantpower | Number | Instant power consumption in Watts. |
-| totalusage | Number | Used energy in Watt hours. |
-| instantamp | Number | Instant current in Amperes. |
-| totalamphours | Number | Used "energy" in ampere-hours. |
-| temperature | Number | Current temperature in degree Celsius. |
-| humidity | Number | Relative humidity level in percentages. |
-| humiditystatus | String | Current humidity status. |
 | signallevel | Number | Received signal strength level. |
-| batterylevel | Number | Battery level. |
-| windspeed | Number | Average wind speed in meters per second. |
+| temperature | Number | Current temperature in degree Celsius. |
+| totalusage | Number | Used energy in Watt hours. |
+| totalamphours | Number | Used "energy" in ampere-hours. |
 | winddirection | Number | Wind direction in degrees. |
+| windspeed | Number | Average wind speed in meters per second. |


### PR DESCRIPTION
Simple doc fixes.