### PR TITLE
Add Groovy Eclipse compiler to the master pom.

### DIFF
--- a/addons/binding/org.openhab.binding.max.test/pom.xml
+++ b/addons/binding/org.openhab.binding.max.test/pom.xml
@@ -16,32 +16,10 @@
 	<properties>
 		<bundle.symbolicName>org.openhab.binding.max.test</bundle.symbolicName>
 		<bundle.namespace>org.openhab.binding.max.test</bundle.namespace>
-		<groovy.eclipse.compiler.version>2.8.0-01</groovy.eclipse.compiler.version>
-        <groovy.eclipse.batch.version>2.1.5-03</groovy.eclipse.batch.version>
 	</properties>
 	
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-compiler-plugin</artifactId>
-				<version>0.24.0</version>
-				<configuration>
-					<compilerId>groovy-eclipse-compiler</compilerId>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.codehaus.groovy</groupId>
-						<artifactId>groovy-eclipse-compiler</artifactId>
-						<version>${groovy.eclipse.compiler.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.codehaus.groovy</groupId>
-						<artifactId>groovy-eclipse-batch</artifactId>
-						<version>${groovy.eclipse.batch.version}</version>
-					</dependency>
-				</dependencies>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>

--- a/addons/binding/org.openhab.binding.systeminfo.test/pom.xml
+++ b/addons/binding/org.openhab.binding.systeminfo.test/pom.xml
@@ -13,8 +13,6 @@
 	<properties>
 		<bundle.symbolicName>org.openhab.binding.systeminfo.test</bundle.symbolicName>
 		<bundle.namespace>org.openhab.binding.systeminfo.test</bundle.namespace>
-		<groovy.eclipse.compiler.version>2.8.0-01</groovy.eclipse.compiler.version>
-		<groovy.eclipse.batch.version>2.1.5-03</groovy.eclipse.batch.version>
 	</properties>
 
 	<artifactId>org.openhab.binding.systeminfo.test</artifactId>
@@ -22,27 +20,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-compiler-plugin</artifactId>
-				<version>0.24.0</version>
-				<configuration>
-					<compilerId>groovy-eclipse-compiler</compilerId>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.codehaus.groovy</groupId>
-						<artifactId>groovy-eclipse-compiler</artifactId>
-						<version>${groovy.eclipse.compiler.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.codehaus.groovy</groupId>
-						<artifactId>groovy-eclipse-batch</artifactId>
-						<version>${groovy.eclipse.batch.version}</version>
-					</dependency>
-				</dependencies>
-			</plugin>
+		<plugins>			
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
         <tycho-groupid>org.eclipse.tycho</tycho-groupid>
         <build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.version>3.1</maven.compiler.version>
+        <groovy.eclipse.compiler.version>2.8.0-01</groovy.eclipse.compiler.version>
+        <groovy.eclipse.batch.version>2.1.5-03</groovy.eclipse.batch.version>
     </properties>
 
     <packaging>pom</packaging>
@@ -114,6 +117,9 @@
                 <configuration>
                     <strictVersions>false</strictVersions>
                 </configuration>
+            </plugin>
+            <plugin>
+                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
         </plugins>
 
@@ -174,6 +180,32 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.version}</version>
+                    <configuration>
+                        <compilerId>groovy-eclipse-compiler</compilerId>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                               <goal>compile</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-eclipse-compiler</artifactId>
+                            <version>${groovy.eclipse.compiler.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-eclipse-batch</artifactId>
+                            <version>${groovy.eclipse.batch.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>${tycho-groupid}</groupId>


### PR DESCRIPTION
Groovy Eclipse compiler is missing in the master pom and .groovy tests can not
be executed without additional configuration.

I have added some workarounds to the Systeminfo binding and Max binding in order to
execute Groovy tests with #772 and #785, but I think it makes more sense
to move the Groovy Eclipse compiler to the master POM, so new test bundles can use it (like in the
ESH repo).

I took as an example the .pom file from the ESH repo.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com