### PR TITLE
[RFXCOM] Ported the RFXComCurrentEnergyMessage & RFXComDateTimeMessage

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
@@ -9,7 +9,12 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+
+import javax.xml.bind.DatatypeConverter;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test for RFXCom-binding
@@ -18,9 +23,32 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
  * @since 1.9.0
  */
 public class RFXComCurrentEnergyMessageTest {
-    @Test(expected = RFXComNotImpException.class)
-    public void checkNotImplemented() throws Exception {
-        // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(RFXComBaseMessage.PacketType.CURRENT_ENERGY);
+    private void testMessage(String hexMsg, RFXComCurrentEnergyMessage.SubType subType, int seqNbr, String deviceId,
+                             int count, double channel1, double channel2, double channel3, double totalUsage, int signalLevel,
+                             int batteryLevel) throws RFXComException, RFXComNotImpException {
+        final RFXComCurrentEnergyMessage msg = (RFXComCurrentEnergyMessage) RFXComMessageFactory
+                .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
+        assertEquals("SubType", subType, msg.subType);
+        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
+        assertEquals("Count", count, msg.count);
+        assertEquals("Channel 1", channel1, msg.channel1Amps, 0.01);
+        assertEquals("Channel 2", channel2, msg.channel2Amps, 0.01);
+        assertEquals("Channel 3", channel3, msg.channel3Amps, 0.01);
+        assertEquals("Total usage", totalUsage, msg.totalUsage, 0.05);
+        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+        assertEquals("Battery Level", batteryLevel, msg.batteryLevel);
+
+        byte[] decoded = msg.decodeMessage();
+
+        assertEquals("Message converted back", hexMsg, DatatypeConverter.printHexBinary(decoded));
+    }
+
+    @Test
+    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+        testMessage("135B0106B800000016000000000000006F148889", RFXComCurrentEnergyMessage.SubType.ELEC4, 6, "47104", 0,
+                2.2d, 0d, 0d, 32547.4d, 8, 9);
+        testMessage("135B014FB80002001D0000000000000000000079", RFXComCurrentEnergyMessage.SubType.ELEC4, 79, "47104",
+                2, 2.9d, 0d, 0d, 0d, 7, 9);
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
@@ -8,9 +8,15 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
+
+import javax.xml.bind.DatatypeConverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.RFXComValueSelector.DATE_TIME;
 
 /**
  * Test for RFXCom-binding
@@ -19,9 +25,21 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComDateTimeMessageTest {
-    @Test(expected = RFXComNotImpException.class)
-    public void checkNotImplemented() throws Exception {
-        // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(PacketType.DATE_TIME);
+    @Test
+    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+        String hexMessage = "0D580117B90003041D030D150A69";
+        byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
+        RFXComDateTimeMessage msg = (RFXComDateTimeMessage) RFXComMessageFactory.createMessage(message);
+        assertEquals("SubType", RFXComDateTimeMessage.SubType.RTGR328N, msg.subType);
+        assertEquals("Seq Number", 23, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Sensor Id", "47360", msg.getDeviceId());
+        assertEquals("Date time", "2003-04-29T13:21:10", msg.dateTime);
+        assertEquals("Signal Level", (byte) 6, msg.signalLevel);
+
+        assertEquals("Converted value", DateTimeType.valueOf("2003-04-29T13:21:10"), msg.convertToState(DATE_TIME));
+
+        byte[] decoded = msg.decodeMessage();
+
+        assertEquals("Message converted back", hexMessage, DatatypeConverter.printHexBinary(decoded));
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
@@ -29,6 +29,12 @@
 		<description>Contact channel</description>
 	</channel-type>
 
+	<channel-type id="datetime">
+		<item-type>DateTime</item-type>
+		<label>DateTime</label>
+		<description>DateTime channel</description>
+	</channel-type>
+
 	<channel-type id="dimminglevel">
 		<item-type>Dimmer</item-type>
 		<label>Dimming Level</label>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/currentenergy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/currentenergy.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="currentenergy">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge"/>
+            <bridge-type-ref id="tcpbridge"/>
+            <bridge-type-ref id="RFXtrx433"/>
+            <bridge-type-ref id="RFXrec433"/>
+        </supported-bridge-type-refs>
+
+        <label>RFXCOM CurrentEnergy Actuator</label>
+        <description>A CurrentEnergy device.</description>
+
+        <channels>
+            <channel id="channel1Amps" typeId="instantamp"/>
+            <channel id="channel2Amps" typeId="instantamp"/>
+            <channel id="channel3Amps" typeId="instantamp"/>
+            <channel id="totalUsage" typeId="totalusage"/>
+            <channel id="signalLevel" typeId="system.signal-strength"/>
+            <channel id="batteryLevel" typeId="system.battery-level"/>
+            <channel id="lowBattery" typeId="system.low-battery"/>
+        </channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 47104</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="ELEC4">OWL - CM180i</option>
+                </options>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/datetime.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/datetime.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="datetime">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+            <bridge-type-ref id="tcpbridge" />
+            <bridge-type-ref id="RFXtrx433" />
+            <bridge-type-ref id="RFXrec433" />
+        </supported-bridge-type-refs>
+
+        <label>RFXCOM Date/time sensor</label>
+        <description>A DateTime device.</description>
+
+        <channels>
+            <channel id="dateTime" typeId="datetime" />
+            <channel id="signalLevel" typeId="system.signal-strength" />
+            <channel id="batteryLevel" typeId="system.battery-level" />
+            <channel id="lowBattery" typeId="system.low-battery" />
+        </channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Device id, example 47360</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="RTGR328N">Oregon RTGR328N</option>
+                </options>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom;
 
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The {@link RFXComBindingConstants} class defines common constants, which are
@@ -88,11 +87,15 @@ public class RFXComBindingConstants {
     public final static String CHANNEL_TOTAL_USAGE = "totalUsage";
     public final static String CHANNEL_INSTANT_AMPS = "instantAmp";
     public final static String CHANNEL_TOTAL_AMP_HOUR = "totalAmpHour";
+    public static final String CHANNEL_CHANNEL1_AMPS = "channel1Amps";
+    public static final String CHANNEL_CHANNEL2_AMPS = "channel2Amps";
+    public static final String CHANNEL_CHANNEL3_AMPS = "channel3Amps";
     public final static String CHANNEL_STATUS = "status";
     public final static String CHANNEL_MOTION = "motion";
     public final static String CHANNEL_CONTACT = "contact";
     public final static String CHANNEL_VOLTAGE = "voltage";
     public final static String CHANNEL_SET_POINT = "setpoint";
+    public static final String CHANNEL_DATE_TIME = "dateTime";
 
     // List of all Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_UNDECODED = new ThingTypeUID(BINDING_ID, "undecoded");

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -8,15 +8,16 @@
  */
 package org.openhab.binding.rfxcom;
 
-import java.io.InvalidClassException;
-
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.items.ContactItem;
+import org.eclipse.smarthome.core.library.items.DateTimeItem;
 import org.eclipse.smarthome.core.library.items.DimmerItem;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.items.StringItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
+
+import java.io.InvalidClassException;
 
 /**
  * Represents all valid value selectors which could be processed by RFXCOM
@@ -49,11 +50,15 @@ public enum RFXComValueSelector {
     TOTAL_USAGE(RFXComBindingConstants.CHANNEL_TOTAL_USAGE, NumberItem.class),
     INSTANT_AMPS(RFXComBindingConstants.CHANNEL_INSTANT_AMPS, NumberItem.class),
     TOTAL_AMP_HOUR(RFXComBindingConstants.CHANNEL_TOTAL_AMP_HOUR, NumberItem.class),
+    CHANNEL1_AMPS(RFXComBindingConstants.CHANNEL_CHANNEL1_AMPS, NumberItem.class),
+    CHANNEL2_AMPS(RFXComBindingConstants.CHANNEL_CHANNEL2_AMPS, NumberItem.class),
+    CHANNEL3_AMPS(RFXComBindingConstants.CHANNEL_CHANNEL3_AMPS, NumberItem.class),
     STATUS(RFXComBindingConstants.CHANNEL_STATUS, StringItem.class),
     MOTION(RFXComBindingConstants.CHANNEL_MOTION, SwitchItem.class),
     CONTACT(RFXComBindingConstants.CHANNEL_CONTACT, ContactItem.class),
     VOLTAGE(RFXComBindingConstants.CHANNEL_VOLTAGE, NumberItem.class),
     SET_POINT(RFXComBindingConstants.CHANNEL_SET_POINT, NumberItem.class),
+    DATE_TIME(RFXComBindingConstants.CHANNEL_DATE_TIME, DateTimeItem.class),
     LOW_BATTERY(RFXComBindingConstants.CHANNEL_LOW_BATTERY, SwitchItem.class);
 
     private final String text;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * RFXCOM data class for Current and Energy message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
+    private static float TOTAL_USAGE_CONVERSION_FACTOR = 223.666F;
+
+    public enum SubType {
+        ELEC4(1), // OWL - CM180i
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+
+        public static SubType fromByte(int input) {
+            for (SubType c : SubType.values()) {
+                if (c.subType == input) {
+                    return c;
+                }
+            }
+
+            return SubType.UNKNOWN;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays.asList(
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.CHANNEL1_AMPS,
+            RFXComValueSelector.CHANNEL2_AMPS, RFXComValueSelector.CHANNEL3_AMPS, RFXComValueSelector.TOTAL_USAGE);
+
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
+
+    public SubType subType = SubType.UNKNOWN;
+    public int sensorId = 0;
+    public byte count = 0;
+    public double channel1Amps = 0.0;
+    public double channel2Amps = 0.0;
+    public double channel3Amps = 0.0;
+    public double totalUsage = 0.0;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComCurrentEnergyMessage() {
+        packetType = PacketType.CURRENT_ENERGY;
+    }
+
+    public RFXComCurrentEnergyMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += ", Sub type = " + subType;
+        str += ", Id = " + sensorId;
+        str += ", Count = " + count;
+        str += ", Channel1 Amps = " + channel1Amps;
+        str += ", Channel2 Amps = " + channel2Amps;
+        str += ", Channel3 Amps = " + channel3Amps;
+        str += ", Total Usage = " + totalUsage;
+        str += ", Signal level = " + signalLevel;
+        str += ", Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        subType = SubType.fromByte(super.subType);
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+        count = data[6];
+
+        // Current = Field / 10
+        channel1Amps = ((data[7] & 0xFF) << 8 | (data[8] & 0xFF)) / 10.0;
+        channel2Amps = ((data[9] & 0xFF) << 8 | (data[10] & 0xFF)) / 10.0;
+        channel3Amps = ((data[11] & 0xFF) << 8 | (data[12] & 0xFF)) / 10.0;
+
+        totalUsage = ((long) (data[13] & 0xFF) << 40 | (long) (data[14] & 0xFF) << 32 | (data[15] & 0xFF) << 24
+                | (data[16] & 0xFF) << 16 | (data[17] & 0xFF) << 8 | (data[18] & 0xFF));
+        totalUsage = totalUsage / TOTAL_USAGE_CONVERSION_FACTOR;
+
+        signalLevel = (byte) ((data[19] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[19] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[20];
+
+        data[0] = (byte) (data.length - 1);
+        data[1] = RFXComBaseMessage.PacketType.CURRENT_ENERGY.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+        data[6] = count;
+
+        data[7] = (byte) (((int) (channel1Amps * 10.0) >> 8) & 0xFF);
+        data[8] = (byte) ((int) (channel1Amps * 10.0) & 0xFF);
+        data[9] = (byte) (((int) (channel2Amps * 10.0) >> 8) & 0xFF);
+        data[10] = (byte) ((int) (channel2Amps * 10.0) & 0xFF);
+        data[11] = (byte) (((int) (channel3Amps * 10.0) >> 8) & 0xFF);
+        data[12] = (byte) ((int) (channel3Amps * 10.0) & 0xFF);
+
+        long totalUsageLoc = (long) (totalUsage * TOTAL_USAGE_CONVERSION_FACTOR);
+
+        data[13] = (byte) ((totalUsageLoc >> 40) & 0xFF);
+        data[14] = (byte) ((totalUsageLoc >> 32) & 0xFF);
+        data[15] = (byte) ((totalUsageLoc >> 24) & 0xFF);
+        data[16] = (byte) ((totalUsageLoc >> 16) & 0xFF);
+        data[17] = (byte) ((totalUsageLoc >> 8) & 0xFF);
+        data[18] = (byte) (totalUsageLoc & 0xFF);
+
+        data[19] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+        State state;
+        if (valueSelector.getItemClass() == NumberItem.class) {
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+                state = new DecimalType(signalLevel);
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+                state = new DecimalType(batteryLevel);
+            } else if (valueSelector == RFXComValueSelector.CHANNEL1_AMPS) {
+                state = new DecimalType(channel1Amps);
+            } else if (valueSelector == RFXComValueSelector.CHANNEL2_AMPS) {
+                state = new DecimalType(channel2Amps);
+            } else if (valueSelector == RFXComValueSelector.CHANNEL3_AMPS) {
+                state = new DecimalType(channel3Amps);
+            } else if (valueSelector == RFXComValueSelector.TOTAL_USAGE) {
+                state = new DecimalType(totalUsage);
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+        } else {
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+        }
+        return state;
+    }
+
+    @Override
+    public String getDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public void setDeviceId(String deviceId) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedInputValueSelectors() throws RFXComException {
+        return supportedInputValueSelectors;
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedOutputValueSelectors() throws RFXComException {
+        return supportedOutputValueSelectors;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, Type type) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (RFXComBlinds1Message.SubType s : RFXComBlinds1Message.SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        // try to find sub type by number
+        try {
+            return RFXComBlinds1Message.SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComException("Unknown sub type " + subType);
+        }
+    }
+
+    @Override
+    public void setSubType(Object subType) throws RFXComException {
+        this.subType = (SubType) subType;
+    }
+}

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import org.eclipse.smarthome.core.library.items.DateTimeItem;
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * RFXCOM data class for Date and Time message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComDateTimeMessage extends RFXComBaseMessage {
+
+    public enum SubType {
+        RTGR328N(1),
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+
+        public static SubType fromByte(int input) {
+            for (SubType c : SubType.values()) {
+                if (c.subType == input) {
+                    return c;
+                }
+            }
+
+            return SubType.UNKNOWN;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays.asList(
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.DATE_TIME);
+
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
+
+    public SubType subType = SubType.UNKNOWN;
+    public int sensorId = 0;
+    String dateTime = "yyyy-MM-dd'T'HH:mm:ss";
+    int yy = 0;
+    int MM = 0;
+    int dd = 0;
+    int dow = 0;
+    int HH = 0;
+    int mm = 0;
+    int ss = 0;
+
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComDateTimeMessage() {
+        packetType = PacketType.DATE_TIME;
+    }
+
+    public RFXComDateTimeMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += ", Sub type = " + subType;
+        str += ", Id = " + sensorId;
+        str += ", Date Time = " + dateTime;
+        str += ", Signal level = " + signalLevel;
+        str += ", Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        subType = SubType.fromByte(super.subType);
+
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+        yy = data[6] & 0xFF;
+        MM = data[7] & 0xFF;
+        dd = data[8] & 0xFF;
+        dow = data[9] & 0xFF;
+        HH = data[10] & 0xFF;
+        mm = data[11] & 0xFF;
+        ss = data[12] & 0xFF;
+
+        dateTime = String.format("20%02d-%02d-%02dT%02d:%02d:%02d", yy, MM, dd, HH, mm, ss);
+
+        signalLevel = (byte) ((data[13] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[13] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[14];
+
+        data[0] = (byte) (data.length - 1);
+        data[1] = RFXComBaseMessage.PacketType.DATE_TIME.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+        data[6] = (byte) (yy & 0x00FF);
+        data[7] = (byte) (MM & 0x00FF);
+        data[8] = (byte) (dd & 0x00FF);
+        data[9] = (byte) (dow & 0x00FF);
+        data[10] = (byte) (HH & 0x00FF);
+        data[11] = (byte) (mm & 0x00FF);
+        data[12] = (byte) (ss & 0x00FF);
+        data[13] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+        State state;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == DateTimeItem.class) {
+
+            if (valueSelector == RFXComValueSelector.DATE_TIME) {
+
+                state = new DateTimeType(dateTime);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, Type type) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public String getDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public void setDeviceId(String deviceId) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedInputValueSelectors() throws RFXComException {
+        return supportedInputValueSelectors;
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedOutputValueSelectors() throws RFXComException {
+        return supportedOutputValueSelectors;
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        // try to find sub type by number
+        try {
+            return RFXComBlinds1Message.SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComException("Unknown sub type " + subType);
+        }
+    }
+
+    @Override
+    public void setSubType(Object subType) throws RFXComException {
+        this.subType = (SubType) subType;
+    }
+}


### PR DESCRIPTION
Ported RFXComCurrentEnergyMessage and RFXComDateTimeMessage which were added in https://github.com/openhab/openhab/pull/3956

I don't have the device so cannot test it properly, but since it's new functionality (for OH2) it's better to have partial support than no support at all.

@Jamstah care for a review?