### PR TITLE
This PR aims to solve issue #1517

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
@@ -12,7 +12,10 @@ import static org.openhab.binding.netatmo.NetatmoBindingConstants.*;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.netatmo.config.NetatmoDeviceConfiguration;
 import org.openhab.binding.netatmo.config.NetatmoModuleConfiguration;
 import org.openhab.binding.netatmo.internal.ChannelTypeUtils;
 import org.openhab.binding.netatmo.internal.NAModuleAdapter;
@@ -29,7 +32,6 @@ import org.slf4j.LoggerFactory;
 public abstract class NetatmoModuleHandler<X extends NetatmoModuleConfiguration>
         extends AbstractNetatmoThingHandler<X> {
     private static Logger logger = LoggerFactory.getLogger(NetatmoModuleHandler.class);
-    // Initialize with default values to avoid div 0 if properties not correctly loaded
     private int batteryMin = 0;
     private int batteryLow = 0;
     private int batteryMax = 1;
@@ -66,24 +68,43 @@ public abstract class NetatmoModuleHandler<X extends NetatmoModuleConfiguration>
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        switch (channelId) {
-            case CHANNEL_BATTERY_LEVEL:
-                return ChannelTypeUtils.toDecimalType(getBatteryPercent());
-            case CHANNEL_LOW_BATTERY:
-                return module.getBatteryVp() < batteryLow ? OnOffType.ON : OnOffType.OFF;
-            case CHANNEL_LAST_MESSAGE:
-                return ChannelTypeUtils.toDateTimeType(module.getLastMessage());
-            case CHANNEL_RF_STATUS:
-                Integer rfStatus = module.getRfStatus();
-                return ChannelTypeUtils.toDecimalType(getSignalStrength(rfStatus));
-            default:
-                return super.getNAThingProperty(channelId);
+        if (module != null) {
+            switch (channelId) {
+                case CHANNEL_BATTERY_LEVEL:
+                    return ChannelTypeUtils.toDecimalType(getBatteryPercent());
+                case CHANNEL_LOW_BATTERY:
+                    return module.getBatteryVp() < batteryLow ? OnOffType.ON : OnOffType.OFF;
+                case CHANNEL_LAST_MESSAGE:
+                    return ChannelTypeUtils.toDateTimeType(module.getLastMessage());
+                case CHANNEL_RF_STATUS:
+                    Integer rfStatus = module.getRfStatus();
+                    return ChannelTypeUtils.toDecimalType(getSignalStrength(rfStatus));
+
+            }
+
         }
+        return super.getNAThingProperty(channelId);
     }
 
     public void updateChannels(NAModuleAdapter module) {
         this.module = module;
         super.updateChannels(configuration.getParentId());
+    }
+
+    protected void requestParentRefresh() {
+        logger.debug("Updating parent modules of {}", configuration.getEquipmentId());
+        for (Thing thing : getBridge().getThings()) {
+            ThingHandler thingHandler = thing.getHandler();
+            if (thingHandler instanceof NetatmoDeviceHandler) {
+                @SuppressWarnings("unchecked")
+                NetatmoDeviceHandler<NetatmoDeviceConfiguration> deviceHandler = (NetatmoDeviceHandler<NetatmoDeviceConfiguration>) thingHandler;
+                NetatmoDeviceConfiguration deviceConfiguration = deviceHandler.configuration;
+                if (deviceConfiguration.getEquipmentId().equalsIgnoreCase(configuration.getParentId())) {
+                    // I'm your father Luke
+                    thingHandler.handleCommand(null, RefreshType.REFRESH);
+                }
+            }
+        }
     }
 
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule1Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule1Handler.java
@@ -33,30 +33,33 @@ public class NAModule1Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        NADashboardData dashboardData = module.getDashboardData();
-        switch (channelId) {
-            case CHANNEL_TEMPERATURE:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getTemperature());
-            case CHANNEL_HUMIDITY:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getHumidity());
-            case CHANNEL_TIMEUTC:
-                return ChannelTypeUtils.toDateTimeType(dashboardData.getTimeUtc());
-            case CHANNEL_HUMIDEX:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getHumidex(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_HEATINDEX:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getHeatIndex(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_DEWPOINT:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_DEWPOINTDEP:
-                Double dewpoint = WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity());
-                return ChannelTypeUtils
-                        .toDecimalType(WeatherUtils.getDewPointDep(dashboardData.getTemperature(), dewpoint));
-            default:
-                return super.getNAThingProperty(channelId);
+        if (module != null) {
+            NADashboardData dashboardData = module.getDashboardData();
+            switch (channelId) {
+                case CHANNEL_TEMPERATURE:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getTemperature());
+                case CHANNEL_HUMIDITY:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getHumidity());
+                case CHANNEL_TIMEUTC:
+                    return ChannelTypeUtils.toDateTimeType(dashboardData.getTimeUtc());
+                case CHANNEL_HUMIDEX:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getHumidex(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_HEATINDEX:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getHeatIndex(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_DEWPOINT:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_DEWPOINTDEP:
+                    Double dewpoint = WeatherUtils.getDewPoint(dashboardData.getTemperature(),
+                            dashboardData.getHumidity());
+                    return ChannelTypeUtils
+                            .toDecimalType(WeatherUtils.getDewPointDep(dashboardData.getTemperature(), dewpoint));
+
+            }
         }
+        return super.getNAThingProperty(channelId);
     }
 
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule2Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule2Handler.java
@@ -33,19 +33,21 @@ public class NAModule2Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        NADashboardData dashboardData = module.getDashboardData();
-        switch (channelId) {
-            case CHANNEL_WIND_ANGLE:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getWindAngle());
-            case CHANNEL_WIND_STRENGTH:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getWindStrength());
-            case CHANNEL_GUST_ANGLE:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getGustAngle());
-            case CHANNEL_GUST_STRENGTH:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getGustStrength());
-            default:
-                return super.getNAThingProperty(channelId);
+        if (module != null) {
+            NADashboardData dashboardData = module.getDashboardData();
+            switch (channelId) {
+                case CHANNEL_WIND_ANGLE:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getWindAngle());
+                case CHANNEL_WIND_STRENGTH:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getWindStrength());
+                case CHANNEL_GUST_ANGLE:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getGustAngle());
+                case CHANNEL_GUST_STRENGTH:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getGustStrength());
+
+            }
         }
+        return super.getNAThingProperty(channelId);
     }
 
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule3Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule3Handler.java
@@ -16,6 +16,8 @@ import org.openhab.binding.netatmo.config.NetatmoModuleConfiguration;
 import org.openhab.binding.netatmo.handler.NetatmoModuleHandler;
 import org.openhab.binding.netatmo.internal.ChannelTypeUtils;
 
+import io.swagger.client.model.NADashboardData;
+
 /**
  * {@link NAModule3Handler} is the class used to handle the Rain Gauge
  * capable of measuring precipitation
@@ -31,12 +33,15 @@ public class NAModule3Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        switch (channelId) {
-            case CHANNEL_RAIN:
-                return ChannelTypeUtils.toDecimalType(module.getDashboardData().getRain());
-            default:
-                return super.getNAThingProperty(channelId);
+        if (module != null) {
+            NADashboardData dashboardData = module.getDashboardData();
+            switch (channelId) {
+                case CHANNEL_RAIN:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getRain());
+
+            }
         }
+        return super.getNAThingProperty(channelId);
     }
 
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule4Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule4Handler.java
@@ -33,32 +33,34 @@ public class NAModule4Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        NADashboardData dashboardData = module.getDashboardData();
-        switch (channelId) {
-            case CHANNEL_CO2:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getCO2());
-            case CHANNEL_TEMPERATURE:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getTemperature());
-            case CHANNEL_TIMEUTC:
-                return ChannelTypeUtils.toDateTimeType(dashboardData.getTimeUtc());
-            case CHANNEL_HUMIDITY:
-                return ChannelTypeUtils.toDecimalType(dashboardData.getHumidity());
-            case CHANNEL_HUMIDEX:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getHumidex(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_HEATINDEX:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getHeatIndex(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_DEWPOINT:
-                return ChannelTypeUtils.toDecimalType(
-                        WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity()));
-            case CHANNEL_DEWPOINTDEP:
-                Double dewpoint = WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity());
-                return ChannelTypeUtils
-                        .toDecimalType(WeatherUtils.getDewPointDep(dashboardData.getTemperature(), dewpoint));
-            default:
-                return super.getNAThingProperty(channelId);
+        if (module != null) {
+            NADashboardData dashboardData = module.getDashboardData();
+            switch (channelId) {
+                case CHANNEL_CO2:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getCO2());
+                case CHANNEL_TEMPERATURE:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getTemperature());
+                case CHANNEL_TIMEUTC:
+                    return ChannelTypeUtils.toDateTimeType(dashboardData.getTimeUtc());
+                case CHANNEL_HUMIDITY:
+                    return ChannelTypeUtils.toDecimalType(dashboardData.getHumidity());
+                case CHANNEL_HUMIDEX:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getHumidex(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_HEATINDEX:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getHeatIndex(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_DEWPOINT:
+                    return ChannelTypeUtils.toDecimalType(
+                            WeatherUtils.getDewPoint(dashboardData.getTemperature(), dashboardData.getHumidity()));
+                case CHANNEL_DEWPOINTDEP:
+                    Double dewpoint = WeatherUtils.getDewPoint(dashboardData.getTemperature(),
+                            dashboardData.getHumidity());
+                    return ChannelTypeUtils
+                            .toDecimalType(WeatherUtils.getDewPointDep(dashboardData.getTemperature(), dewpoint));
+            }
         }
+        return super.getNAThingProperty(channelId);
     }
 
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NATherm1Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NATherm1Handler.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.netatmo.config.NATherm1Configuration;
@@ -32,6 +33,7 @@ import io.swagger.client.CollectionFormats.CSVParams;
 import io.swagger.client.api.ThermostatApi;
 import io.swagger.client.model.NAThermProgram;
 import io.swagger.client.model.NAThermostat;
+import io.swagger.client.model.NATimeTableItem;
 
 /**
  * {@link NATherm1Handler} is the class used to handle the thermostat
@@ -61,73 +63,106 @@ public class NATherm1Handler extends NetatmoModuleHandler<NATherm1Configuration>
 
     @Override
     protected State getNAThingProperty(String channelId) {
-        NAThermostat thermostat = module.getThermostat();
 
-        @SuppressWarnings("unused")
-        List<NAThermProgram> a = thermostat.getThermProgramList();
+        if (module != null) {
+            NAThermostat thermostat = module.getThermostat();
+            if (thermostat != null) {
+                switch (channelId) {
+                    case CHANNEL_THERM_ORIENTATION:
+                        return new DecimalType(thermostat.getThermOrientation());
+                    case CHANNEL_THERM_RELAY:
+                        return thermostat.getThermRelayCmd() == 100 ? OnOffType.ON : OnOffType.OFF;
+                    case CHANNEL_TEMPERATURE:
+                        return ChannelTypeUtils.toDecimalType(thermostat.getMeasured().getTemperature());
+                    case CHANNEL_SETPOINT_TEMP:
+                        return ChannelTypeUtils.toDecimalType(thermostat.getMeasured().getSetpointTemp());
+                    case CHANNEL_TIMEUTC:
+                        return ChannelTypeUtils.toDateTimeType(thermostat.getMeasured().getTime());
+                    case CHANNEL_SETPOINT_END_TIME: {
+                        if (thermostat.getSetpoint() == null) {
+                            return UnDefType.NULL;
+                        }
 
-        if (thermostat != null) {
-            switch (channelId) {
-                case CHANNEL_THERM_ORIENTATION:
-                    return new DecimalType(thermostat.getThermOrientation());
-                case CHANNEL_THERM_RELAY:
-                    return thermostat.getThermRelayCmd() == 100 ? OnOffType.ON : OnOffType.OFF;
-                case CHANNEL_TEMPERATURE:
-                    return ChannelTypeUtils.toDecimalType(thermostat.getMeasured().getTemperature());
-                case CHANNEL_SETPOINT_TEMP:
-                    return ChannelTypeUtils.toDecimalType(thermostat.getMeasured().getSetpointTemp());
-                case CHANNEL_TIMEUTC:
-                    return ChannelTypeUtils.toDateTimeType(thermostat.getMeasured().getTime());
-                case CHANNEL_SETPOINT_END_TIME: {
-                    if (thermostat.getSetpoint() != null) {
                         Integer endTime = thermostat.getSetpoint().getSetpointEndtime();
                         if (endTime != null) {
                             return ChannelTypeUtils.toDateTimeType(endTime);
+                        } else {
+                            return ChannelTypeUtils.toDateTimeType(getNextSchedule(thermostat.getThermProgramList()));
                         }
+
+                    }
+                    case CHANNEL_SETPOINT_MODE: {
+                        return thermostat.getSetpoint() != null
+                                ? new StringType(thermostat.getSetpoint().getSetpointMode()) : UnDefType.NULL;
                     }
 
-                    return UnDefType.NULL;
-
-                }
-                case CHANNEL_SETPOINT_MODE: {
-                    if (thermostat.getSetpoint() != null) {
-                        return new StringType(thermostat.getSetpoint().getSetpointMode());
-                    }
-                    return UnDefType.NULL;
                 }
             }
         }
         return super.getNAThingProperty(channelId);
+    }
 
+    private int getNextSchedule(List<NAThermProgram> thermProgramList) {
+        Calendar mondayZero = Calendar.getInstance();
+        mondayZero.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+        mondayZero.set(Calendar.HOUR_OF_DAY, 0);
+        mondayZero.set(Calendar.MINUTE, 0);
+        mondayZero.set(Calendar.SECOND, 0);
+
+        Calendar now = Calendar.getInstance();
+        long diff = (now.getTimeInMillis() - mondayZero.getTimeInMillis()) / 1000 / 60;
+
+        int result = -1;
+
+        for (NAThermProgram thermProgram : thermProgramList) {
+            if (thermProgram.getSelected() != null && thermProgram.getSelected().booleanValue()) {
+                // By default we'll use the first slot of next week - this case will be true if
+                // we are in the last schedule of the week so below loop will not exit by break
+                int next = thermProgram.getTimetable().get(0).getMOffset() + (7 * 24 * 60);
+
+                for (NATimeTableItem timeTable : thermProgram.getTimetable()) {
+                    if (timeTable.getMOffset() > diff) {
+                        next = timeTable.getMOffset();
+                        break;
+                    }
+                }
+
+                result = (int) (next * 60 + (mondayZero.getTimeInMillis() / 1000));
+
+            }
+        }
+        return result;
     }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         super.handleCommand(channelUID, command);
-        try {
-            // To get sorted : if these commands consequencies are wider that the only source channel
-            // then we must refresh the module and its parent device to correctly update all data
+        if (!(command instanceof RefreshType)) {
+            try {
+                switch (channelUID.getId()) {
+                    case CHANNEL_SETPOINT_MODE: {
+                        getBridgeHandler().getThermostatApi().setthermpoint(configuration.getParentId(),
+                                configuration.getEquipmentId(), command.toString(), null, null);
 
-            switch (channelUID.getId()) {
-                case CHANNEL_SETPOINT_MODE: {
-                    getBridgeHandler().getThermostatApi().setthermpoint(configuration.getParentId(),
-                            configuration.getEquipmentId(), command.toString(), null, null);
-
-                    break;
+                        updateState(channelUID, new StringType(command.toString()));
+                        requestParentRefresh();
+                        break;
+                    }
+                    case CHANNEL_SETPOINT_TEMP: {
+                        // Switch the thermostat to manual mode on the desired setpoint for given duration
+                        Calendar cal = Calendar.getInstance();
+                        cal.add(Calendar.MINUTE, configuration.setpointDefaultDuration);
+                        getBridgeHandler().getThermostatApi().setthermpoint(configuration.getParentId(),
+                                configuration.getEquipmentId(), "manual", (int) (cal.getTimeInMillis() / 1000),
+                                Float.parseFloat(command.toString()));
+                        updateState(channelUID, new DecimalType(command.toString()));
+                        requestParentRefresh();
+                        break;
+                    }
                 }
-                case CHANNEL_SETPOINT_TEMP: {
-                    // Switch the thermostat to manual mode on the desired setpoint for given duration
-                    Calendar cal = Calendar.getInstance();
-                    cal.add(Calendar.MINUTE, configuration.setpointDefaultDuration);
-                    getBridgeHandler().getThermostatApi().setthermpoint(configuration.getParentId(),
-                            configuration.getEquipmentId(), "manual", (int) (cal.getTimeInMillis() / 1000),
-                            Float.parseFloat(command.toString()));
-
-                    break;
-                }
+            } catch (Exception e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, e.getMessage());
             }
-        } catch (Exception e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Other modifications, concerning Thermostat, are :
* address refresh of parent device when module channel updated via OH
* Now, if not in manual mode, the end of current scheduled program is retrieved instead of null value previously grabbed for CHANNEL_SETPOINT_END_TIME

Signed-off-by: Gaël L'hopital <glhopital@gmail.com>