### PR TITLE
toon: update refresh

### DIFF
--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonBridgeHandler.java
@@ -63,12 +63,23 @@ public class ToonBridgeHandler extends BaseBridgeHandler {
     }
 
     private void startAutomaticRefresh() {
+        if (refreshJob != null) {
+            refreshJob.cancel(true);
+        }
+
         refreshJob = scheduler.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
                 updateChannels();
             }
-        }, 1, configuration.refreshInterval, TimeUnit.MILLISECONDS);
+        }, 50, configuration.refreshInterval, TimeUnit.MILLISECONDS);
+    }
+
+    public void requestRefresh() {
+        if (configuration == null) {
+            return;
+        }
+        startAutomaticRefresh();
     }
 
     private void updateChannels() {
@@ -130,7 +141,7 @@ public class ToonBridgeHandler extends BaseBridgeHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command == RefreshType.REFRESH) {
-            updateChannels();
+            requestRefresh();
         } else {
             logger.warn("This Bridge can only handle the REFRESH command");
         }

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonDisplayHandler.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonDisplayHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.toon.internal.api.GasUsage;
 import org.openhab.binding.toon.internal.api.PowerUsage;
 import org.openhab.binding.toon.internal.api.ThermostatInfo;
@@ -130,6 +131,11 @@ public class ToonDisplayHandler extends AbstractToonHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         logger.debug("handleCommand {} for {}", command, channelUID.getAsString());
         try {
+            if (command == RefreshType.REFRESH) {
+                getToonBridgeHandler().requestRefresh();
+                return;
+            }
+
             switch (channelUID.getId()) {
                 case CHANNEL_SETPOINT:
                     if (command instanceof DecimalType) {
@@ -145,7 +151,7 @@ public class ToonDisplayHandler extends AbstractToonHandler {
                     }
                     break;
                 default:
-                    logger.warn("unkonwn channel / command");
+                    logger.warn("unknown channel:{} / command:{}", channelUID.getAsString(), command);
             }
         } catch (ToonConnectionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonPlugHandler.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonPlugHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.toon.internal.api.DeviceConfig;
 import org.openhab.binding.toon.internal.api.ToonConnectionException;
 import org.openhab.binding.toon.internal.api.ToonState;
@@ -87,6 +88,11 @@ public class ToonPlugHandler extends AbstractToonHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         logger.debug("handleCommand {} for {}", command, channelUID.getAsString());
         try {
+            if (command == RefreshType.REFRESH) {
+                getToonBridgeHandler().requestRefresh();
+                return;
+            }
+
             if (CHANNEL_SWITCH_BINARY.equals(channelUID.getId())) {
                 int value = 0;
                 if (command instanceof OnOffType) {
@@ -100,7 +106,7 @@ public class ToonPlugHandler extends AbstractToonHandler {
                 getToonBridgeHandler().getApiClient().setPlugState(value,
                         getThing().getProperties().get(PROPERTY_DEV_UUID));
             } else {
-                logger.warn("unkown channel / command");
+                logger.warn("unknown channel:{} / command:{}", channelUID.getAsString(), command);
             }
         } catch (ToonConnectionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());


### PR DESCRIPTION
When refreshing a channel, restart the update job with a little delay.
To prevent multiple update request at very short intervals.

Signed-off-by: Jorg de Jong <jorg@dejong.info> (github: jongj)