### PR TITLE
add menu-based netradio support to Yamaha Receiver Binding

### DIFF
--- a/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
@@ -12,6 +12,7 @@
         <channels>
             <channel id="power" typeId="power"/>
             <channel id="netradiotune" typeId="netradiotune"/>
+            <channel id="netradiostation" typeId="netradiostation"/>
             <channel id="input" typeId="input"/>
             <channel id="surroundProgram" typeId="surroundProgram"/>
             <channel id="volume" typeId="volume"/>
@@ -37,6 +38,12 @@
                 <default>2.0</default>
                 <advanced>true</advanced>
             </parameter>
+            <parameter name="NETRADIOMENU" type="text" required="false">
+                <label>Net radio menu</label>
+                <description>Menu used for menu-based net radio tuning.</description>
+                <default>Bookmarks/__My_Favorites</default>
+                <advanced>true</advanced>
+            </parameter>
         </config-description>
         
     </thing-type>
@@ -57,6 +64,12 @@
         <item-type>Number</item-type>
         <label>NetRadio Channel</label>
         <description>Select the net radio channel of the AVR</description>
+    </channel-type>
+
+    <channel-type id="netradiostation">
+        <item-type>String</item-type>
+        <label>NetRadio Station</label>
+        <description>Select the net radio station of the AVR</description>
     </channel-type>
     
     <channel-type id="surroundProgram">

--- a/addons/binding/org.openhab.binding.yamahareceiver/readme.md
+++ b/addons/binding/org.openhab.binding.yamahareceiver/readme.md
@@ -10,6 +10,11 @@ by providing host and port.
 Initially a thing for the main zone will be created. This will trigger a zone
 detection internally and all available additional zones will appear as new things.
 
+If your receiver is using menu-based net radio navigation, you can use this binding to
+select radio stations from a configured menu. By default, `Bookmarks/__My_Favorites` is
+used, but it can be overridden with the thing setting `NETRADIOMENU`. The German favorites
+folder, for example, is `Lesezeichen/__My_Favorites`. 
+
 ## Features
 The implemented channels are so far:
 
@@ -18,6 +23,7 @@ The implemented channels are so far:
 * `volume`: Openhab Type `Dimmer`, Set's the receivers Volume percent Value.
 * `input`: Openhab Type `String`, Set's the input selection, depends on your receiver's real inputs. Examples: HDMI1, HDMI2, AV4, TUNER, NET RADIO, etc. Those names can be changed on the receiver. A list of available inputs is fetched internally, but there is now way to make that available to sitemaps at the moment.
 * `surroundProgram`: Openhab Type `String`, Set's the surround Mode. Examples: 2ch Stereo, 7ch Stereo, Hall in Munic, Straight, Surround Decoder. A list of available modes is already defined but is not available for sitemaps at the moment due to openhab2 limitations.
+* `netradiostation`: Openhab Type `String`, Select the net radio station by name in the configured menu folder.
  
 ## Example
 
@@ -32,7 +38,8 @@ The implemented channels are so far:
      Switch Yamaha_Mute             "Mute [%s]"            
      String Yamaha_Input         "Input [%s]"              
      String Yamaha_Surround         "surround [%s]"        
-     Number Yamaha_NetRadio  "Net Radio" <netRadio> 
+     Number Yamaha_NetRadio  "Net Radio" <netRadio>   # Preset-based net radio
+     String Yamaha_NetRadioStation  "Net Radio [%s]" <netRadio>   # Menu-based net radio
 	 
 	 # Manually linking
 	 # Replace the UPNP UDN (here: 9ab0c000_f668_11de_9976_00a0de88ee65) with the real UDN provided by your UPNP discovery.
@@ -45,10 +52,12 @@ The implemented channels are so far:
      String Yamaha_Input         "Input [%s]"              {channel="yamahareceiver:yamahaAV:9ab0c000_f668_11de_9976_00a0de88ee65:MAIN_ZONE:input"}
      String Yamaha_Surround         "surround [%s]"        {channel="yamahareceiver:yamahaAV:9ab0c000_f668_11de_9976_00a0de88ee65:MAIN_ZONE:surroundProgram"}
      Number Yamaha_NetRadio  "Net Radio" <netRadio>        {channel="yamahareceiver:yamahaAV:9ab0c000_f668_11de_9976_00a0de88ee65:MAIN_ZONE:netradiotune"}
+      String Yamaha_NetRadioStation  "Net Radio" <netRadio>        {channel="yamahareceiver:yamahaAV:9ab0c000_f668_11de_9976_00a0de88ee65:MAIN_ZONE:netradiostation"}
  
      .sitemap
-
+     
      Selection item=Yamaha_NetRadio label="Sender" mappings=[1="N Joy", 2="Radio Sport", 3="RDU", 4="91ZM", 5="Hauraki"]
+     Selection item=Yamaha_NetRadioStation label="Sender" mappings=["N Joy"="N Joy", "Radio Sport"="Radio Sport", "RDU"="RDU","91ZM" ="91ZM", "Hauraki"="Hauraki"]
      Selection item=Yamaha_Input mappings=[HDMI1="BlueRay",HDMI2="Satellite","NET RADIO"="NetRadio",TUNER="Tuner"]
      Selection item=Yamaha_Surround label="Surround Mode" mappings=["2ch Stereo"="2ch","7ch Stereo"="7ch"]
 	 

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
@@ -31,6 +31,7 @@ public class YamahaReceiverBindingConstants {
     public final static String CHANNEL_VOLUME_DB = "volumeDB";
     public final static String CHANNEL_MUTE = "mute";
     public final static String CHANNEL_NETRADIO_TUNE = "netradiotune";
+    public final static String CHANNEL_NETRADIO_STATION = "netradiostation";
 
     public static final String UPNP_TYPE = "MediaRenderer";
 
@@ -40,5 +41,5 @@ public class YamahaReceiverBindingConstants {
     public static final String CONFIG_HOST_NAME = "HOST";
     public static final String CONFIG_ZONE = "ZONE";
     public static final String CONFIG_RELVOLUMECHANGE = "RELVOLUMECHANGE";
-
+    public static final String CONFIG_NETRADIOMENU = "NETRADIOMENU";
 }

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
@@ -195,10 +195,14 @@ public class YamahaReceiverHandler extends BaseThingHandler {
         }
         lastRefreshInMS = System.currentTimeMillis();
 
-        boolean includeNetradioStation = isLinked(YamahaReceiverBindingConstants.CHANNEL_NETRADIO_STATION);
+        boolean hasNetradioStationChannel = isLinked(YamahaReceiverBindingConstants.CHANNEL_NETRADIO_STATION);
 
         try {
-            state.updateState(includeNetradioStation);
+            state.updateState();
+            if (hasNetradioStationChannel) {
+                state.updateNetRadioState();
+            }
+
             updateStatus(ThingStatus.ONLINE);
             updateState(YamahaReceiverBindingConstants.CHANNEL_POWER, state.isPower() ? OnOffType.ON : OnOffType.OFF);
             updateState(YamahaReceiverBindingConstants.CHANNEL_INPUT, new StringType(state.getInput()));

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
@@ -30,6 +30,7 @@ public class YamahaReceiverState {
     public List<String> inputNames = new ArrayList<String>();
     private final YamahaReceiverCommunication com;
     public int netRadioChannel = 0;
+    public String netRadioStation = "";
 
     // Some AVR information
     public String name = "";
@@ -57,8 +58,8 @@ public class YamahaReceiverState {
      *
      * @throws IOException
      */
-    public void updateState() throws IOException {
-        com.updateState(this);
+    public void updateState(boolean includeNetradioStation) throws IOException {
+        com.updateState(this, includeNetradioStation);
     }
 
     public Zone getZone() {
@@ -160,6 +161,11 @@ public class YamahaReceiverState {
     public void setNetRadio(int netRadioChannel) throws IOException {
         com.setNetRadio(netRadioChannel);
         this.netRadioChannel = netRadioChannel;
+    }
+
+    public void setNetRadio(String menuDir, String netRadioStation) throws IOException {
+        com.setNetRadio(menuDir, netRadioStation, name);
+        this.netRadioStation = netRadioStation;
     }
 
     public String getHost() {

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
@@ -58,8 +58,17 @@ public class YamahaReceiverState {
      *
      * @throws IOException
      */
-    public void updateState(boolean includeNetradioStation) throws IOException {
-        com.updateState(this, includeNetradioStation);
+    public void updateState() throws IOException {
+        com.updateState(this);
+    }
+
+    /**
+     * Update net radio station
+     *
+     * @throws IOException
+     */
+    public void updateNetRadioState() throws IOException {
+        com.updateNetRadioState(this);
     }
 
     public Zone getZone() {

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
@@ -185,7 +185,7 @@ public class YamahaReceiverCommunication {
         menu.selectItem(stationName);
     }
 
-    public void updateState(YamahaReceiverState state, boolean includeNetradioStation) throws IOException {
+    public void updateState(YamahaReceiverState state) throws IOException {
         Document doc = postAndGetXmlResponse("<?xml version=\"1.0\" encoding=\"utf-8\"?><YAMAHA_AV cmd=\"GET\"><" + zone
                 + "><Basic_Status>GetParam</Basic_Status></" + zone + "></YAMAHA_AV>");
         Node basicStatus = getNode(doc.getFirstChild(), "" + zone + "/Basic_Status");
@@ -218,16 +218,14 @@ public class YamahaReceiverCommunication {
         node = getNode(basicStatus, "Input/Input_Sel_Item_Info/Src_Number");
         value = node != null ? node.getTextContent() : "0";
         state.netRadioChannel = Integer.parseInt(value);
+    }
 
+    public void updateNetRadioState(YamahaReceiverState state) throws IOException {
         // Get currently playing net radio station for menu based receivers
-        if (includeNetradioStation) {
-            doc = postAndGetXmlResponse(
-                    "<?xml version=\"1.0\" encoding=\"utf-8\"?><YAMAHA_AV cmd=\"GET\"><NET_RADIO><Play_Info>GetParam</Play_Info></NET_RADIO></YAMAHA_AV>");
-            node = getNode(doc.getFirstChild(), "NET_RADIO/Play_Info/Meta_Info/Station");
-            state.netRadioStation = node != null ? node.getTextContent() : "";
-        } else {
-            state.netRadioStation = "";
-        }
+        Document doc = postAndGetXmlResponse(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><YAMAHA_AV cmd=\"GET\"><NET_RADIO><Play_Info>GetParam</Play_Info></NET_RADIO></YAMAHA_AV>");
+        Node node = getNode(doc.getFirstChild(), "NET_RADIO/Play_Info/Meta_Info/Station");
+        state.netRadioStation = node != null ? node.getTextContent() : "";
     }
 
     public void updateInputsList(YamahaReceiverState state) throws IOException {


### PR DESCRIPTION
The Yamaha Receiver Binding has support for preset-based netradio, i.e. radio stations are assigned to a preset number on the remote.
Newer Yamaha AVRs are using  a menu-based netradio selection, where the user has to navigate through a menu to select the desired radio station.

This enhancement implements a new `String` channel `netradiostation` that is keeping track of the currently playing netradio station on menu-based receivers. It also lets you select a station by name in a predefined directory. The directory can be configured using the thing configuration `NETRADIOMENU`.

The restriction to a certain directory was required, because the Yamaha API is providing information about the currently playing station name, but not the directory.

This change should not have any impact unless an item for the `netradiostation` channel is defined, so preset-based receivers should be fine. Nevertheless, some testing with a preset-based receiver would be highly appreciated.
