### PR TITLE
[cometvisu] Add missing oh2 backend definition to visu_config (#1360)

### DIFF
--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/VisuConfig.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/VisuConfig.java
@@ -105,6 +105,7 @@ public class VisuConfig {
      */
     public String getConfigXml(HttpServletRequest req) {
         SchemaPages pagesBean = new SchemaPages();
+        pagesBean.setBackend("oh2");
         pagesBean.setDesign("metal");
         pagesBean.setMaxMobileScreenWidth(new BigDecimal(480));
         pagesBean.setBindClickToWidget(true);


### PR DESCRIPTION
Just a small fix to automatically add the `backend="oh2"` definition to the generated visu_config. 
