### PR TITLE
Updated channel types to values in RFXComBindingConstants.java fixes #1754

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/README.md
+++ b/addons/binding/org.openhab.binding.rfxcom/README.md
@@ -91,26 +91,26 @@ This binding currently supports following channels:
 
 | Channel Type ID | Item Type    | Description  |
 |-----------------|------------------------|--------------|
-| batterylevel | Number | Battery level. |
+| batteryLevel | Number | Battery level. |
 | command | Switch | Command channel. |
 | contact | Contact | Contact channel. |
-| dimminglevel | Dimmer | Dimming level channel. |
+| dimmingLevel | Dimmer | Dimming level channel. |
 | humidity | Number | Relative humidity level in percentages. |
-| humiditystatus | String | Current humidity status. |
+| humidityStatus | String | Current humidity status. |
 | instantamp | Number | Instant current in Amperes. |
 | instantpower | Number | Instant power consumption in Watts. |
 | status | String | Status channel. |
 | setpoint | Number | Requested temperature. |
 | mood | Number | Mood channel. |
 | motion | Switch | Motion detection sensor state. |
-| rainrate | Number | Rain fall rate in millimeters per hour. |
-| raintotal | Number | Total rain in millimeters. |
-| rawmessage | String | Hexadecimal string of the raw RF message. |
-| rawpayload | String | Hexadecimal string of the message payload, without header. |
+| rainRate | Number | Rain fall rate in millimeters per hour. |
+| rainTotal | Number | Total rain in millimeters. |
+| rawMessage | String | Hexadecimal string of the raw RF message. |
+| rawPayload | String | Hexadecimal string of the message payload, without header. |
 | shutter | Rollershutter | Shutter channel. |
-| signallevel | Number | Received signal strength level. |
+| signalLevel | Number | Received signal strength level. |
 | temperature | Number | Current temperature in degree Celsius. |
-| totalusage | Number | Used energy in Watt hours. |
-| totalamphour | Number | Used "energy" in ampere-hours. |
-| winddirection | Number | Wind direction in degrees. |
-| windspeed | Number | Average wind speed in meters per second. |
+| totalUsage | Number | Used energy in Watt hours. |
+| totalAmpHour | Number | Used "energy" in ampere-hours. |
+| windDirection | Number | Wind direction in degrees. |
+| windSpeed | Number | Average wind speed in meters per second. |


### PR DESCRIPTION
Fixes case sensitive channel types.

I have noticed that the constants file contains more possible values in the docs, but I am not sure if these are already supported. Therefor I have not added those to the README as well.