### PR TITLE
Yamaha: 	Add menu-based netradio support

### DIFF
--- a/addons/binding/org.openhab.binding.astro/README.md
+++ b/addons/binding/org.openhab.binding.astro/README.md
@@ -16,7 +16,8 @@ No binding configuration required.
 
 ## Thing Configuration
 
-The things requires the geolocation (latitude, longitude) for which the calculation is done. Optionally, a refresh interval (in seconds) can be defined to also calculate positional data like azimuth and elevation.
+A thing requires the geolocation (latitude, longitude) for which the calculation is done.
+Optionally, a refresh interval (in seconds) can be defined to also calculate positional data like azimuth and elevation.
 
 ## Channels
 
@@ -49,37 +50,7 @@ The things requires the geolocation (latitude, longitude) for which the calculat
     * **group** `position`
         * **channel** `azimuth, elevation` (Number)
 
-## Full Example
-
-Things:
-
-```
-astro:sun:home  [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60]
-astro:moon:home [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60]
-```
-
-Items:
-
-```
-DateTime Sunrise_Time  "Sunrise [%1$tH:%1$tM]"  { channel="astro:sun:home:rise#start" }
-DateTime Sunset_Time   "Sunset [%1$tH:%1$tM]"   { channel="astro:sun:home:set#start" }
-Number   Azimuth       "Azimuth"                { channel="astro:sun:home:position#azimuth" }
-Number   Elevation     "Elevation"              { channel="astro:sun:home:position#elevation" }
-String   MoonPhase     "MoonPhase"              { channel="astro:moon:home:phase#name" }
-```
-
-Events:
-
-```
-rule "example trigger rule"
-when
-    Channel 'astro:sun:home:rise#event' triggered START 
-then
-    ...
-end
-```
-
-Available events:
+### Trigger Channels
 * **thing** `sun`
     * **group** `rise, set, noon, night, morningNight, astroDawn, nauticDawn, civilDawn, astroDusk, nauticDusk, civilDusk, eveningNight, daylight`
         * **event** `START, END`
@@ -99,5 +70,48 @@ Available events:
     * **group** `apogee`
         * **event**: `APOGEE`
 
-**Note**: Offsets for each event group can be configured in the channel properties
+**Offsets:** For each event group you can optionally configure an offset in minutes.
+The offset must be configured in the channel properties for the corresponding thing.
+The minimum allowed offset is -1440 and the maximum allowed offset is 1440.
 
+## Full Example
+
+Things:
+
+```
+astro:sun:home  [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60 ]
+astro:moon:home [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60 ]
+```
+
+or optionally with an offset
+
+```
+astro:sun:home [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60 ] {
+    Channels:
+        Type rangeEvent : rise#event [
+            offset=-30
+        ]
+}
+astro:moon:home [ geolocation="xx.xxxxxx,xx.xxxxxx", interval=60 ]
+```
+
+Items:
+
+```
+DateTime Sunrise_Time  "Sunrise [%1$tH:%1$tM]"  { channel="astro:sun:home:rise#start" }
+DateTime Sunset_Time   "Sunset [%1$tH:%1$tM]"   { channel="astro:sun:home:set#start" }
+Number   Azimuth       "Azimuth [%.1f °]"       { channel="astro:sun:home:position#azimuth" }
+Number   Elevation     "Elevation [%.1f °]"     { channel="astro:sun:home:position#elevation" }
+String   MoonPhase     "Moon Phase [%s]"        { channel="astro:moon:home:phase#name" }
+```
+
+Events:
+
+```
+rule "example trigger rule"
+when
+    Channel 'astro:sun:home:rise#event' triggered START 
+then
+    ...
+end
+```

--- a/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
@@ -12,6 +12,7 @@
         <channels>
             <channel id="power" typeId="power"/>
             <channel id="netradiotune" typeId="netradiotune"/>
+            <channel id="netradiostation" typeId="netradiostation"/>
             <channel id="input" typeId="input"/>
             <channel id="surroundProgram" typeId="surroundProgram"/>
             <channel id="volume" typeId="volume"/>
@@ -37,6 +38,12 @@
                 <default>2.0</default>
                 <advanced>true</advanced>
             </parameter>
+            <parameter name="NETRADIOMENU" type="text" required="false">
+                <label>Net radio menu</label>
+                <description>Menu used for menu-based net radio tuning.</description>
+                <default>Bookmarks/__My_Favorites</default>
+                <advanced>true</advanced>
+            </parameter>
         </config-description>
         
     </thing-type>
@@ -57,6 +64,12 @@
         <item-type>Number</item-type>
         <label>NetRadio Channel</label>
         <description>Select the net radio channel of the AVR</description>
+    </channel-type>
+
+    <channel-type id="netradiostation">
+        <item-type>String</item-type>
+        <label>NetRadio Station</label>
+        <description>Select the net radio station of the AVR</description>
     </channel-type>
     
     <channel-type id="surroundProgram">

--- a/addons/binding/org.openhab.binding.yamahareceiver/README.md
+++ b/addons/binding/org.openhab.binding.yamahareceiver/README.md
@@ -11,6 +11,11 @@ by providing host and port.
 Initially a thing for the main zone will be created. This will trigger a zone
 detection internally and all available additional zones will appear as new things.
 
+If your receiver is using menu-based net radio navigation, you can use this binding to
+select radio stations from a configured menu. By default, `Bookmarks/__My_Favorites` is
+used, but it can be overridden with the thing setting `NETRADIOMENU`. The German favorites
+folder, for example, is `Lesezeichen/__My_Favorites`. 
+
 ## Features
 
 The implemented channels are:
@@ -20,6 +25,7 @@ The implemented channels are:
 * `volume`: openHAB Type `Dimmer`, Set's the receivers Volume percent Value.
 * `input`: openHAB Type `String`, Set's the input selection, depends on your receiver's real inputs. Examples: HDMI1, HDMI2, AV4, TUNER, NET RADIO, etc.
 * `surroundProgram`: openHAB Type `String`, Set's the surround mode. Examples: 2ch Stereo, 7ch Stereo, Hall in Munic, Straight, Surround Decoder.
+* `netradiostation`: openHAB Type `String`, Select the net radio station by name in the configured menu folder.
  
 ## Example
 
@@ -35,7 +41,8 @@ Items:
      Switch Yamaha_Mute             "Mute [%s]"            
      String Yamaha_Input         "Input [%s]"              
      String Yamaha_Surround         "surround [%s]"        
-     Number Yamaha_NetRadio  "Net Radio" <netRadio> 
+     Number Yamaha_NetRadio  "Net Radio" <netRadio>   # Preset-based net radio
+     String Yamaha_NetRadioStation  "Net Radio [%s]" <netRadio>   # Menu-based net radio
 ```
 	 
 ### Manually linking
@@ -56,7 +63,9 @@ Items:
 Sitemap:
 
 ```
+     String Yamaha_NetRadioStation  "Net Radio" <netRadio>        {channel="yamahareceiver:yamahaAV:9ab0c000_f668_11de_9976_00a0de88ee65:MAIN_ZONE:netradiostation"}
      Selection item=Yamaha_NetRadio label="Sender" mappings=[1="N Joy", 2="Radio Sport", 3="RDU", 4="91ZM", 5="Hauraki"]
+     Selection item=Yamaha_NetRadioStation label="Sender" mappings=["N Joy"="N Joy", "Radio Sport"="Radio Sport", "RDU"="RDU","91ZM" ="91ZM", "Hauraki"="Hauraki"]
      Selection item=Yamaha_Input mappings=[HDMI1="BlueRay",HDMI2="Satellite","NET RADIO"="NetRadio",TUNER="Tuner"]
      Selection item=Yamaha_Surround label="Surround Mode" mappings=["2ch Stereo"="2ch","7ch Stereo"="7ch"]
 ```

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
@@ -31,6 +31,7 @@ public class YamahaReceiverBindingConstants {
     public final static String CHANNEL_VOLUME_DB = "volumeDB";
     public final static String CHANNEL_MUTE = "mute";
     public final static String CHANNEL_NETRADIO_TUNE = "netradiotune";
+    public final static String CHANNEL_NETRADIO_STATION = "netradiostation";
 
     public static final String UPNP_TYPE = "MediaRenderer";
 
@@ -40,5 +41,5 @@ public class YamahaReceiverBindingConstants {
     public static final String CONFIG_HOST_NAME = "HOST";
     public static final String CONFIG_ZONE = "ZONE";
     public static final String CONFIG_RELVOLUMECHANGE = "RELVOLUMECHANGE";
-
+    public static final String CONFIG_NETRADIOMENU = "NETRADIOMENU";
 }

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author David Gräff - Initial contribution
  */
 public class YamahaReceiverHandler extends BaseThingHandler {
+    private static final String DEFAULT_NET_RADIO_MENU_DIR = "Bookmarks/__My_Favorites";
 
     private Logger logger = LoggerFactory.getLogger(YamahaReceiverHandler.class);
     private String host;
@@ -49,6 +50,7 @@ public class YamahaReceiverHandler extends BaseThingHandler {
     private YamahaReceiverState state = null;
     private ScheduledFuture<?> refreshTimer;
     private ZoneDiscoveryService zoneDiscoveryService;
+    private String netRadioMenuDir = DEFAULT_NET_RADIO_MENU_DIR;
 
     public YamahaReceiverHandler(Thing thing) {
         super(thing);
@@ -83,6 +85,10 @@ public class YamahaReceiverHandler extends BaseThingHandler {
         } else {
             relativeVolumeChangeFactor = 0.5f;
         }
+
+        String netRadioMenuConfig = (String) thing.getConfiguration()
+                .get(YamahaReceiverBindingConstants.CONFIG_NETRADIOMENU);
+        netRadioMenuDir = netRadioMenuConfig != null ? netRadioMenuConfig : DEFAULT_NET_RADIO_MENU_DIR;
     }
 
     /**
@@ -111,6 +117,10 @@ public class YamahaReceiverHandler extends BaseThingHandler {
         if (relVolumeChange != null) {
             relativeVolumeChangeFactor = relVolumeChange.floatValue();
         }
+
+        String netRadioMenuConfig = (String) thing.getConfiguration()
+                .get(YamahaReceiverBindingConstants.CONFIG_NETRADIOMENU);
+        netRadioMenuDir = netRadioMenuConfig != null ? netRadioMenuConfig : DEFAULT_NET_RADIO_MENU_DIR;
 
         // Determine the zone of this thing
         String zoneName = (String) thing.getConfiguration().get(YamahaReceiverBindingConstants.CONFIG_ZONE);
@@ -185,8 +195,15 @@ public class YamahaReceiverHandler extends BaseThingHandler {
         }
         lastRefreshInMS = System.currentTimeMillis();
 
+        boolean includeNetradioStation = isLinked(YamahaReceiverBindingConstants.CHANNEL_NETRADIO_STATION);
+
         try {
             state.updateState();
+
+            if (includeNetradioStation) {
+                state.updateNetRadioStationList();
+            }
+
             updateStatus(ThingStatus.ONLINE);
             updateState(YamahaReceiverBindingConstants.CHANNEL_POWER, state.isPower() ? OnOffType.ON : OnOffType.OFF);
             updateState(YamahaReceiverBindingConstants.CHANNEL_INPUT, new StringType(state.getInput()));
@@ -194,6 +211,7 @@ public class YamahaReceiverHandler extends BaseThingHandler {
             updateState(YamahaReceiverBindingConstants.CHANNEL_VOLUME, new PercentType((int) state.getVolume()));
             updateState(YamahaReceiverBindingConstants.CHANNEL_MUTE, state.isMute() ? OnOffType.ON : OnOffType.OFF);
             updateState(YamahaReceiverBindingConstants.CHANNEL_NETRADIO_TUNE, new DecimalType(state.netRadioChannel));
+            updateState(YamahaReceiverBindingConstants.CHANNEL_NETRADIO_STATION, new StringType(state.netRadioStation));
             logger.trace("State upddated!");
         } catch (IOException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
@@ -244,6 +262,9 @@ public class YamahaReceiverHandler extends BaseThingHandler {
                     break;
                 case YamahaReceiverBindingConstants.CHANNEL_NETRADIO_TUNE:
                     state.setNetRadio(((DecimalType) command).intValue());
+                    break;
+                case YamahaReceiverBindingConstants.CHANNEL_NETRADIO_STATION:
+                    state.setNetRadio(netRadioMenuDir, ((StringType) command).toString());
                     break;
                 default:
                     logger.error("Channel " + id + " not supported!");

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverState.java
@@ -30,6 +30,7 @@ public class YamahaReceiverState {
     public List<String> inputNames = new ArrayList<String>();
     private final YamahaReceiverCommunication com;
     public int netRadioChannel = 0;
+    public String netRadioStation = "";
 
     // Some AVR information
     public String name = "";
@@ -59,6 +60,11 @@ public class YamahaReceiverState {
      */
     public void updateState() throws IOException {
         com.updateState(this);
+    }
+
+    // Get currently playing net radio station for menu based receivers
+    public void updateNetRadioStationList() throws IOException {
+        com.updateNetRadioStationList(this);
     }
 
     public Zone getZone() {
@@ -160,6 +166,11 @@ public class YamahaReceiverState {
     public void setNetRadio(int netRadioChannel) throws IOException {
         com.setNetRadio(netRadioChannel);
         this.netRadioChannel = netRadioChannel;
+    }
+
+    public void setNetRadio(String menuDir, String netRadioStation) throws IOException {
+        com.setNetRadio(menuDir, netRadioStation, name);
+        this.netRadioStation = netRadioStation;
     }
 
     public String getHost() {

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/NetRadioMenu.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/NetRadioMenu.java
@@ -1,0 +1,179 @@
+package org.openhab.binding.yamahareceiver.internal.protocol;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+/**
+ * Yamaha Receiver protocol related to net radio functionally. No state is saved in this class.
+ * Usually you want to create an instance, manipulate or request data and forget.
+ *
+ * Example:
+ *
+ * NetRadioMenu menu = new NetRadioMenu(com_object, receiverName);
+ * menu.goToPath(menuDir);
+ * menu.selectItem(stationName);
+ *
+ * @author Dennis Frommknecht
+ * @author David Graeff
+ * @since 2.0.0
+ */
+public class NetRadioMenu {
+    private Document menuState;
+    private boolean menuStateRequiresUpdate = true;
+    private final WeakReference<YamahaReceiverCommunication> com;
+    private final String rootCommand;
+
+    /**
+     * Create a NetRadioMenu class for altering and requesting the current net radio channel.
+     * 
+     * @param com The Yamaha communication object to send http requests.
+     * @param modelTypeName Some models support a different set of features or need different commands.
+     */
+    public NetRadioMenu(YamahaReceiverCommunication com, String modelTypeName) {
+        this.com = new WeakReference<YamahaReceiverCommunication>(com);
+
+        if (modelTypeName.matches("^(?:RX-A\\d{1,2}10|RX-A\\d{1,2}00|RX-V\\d{1,2}(?:71|67|65))$")) {
+            rootCommand = "Back to Home";
+        } else {
+            rootCommand = "Return to Home";
+        }
+    }
+
+    public boolean isInDirectory(String path) throws IOException {
+        String[] pathArr = path.split("/");
+        // Full path info not available, so guess from last path element and number of path elements
+        return getMenuName().equals(pathArr[pathArr.length - 1]) && getLevel() == pathArr.length;
+    }
+
+    public void goToRoot() throws IOException {
+        if (getLevel() > 0) {
+            com.get().postAndGetResponse("<YAMAHA_AV cmd=\"PUT\"><NET_RADIO><List_Control><Cursor>" + rootCommand
+                    + "</Cursor></List_Control></NET_RADIO></YAMAHA_AV>");
+            menuChanged();
+        }
+    }
+
+    public void goToPage(int page) throws IOException {
+        int line = (page - 1) * 8 + 1;
+        com.get().postAndGetResponse("<YAMAHA_AV cmd=\"PUT\"><NET_RADIO><List_Control><Jump_Line>" + line
+                + "</Jump_Line></List_Control></NET_RADIO></YAMAHA_AV>");
+        menuChanged();
+    }
+
+    public void goToPath(String fullPath) throws IOException {
+        if (!isInDirectory(fullPath)) {
+            goToRoot();
+
+            String[] pathArr = fullPath.split("/");
+            for (String pathElement : pathArr) {
+                selectItem(pathElement);
+            }
+        }
+    }
+
+    public String getMenuName() throws IOException {
+        Node menuNameNode = getStateNode("List_Info/Menu_Name");
+        return menuNameNode != null ? menuNameNode.getTextContent() : null;
+    }
+
+    public int getLevel() throws IOException {
+        Node menuLayerNode = getStateNode("List_Info/Menu_Layer");
+        return menuLayerNode != null ? Integer.parseInt(menuLayerNode.getTextContent()) - 1 : -1;
+    }
+
+    public int getPageNumber() throws IOException {
+        Node node = getStateNode("List_Info/Cursor_Position/Current_Line");
+        if (node != null) {
+            int currentLine = Integer.parseInt(node.getTextContent());
+            return (currentLine - 1) / 8;
+        }
+        return 0;
+    }
+
+    public int getNumberOfPages() throws IOException {
+        Node node = getStateNode("List_Info/Cursor_Position/Max_Line");
+        if (node != null) {
+            int maxLines = Integer.parseInt(node.getTextContent());
+            return (int) Math.ceil(maxLines / 8d);
+        }
+        return 0;
+    }
+
+    public void selectItem(String name) throws IOException {
+        for (int page = 1; page <= getNumberOfPages(); page++) {
+            if (getPageNumber() != page) {
+                goToPage(page);
+            }
+
+            int index = findItemOnCurrentPage(name);
+            if (index > 0) {
+                com.get().postAndGetResponse("<YAMAHA_AV cmd=\"PUT\"><NET_RADIO><List_Control><Direct_Sel>Line_" + index
+                        + "</Direct_Sel></List_Control></NET_RADIO></YAMAHA_AV>");
+                menuChanged();
+                return;
+            }
+        }
+
+        throw new IOException("Item '" + name + "' doesn't exist in menu " + getMenuName());
+    }
+
+    private int findItemOnCurrentPage(String itemName) throws IOException {
+        for (int i = 1; i <= 8; i++) {
+            Node node = getStateNode("List_Info/Current_List/Line_" + i + "/Txt");
+            if (node != null && node.getTextContent().equals(itemName)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private Node getStateNode(String path) throws IOException {
+        return YamahaReceiverCommunication.getNode(getMenuState().getFirstChild(), path);
+    }
+
+    private Document getMenuState() throws IOException {
+        if (menuStateRequiresUpdate) {
+            refreshMenuState();
+        }
+        return this.menuState;
+    }
+
+    private void menuChanged() {
+        this.menuStateRequiresUpdate = true;
+    }
+
+    private void refreshMenuState() throws IOException {
+        int totalWaitingTime = 0;
+
+        Document doc;
+
+        while (true) {
+            doc = com.get().postAndGetXmlResponse(
+                    "<YAMAHA_AV cmd=\"GET\"><NET_RADIO><List_Info>GetParam</List_Info></NET_RADIO></YAMAHA_AV>");
+            Node node = YamahaReceiverCommunication.getNode(doc.getFirstChild(), "List_Info/Menu_Status");
+
+            if (node == null || node.getTextContent().equals("Ready")) {
+                break;
+            }
+
+            totalWaitingTime += YamahaReceiverCommunication.MENU_RETRY_DELAY;
+            if (totalWaitingTime > YamahaReceiverCommunication.MENU_MAX_WAITING_TIME) {
+                throw new IOException(
+                        "Menu still not ready after " + YamahaReceiverCommunication.MENU_MAX_WAITING_TIME + "ms");
+            }
+
+            try {
+                Thread.sleep(YamahaReceiverCommunication.MENU_RETRY_DELAY);
+            } catch (InterruptedException e) {
+                // Ignore and just retry immediately
+            }
+        }
+
+        this.menuState = doc;
+        this.menuStateRequiresUpdate = false;
+    }
+}


### PR DESCRIPTION
The Yamaha Receiver Binding has support for preset-based netradio, i.e. radio stations are assigned to a preset number on the remote.
Newer Yamaha AVRs are using a menu-based netradio selection, where the user has to navigate through a menu to select the desired radio station.

This enhancement implements a new String channel netradiostation that is keeping track of the currently playing netradio station on menu-based receivers. It also lets you select a station by name in a predefined directory. The directory can be configured using the thing configuration NETRADIOMENU.

The restriction to a certain directory was required, because the Yamaha API is providing information about the currently playing station name, but not the directory.

This change should not have any impact unless an item for the netradiostation channel is defined.

Contributed by Dennis Frommknecht (https://github.com/dfrommi).

Some changes to the original contribution have been made.