### PR TITLE
Harryzz patch 3

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturehumidity.xml
@@ -3,7 +3,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="temperaturehumidity">
+	<thing-type id="temperature_humidity">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge" />
 			<bridge-type-ref id="tcpbridge" />

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -114,7 +114,7 @@ public class RFXComBindingConstants {
     public final static ThingTypeUID THING_TYPE_TEMPERATURE = new ThingTypeUID(BINDING_ID, "temperature");
     public final static ThingTypeUID THING_TYPE_HUMIDITY = new ThingTypeUID(BINDING_ID, "humidity");
     public final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY = new ThingTypeUID(BINDING_ID,
-            "temperaturehumidity");
+            "temperature_humidity");
     public final static ThingTypeUID THING_TYPE_BAROMETRIC = new ThingTypeUID(BINDING_ID, "barometric");
     public final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC = new ThingTypeUID(BINDING_ID,
             "temperaturehumiditybarometric");


### PR DESCRIPTION
exception in log:
Exception occured while informing handler:Unknown packet type
TEMPERATUREHUMIDITY
java.lang.IllegalArgumentException: Unknown packet type
TEMPERATUREHUMIDITY
        at
org.openhab.binding.rfxcom.internal.messages.RFXComMessageFactory.convertPacketType(RFXComMessageFactory.java:143)[198:org.openhab.binding.rfxcom:2.0.0.201610211435]
        
Problem caused by different names in xml and java (underscore missing)
Tested with TH7, TFA TS34C, Cresta type.
There is similar problem with temperature_humidity_barometric (and other w/o underscore) but i
can't find xml file in ESH-INF and don't have sensor to test.

Signed-off-by: Zahari Zahariev <harryzz@gmail.com>