### PR TITLE
[rfxcom] Added Livolo scene support, “Livolo On/Off 1-10” subtype in Lighting 5

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.junit.Test;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
@@ -18,8 +19,8 @@ import javax.xml.bind.DatatypeConverter;
 
 import static org.junit.Assert.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING5;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.Commands.ON;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.IT;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.Commands.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.*;
 
 /**
  * Test for RFXCom-binding
@@ -46,6 +47,36 @@ public class RFXComLighting5MessageTest {
         assertEquals("SubType", IT, msg.subType);
         assertEquals("Sensor Id", "2061.1", msg.getDeviceId());
         assertEquals("Command", ON, msg.command);
+    }
+
+    @Test
+    public void convertFromStateLivoloApplianceMessage() throws RFXComException, RFXComNotImpException {
+        RFXComMessage livoloMessage = RFXComMessageFactory.createMessage(LIGHTING5);
+        livoloMessage.setDeviceId("1187.1");
+        livoloMessage.setSubType(LIVOLO);
+        livoloMessage.convertFromState(RFXComValueSelector.COMMAND, OnOffType.ON);
+        byte[] message = livoloMessage.decodeMessage();
+        String hexMessage = DatatypeConverter.printHexBinary(message);
+        assertEquals("Message is not as expected", "0A1405000004A301010000", hexMessage);
+        RFXComLighting5Message msg = (RFXComLighting5Message) RFXComMessageFactory.createMessage(message);
+        assertEquals("SubType", LIVOLO, msg.subType);
+        assertEquals("Device Id", "1187.1", msg.getDeviceId());
+        assertEquals("Command", ON, msg.command);
+    }
+
+    @Test
+    public void convertFromStateLivoloMessage() throws RFXComException, RFXComNotImpException {
+        RFXComMessage livoloApplianceMessage = RFXComMessageFactory.createMessage(LIGHTING5);
+        livoloApplianceMessage.setDeviceId("24.1");
+        livoloApplianceMessage.setSubType(LIVOLO_APPLIANCE);
+        livoloApplianceMessage.convertFromState(RFXComValueSelector.SCENE, new DecimalType(0));
+        byte[] message = livoloApplianceMessage.decodeMessage();
+        String hexMessage = DatatypeConverter.printHexBinary(message);
+        assertEquals("Message is not as expected", "0A140A0000001801040000", hexMessage);
+        RFXComLighting5Message msg = (RFXComLighting5Message) RFXComMessageFactory.createMessage(message);
+        assertEquals("SubType", LIVOLO_APPLIANCE, msg.subType);
+        assertEquals("Device Id", "24.1", msg.getDeviceId());
+        assertEquals("Command", SCENE1, msg.command);
     }
 
     // TODO please add more tests for different messages

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
@@ -176,4 +176,24 @@
 		<state min="0" max="360" step="1" readOnly="true"></state>
 	</channel-type>
 
+	<channel-type id="scene">
+		<item-type>Number</item-type>
+		<label>Scene</label>
+		<description>Scene channel</description>
+		<state readOnly="false">
+			<options>
+				<option value="0">Scene1</option>
+				<option value="1">Scene2</option>
+				<option value="2">Scene1 Room2</option>
+				<option value="3">Scene2 Room2</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="sceneswitch">
+		<item-type>Switch</item-type>
+		<label>Scene Switch</label>
+		<description>Scene switch channel</description>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/lighting5.xml
@@ -20,6 +20,9 @@
 			<channel id="dimmingLevel" typeId="dimminglevel" />
 			<channel id="mood" typeId="mood" />
 			<channel id="signalLevel" typeId="system.signal-strength" />
+			<channel id="scene" typeId="scene" />
+			<channel id="sceneSwitch" typeId="sceneswitch" />
+			<channel id="sceneSwitch2" typeId="sceneswitch" />
 		</channels>
 
 		<config-description>
@@ -40,6 +43,7 @@
 					<option value="IT">IT</option>
 					<option value="LIGHTWAVERF">LightwaveRF, Siemens</option>
 					<option value="LIVOLO">Livolo Dimmer or On/Off 1-3</option>
+					<option value="LIVOLO_APPLIANCE">Livolo On/Off 1-10</option>
 					<option value="MDREMOTE">MDREMOTE LED dimmer v106</option>
 					<option value="MDREMOTE_107">MDREMOTE v107</option>
 					<option value="MDREMOTE_108">MDREMOTE v108, EKAB-10KRF</option>

--- a/addons/binding/org.openhab.binding.rfxcom/README.md
+++ b/addons/binding/org.openhab.binding.rfxcom/README.md
@@ -114,3 +114,5 @@ This binding currently supports following channels:
 | totalamphour | Number | Used "energy" in ampere-hours. |
 | winddirection | Number | Wind direction in degrees. |
 | windspeed | Number | Average wind speed in meters per second. |
+| scene | Number | Livolo scene. |
+| sceneswitch | Switch | Switch between two Livolo scenes. |

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -96,6 +96,9 @@ public class RFXComBindingConstants {
     public final static String CHANNEL_VOLTAGE = "voltage";
     public final static String CHANNEL_SET_POINT = "setpoint";
     public static final String CHANNEL_DATE_TIME = "dateTime";
+    public final static String CHANNEL_SCENE = "scene";
+    public final static String CHANNEL_SCENE_SWITCH = "sceneSwitch";
+    public final static String CHANNEL_SCENE_SWITCH2 = "sceneSwitch2";
 
     // List of all Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_UNDECODED = new ThingTypeUID(BINDING_ID, "undecoded");

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -59,7 +59,10 @@ public enum RFXComValueSelector {
     VOLTAGE(RFXComBindingConstants.CHANNEL_VOLTAGE, NumberItem.class),
     SET_POINT(RFXComBindingConstants.CHANNEL_SET_POINT, NumberItem.class),
     DATE_TIME(RFXComBindingConstants.CHANNEL_DATE_TIME, DateTimeItem.class),
-    LOW_BATTERY(RFXComBindingConstants.CHANNEL_LOW_BATTERY, SwitchItem.class);
+    LOW_BATTERY(RFXComBindingConstants.CHANNEL_LOW_BATTERY, SwitchItem.class),
+    SCENE(RFXComBindingConstants.CHANNEL_SCENE, NumberItem.class),
+    SCENE_SWITCH(RFXComBindingConstants.CHANNEL_SCENE_SWITCH, SwitchItem.class),
+    SCENE_SWITCH2(RFXComBindingConstants.CHANNEL_SCENE_SWITCH2, SwitchItem.class);
 
     private final String text;
     private Class<? extends Item> itemClass;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -35,6 +35,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Messag
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.EURODOMEST;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.IT;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.LIGHTWAVERF;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.LIVOLO_APPLIANCE;
 
 /**
  * RFXCOM data class for lighting5 message.
@@ -119,6 +120,10 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
         COLOUR_PALETTE(0x11, LIGHTWAVERF),
         COLOUR_TONE(0x12, LIGHTWAVERF),
         COLOUR_CYCLE(0x13, LIGHTWAVERF),
+        SCENE1(0x04, LIVOLO_APPLIANCE),
+        SCENE2(0X05, LIVOLO_APPLIANCE),
+        SCENE1_ROOM2(0x08, LIVOLO_APPLIANCE),
+        SCENE2_ROOM2(0X09, LIVOLO_APPLIANCE),
 
         UNKNOWN(255);
 
@@ -154,7 +159,8 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
             RFXComValueSelector.DIMMING_LEVEL, RFXComValueSelector.CONTACT);
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
-            .asList(RFXComValueSelector.COMMAND, RFXComValueSelector.DIMMING_LEVEL);
+            .asList(RFXComValueSelector.COMMAND, RFXComValueSelector.DIMMING_LEVEL, RFXComValueSelector.SCENE,
+                    RFXComValueSelector.SCENE_SWITCH, RFXComValueSelector.SCENE_SWITCH2);
 
     public SubType subType = SubType.UNKNOWN;
     public int sensorId = 0;
@@ -402,6 +408,46 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
                     // Evert: I do not know how to get previous object state...
                     dimmingLevel = 5;
 
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            case SCENE:
+                if (type instanceof DecimalType) {
+                    byte scene = ((DecimalType) type).byteValue();
+                    switch (scene) {
+                        case 0:
+                            command = Commands.SCENE1;
+                            break;
+                        case 1:
+                            command = Commands.SCENE2;
+                            break;
+                        case 2:
+                            command = Commands.SCENE1_ROOM2;
+                            break;
+                        case 3:
+                            command = Commands.SCENE2_ROOM2;
+                            break;
+                        default:
+                            throw new RFXComException("Unexpected scene: " + scene);
+                    }
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Scene");
+                }
+                break;
+
+            case SCENE_SWITCH:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.SCENE1 : Commands.SCENE2);
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            case SCENE_SWITCH2:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.SCENE1_ROOM2 : Commands.SCENE2_ROOM2);
                 } else {
                     throw new RFXComException("Can't convert " + type + " to Command");
                 }


### PR DESCRIPTION
Added Livolo scene support.
It's possible to trigger 4 scenes and also using Scene Switch channel we can mimic a real switch.
The difference between standard (toggle) button code (Unit 1-10 in terms of RFXCOM) and scene button code is that scene code is associated with the switch state in the moment of synchronization/learning. If switch is in On state - the scene code will be triggering On command and vice versa - if the switch is in Off state when learning the code, it will work as Off code.
