### PR TITLE
[squeezebox] Fixes reconnect, player status, requestPlayerJob cancellation.

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.squeezebox.discovery;
 
-import static org.openhab.binding.squeezebox.SqueezeBoxBindingConstants.*;
+import static org.openhab.binding.squeezebox.SqueezeBoxBindingConstants.SQUEEZEBOXPLAYER_THING_TYPE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,148 +29,160 @@ import org.slf4j.LoggerFactory;
 /**
  * When a {@link SqueezeBoxServerHandler} finds a new SqueezeBox Player we will
  * add it to the system.
- * 
+ *
  * @author Dan Cunningham
+ * @author Mark Hilbush - added method to cancel request player job, and to set thing properties
  *
  */
 public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryService
-		implements SqueezeBoxPlayerEventListener {
-	private final Logger logger = LoggerFactory
-			.getLogger(SqueezeBoxPlayerDiscoveryParticipant.class);
+        implements SqueezeBoxPlayerEventListener {
+    private final Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerDiscoveryParticipant.class);
 
-	private final static int TIMEOUT = 60;
-	private final static int TTL = 60;
+    private final static int TIMEOUT = 60;
+    private final static int TTL = 60;
 
-	private SqueezeBoxServerHandler squeezeBoxServerHandler;
-	private ScheduledFuture<?> requestPlayerJob;
+    private SqueezeBoxServerHandler squeezeBoxServerHandler;
+    private ScheduledFuture<?> requestPlayerJob;
 
-	/**
-	 * Discovers SqueezeBox Players attached to a SqueezeBox Server
-	 * 
-	 * @param squeezeBoxServerHandler
-	 */
-	public SqueezeBoxPlayerDiscoveryParticipant(
-			SqueezeBoxServerHandler squeezeBoxServerHandler) {
-		super(SqueezeBoxPlayerHandler.SUPPORTED_THING_TYPES_UIDS, TIMEOUT, true);
-		this.squeezeBoxServerHandler = squeezeBoxServerHandler;
-		setupRequestPlayerJob();
-	}
+    /**
+     * Discovers SqueezeBox Players attached to a SqueezeBox Server
+     *
+     * @param squeezeBoxServerHandler
+     */
+    public SqueezeBoxPlayerDiscoveryParticipant(SqueezeBoxServerHandler squeezeBoxServerHandler) {
+        super(SqueezeBoxPlayerHandler.SUPPORTED_THING_TYPES_UIDS, TIMEOUT, true);
+        this.squeezeBoxServerHandler = squeezeBoxServerHandler;
+        setupRequestPlayerJob();
+    }
 
-	@Override
-	protected void startScan() {
-		this.squeezeBoxServerHandler.requestPlayers();
-	}
+    @Override
+    protected void startScan() {
+        logger.debug("startScan invoked in SqueezeBoxPlayerDiscoveryParticipant");
+        this.squeezeBoxServerHandler.requestPlayers();
+    }
 
-	@Override
-	protected void startBackgroundDiscovery() {
-		this.squeezeBoxServerHandler.requestPlayers();
-	};
+    /*
+     * Allows request player job to be canceled when server handler is removed
+     */
+    public void cancelRequestPlayerJob() {
+        logger.debug("canceling RequestPlayerJob");
+        if (requestPlayerJob != null) {
+            requestPlayerJob.cancel(true);
+            requestPlayerJob = null;
+        }
+    }
 
-	@Override
-	protected void deactivate() {
-		super.deactivate();
-		if (requestPlayerJob != null) {
-			requestPlayerJob.cancel(true);
-			requestPlayerJob = null;
-		}
-	}
+    @Override
+    public void playerAdded(SqueezeBoxPlayer player) {
+        ThingUID bridgeUID = squeezeBoxServerHandler.getThing().getUID();
 
-	@Override
-	public void playerAdded(SqueezeBoxPlayer player) {
-		logger.debug("Player added {} {} ", player.getMacAddress(),
-				player.getName());
-		ThingUID bridgeUID = squeezeBoxServerHandler.getThing().getUID();
-		ThingUID thingUID = new ThingUID(SQUEEZEBOXPLAYER_THING_TYPE,
-				bridgeUID, player.getMacAddress().replace(":", ""));
-		Map<String, Object> properties = new HashMap<>(1);
-		properties.put("mac", player.getMacAddress());
-		DiscoveryResult discoveryResult = DiscoveryResultBuilder
-				.create(thingUID).withProperties(properties)
-				.withBridge(bridgeUID)
-				.withLabel(player.getName()).build();
-		thingDiscovered(discoveryResult);
-		
-	}
+        ThingUID thingUID = new ThingUID(SQUEEZEBOXPLAYER_THING_TYPE, bridgeUID,
+                player.getMacAddress().replace(":", ""));
 
-	/**
-	 * Tells the bridge to request a list of players
-	 */
-	private void setupRequestPlayerJob() {
-		Runnable runnable = new Runnable() {
-			public void run() {
-				squeezeBoxServerHandler.requestPlayers();
-			}
-		};
-		requestPlayerJob = scheduler.scheduleWithFixedDelay(runnable, 10, TTL,
-				TimeUnit.SECONDS);
-	}
+        if (!playerThingExists(thingUID)) {
+            logger.debug("player added {} : {} ", player.getMacAddress(), player.getName());
 
-	// we can ignore the other events
-	@Override
-	public void powerChangeEvent(String mac, boolean power) {
-	}
+            Map<String, Object> properties = new HashMap<>(1);
+            properties.put("mac", player.getMacAddress());
 
-	@Override
-	public void modeChangeEvent(String mac, String mode) {
-	}
+            // Added other properties
+            properties.put("modelId", player.getModel());
+            properties.put("name", player.getName());
+            properties.put("uid", player.getUuid());
+            properties.put("ip", player.getIpAddr());
 
-	@Override
-	public void volumeChangeEvent(String mac, int volume) {
-	}
+            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                    .withBridge(bridgeUID).withLabel(player.getName()).build();
 
-	@Override
-	public void muteChangeEvent(String mac, boolean mute) {
-	}
+            thingDiscovered(discoveryResult);
+        }
+    }
 
-	@Override
-	public void currentPlaylistIndexEvent(String mac, int index) {
-	}
+    private boolean playerThingExists(ThingUID newThingUID) {
+        return squeezeBoxServerHandler.getThingByUID(newThingUID) != null ? true : false;
+    }
 
-	@Override
-	public void currentPlayingTimeEvent(String mac, int time) {
-	}
+    /**
+     * Tells the bridge to request a list of players
+     */
+    private void setupRequestPlayerJob() {
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                squeezeBoxServerHandler.requestPlayers();
+            }
+        };
+        
+        logger.debug("request player job scheduled to run every {} seconds", TTL);
+        requestPlayerJob = scheduler.scheduleWithFixedDelay(runnable, 10, TTL, TimeUnit.SECONDS);
+    }
 
-	@Override
-	public void numberPlaylistTracksEvent(String mac, int track) {
-	}
+    // we can ignore the other events
+    @Override
+    public void powerChangeEvent(String mac, boolean power) {
+    }
 
-	@Override
-	public void currentPlaylistShuffleEvent(String mac, int shuffle) {
-	}
+    @Override
+    public void modeChangeEvent(String mac, String mode) {
+    }
 
-	@Override
-	public void currentPlaylistRepeatEvent(String mac, int repeat) {
-	}
+    @Override
+    public void volumeChangeEvent(String mac, int volume) {
+    }
 
-	@Override
-	public void titleChangeEvent(String mac, String title) {
-	}
+    @Override
+    public void muteChangeEvent(String mac, boolean mute) {
+    }
 
-	@Override
-	public void albumChangeEvent(String mac, String album) {
-	}
+    @Override
+    public void currentPlaylistIndexEvent(String mac, int index) {
+    }
 
-	@Override
-	public void artistChangeEvent(String mac, String artist) {
-	}
+    @Override
+    public void currentPlayingTimeEvent(String mac, int time) {
+    }
 
-	@Override
-	public void coverArtChangeEvent(String mac, String coverArtUrl) {
-	}
+    @Override
+    public void numberPlaylistTracksEvent(String mac, int track) {
+    }
 
-	@Override
-	public void yearChangeEvent(String mac, String year) {
-	}
+    @Override
+    public void currentPlaylistShuffleEvent(String mac, int shuffle) {
+    }
 
-	@Override
-	public void genreChangeEvent(String mac, String genre) {
-	}
+    @Override
+    public void currentPlaylistRepeatEvent(String mac, int repeat) {
+    }
 
-	@Override
-	public void remoteTitleChangeEvent(String mac, String title) {
-	}
+    @Override
+    public void titleChangeEvent(String mac, String title) {
+    }
 
-	@Override
-	public void irCodeChangeEvent(String mac, String ircode) {
-	}
+    @Override
+    public void albumChangeEvent(String mac, String album) {
+    }
+
+    @Override
+    public void artistChangeEvent(String mac, String artist) {
+    }
+
+    @Override
+    public void coverArtChangeEvent(String mac, String coverArtUrl) {
+    }
+
+    @Override
+    public void yearChangeEvent(String mac, String year) {
+    }
+
+    @Override
+    public void genreChangeEvent(String mac, String genre) {
+    }
+
+    @Override
+    public void remoteTitleChangeEvent(String mac, String title) {
+    }
+
+    @Override
+    public void irCodeChangeEvent(String mac, String ircode) {
+    }
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * @author Ben Jones
  * @author Dan Cunningham (OH2 Port)
  * @author Daniel Walters - Fix player discovery when player name contains spaces
+ * @author Mark Hilbush - Improve reconnect logic. Improve player status updates.
  */
 public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
@@ -84,6 +85,8 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
     @Override
     public void initialize() {
+        logger.debug("initializing server handler for thing {}", getThing());
+
         scheduler.schedule(new Runnable() {
 
             @Override
@@ -91,13 +94,14 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 connect();
             }
         }, 0, TimeUnit.SECONDS);
-    };
+    }
 
     @Override
     public void dispose() {
+        logger.debug("disposing server handler for thing {}", getThing());
         cancelReconnect();
         disconnect();
-    };
+    }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
@@ -267,13 +271,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
 
         if (!isConnected()) {
-            logger.debug("No connection to SqueezeServer, will attempt to reconnect now...");
-            connect();
-            if (!isConnected()) {
-                logger.error("Failed to reconnect to SqueezeServer, unable to send command {}", command);
-                return;
-            }
+            logger.debug("no connection to squeeze server when trying to send command, returning...");
+            return;
         }
+
         logger.debug("Sending command: {}", command);
         try {
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(clientSocket.getOutputStream()));
@@ -288,6 +289,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
      * Connects to a SqueezeBox Server
      */
     private void connect() {
+        logger.trace("attempting to get a connection to the server");
         disconnect();
         SqueezeBoxServerConfig config = getConfigAs(SqueezeBoxServerConfig.class);
         this.host = config.ipAddress;
@@ -301,17 +303,23 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         try {
             clientSocket = new Socket(host, cliport);
         } catch (IOException e) {
+            logger.debug("unable to open socket to server: {}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
+            scheduleReconnect();
             return;
         }
 
         try {
             listener = new SqueezeServerListener();
             listener.start();
-            logger.info("Squeeze Server connection started to server " + this.host);
+            logger.debug("listener connection started to server {}:{}", host, cliport);
         } catch (IllegalThreadStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
+
+        // Mark the server ONLINE. bridgeStatusChanged will cause the players to come ONLINE
+        updateStatus(ThingStatus.ONLINE);
+
     }
 
     /**
@@ -344,22 +352,25 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
 
         public void terminate() {
-            logger.debug("Squeeze Server listener being terminated");
+            logger.debug("setting squeeze server listener terminate flag");
             this.terminate = true;
         }
 
         @Override
         public void run() {
             BufferedReader reader = null;
+            boolean endOfStream = false;
+
             try {
                 reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
                 updateStatus(ThingStatus.ONLINE);
                 requestPlayers();
                 sendCommand("listen 1");
 
-                String message;
+                String message = null;
                 while (!terminate && (message = reader.readLine()) != null) {
-                    logger.debug("Message received: {}", message);
+                    // Message is very long and frequent; only show when running at trace level logging
+                    logger.trace("Message received: {}", message);
 
                     if (message.startsWith("listen 1")) {
                         continue;
@@ -371,8 +382,12 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                         handlePlayerUpdate(message);
                     }
                 }
+                if (message == null) {
+                    endOfStream = true;
+                }
             } catch (IOException e) {
                 if (!terminate) {
+                    logger.warn("failed to read line from squeeze server socket: {}", e.getMessage());
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                     scheduleReconnect();
                 }
@@ -385,6 +400,14 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     }
                     reader = null;
                 }
+            }
+
+            // check for end of stream from readLine
+            if (endOfStream == true && !terminate) {
+                logger.info("end of stream received from socket during readLine");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "end of stream on socket read");
+                scheduleReconnect();
             }
 
             logger.debug("Squeeze Server listener exiting.");
@@ -425,11 +448,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     continue;
                 }
 
-                // if we already know about it, ignore this set of params
-                if (players.containsKey(macAddress)) {
-                    continue;
-                }
-
                 final SqueezeBoxPlayer player = new SqueezeBoxPlayer();
                 player.setMacAddress(macAddress);
                 // populate the player state
@@ -445,17 +463,20 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     }
                 }
 
-                players.put(macAddress, player);
+                // Save player if we haven't seen it yet
+                if (!players.containsKey(macAddress)) {
+                    players.put(macAddress, player);
 
-                updatePlayer(new PlayerUpdateEvent() {
-                    @Override
-                    public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                        listener.playerAdded(player);
-                    }
-                });
+                    updatePlayer(new PlayerUpdateEvent() {
+                        @Override
+                        public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                            listener.playerAdded(player);
+                        }
+                    });
 
-                // tell the server we want to subscribe to player updates
-                sendCommand(player.getMacAddress() + " status - 1 subscribe:10 tags:yagJlN");
+                    // tell the server we want to subscribe to player updates
+                    sendCommand(player.getMacAddress() + " status - 1 subscribe:10 tags:yagJlN");
+                }
             }
         }
 
@@ -491,8 +512,8 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             } else if (messageType.equals("play") || messageType.equals("pause") || messageType.equals("stop")) {
                 // ignore these for now
                 // player.setMode(Mode.valueOf(messageType));
-            } else
-                if (messageType.equals("mixer") || messageType.equals("menustatus") || messageType.equals("button")) {
+            } else if (messageType.equals("mixer") || messageType.equals("menustatus")
+                    || messageType.equals("button")) {
                 // ignore these for now
             } else {
                 logger.debug("Unhandled message type '{}'. Ignoring.", messageType);
@@ -767,6 +788,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
      * @return
      */
     public boolean registerSqueezeBoxPlayerListener(SqueezeBoxPlayerEventListener squeezeBoxPlayerListener) {
+        logger.debug("registering player listener");
         return squeezeBoxPlayerListeners.add(squeezeBoxPlayerListener);
     }
 
@@ -777,6 +799,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
      * @return
      */
     public boolean unregisterSqueezeBoxPlayerListener(SqueezeBoxPlayerEventListener squeezeBoxPlayerListener) {
+        logger.debug("unregistering player listener");
         return squeezeBoxPlayerListeners.remove(squeezeBoxPlayerListener);
     }
 
@@ -794,6 +817,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
      * Schedule the server to try and reconnect
      */
     private void scheduleReconnect() {
+        logger.debug("scheduling squeeze server reconnect in {} seconds", RECONNECT_TIME);
         cancelReconnect();
         reconnectFuture = scheduler.schedule(new Runnable() {
             @Override


### PR DESCRIPTION
Fixes #1186 
Signed-off-by: Mark Hilbush mark@hilbush.com

Corrects/improves the following:
- the binding was not reconnecting to the squeeze server after a connection loss.  The reconnect logic was changed to schedule the reconnect job upon detection of loss of connection to the squeezebox server.

- requestPlayerJob in SqueezeBoxPlayerDiscoveryParticipant was not being canceled when the SqueezeBoxServerHandler is removed and/or the binding is restarted.  From what I've been able to determine, the deactivate method was not being called because the player discovery participant service is not set up as a Declarative Service.

- squeeze server and player ONLINE/OFFLINE status was not being updated in some conditions.

- Squeeze player properties were not being saved to the player thing.  editConfiguration was commented out in the previous version of the code.  Player properties are now saved with the thing at time of discovery.

- REFRESH is causing class cast exceptions in handleCommand.  Several cases of the switch statement were not designed to handle REFRESH.  The solution I'm proposing is probably not the correct long-term solution, but it will eliminate the class cast exceptions.
