### PR TITLE
[MAX] avoid NPE during reboot action

### DIFF
--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class CubeCommand {
 
-    protected final static Logger logger = LoggerFactory.getLogger(CubeCommand.class);
+    protected final Logger logger = LoggerFactory.getLogger(CubeCommand.class);
 
     /**
      * @return the String to be send to the MAX! Cube

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
@@ -36,7 +36,7 @@ public class UdpCubeCommand {
 
     static final String MAXCUBE_COMMAND_STRING = "eQ3Max*\0";
 
-    private final static Logger logger = LoggerFactory.getLogger(UdpCubeCommand.class);
+    private final Logger logger = LoggerFactory.getLogger(UdpCubeCommand.class);
 
     static boolean commandRunning = false;
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -47,7 +47,7 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
     static final String MAXCUBE_DISCOVER_STRING = "eQ3Max*\0**********I";
     private final static int SEARCH_TIME = 15;
 
-    private final static Logger logger = LoggerFactory.getLogger(MaxCubeBridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(MaxCubeBridgeDiscovery.class);
 
     static boolean discoveryRunning = false;
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class MaxDeviceDiscoveryService extends AbstractDiscoveryService implements DeviceStatusListener {
 
     private final static int SEARCH_TIME = 60;
-    private final static Logger logger = LoggerFactory.getLogger(MaxDeviceDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(MaxDeviceDiscoveryService.class);
 
     private MaxCubeBridgeHandler maxCubeBridgeHandler;
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
@@ -226,7 +226,6 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
             }
             if (configurationParameter.getKey().startsWith("action-")) {
                 if (configurationParameter.getValue().toString().equals(BUTTON_ACTION_VALUE)) {
-                    configurationParameter.setValue(BigDecimal.valueOf(BUTTON_NOACTION_VALUE));
                     if (configurationParameter.getKey().equals(ACTION_CUBE_REBOOT)) {
                         cubeReboot();
                     }
@@ -235,9 +234,10 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
                         refresh = false;
                     }
                 }
+                configuration.put(configurationParameter.getKey(), BigDecimal.valueOf(BUTTON_NOACTION_VALUE));
+            } else {
+                configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
             }
-
-            configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
         }
 
         // Persist changes and restart with new parameters

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
@@ -37,7 +37,7 @@ import com.google.common.base.Strings;
  */
 public final class C_Message extends Message {
 
-    private static final Logger logger = LoggerFactory.getLogger(C_Message.class);
+    private final Logger logger = LoggerFactory.getLogger(C_Message.class);
 
     private String rfAddress = null;
     private int length = 0;


### PR DESCRIPTION
FIX: Avoid NPE during reboot action
CHN: Changed static loggers to non-static loggers
Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>