### PR TITLE
Added AVM Fritz!DECT Repeater 100

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
@@ -4,6 +4,7 @@ binding.fritzaha.description = AVM Fritz! AHA Geräte (DECT 100/200, Powerline 54
 
 # thing types
 thing-type.Fritz_DECT_200.description = Fritz!DECT200 schaltbare Steckdose
+thing-type.Fritz_DECT_Repeater_100.description = Fritz!DECT Repeater 100
 
 # channel types
 channel-type.temperature.label = Temperatur

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -108,8 +108,22 @@
 			</parameter>
 		</config-description>
     </thing-type>
+    <thing-type id="FRITZ_DECT_Repeater_100">
+    	<supported-bridge-type-refs>
+    		<bridge-type-ref id="fritzbox" />
+    	</supported-bridge-type-refs>
+    	<label>FRITZ!DECT Repeater 100</label>
+    	<description>FRITZ!DECT Repeater 100 DECT repeater</description>
+    	<channels>
+    		<channel typeId="temperature" id="temperature"></channel>
+    	</channels>
+    	<config-description>
+    		<parameter name="ain" type="text" required="true">
+    			<label>AIN</label>
+    			<description>The AHA id (AIN) that identifies one specific device.</description></parameter></config-description>
+    </thing-type>
 
-	<!-- Channel definitions of fritz devices -->
+    <!-- Channel definitions of fritz devices -->
 	<channel-type id="temperature">
 		<item-type>Number</item-type>
 		<label>Actual Temperature</label>

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -13,6 +13,10 @@ The well known FRITZ!Boxes are supported as bridge for accessing other AHA devic
 
 This [switchable outlet](http://avm.de/produkte/fritzdect/fritzdect-200/) has to be connected to a FRITZ!Box by DECT protocol. It supports switching the outlet, current power and accumulated energy consumption and temperature readings.
 
+### FRITZ!DECT Repeater 100
+
+This [DECT repeater](https://avm.de/produkte/fritzdect/fritzdect-repeater-100/) has to be connected to a FRITZ!Box by DECT protocol. It only supports temperature readings.
+
 ### FRITZ!Powerline 546E
 
 This [powerline adapter](http://avm.de/produkte/fritzpowerline/fritzpowerline-546e/) can be used via the bridge or in standalone mode. It supports switching the outlet and current power and energy consumption readings. This device does not contain a temperature sensor.
@@ -55,7 +59,7 @@ If correct credentials are set in the bridge configuration, connected AHA device
 
 | Channel Type ID | Item Type    | Description  | Available on thing |
 |-------------|--------|-----------------------------|------------------------------------|
-| temperature | Number | Actual measured temperature | FRITZ!DECT 200 |
+| temperature | Number | Actual measured temperature | FRITZ!DECT 200, FRITZ!DECT Repeater 100 |
 | energy | Number | Accumulated energy consumption | FRITZ!DECT 200, FRITZ!Powerline 546E |
 | power | Number | Current power consumption | FRITZ!DECT 200, FRITZ!Powerline 546E |
 | outlet | Switch | Switchable outlet | FRITZ!DECT 200, FRITZ!Powerline 546E |

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
@@ -17,47 +17,49 @@ import com.google.common.collect.ImmutableSet;
 /**
  * This class defines common constants, which are used
  * across the whole binding.
- * 
+ *
  * @author Robert Bausdorf
- * 
+ *
  */
 public class BindingConstants {
 
-	public static final String BINDING_ID = "avmfritz";
-	public static final String IP_ADDRESS = "ipAddress";
-	public static final String BRIDGE_FRITZBOX = "fritzbox";
+    public static final String BINDING_ID = "avmfritz";
+    public static final String IP_ADDRESS = "ipAddress";
+    public static final String BRIDGE_FRITZBOX = "fritzbox";
     public static final String SERIAL_NUMBER = "serialNumber";
     public static final String DEVICE_ID = "deviceId";
     public static final String BRIDGE_MODEL_NAME = "FRITZ!Box";
     public static final String PL546E_MODEL_NAME = "FRITZ!Powerline";
     public static final String THING_AIN = "ain";
 
-	// List of main device types
-	public static final String DEVICE_DECT200 = "FRITZ_DECT_200";
-	public static final String DEVICE_PL546E = "FRITZ_Powerline_546E";
-	public static final String DEVICE_PL546E_STANDALONE = "FRITZ_Powerline_546E_Solo";
+    // List of main device types
+    public static final String DEVICE_DECT200 = "FRITZ_DECT_200";
+    public static final String DEVICE_DECT100 = "FRITZ_DECT_Repeater_100";
+    public static final String DEVICE_PL546E = "FRITZ_Powerline_546E";
+    public static final String DEVICE_PL546E_STANDALONE = "FRITZ_Powerline_546E_Solo";
 
     // List of all Thing Type UIDs
     public final static ThingTypeUID BRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, BRIDGE_FRITZBOX);
 
     public final static ThingTypeUID DECT200_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_DECT200);
+    public final static ThingTypeUID DECT100_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_DECT100);
     public final static ThingTypeUID PL546E_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_PL546E);
-    public final static ThingTypeUID PL546E_STANDALONE_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_PL546E_STANDALONE);
+    public final static ThingTypeUID PL546E_STANDALONE_THING_TYPE = new ThingTypeUID(BINDING_ID,
+            DEVICE_PL546E_STANDALONE);
 
-	// List of all Channel ids
+    // List of all Channel ids
     public final static String CHANNEL_TEMP = "temperature";
     public final static String CHANNEL_ENERGY = "energy";
     public final static String CHANNEL_POWER = "power";
     public final static String CHANNEL_SWITCH = "outlet";
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(
-    		DECT200_THING_TYPE, PL546E_THING_TYPE, BRIDGE_THING_TYPE, PL546E_STANDALONE_THING_TYPE);
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(DECT100_THING_TYPE,
+            DECT200_THING_TYPE, PL546E_THING_TYPE, BRIDGE_THING_TYPE, PL546E_STANDALONE_THING_TYPE);
 
-    public final static Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS =ImmutableSet.of(
-    		DECT200_THING_TYPE, PL546E_THING_TYPE);
+    public final static Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = ImmutableSet.of(DECT100_THING_TYPE,
+            DECT200_THING_TYPE, PL546E_THING_TYPE);
 
-
-    public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS =ImmutableSet.of(
-    		BRIDGE_THING_TYPE, PL546E_STANDALONE_THING_TYPE);
+    public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS = ImmutableSet.of(BRIDGE_THING_TYPE,
+            PL546E_STANDALONE_THING_TYPE);
 
 }


### PR DESCRIPTION
- added support for AVM Fritz!DECT Repeater 100 (only temperature
readings)

Signed-off-by: Stephan Kratzer <stephan.kratzer@gmx.net>