### PR TITLE
Revert "only send updates if persistence is enabled"

### DIFF
--- a/addons/io/org.openhab.io.myopenhab/src/main/java/org/openhab/io/myopenhab/internal/MyOpenHABService.java
+++ b/addons/io/org.openhab.io.myopenhab/src/main/java/org/openhab/io/myopenhab/internal/MyOpenHABService.java
@@ -314,7 +314,7 @@ public class MyOpenHABService implements PersistenceService, ActionService, MyOp
 
     @Override
     public void receive(Event event) {
-        if (persistenceEnabled) {
+        if (!persistenceEnabled) {
             ItemStateEvent ise = (ItemStateEvent) event;
             myOHClient.sendItemUpdate(ise.getItemName(), ise.getItemState().toString());
         }


### PR DESCRIPTION
Reverts openhab/openhab2-addons#1456

Changed by mistake; this IS actually the correct logic: If no persistence file is there, ALL items are persisted to enable easy use of IFTTT.