### PR TITLE
removed maven nature from systeminfo binding

### DIFF
--- a/addons/binding/org.openhab.binding.systeminfo/.project
+++ b/addons/binding/org.openhab.binding.systeminfo/.project
@@ -25,14 +25,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab2-addons/issues/1363

Signed-off-by: Kai Kreuzer <kai@openhab.org>