### PR TITLE
Netatmo binding: fix potential NPE on device field

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
@@ -83,8 +83,9 @@ public abstract class NetatmoDeviceHandler<X extends NetatmoDeviceConfiguration>
     @Override
     protected void updateChannels(String equipmentId) {
         try {
-            device = updateReadings(equipmentId);
-            if (device != null) {
+            NADeviceAdapter<?> tmpDevice = updateReadings(equipmentId);
+            if (tmpDevice != null) {
+            	this.device = tmpDevice;
                 super.updateChannels(equipmentId);
                 updateChildModules(equipmentId);
             }


### PR DESCRIPTION
Use a temp variable when getting new readings, avoiding the risk to set the device field to null.

Signed-off-by: Alan Alberghini <alan@iooota.com>