### PR TITLE
Deal with null altitude values

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
@@ -108,8 +108,12 @@ public abstract class NetatmoDeviceHandler<X extends NetatmoDeviceConfiguration>
                 return ChannelTypeUtils.toDateTimeType(device.getLastStatusStore());
             case CHANNEL_LOCATION:
                 NAPlace place = device.getPlace();
-                return new PointType(new DecimalType(place.getLocation().get(1)),
-                        new DecimalType(place.getLocation().get(0)), new DecimalType(place.getAltitude()));
+                PointType point = new PointType(new DecimalType(place.getLocation().get(1)),
+                        new DecimalType(place.getLocation().get(0)));
+                if (place.getAltitude() != null) {
+                    point.setAltitude(new DecimalType(place.getAltitude()));
+                }
+                return point;
             case CHANNEL_WIFI_STATUS:
                 Integer wifiStatus = device.getWifiStatus();
                 return new DecimalType(getSignalStrength(wifiStatus));


### PR DESCRIPTION
I've never set an altitude for my Netatmo Weather Station. Therefore the altitude is null. This lead to an NPE when the NetatmoDeviceHandler was trying to convert NAPlace to PointType.

Signed-off-by: Sebastian Lorenz <sebastian.p.lorenz@gmail.com> (github: sebplorenz)