### PR TITLE
Meteostick: Add example things definition and improve config handling

### DIFF
--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -15,7 +15,7 @@
 				<label>Serial Port</label>
 				<description>Serial port that the Meteostick is plugged in to</description>
 			</parameter>
-			<parameter name="mode" type="text" required="true">
+			<parameter name="mode" type="integer" required="true">
 				<label>Frequency Band</label>
 				<description>Specifies the frequency band Meteostick shall listen to</description>
 				<options>

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -6,10 +6,10 @@ This is the binding for the [Meteostick](http://www.smartbedded.com/wiki/index.p
 
 This binding support 2 different things types
 
-| Thing | Type    | Description  |
-|----------------|---------|-----------------------------------|
-| meteostick_bridge | Bridge | This is the Meteostick USB stick  |
-| meteostick_davis_iss | Thing | This is the Davis Vue ISS |
+| Thing                | Type   | Description                       |
+|----------------------|--------|-----------------------------------|
+| meteostick_bridge    | Bridge | This is the Meteostick USB stick  |
+| meteostick_davis_iss | Thing  | This is the Davis Vue ISS         |
 
 
 ## Binding Configuration
@@ -18,6 +18,22 @@ The Meteostick things need to be manually added - there is no discovery in the M
 
 First add and configure the Meteostick bridge - the port and frequency band for your region need to be set.
 Next add the sensor and configure the channel number.
+
+## Thing Configuration
+
+### meteostick_bridge Configuration Options
+
+| Option | Description                                                                |
+|--------|----------------------------------------------------------------------------|
+| port   | Sets the serial port to be used for the stick                              |
+| mode   | Sets the operating mode 0 = USA, 1 = Europe, 2 = Australia. 3 = FineOffset |
+
+
+### meteostick_davis_iss Configuration Options
+
+| Option  | Description                               |
+|---------|-------------------------------------------|
+| channel | Sets the RF channel used for this sensor  |
 
 ## Channels
 
@@ -43,8 +59,17 @@ Next add the sensor and configure the channel number.
 | signal-strength | Number       | Received signal strength |
 | low-battery | Number       | Low battery warning |
 
-### Rainfall
+#### Rainfall
 
 There are three channels associated with rainfall. The raw counter from the tipping bucket is provided, the rainfall 
 in the last 60 minutes is updated on each received rainfall and provides the past 60 minutes of rainfall. The rainfall
 in the previous hour is the rainfall for each hour of the day and is updated on the hour.
+
+## Full Example
+
+Things can be defined in the .thing file as follows
+
+```
+meteostick:meteostick_bridge:receiver [ port="/dev/tty.usbserial-AI02XA60" mode="1" ]
+meteostick:meteostick_davis_iss:iss (meteostick:meteostick_bridge:receiver) [ channel=1 ]
+```

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickBridgeHandler.java
@@ -82,6 +82,11 @@ public class MeteostickBridgeHandler extends BaseThingHandler {
 
         final String port = (String) config.get("port");
 
+        final BigDecimal mode = (BigDecimal) config.get("mode");
+        if (mode != null) {
+            meteostickMode = "m" + mode.toString();
+        }
+
         Runnable pollingRunnable = new Runnable() {
             @Override
             public void run() {

--- a/addons/binding/pom.xml.orig
+++ b/addons/binding/pom.xml.orig
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.openhab.addons</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>pom</artifactId>
+
+  <name>openHAB Bindings</name>
+
+  <packaging>pom</packaging>
+ 
+  <modules>
+    <module>org.openhab.binding.astro</module>
+    <module>org.openhab.binding.autelis</module>
+    <module>org.openhab.binding.avmfritz</module>
+    <module>org.openhab.binding.dscalarm</module>
+    <module>org.openhab.binding.freebox</module>
+    <module>org.openhab.binding.harmonyhub</module>
+    <module>org.openhab.binding.hdanywhere</module>
+    <module>org.openhab.binding.homematic</module>
+    <module>org.openhab.binding.ipp</module>
+    <module>org.openhab.binding.keba</module>
+    <module>org.openhab.binding.kostalinverter</module>
+    <module>org.openhab.binding.lutron</module>
+    <module>org.openhab.binding.max</module>
+    <module>org.openhab.binding.max.test</module>
+    <module>org.openhab.binding.milight</module>
+    <module>org.openhab.binding.netatmo</module>
+    <module>org.openhab.binding.network</module>
+    <module>org.openhab.binding.opensprinkler</module>
+    <module>org.openhab.binding.orvibo</module>
+    <module>org.openhab.binding.pioneeravr</module>
+    <module>org.openhab.binding.pulseaudio</module>
+    <module>org.openhab.binding.rme</module>
+    <module>org.openhab.binding.rfxcom</module>
+    <module>org.openhab.binding.samsungtv</module>
+    <module>org.openhab.binding.smaenergymeter</module>
+    <module>org.openhab.binding.squeezebox</module>
+    <module>org.openhab.binding.tesla</module>
+    <module>org.openhab.binding.urtsi</module>
+    <module>org.openhab.binding.vitotronic</module>
+<<<<<<< HEAD
+    <module>org.openhab.binding.meteostick</module>
+=======
+    <module>org.openhab.binding.yamahareceiver</module>
+    <module>org.openhab.binding.zwave</module>
+    <module>org.openhab.binding.systeminfo</module>
+    <module>org.openhab.binding.systeminfo.test</module>
+    <module>org.openhab.binding.zwave.test</module>
+>>>>>>> master
+  </modules>
+
+</project>


### PR DESCRIPTION
Changed mode config to integer from text and actually use it in the initialisation. Added example thing definition.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>