### PR TITLE
ZWave fix processing of alarm supported report

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
@@ -154,7 +154,9 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
             case ALARM_SUPPORTED_REPORT:
                 logger.debug("NODE {}: Process Alarm Supported Report", getNode().getNodeId());
 
-                int numBytes = serialMessage.getMessagePayloadByte(offset + 1);
+                // On at least some devices, the top bit is set, so let's mask this out.
+                // TODO: This bit probably has some meaning that we don't yet know
+                int numBytes = serialMessage.getMessagePayloadByte(offset + 1) & 0x7f;
                 for (int i = 0; i < numBytes; ++i) {
                     for (int bit = 0; bit < 8; ++bit) {
                         if (((serialMessage.getMessagePayloadByte(offset + i + 2)) & (1 << bit)) == 0) {


### PR DESCRIPTION
Some devices report the length with the top bit set - this needs to be masked out.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>