### PR TITLE
onkyo-binding: support for StringType commands for player control

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
@@ -413,7 +413,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
         } else if ("FastForward".equals(cmdName)) {
             sendCommand(EiscpCommandRef.NETUSB_OP_FF);
         } else {
-            logger.debug("Received unknown playercommand " + cmdName);
+            logger.debug("Received unknown playercommand {}", cmdName);
         }
     }
 

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
@@ -173,6 +173,9 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                     }
                 } else if (command.equals(RefreshType.REFRESH)) {
                     sendCommand(EiscpCommandRef.NETUSB_PLAY_STATUS_QUERY);
+                } else if (command instanceof StringType) {
+                    final String cmdName = command.toString();
+                    handlePlayerCommand(cmdName);
                 }
                 break;
             case CHANNEL_PLAY_URI:
@@ -393,6 +396,24 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
             connection.send(deviceCommand.getCommand());
         } else {
             logger.debug("Connect send command to onkyo receiver since the onkyo binding is not initialized");
+        }
+    }
+
+    private void handlePlayerCommand(String cmdName) {
+        if ("Play".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_PLAY);
+        } else if ("Pause".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_PAUSE);
+        } else if ("Next".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_TRACKUP);
+        } else if ("Previous".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_TRACKDWN);
+        } else if ("Rewind".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_REW);
+        } else if ("FastForward".equals(cmdName)) {
+            sendCommand(EiscpCommandRef.NETUSB_OP_FF);
+        } else {
+            logger.debug("Received unknown playercommand " + cmdName);
         }
     }
 


### PR DESCRIPTION
This adds support for the following StringType commands to the player#control channel:
Play
Pause
Next
Previous
Rewind
FastForward

This allows to control the player by using a switch item like
Switch item=onkyoPlayerControl icon="none" mappings=[Previous="⏮", Rewind="⏪", Play="▶", Pause="⏸", FastForward="⏩", Next="⏭"]

Signed-off-by: Volker Bier <volker.bier@web.de>