### PR TITLE
Surface the error that occurs when the connection fails

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
@@ -213,7 +213,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
         } catch (NoSuchPortException e) {
             logger.error("Connection to RFXCOM transceiver failed: invalid port");
         } catch (Exception e) {
-            logger.error("Connection to RFXCOM transceiver failed: {}", e.getMessage());
+            logger.error("Connection to RFXCOM transceiver failed", e);
         } catch (UnsatisfiedLinkError e) {
             logger.error("Error occured when trying to load native library for OS '{}' version '{}', processor '{}'",
                     System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"), e);


### PR DESCRIPTION
I had trouble connecting to the serial device after doing a bundle:stop/bundle:start in karaf a number of times, and this catch was hiding the cause of the error. This change makes it more clear why its not reconnecting.

It seems there is a bug in that the lock file is not being deleted on bundle:stop, so that needs to be looked into. I know there are other serial port locking problems around, so I guess they're related.