### PR TITLE
[Kodi] Fix offline/online issue

### DIFF
--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
@@ -211,14 +211,14 @@ public class KodiConnection implements KodiClientSocketEventListener {
 
         /*
          * try {
-         * 
+         *
          * String encodedURL = URLEncoder.encode(imagePath, "UTF-8");
          * String decodedURL = URLDecoder.decode(imagePath, "UTF-8");
-         * 
+         *
          * JsonObject params = new JsonObject();
          * params.addProperty("path", "");
          * JsonElement response = socket.callMethod("Files.PrepareDownload", params);
-         * 
+         *
          * } catch (Exception e) {
          * logger.error("updateFanartUrl error", e);
          * }
@@ -505,7 +505,8 @@ public class KodiConnection implements KodiClientSocketEventListener {
                 return false;
             }
         } else {
-            return true;
+            // Ping kodi with the get version command. This prevents the idle timeout on the websocket
+            return !getVersion().isEmpty();
         }
     }
 


### PR DESCRIPTION
Fix #1659

If there is no communication for 5 minutes on the websocket, jetty closes the connection. With this change kodi is regularly (every 10 sec) polled and therefor there is no timeout anymore.

Signed-off-by: Paul Frank <pail@gmx.net>