### PR TITLE
Fix usage of native ping utility for linux in the network binding

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkUtils.java
@@ -150,7 +150,7 @@ public class NetworkUtils {
             throws InvalidConfigurationException, IOException, InterruptedException {
         Process proc;
         if (SystemUtils.IS_OS_UNIX) {
-            proc = new ProcessBuilder("ping", "-t", String.valueOf(timeout / 1000), "-c", "1", hostname).start();
+            proc = new ProcessBuilder("ping", "-w", String.valueOf(timeout / 1000), "-c", "1", hostname).start();
         } else if (SystemUtils.IS_OS_WINDOWS) {
             proc = new ProcessBuilder("ping", "-w", String.valueOf(timeout), "-n", "1", hostname).start();
         } else {


### PR DESCRIPTION
Fix for #1778
The wrong flag was used and the ttl instead of the timeout was changed.