### PR TITLE
Samsung TV binding: compliant with updated UpnpIOParticipant interface

### DIFF
--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
@@ -169,6 +169,10 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
     }
 
     @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+    }
+
+    @Override
     public void onValueReceived(String variable, String value, String service) {
 
         String oldValue = stateMap.get(variable);

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
@@ -181,6 +181,10 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
     }
 
     @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+    }
+
+    @Override
     public void onValueReceived(String variable, String value, String service) {
 
         String oldValue = stateMap.get(variable);


### PR DESCRIPTION
Should be merged when https://github.com/eclipse/smarthome/pull/1967 is merged in Eclupse smarthome

Signed-off-by: Laurent Garnier <lg.hc@free.fr>