### PR TITLE
PioneerAVR Binding: Added missing "unsupported" thing type.

### DIFF
--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AvrHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AvrHandlerFactory.java
@@ -27,8 +27,9 @@ import com.google.common.collect.Sets;
  */
 public class AvrHandlerFactory extends BaseThingHandlerFactory {
 
-    private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets
-            .newHashSet(PioneerAvrBindingConstants.IP_AVR_THING_TYPE, PioneerAvrBindingConstants.SERIAL_AVR_THING_TYPE);
+    private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(
+            PioneerAvrBindingConstants.IP_AVR_THING_TYPE, PioneerAvrBindingConstants.IP_AVR_UNSUPPORTED_THING_TYPE,
+            PioneerAvrBindingConstants.SERIAL_AVR_THING_TYPE);
 
     protected void activate(ComponentContext componentContext, Map<String, Object> configProps) {
         super.activate(componentContext);


### PR DESCRIPTION
The ipAvrUnsupported thing type was missing and would throw an exception if trying to configure an AVR model that is "not officially supported" via the Paper UI. Even though this thing type is "unsupported", the rest of binding can handle these models, even though users may experience odd behaviors.

Signed-off-by: Matthew Bowman <mgbowman@users.noreply.github.com> (github: mgbowman)