### PR TITLE
[DSC Alarm] Bug Fix: Binding Not Updating Channels

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
@@ -254,6 +254,14 @@ public class PartitionThingHandler extends DSCAlarmBaseThingHandler {
 
                         partitionStatus(dscAlarmMessageName);
                         break;
+                    case ExitDelayInProgress: /* 656 */
+                        channelUID = new ChannelUID(getThing().getUID(), PARTITION_EXIT_DELAY);
+                        updateChannel(channelUID, 1, "");
+                        break;
+                    case EntryDelayInProgress: /* 657 */
+                        channelUID = new ChannelUID(getThing().getUID(), PARTITION_ENTRY_DELAY);
+                        updateChannel(channelUID, 1, "");
+                        break;
                     case FailureToArm: /* 672 */
                         channelUID = new ChannelUID(getThing().getUID(), PARTITION_ARM_MODE);
                         updateChannel(channelUID, 0, "");


### PR DESCRIPTION
The 'partition_entry_delay' and the 'partition_exit_delay' channels were
not being updated by the binding.  This fixes that bug.

Signed-off by: Russell Stephens rsstephens@gmail.com (github:
@RSStephens)