### PR TITLE
Adding Lock and ColorfulLightbulb Homekit Characteristics

### DIFF
--- a/addons/io/org.openhab.io.homekit/README.md
+++ b/addons/io/org.openhab.io.homekit/README.md
@@ -39,7 +39,7 @@ A full list of supported accessory types can be found in the table below.
   <td>Lighting</td>
   <td>&nbsp;</td>
   <td>Switch, Dimmer, Color</td>
-  <td>A lightbulb, either switchable or dimmable</td>
+  <td>A lightbulb, switchable, dimmable or rgb</td>
  </tr>
  <tr>
   <td>Switchable</td>
@@ -58,6 +58,12 @@ A full list of supported accessory types can be found in the table below.
   <td>&nbsp;</td>
   <td>Number</td>
   <td>An accessory that provides a single read-only value indicating the relative humidity.</td>
+ </tr>
+ <tr>
+  <td>Lock</td>
+  <td>&nbsp;</td>
+  <td>Switch</td>
+  <td>An lockable accessory. Use this to tell Siri to lock or unlock something. Bind to a Switch item. ON state means the lock is closed, OFF means it's open. We cannot use OPEN/CLOSED because ContactItems don't support receiving commands.</td>
  </tr>
  <tr>
   <td>Thermostat</td>

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDeviceType.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDeviceType.java
@@ -24,7 +24,9 @@ public enum HomekitDeviceType {
     LIGHTBULB("Lighting"),
     SWITCH("Switchable"),
     TEMPERATURE_SENSOR("CurrentTemperature"),
-    THERMOSTAT("Thermostat");
+    THERMOSTAT("Thermostat"),
+    COLORFUL_LIGHTBULB("ColorfulLighting"),
+    LOCK("Lock");
 
     private static final Map<String, HomekitDeviceType> tagMap = new HashMap<>();
 

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.library.items.ColorItem;
 import org.eclipse.smarthome.core.library.items.DimmerItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,9 +37,13 @@ public class HomekitTaggedItem {
     public HomekitTaggedItem(Item item, ItemRegistry itemRegistry) {
         this.item = item;
         for (String tag : item.getTags()) {
-            if (item instanceof DimmerItem) {
+
+            if (item instanceof ColorItem) {
+                tag = "Colorful" + tag;
+            } else if (item instanceof DimmerItem) {
                 tag = "Dimmable" + tag;
             }
+
             /*
              * Is the item part of a tagged group AND does it have a matching CharacteristicType ?
              * This matches items with tags that require a parent group like the "TargetTemperature" in

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -95,7 +95,8 @@ abstract class AbstractHomekitAccessoryImpl<T extends GenericItem> implements Ho
         return updater;
     }
 
-    protected GenericItem getItem() {
-        return (GenericItem) getItemRegistry().get(getItemName());
+    @SuppressWarnings("unchecked")
+    protected T getItem() {
+        return (T) getItemRegistry().get(getItemName());
     }
 }

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -31,6 +31,9 @@ public class HomekitAccessoryFactory {
             case DIMMABLE_LIGHTBULB:
                 return new HomekitDimmableLightbulbImpl(taggedItem, itemRegistry, updater);
 
+            case COLORFUL_LIGHTBULB:
+                return new HomekitColorfulLightbulbImpl(taggedItem, itemRegistry, updater);
+
             case THERMOSTAT:
                 return new HomekitThermostatImpl(taggedItem, itemRegistry, updater, settings);
 
@@ -42,6 +45,9 @@ public class HomekitAccessoryFactory {
 
             case HUMIDITY_SENSOR:
                 return new HomekitHumiditySensorImpl(taggedItem, itemRegistry, updater);
+
+            case LOCK:
+                return new HomekitLockImpl(taggedItem, itemRegistry, updater);
         }
 
         throw new Exception("Unknown homekit type: " + taggedItem.getDeviceType());

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitColorfulLightbulbImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitColorfulLightbulbImpl.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.homekit.internal.accessories;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.library.items.ColorItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
+import org.openhab.io.homekit.internal.HomekitTaggedItem;
+
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.accessories.ColorfulLightbulb;
+import com.beowulfe.hap.accessories.DimmableLightbulb;
+
+/**
+ * Implements ColorfulLightBulb using an Item that provides a On/Off and color state
+ *
+ * @author Felix Rotthowe
+ */
+class HomekitColorfulLightbulbImpl extends AbstractHomekitLightbulbImpl<ColorItem>implements ColorfulLightbulb, DimmableLightbulb {
+
+    public HomekitColorfulLightbulbImpl(HomekitTaggedItem taggedItem, ItemRegistry itemRegistry,
+            HomekitAccessoryUpdater updater) {
+        super(taggedItem, itemRegistry, updater, ColorItem.class);
+    }
+
+    @Override
+    public CompletableFuture<Double> getHue() {
+        State state = getItem().getStateAs(HSBType.class);
+        if (state instanceof HSBType) {
+            HSBType hsb = (HSBType) state;
+            return CompletableFuture.completedFuture(hsb.getHue().doubleValue());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Double> getSaturation() {
+        State state = getItem().getStateAs(HSBType.class);
+        if (state instanceof HSBType) {
+            HSBType hsb = (HSBType) state;
+            return CompletableFuture.completedFuture(hsb.getSaturation().doubleValue());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getBrightness() {
+        State state = getItem().getStateAs(PercentType.class);
+        if (state instanceof PercentType) {
+            PercentType brightness = (PercentType) state;
+            return CompletableFuture.completedFuture(brightness.intValue());
+        } else {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+
+    @Override
+    public CompletableFuture<Void> setHue(Double value) throws Exception {
+        if (value == null) {
+            value = 0.0;
+        }
+        State state = getItem().getStateAs(HSBType.class);
+        if (state instanceof HSBType) {
+            HSBType hsb = (HSBType) state;
+            HSBType newState = new HSBType(new DecimalType(value), hsb.getSaturation(), hsb.getBrightness());
+            getItem().send(newState);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            // state is undefined (light is not connected)
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setSaturation(Double value) throws Exception {
+        if (value == null) {
+            value = 0.0;
+        }
+        State state = getItem().getStateAs(HSBType.class);
+        if (state instanceof HSBType) {
+            HSBType hsb = (HSBType) state;
+            HSBType newState = new HSBType(hsb.getHue(), new PercentType(value.intValue()), hsb.getBrightness());
+            getItem().send(newState);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            // state is undefined (light is not connected)
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setBrightness(Integer value) throws Exception {
+        if (value == null) {
+            value = 0;
+        }
+        State state = getItem().getStateAs(HSBType.class);
+        if (state instanceof HSBType) {
+            HSBType hsb = (HSBType) state;
+            HSBType newState = new HSBType(hsb.getHue(),hsb.getSaturation(), new PercentType(value));
+            getItem().send(newState);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            // state is undefined (light is not connected)
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+
+    @Override
+    public void subscribeHue(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), "hue", callback);
+    }
+
+    @Override
+    public void subscribeSaturation(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), "saturation", callback);
+    }
+
+    @Override
+    public void subscribeBrightness(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), "brightness", callback);
+    }
+
+    @Override
+    public void unsubscribeHue() {
+        getUpdater().unsubscribe(getItem(), "hue");
+    }
+
+    @Override
+    public void unsubscribeSaturation() {
+        getUpdater().unsubscribe(getItem(), "saturation");
+    }
+
+    @Override
+    public void unsubscribeBrightness() {
+        getUpdater().unsubscribe(getItem(), "brightness");
+    }
+
+}

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDimmableLightbulbImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDimmableLightbulbImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.library.items.DimmerItem;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.State;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
@@ -35,8 +36,13 @@ class HomekitDimmableLightbulbImpl extends AbstractHomekitLightbulbImpl<DimmerIt
 
     @Override
     public CompletableFuture<Integer> getBrightness() {
-        PercentType state = (PercentType) getItem().getStateAs(PercentType.class);
-        return CompletableFuture.completedFuture(state.intValue());
+        State state = getItem().getStateAs(PercentType.class);
+        if (state instanceof PercentType) {
+            PercentType brightness = (PercentType) state;
+            return CompletableFuture.completedFuture(brightness.intValue());
+        } else {
+            return CompletableFuture.completedFuture(null);
+        }
     }
 
     @Override

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.homekit.internal.accessories;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
+import org.openhab.io.homekit.internal.HomekitTaggedItem;
+
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.Service;
+import com.beowulfe.hap.accessories.LockableLockMechanism;
+import com.beowulfe.hap.accessories.properties.LockMechanismState;
+import com.beowulfe.hap.impl.services.LockMechanismService;
+
+/**
+ * Implements LockableLockMechanism using an Item that provides an On/Off state.
+ *
+ * Unfortunately, we cannot use OpenClosedType because ContactItems cannot receive commands.
+ *
+ * @author Felix Rotthowe
+ *
+ */
+public class HomekitLockImpl extends AbstractHomekitAccessoryImpl<SwitchItem>implements LockableLockMechanism {
+
+    public HomekitLockImpl(HomekitTaggedItem taggedItem, ItemRegistry itemRegistry, HomekitAccessoryUpdater updater) {
+        super(taggedItem, itemRegistry, updater, SwitchItem.class);
+    }
+
+    @Override
+    public CompletableFuture<LockMechanismState> getCurrentMechanismState() {
+        OnOffType state = (OnOffType) getItem().getStateAs(OnOffType.class);
+        if (state == null || getItem().getState() instanceof UnDefType) {
+            return CompletableFuture.completedFuture(LockMechanismState.UNKNOWN);
+        }
+        return CompletableFuture.completedFuture(
+                state.equals(OnOffType.ON) ? LockMechanismState.SECURED : LockMechanismState.UNSECURED);
+    }
+
+    @Override
+    public void setTargetMechanismState(LockMechanismState state) throws Exception {
+        getItem().send(state.equals(LockMechanismState.SECURED) ? OnOffType.ON : OnOffType.OFF);
+    }
+
+    @Override
+    public CompletableFuture<LockMechanismState> getTargetMechanismState() {
+        // TODO: Maybe implement this as a group in combination with a ContactType to
+        // differentiate between the current and the target state.
+        return getCurrentMechanismState();
+    }
+
+    @Override
+    public void subscribeCurrentMechanismState(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), callback);
+    }
+
+    @Override
+    public void unsubscribeCurrentMechanismState() {
+        getUpdater().unsubscribe(getItem());
+    }
+
+    @Override
+    public void subscribeTargetMechanismState(HomekitCharacteristicChangeCallback callback) {
+        // Not supported
+    }
+
+    @Override
+    public void unsubscribeTargetMechanismState() {
+        // Not supported
+    }
+
+    @Override
+    public Collection<Service> getServices() {
+        return Collections.singleton(new LockMechanismService(this));
+    }
+
+}

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -109,6 +109,9 @@ class HomekitThermostatImpl extends AbstractTemperatureHomekitAccessoryImpl<Grou
                 mode = ThermostatMode.AUTO;
             } else if (stringValue.equals(settings.getThermostatOffMode())) {
                 mode = ThermostatMode.OFF;
+            } else if (  stringValue.equals("UNDEF") || stringValue.equals("NULL") ) {
+                logger.debug("Heating cooling target mode not available. Relaying value of OFF to Homekit");
+                mode = ThermostatMode.OFF;
             } else {
                 logger.error("Unrecognized heating cooling target mode: " + stringValue
                         + ". Expected cool, heat, auto, or off strings in value.");


### PR DESCRIPTION
- Added color support for "Lighting" items that are mapped to a ColorItem
- Stop filling the log with warnings while the thermostat states have not yet been updated.
- Adding a "Lock" characteristic to support "Siri, open the door" requests.

Signed-off-by: Felix Rotthowe <felix@planbnet.org> (github: planbnet)