### PR TITLE
Multiple ImperiHome binding fixes

### DIFF
--- a/addons/io/org.openhab.io.imperihome/OSGI-INF/imperihome.xml
+++ b/addons/io/org.openhab.io.imperihome/OSGI-INF/imperihome.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" configuration-policy="optional" immediate="true" name="org.openhab.imperihome">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" modified="modified" deactivate="deactivate" configuration-policy="optional" immediate="true" name="org.openhab.imperihome">
    <implementation class="org.openhab.io.imperihome.internal.ImperiHomeApiServlet"/>
    <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unsetHttpService"/>
    <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>

--- a/addons/io/org.openhab.io.imperihome/README.md
+++ b/addons/io/org.openhab.io.imperihome/README.md
@@ -5,14 +5,40 @@ It creates a REST service at _/imperihome/iss_ that implements the [ImperiHome S
 
 ## Installation
 
-The ImperiHome integration service can be installed through the Paper UI. Navigate to Extensions &gt; Misc and click Install.
+The ImperiHome integration service can be installed through the Paper UI. Navigate to Add-ons &gt; Misc and click Install.
+
+<a name="configuration"></a>
 
 ## Configuration
 
-The service itself has no configuration. ImperiHome on the other hand must be configured to connect to your openHAB instance.
+### openHAB Add-on
+
+To configure the ImperiHome integration add-on in openHAB, create a _imperihome.cfg_ file in the _conf/services_ directory. The following configuration options can be used:
+ 
+**System ID**
+
+The ImperiHome integration service identifies itself to ImperiHome using a system ID. By default the unique identifier of your openHAB installation is used. To override the ID, use the _system.id_ configuration option. 
+
+```
+system.id=my-openhab-123
+```
+
+*Warning*: the system ID can not contain the underscore character (_). 
+
+**Root URL**
+
+Root URL of your openHAB installation. Should point to the openHAB welcome page. This option is currently only required when using the custom icon tag. 
+
+```
+openhab.rootUrl=http://myserver.example.org:7070/
+```
+
+### ImperiHome
+
+ImperiHome must be configured to connect to your openHAB instance.
 
 Start ImperiHome, open the menu and go to My Systems. Add a new system (+) and choose 'ImperiHome Standard System' as the object type. Now enter the URL to your openHAB instance
- as Local URL, followed by _/imperihome/iss_. For example, if your OH instance is running at _http://192.168.1.10:8080/_, the Local URL would be _http://192.168.1.10:8080/imperihome/iss_. 
+ as Local URL, followed by _/imperihome/iss_. For example, if your openHAB instance is running at _http://192.168.1.10:8080/_, the Local URL would be _http://192.168.1.10:8080/imperihome/iss_. 
 
 If you have port forwarding or similar set up to access your OH form the internet, you can also fill the Remote URL in the same way. For example: 
 _http://my-openhab-url.dyndns.org:8080/imperihome/iss_. Please be aware that this service provides no authentication mechanism, so anyone could use the API to control your 
@@ -130,6 +156,19 @@ _Example_:
 
 ```
 iss:invert:true
+```
+
+### Tag: _icon_
+
+Sets a custom icon to be shown in ImperiHome. You can use all icon names that are also available for use in your sitemaps, including custom icons.
+To use this tag you must set the openHAB root URL in your [configuration](#configuration).
+
+_Required_: no<br>
+_Default_: none<br>
+_Example_: 
+
+```
+iss:icon:sofa
 ```
 
 <a name="deviceTypes"></a> 

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/ImperiHomeApiServlet.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/ImperiHomeApiServlet.java
@@ -37,7 +37,6 @@ import org.openhab.io.imperihome.internal.model.param.DeviceParameters;
 import org.openhab.io.imperihome.internal.model.param.ParamType;
 import org.openhab.io.imperihome.internal.processor.DeviceRegistry;
 import org.openhab.io.imperihome.internal.processor.ItemProcessor;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.http.HttpService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +69,7 @@ public class ImperiHomeApiServlet extends HttpServlet {
     private final Logger logger = LoggerFactory.getLogger(ImperiHomeApiServlet.class);
 
     private final Gson gson;
+    private final ImperiHomeConfig imperiHomeConfig;
 
     private HttpService httpService;
     private ItemRegistry itemRegistry;
@@ -89,6 +89,8 @@ public class ImperiHomeApiServlet extends HttpServlet {
      * Default constructor.
      */
     public ImperiHomeApiServlet() {
+        imperiHomeConfig = new ImperiHomeConfig();
+
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(DeviceType.class, new DeviceTypeSerializer());
         gsonBuilder.registerTypeAdapter(ParamType.class, new ParamTypeSerializer());
@@ -102,10 +104,12 @@ public class ImperiHomeApiServlet extends HttpServlet {
      * @param config Service config.
      */
     protected void activate(Map<String, Object> config) {
-        systemHandler = new SystemHandler();
+        modified(config);
+
+        systemHandler = new SystemHandler(imperiHomeConfig);
         deviceRegistry = new DeviceRegistry();
         actionRegistry = new ActionRegistry(eventPublisher);
-        itemProcessor = new ItemProcessor(itemRegistry, deviceRegistry, actionRegistry);
+        itemProcessor = new ItemProcessor(itemRegistry, deviceRegistry, actionRegistry, imperiHomeConfig);
         roomListHandler = new RoomListHandler(deviceRegistry);
         devicesListHandler = new DevicesListHandler(deviceRegistry);
         deviceActionHandler = new DeviceActionHandler(deviceRegistry);
@@ -121,11 +125,18 @@ public class ImperiHomeApiServlet extends HttpServlet {
     }
 
     /**
-     * OSGi deactivation callback.
-     *
-     * @param componentContext Context.
+     * OSGi config modification callback.
+
+     * @param config Service config.
      */
-    protected void deactivate(ComponentContext componentContext) {
+    protected void modified(Map<String, Object> config) {
+        imperiHomeConfig.update(config);
+    }
+
+    /**
+     * OSGi deactivation callback.
+     */
+    protected void deactivate() {
         try {
             httpService.unregister(PATH);
         } catch (IllegalArgumentException ignored) {

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/ImperiHomeConfig.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/ImperiHomeConfig.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.imperihome.internal;
+
+import java.util.Map;
+
+import org.eclipse.smarthome.core.id.InstanceUUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration parser and container.
+ *
+ * @author Pepijn de Geus - Initial contribution
+ */
+public class ImperiHomeConfig {
+
+    private final Logger logger = LoggerFactory.getLogger(ImperiHomeConfig.class);
+
+    private String systemId;
+    private String rootUrl;
+
+    public void update(Map<String, Object> config) {
+        Object cSystemId = config.get("system.id");
+        if (cSystemId == null || cSystemId.toString().isEmpty()) {
+            systemId = InstanceUUID.get();
+        } else {
+            systemId = cSystemId.toString();
+        }
+
+        Object rootUrlObj = config.get("openhab.rootUrl");
+        if (rootUrlObj != null) {
+            rootUrl = String.valueOf(rootUrlObj);
+            if (!rootUrl.endsWith("/")) {
+                rootUrl += "/";
+            }
+        }
+
+        logger.info("Configuration updated");
+    }
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getRootUrl() {
+        return rootUrl;
+    }
+
+}

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/handler/SystemHandler.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/handler/SystemHandler.java
@@ -10,7 +10,7 @@ package org.openhab.io.imperihome.internal.handler;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.smarthome.core.id.InstanceUUID;
+import org.openhab.io.imperihome.internal.ImperiHomeConfig;
 import org.openhab.io.imperihome.internal.model.System;
 
 /**
@@ -20,9 +20,15 @@ import org.openhab.io.imperihome.internal.model.System;
  */
 public class SystemHandler {
 
+    private ImperiHomeConfig config;
+
+    public SystemHandler(ImperiHomeConfig imperiHomeConfig) {
+        config = imperiHomeConfig;
+    }
+
     public System handle(HttpServletRequest req) {
         System system = new System();
-        system.setId(InstanceUUID.get());
+        system.setId(config.getSystemId());
         system.setApiVersion(1);
         return system;
     }

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/device/AbstractDevice.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/device/AbstractDevice.java
@@ -38,9 +38,10 @@ public abstract class AbstractDevice implements StateChangeListener {
     private String name;
     private String room;
     private DeviceType type;
-    private boolean inverted;
+    private String defaultIcon;
     private final DeviceParameters params;
 
+    private transient boolean inverted;
     private transient String roomName;
     private transient Item item;
 
@@ -117,6 +118,14 @@ public abstract class AbstractDevice implements StateChangeListener {
 
     public void setInverted(boolean inverted) {
         this.inverted = inverted;
+    }
+
+    public String getDefaultIcon() {
+        return defaultIcon;
+    }
+
+    public void setDefaultIcon(String defaultIcon) {
+        this.defaultIcon = defaultIcon;
     }
 
     public DeviceParameters getParams() {
@@ -218,7 +227,7 @@ public abstract class AbstractDevice implements StateChangeListener {
     @Override
     public String toString() {
         return "AbstractDevice{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", room='" + room + '\'' + ", type="
-                + type + ", invert=" + inverted + ", links=" + links + '}';
+                + type + ", invert=" + inverted + ", icon=" + defaultIcon + ", links=" + links + '}';
     }
 
 }

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/device/TrippableDevice.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/device/TrippableDevice.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.io.imperihome.internal.model.device;
 
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -41,21 +39,20 @@ public class TrippableDevice extends AbstractDevice {
 
         boolean tripped = false;
 
-        List<Class<? extends State>> acceptedDataTypes = item.getAcceptedDataTypes();
-        if (acceptedDataTypes.contains(OpenClosedType.class)) {
+        if (item.getStateAs(OpenClosedType.class) != null) {
             OpenClosedType state = (OpenClosedType) item.getStateAs(OpenClosedType.class);
             tripped = state == OpenClosedType.CLOSED;
-        } else if (acceptedDataTypes.contains(OnOffType.class)) {
+        } else if (item.getStateAs(OnOffType.class) != null) {
             OnOffType state = (OnOffType) item.getStateAs(OnOffType.class);
             tripped = state == OnOffType.ON;
-        } else if (acceptedDataTypes.contains(DecimalType.class)) {
+        } else if (item.getStateAs(DecimalType.class) != null) {
             DecimalType state = (DecimalType) item.getStateAs(DecimalType.class);
             tripped = state.intValue() != 0;
-        } else if (acceptedDataTypes.contains(StringType.class)) {
+        } else if (item.getStateAs(StringType.class) != null) {
             StringType state = (StringType) item.getStateAs(StringType.class);
             tripped = StringUtils.isNotBlank(state.toString()) && !state.toString().trim().equals("ok");
         } else {
-            logger.warn("Can't interpret state {} as tripped status", item.getState());
+            logger.debug("Can't interpret state {} as tripped status", item.getState());
         }
 
         addParam(new DeviceParam(ParamType.TRIPPED, tripped ^ isInverted() ? "1" : "0"));

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/param/ParamType.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/model/param/ParamType.java
@@ -15,6 +15,7 @@ package org.openhab.io.imperihome.internal.model.param;
  */
 public enum ParamType {
 
+    DEFAULT_ICON("defaultIcon"),
     GENERIC_VALUE("Value"),
     TEMPERATURE_VALUE("Value"),
     TEMPERATURE_DUAL("temp"),

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/processor/ItemProcessor.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/processor/ItemProcessor.java
@@ -25,29 +25,11 @@ import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.types.State;
+import org.openhab.io.imperihome.internal.ImperiHomeConfig;
 import org.openhab.io.imperihome.internal.action.ActionRegistry;
-import org.openhab.io.imperihome.internal.model.device.AbstractDevice;
-import org.openhab.io.imperihome.internal.model.device.AbstractNumericValueDevice;
-import org.openhab.io.imperihome.internal.model.device.Co2SensorDevice;
-import org.openhab.io.imperihome.internal.model.device.DeviceType;
-import org.openhab.io.imperihome.internal.model.device.DimmerDevice;
-import org.openhab.io.imperihome.internal.model.device.ElectricityDevice;
-import org.openhab.io.imperihome.internal.model.device.GenericSensorDevice;
-import org.openhab.io.imperihome.internal.model.device.HygrometryDevice;
-import org.openhab.io.imperihome.internal.model.device.LockDevice;
-import org.openhab.io.imperihome.internal.model.device.LuminosityDevice;
-import org.openhab.io.imperihome.internal.model.device.MultiSwitchDevice;
-import org.openhab.io.imperihome.internal.model.device.NoiseDevice;
-import org.openhab.io.imperihome.internal.model.device.PressureDevice;
-import org.openhab.io.imperihome.internal.model.device.RainDevice;
-import org.openhab.io.imperihome.internal.model.device.RgbLightDevice;
-import org.openhab.io.imperihome.internal.model.device.SceneDevice;
-import org.openhab.io.imperihome.internal.model.device.SwitchDevice;
-import org.openhab.io.imperihome.internal.model.device.TempHygroDevice;
-import org.openhab.io.imperihome.internal.model.device.TemperatureDevice;
-import org.openhab.io.imperihome.internal.model.device.TrippableDevice;
-import org.openhab.io.imperihome.internal.model.device.UvDevice;
-import org.openhab.io.imperihome.internal.model.device.WindDevice;
+import org.openhab.io.imperihome.internal.model.device.*;
+import org.openhab.io.imperihome.internal.model.param.DeviceParam;
+import org.openhab.io.imperihome.internal.model.param.ParamType;
 import org.openhab.io.imperihome.internal.util.DigestUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,11 +49,13 @@ public class ItemProcessor implements ItemRegistryChangeListener {
     private final ItemRegistry itemRegistry;
     private final DeviceRegistry deviceRegistry;
     private final ActionRegistry actionRegistry;
+    private final ImperiHomeConfig config;
 
-    public ItemProcessor(ItemRegistry itemRegistry, DeviceRegistry deviceRegistry, ActionRegistry actionRegistry) {
+    public ItemProcessor(ItemRegistry itemRegistry, DeviceRegistry deviceRegistry, ActionRegistry actionRegistry, ImperiHomeConfig config) {
         this.itemRegistry = itemRegistry;
         this.deviceRegistry = deviceRegistry;
         this.actionRegistry = actionRegistry;
+        this.config = config;
 
         allItemsChanged(null);
         itemRegistry.addRegistryChangeListener(this);
@@ -104,6 +88,7 @@ public class ItemProcessor implements ItemRegistryChangeListener {
                 device.setInverted(isInverted(issTags));
                 device.setActionRegistry(actionRegistry);
 
+                setIcon(device, issTags);
                 setDeviceRoom(device, issTags);
                 setDeviceLinks(device, item, issTags);
                 setMapping(device, item, issTags);
@@ -116,6 +101,23 @@ public class ItemProcessor implements ItemRegistryChangeListener {
                 deviceRegistry.add(device);
             }
         }
+    }
+
+    private void setIcon(AbstractDevice device, Map<TagType, List<String>> issTags) {
+        if (!issTags.containsKey(TagType.ICON)) {
+            return;
+        }
+
+        String icon = issTags.get(TagType.ICON).get(0);
+        if (!icon.toLowerCase().startsWith("http")) {
+            if (StringUtils.isEmpty(config.getRootUrl())) {
+                logger.error("Can't set icon; 'openhab.rootUrl' not set in configuration");
+                return;
+            }
+            icon = config.getRootUrl() + "icon/" + icon;
+        }
+
+        device.addParam(new DeviceParam(ParamType.DEFAULT_ICON, icon));
     }
 
     private AbstractDevice getDeviceInstance(DeviceType deviceType, Item item) {

--- a/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/processor/TagType.java
+++ b/addons/io/org.openhab.io.imperihome/src/main/java/org/openhab/io/imperihome/internal/processor/TagType.java
@@ -21,7 +21,8 @@ public enum TagType {
     MAPPING("mapping", false),
     LINK("link", true),
     UNIT("unit", false),
-    INVERT("invert", false);
+    INVERT("invert", false),
+    ICON("icon", false);
 
     private final String prefix;
     private final boolean multiValue;


### PR DESCRIPTION
Multiple ImperiHome binding fixes:
- Fixes NPE for 'trippable' devices (motion, contact) when state is null
- Added option to configure system ID
- Added support for custom 'defaultIcon' in ImperiHome