### PR TITLE
Fix rollershutter issue.

### DIFF
--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
@@ -73,7 +73,7 @@ public class ZWayBindingConstants {
     // switch binary
     public final static String SWITCH_POWER_OUTLET_CHANNEL = "switchPowerOutlet";
     // switch multilevel
-    public final static String SWITCH_ROLLERSHUTTER_CHANNEL = "switchColorTemperature";
+    public final static String SWITCH_ROLLERSHUTTER_CHANNEL = "switchBlinds";
     // special channels
     public final static String ACTIONS_CHANNEL = "actions";
     public final static String SECURE_INCLUSION_CHANNEL = "secureInclusion";

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
@@ -313,8 +313,19 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                     return;
                 }
 
-                updateState(channel.getUID(), ZWayDeviceStateConverter.toState(device, channel));
+                try {
+                    updateState(channel.getUID(), ZWayDeviceStateConverter.toState(device, channel));
+                } catch (IllegalArgumentException iae) {
+                    logger.debug(
+                            "IllegalArgumentException ({}) during refresh channel for device: {} (level: {}) with channel: {}",
+                            iae.getMessage(), device.getMetrics().getTitle(), device.getMetrics().getLevel(),
+                            channel.getChannelTypeUID());
 
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
+                            "Channel refresh for device: " + device.getMetrics().getTitle() + " (level: "
+                                    + device.getMetrics().getLevel() + ") with channel: " + channel.getChannelTypeUID()
+                                    + " failed!");
+                }
                 // 2.) Trigger update function, soon as the value has been updated, openHAB will be notified
                 try {
                     device.update();

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/converter/ZWayDeviceStateConverter.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/converter/ZWayDeviceStateConverter.java
@@ -12,6 +12,7 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -56,7 +57,11 @@ public class ZWayDeviceStateConverter {
         } else if (device instanceof SwitchBinary) {
             return getBinaryState(level.toLowerCase());
         } else if (device instanceof SwitchMultilevel) {
-            return getMultilevelState(level);
+            if (channel.getAcceptedItemType().equals("Rollershutter")) {
+                return getPercentState(level);
+            } else {
+                return getMultilevelState(level);
+            }
         } else if (device instanceof SwitchRGBW) {
             return getColorState(device.getMetrics().getColor());
         } else if (device instanceof SwitchToggle) {
@@ -78,9 +83,16 @@ public class ZWayDeviceStateConverter {
      * @param multilevel sensor value
      * @return transformed openHAB state
      */
-    private static State getMultilevelState(String multilevelSensorValue) {
-        if (multilevelSensorValue != null) {
-            return new DecimalType(multilevelSensorValue);
+    private static State getMultilevelState(String multilevelValue) {
+        if (multilevelValue != null) {
+            return new DecimalType(multilevelValue);
+        }
+        return UnDefType.UNDEF;
+    }
+
+    private static State getPercentState(String multilevelValue) {
+        if (multilevelValue != null) {
+            return new PercentType(multilevelValue);
         }
         return UnDefType.UNDEF;
     }

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
@@ -89,7 +89,11 @@ public class ZWayDeviceDiscoveryService extends AbstractDiscoveryService {
                     if (locationList != null) {
                         // Add only the location if this differs from globalRoom (with id 0)
                         if (device.getLocation() != -1 && device.getLocation() != 0) {
-                            location = locationList.getLocationById(device.getLocation()).getTitle();
+                            try {
+                                location = locationList.getLocationById(device.getLocation()).getTitle();
+                            } catch (NullPointerException npe) {
+                                location = "";
+                            }
                         }
                     }
                 }
@@ -158,7 +162,11 @@ public class ZWayDeviceDiscoveryService extends AbstractDiscoveryService {
                     if (locationList != null) {
                         // Add only the location if this differs from globalRoom (with id 0)
                         if (device.getLocation() != -1 && device.getLocation() != 0) {
-                            location = locationList.getLocationById(device.getLocation()).getTitle();
+                            try {
+                                location = locationList.getLocationById(device.getLocation()).getTitle();
+                            } catch (NullPointerException npe) {
+                                location = "";
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fix rollershutter issue (state updates now as percenttype and not longer with wrong decimaltype).
Additionally I improved status message of thing.

New version for testing: [org.openhab.binding.zway-2.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab2-addons/files/733286/org.openhab.binding.zway-2.1.0-SNAPSHOT.zip)

Signed-off-by: Patrick Hecker <pah111kg@fh-zwickau.de> (github: pathec)