### PR TITLE
[exec] Disable default interval

### DIFF
--- a/addons/binding/org.openhab.binding.exec/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.exec/ESH-INF/thing/thing-types.xml
@@ -29,7 +29,7 @@
             <parameter name="interval" type="integer"  required="false">
                 <label>Interval</label>
                 <description>Interval, in seconds, the command will be repeatedly executed</description>
-                <default>60</default>
+                <default>0</default>
             </parameter>
             <parameter name="timeout" type="integer"  required="false">
                 <label>Timeout</label>


### PR DESCRIPTION
Currently, if the `interval` parameter is not explicitely set to `0` within the Thing Configuration, the command specified gets automatically executed every minute. This behaviour is neither documented nor expected or useful. So I'd suggest to not execute the command repeatedly by default at all.

Signed-off-by: Patrick Fink <mail@pfink.de>