### PR TITLE
Homematic: Fixed XML-RPC server timeout settings and -1 failure workaround activation

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -94,6 +94,8 @@ public class XmlRpcClient extends RpcClient {
 
             Object[] data = new XmlRpcResponse(new ByteArrayInputStream(result.getBytes())).getResponseData();
             return new RpcResponseParser(request).parse(data);
+        } catch (UnknownRpcFailureException ex) {
+            throw ex;
         } catch (Exception ex) {
             throw new IOException(ex.getMessage(), ex);
         }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
@@ -59,7 +59,7 @@ public class XmlRpcServer implements RpcServer {
         logger.debug("Initializing XML-RPC server at port {}", config.getCallbackPort());
 
         xmlRpcHTTPD = new XmlRpcHTTPD(config.getCallbackPort());
-        xmlRpcHTTPD.start(NanoHTTPD.SOCKET_READ_TIMEOUT, true);
+        xmlRpcHTTPD.start(config.getTimeout() * 1000, true);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Gerhard Riegler <gerhard.riegler@gmail.com>

see: https://community.openhab.org/t/homematic-read-timeout-ccu2/13496