### PR TITLE
[RFXCom] Remove unknown values from enums as they can cover errors elsewhere

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComBBQMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.BBQ1);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
@@ -8,15 +8,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.Commands;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.SubType;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.Commands;
+import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.SubType;
 
 /**
  * Test for RFXCom-binding
@@ -26,7 +25,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class RFXComBlinds1MessageTest {
     private void testMessage(String hexMsg, SubType subType, int seqNbr, String deviceId, int signalLevel,
-            RFXComBlinds1Message.Commands command) throws RFXComException, RFXComNotImpException {
+            RFXComBlinds1Message.Commands command) throws RFXComException {
         final RFXComBlinds1Message msg = (RFXComBlinds1Message) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
         assertEquals("SubType", subType, msg.subType);
@@ -41,7 +40,7 @@ public class RFXComBlinds1MessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("0919040600A21B010280", SubType.T4, 6, "41499.1", 8, Commands.STOP);
 
         testMessage("091905021A6280010000", SubType.T5, 2, "1729152.1", 0, Commands.OPEN);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComCamera1MessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.CAMERA1);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComChimeMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.CHIME);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -24,8 +23,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class RFXComCurrentEnergyMessageTest {
     private void testMessage(String hexMsg, RFXComCurrentEnergyMessage.SubType subType, int seqNbr, String deviceId,
-                             int count, double channel1, double channel2, double channel3, double totalUsage, int signalLevel,
-                             int batteryLevel) throws RFXComException, RFXComNotImpException {
+            int count, double channel1, double channel2, double channel3, double totalUsage, int signalLevel,
+            int batteryLevel) throws RFXComException {
         final RFXComCurrentEnergyMessage msg = (RFXComCurrentEnergyMessage) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
         assertEquals("SubType", subType, msg.subType);
@@ -45,10 +44,11 @@ public class RFXComCurrentEnergyMessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("135B0106B800000016000000000000006F148889", RFXComCurrentEnergyMessage.SubType.ELEC4, 6, "47104", 0,
                 2.2d, 0d, 0d, 32547.4d, 8, 9);
         testMessage("135B014FB80002001D0000000000000000000079", RFXComCurrentEnergyMessage.SubType.ELEC4, 79, "47104",
                 2, 2.9d, 0d, 0d, 0d, 7, 9);
+
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
  * Test for RFXCom-binding
@@ -18,7 +18,7 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
  * @since 1.9.0
  */
 public class RFXComCurrentMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(RFXComBaseMessage.PacketType.CURRENT);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
@@ -8,10 +8,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.CURTAIN1;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
@@ -21,13 +21,18 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComCurtain1MessageTest {
     @Test
-    public void checkForSupportTest() throws RFXComException, RFXComNotImpException {
-        RFXComMessageFactory.createMessage(PacketType.CURTAIN1);
+    public void checkForSupportTest() throws RFXComException {
+        RFXComMessageFactory.createMessage(CURTAIN1);
     }
 
     @Test
-    public void basicBoundaryCheck() throws RFXComException, RFXComNotImpException {
-        RFXComTestHelper.basicBoundaryCheck(PacketType.CURTAIN1);
+    public void basicBoundaryCheck() throws RFXComException {
+        RFXComCurtain1Message message = (RFXComCurtain1Message) RFXComMessageFactory.createMessage(CURTAIN1);
+
+        message.subType = RFXComCurtain1Message.SubType.HARRISON;
+        message.command = RFXComCurtain1Message.Commands.OPEN;
+
+        RFXComTestHelper.basicBoundaryCheck(CURTAIN1, message);
     }
 
     // TODO please add tests for real messages

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
@@ -8,15 +8,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.eclipse.smarthome.core.library.types.DateTimeType;
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.RFXComValueSelector.DATE_TIME;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.RFXComValueSelector.DATE_TIME;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -26,7 +25,7 @@ import static org.openhab.binding.rfxcom.RFXComValueSelector.DATE_TIME;
  */
 public class RFXComDateTimeMessageTest {
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "0D580117B90003041D030D150A69";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComDateTimeMessage msg = (RFXComDateTimeMessage) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2017 by the respective copyright holders.
  * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,20 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.EDISIO;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
+ * @since 2.0.0
  */
-public class RFXComBarometricMessageTest {
-
+public class RFXComEdisioTest {
     @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+        RFXComMessageFactory.createMessage(EDISIO);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComEnergyMessage.SubType.ELEC2;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComEnergyMessage.SubType.ELEC2;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComEnergyMessage.S
  */
 public class RFXComEnergyMessageTest {
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "115A01071A7300000003F600000000350B89";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComEnergyMessage msg = (RFXComEnergyMessage) RFXComMessageFactory.createMessage(message);
@@ -33,7 +32,6 @@ public class RFXComEnergyMessageTest {
         assertEquals("Seq Number", 7, msg.seqNbr);
         assertEquals("Sensor Id", "6771", msg.getDeviceId());
         assertEquals("Count", 0, msg.count);
-        // TODO what is the expected behaviour
         assertEquals("Instant usage", 1014d / 230, msg.instantAmp, 0.01);
         assertEquals("Total usage", 60.7d / 230, msg.totalAmpHour, 0.01);
         assertEquals("Signal Level", (byte) 8, msg.signalLevel);
@@ -41,7 +39,6 @@ public class RFXComEnergyMessageTest {
 
         byte[] decoded = msg.decodeMessage();
 
-        // TODO
-        // assertEquals("Message converted back", hexMessage, DatatypeConverter.printHexBinary(decoded));
+        assertEquals("Message converted back", hexMessage, DatatypeConverter.printHexBinary(decoded));
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComFS20MessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.FS20);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -19,7 +19,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComFanMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.FAN);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComGasMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.GAS);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2017 by the respective copyright holders.
  * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,20 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.HOME_CONFORT;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
+ * @since 2.0.0
  */
-public class RFXComBarometricMessageTest {
-
+public class RFXComHomeConfortTest {
     @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+        RFXComMessageFactory.createMessage(HOME_CONFORT);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class RFXComHumidityMessageTest {
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "085101027700360189";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComHumidityMessage msg = (RFXComHumidityMessage) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComIOLinesMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.IO_LINES);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.Commands.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType.START_RECEIVER;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.TransceiverType._433_92MHZ_TRANSCEIVER;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.Commands;
+import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType;
+
+/**
+ * Test for RFXCom-binding
+ *
+ * @author Martin van Wingerden
+ * @since 2.0.0
+ */
+public class RFXComInterfaceMessageTest {
+    private RFXComInterfaceMessage testMessage(String hexMsg, SubType subType, int seqNbr, Commands command,
+            boolean skipDecode) throws RFXComException {
+        RFXComInterfaceMessage msg = (RFXComInterfaceMessage) RFXComMessageFactory
+                .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
+        assertEquals("SubType", subType, msg.subType);
+        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Command", command, msg.command);
+
+        return msg;
+    }
+
+    @Test
+    public void testWelcomeCopyRightMessage() throws RFXComException {
+        RFXComInterfaceMessage msg = testMessage("1401070307436F7079726967687420524658434F4D", START_RECEIVER, 3,
+                Commands.START_RECEIVER, true);
+
+        assertEquals("text", "Copyright RFXCOM", msg.text);
+    }
+
+    @Test
+    public void testResetBecauseOfUnknownMessage() throws RFXComException {
+        testMessage("0D01FF190053E2000C2701020000", UNKNOWN_COMMAND, 25, RESET, true);
+    }
+
+    @Test
+    public void testStatusMessage() throws RFXComException {
+        RFXComInterfaceMessage msg = testMessage("1401000102530C0800270001031C04524658434F4D", RESPONSE, 1, GET_STATUS,
+                false);
+
+        assertEquals("Command", _433_92MHZ_TRANSCEIVER, msg.transceiverType);
+
+        // TODO this is not correct, improvements for this have been made in the OH1 repo
+        assertEquals("firmwareVersion", 12, msg.firmwareVersion);
+    }
+}

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+
+/**
+ * Test for RFXCom-binding
+ *
+ * @author James Hewitt-Thomas
+ * @since 1.9.0
+ */
+public class RFXComInvalidMessageTypeTest {
+
+    @Test(expected = RFXComUnsupportedValueException.class)
+    public void testMessage() throws RFXComException {
+        byte[] message = DatatypeConverter.parseHexBinary("07CC01271356ECC0");
+        final RFXComMessage msg = RFXComMessageFactory.createMessage(message);
+    }
+}

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComLighting1Message.Commands;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.messages.RFXComLighting1Message.Commands;
 
 /**
  * Test for RFXCom-binding
@@ -26,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class RFXComLighting1MessageTest {
 
     private void testMessage(String hexMsg, RFXComLighting1Message.SubType subType, int seqNbr, String deviceId,
-            byte signalLevel, RFXComLighting1Message.Commands command) throws RFXComException, RFXComNotImpException {
+            byte signalLevel, RFXComLighting1Message.Commands command) throws RFXComException {
         final RFXComLighting1Message msg = (RFXComLighting1Message) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
         assertEquals("SubType", subType, msg.subType);
@@ -41,7 +40,7 @@ public class RFXComLighting1MessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("0710015242080780", RFXComLighting1Message.SubType.ARC, 82, "B.8", (byte) 8, Commands.CHIME);
 
         testMessage("0710010047010070", RFXComLighting1Message.SubType.ARC, 0, "G.1", (byte) 7, Commands.OFF);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class RFXComLighting2MessageTest {
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "0B11000600109B520B000080";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComLighting2Message msg = (RFXComLighting2Message) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComLighting3MessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.LIGHTING3);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
@@ -8,10 +8,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING4;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
@@ -21,13 +21,18 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComLighting4MessageTest {
     @Test
-    public void checkForSupportTest() throws RFXComException, RFXComNotImpException {
-        RFXComMessageFactory.createMessage(PacketType.LIGHTING4);
+    public void checkForSupportTest() throws RFXComException {
+        RFXComMessageFactory.createMessage(LIGHTING4);
     }
 
     @Test
-    public void basicBoundaryCheck() throws RFXComException, RFXComNotImpException {
-        RFXComTestHelper.basicBoundaryCheck(PacketType.LIGHTING4);
+    public void basicBoundaryCheck() throws RFXComException {
+        RFXComLighting4Message message = (RFXComLighting4Message) RFXComMessageFactory.createMessage(LIGHTING4);
+
+        message.subType = RFXComLighting4Message.SubType.PT2262;
+        message.command = RFXComLighting4Message.Commands.ON;
+
+        RFXComTestHelper.basicBoundaryCheck(LIGHTING4, message);
     }
 
     // TODO please add tests for real messages

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
@@ -8,18 +8,17 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.junit.Test;
-import org.openhab.binding.rfxcom.RFXComValueSelector;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-
-import javax.xml.bind.DatatypeConverter;
-
 import static org.junit.Assert.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING5;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.Commands.ON;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.IT;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -28,13 +27,9 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Messag
  * @since 1.9.0
  */
 public class RFXComLighting5MessageTest {
-    @Test
-    public void basicBoundaryCheck() throws RFXComException, RFXComNotImpException {
-        RFXComTestHelper.basicBoundaryCheck(LIGHTING5);
-    }
 
     @Test
-    public void convertFromStateItMessage() throws RFXComException, RFXComNotImpException {
+    public void convertFromStateItMessage() throws RFXComException {
         RFXComMessage itMessageObject = RFXComMessageFactory.createMessage(LIGHTING5);
         itMessageObject.setDeviceId("2061.1");
         itMessageObject.setSubType(IT);
@@ -46,6 +41,16 @@ public class RFXComLighting5MessageTest {
         assertEquals("SubType", IT, msg.subType);
         assertEquals("Sensor Id", "2061.1", msg.getDeviceId());
         assertEquals("Command", ON, msg.command);
+    }
+
+    @Test
+    public void basicBoundaryCheck() throws RFXComException {
+        RFXComLighting5Message message = (RFXComLighting5Message) RFXComMessageFactory.createMessage(LIGHTING5);
+
+        message.subType = RFXComLighting5Message.SubType.LIGHTWAVERF;
+        message.command = ON;
+
+        RFXComTestHelper.basicBoundaryCheck(LIGHTING5, message);
     }
 
     // TODO please add more tests for different messages

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class RFXComLighting6MessageTest {
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "0B150005D950450101011D80";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComLighting6Message msg = (RFXComLighting6Message) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
  * Test for RFXCom-binding
@@ -18,7 +18,7 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
  * @since 1.9.0
  */
 public class RFXComPowerMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(RFXComBaseMessage.PacketType.POWER);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComRFXMeterMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.RFXMETER);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComRFXSensorMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.RFXSENSOR);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2017 by the respective copyright holders.
  * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,20 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.RADIATOR1;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
+ * @since 2.0.0
  */
-public class RFXComBarometricMessageTest {
-
+public class RFXComRadiator1MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+        RFXComMessageFactory.createMessage(RADIATOR1);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
@@ -15,7 +15,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
 
 /**
  * Test for RFXCom-binding
@@ -26,7 +25,7 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
 public class RFXComRainMessageTest {
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "0B550217B6000000004D3C69";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComRainMessage msg = (RFXComRainMessage) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -19,7 +19,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComRemoteControlMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.REMOTE_CONTROL);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
@@ -8,10 +8,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.RFY;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
@@ -21,13 +21,18 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComRfyMessageTest {
     @Test
-    public void checkForSupportTest() throws RFXComException, RFXComNotImpException {
-        RFXComMessageFactory.createMessage(PacketType.RFY);
+    public void checkForSupportTest() throws RFXComException {
+        RFXComMessageFactory.createMessage(RFY);
     }
 
     @Test
-    public void basicBoundaryCheck() throws RFXComException, RFXComNotImpException {
-        RFXComTestHelper.basicBoundaryCheck(PacketType.RFY);
+    public void basicBoundaryCheck() throws RFXComException {
+        RFXComRfyMessage message = (RFXComRfyMessage) RFXComMessageFactory.createMessage(RFY);
+
+        message.subType = RFXComRfyMessage.SubType.RFY;
+        message.command = RFXComRfyMessage.Commands.OPEN;
+
+        RFXComTestHelper.basicBoundaryCheck(RFY, message);
     }
 
     // TODO please add tests for real messages

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
@@ -8,13 +8,17 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.SubType.*;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.Contact;
+import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.Motion;
+import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.Status;
 
 /**
  * Test for RFXCom-binding
@@ -23,23 +27,41 @@ import static org.junit.Assert.assertEquals;
  * @since 1.9.0
  */
 public class RFXComSecurity1MessageTest {
-
-    @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
-        String hexMessage = "0820004DD3DC540089";
+    private void testSomeMessages(String hexMessage, RFXComSecurity1Message.SubType subType, int sequenceNumber,
+            String deviceId, int batteryLevel, Contact contact, Motion motion, Status status, int signalLevel)
+            throws RFXComException {
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComSecurity1Message msg = (RFXComSecurity1Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComSecurity1Message.SubType.X10_SECURITY, msg.subType);
-        assertEquals("Seq Number", 77, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "13884500", msg.getDeviceId());
-        assertEquals("Battery level", 8, msg.batteryLevel);
-        assertEquals("Contact", RFXComSecurity1Message.Contact.NORMAL, msg.contact);
-        assertEquals("Motion", RFXComSecurity1Message.Motion.UNKNOWN, msg.motion);
-        assertEquals("Status", RFXComSecurity1Message.Status.NORMAL, msg.status);
-        assertEquals("Signal Level", 9, msg.signalLevel);
+        assertEquals("SubType", subType, msg.subType);
+        assertEquals("Seq Number", sequenceNumber, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
+        assertEquals("Battery level", batteryLevel, msg.batteryLevel);
+        assertEquals("Contact", contact, msg.contact);
+        assertEquals("Motion", motion, msg.motion);
+        assertEquals("Status", status, msg.status);
+        assertEquals("Signal Level", signalLevel, msg.signalLevel);
 
         byte[] decoded = msg.decodeMessage();
 
         assertEquals("Message converted back", hexMessage, DatatypeConverter.printHexBinary(decoded));
+    }
+
+    @Test
+    public void testX10SecurityMessage() throws RFXComException {
+        testSomeMessages("0820004DD3DC540089", X10_SECURITY, 77, "13884500", 8, Contact.NORMAL, Motion.UNKNOWN,
+                Status.NORMAL, 9);
+    }
+
+    @Test
+    public void testRM174RFSecurityMessage() throws RFXComException {
+        testSomeMessages("08200A0E8000200650", RM174RF, 14, "8388640", 5, Contact.UNKNOWN, Motion.UNKNOWN, Status.PANIC,
+                0);
+        testSomeMessages("08200A081450450650", RM174RF, 8, "1331269", 5, Contact.UNKNOWN, Motion.UNKNOWN, Status.PANIC,
+                0);
+    }
+
+    @Test(expected = RFXComUnsupportedValueException.class)
+    public void testSomeInvalidSecurityMessage() throws RFXComException {
+        testSomeMessages("08FF0A1F0000000650", null, 0, null, 0, null, null, null, 0);
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2017 by the respective copyright holders.
  * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,20 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.SECURITY2;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
+ * @since 2.0.0
  */
-public class RFXComBarometricMessageTest {
-
+public class RFXComSecurity2MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+        RFXComMessageFactory.createMessage(SECURITY2);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
@@ -11,7 +11,7 @@ package org.openhab.binding.rfxcom.internal.messages;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
  * Test for RFXCom-binding
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
  * @since 1.9.0
  */
 public class RFXComTemperatureHumidityBarometricMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(TEMPERATURE_HUMIDITY_BAROMETRIC);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
@@ -8,19 +8,15 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.SubType.*;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus.NORMAL;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus.WET;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.SubType.TH1;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.SubType.TH2;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.SubType.TH5;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus;
 
 /**
  * Test for RFXCom-binding
@@ -33,7 +29,7 @@ public class RFXComTemperatureHumidityMessageTest {
 
     private void testMessage(String hexMsg, RFXComTemperatureHumidityMessage.SubType subType, int seqNbr, int sensorId,
             double temperature, int humidity, HumidityStatus humidityStatus, int signalLevel, int batteryLevel)
-            throws RFXComException, RFXComNotImpException {
+            throws RFXComException {
         byte[] binaryMessage = DatatypeConverter.parseHexBinary(hexMsg);
         final RFXComTemperatureHumidityMessage msg = (RFXComTemperatureHumidityMessage) RFXComMessageFactory
                 .createMessage(binaryMessage);
@@ -52,7 +48,7 @@ public class RFXComTemperatureHumidityMessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("0A5201800F0201294C0349", TH1, 128, 3842, 29.7, 76, WET, 4, 9);
         testMessage("0A520211700200A72D0089", TH2, 17, 28674, 16.7, 45, NORMAL, 8, 9);
         testMessage("0A5205D42F000082590379", TH5, 212, 12032, 13, 89, WET, 7, 9);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureMessage.SubType.*;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureMessage.SubType.*;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureMess
  */
 public class RFXComTemperatureMessageTest {
     private void testMessage(String hexMsg, RFXComTemperatureMessage.SubType subType, int seqNbr, String deviceId,
-            double temperature, int signalLevel, int bateryLevel) throws RFXComException, RFXComNotImpException {
+            double temperature, int signalLevel, int bateryLevel) throws RFXComException {
         final RFXComTemperatureMessage msg = (RFXComTemperatureMessage) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
         assertEquals("SubType", subType, msg.subType);
@@ -41,7 +40,7 @@ public class RFXComTemperatureMessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("08500110000180BC69", TEMP1, 16, "1", -18.8d, 6, 9);
         testMessage("0850021DFB0100D770", TEMP2, 29, "64257", 21.5d, 7, 0);
         testMessage("08500502770000D389", TEMP5, 2, "30464", 21.1d, 8, 9);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComTemperatureRainMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.TEMPERATURE_RAIN);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
@@ -11,7 +11,6 @@ package org.openhab.binding.rfxcom.internal.messages;
 import static org.junit.Assert.assertEquals;
 
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -21,13 +20,11 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComTestHelper {
-    static void basicBoundaryCheck(PacketType packetType) throws RFXComException, RFXComNotImpException {
-        RFXComMessage intf = RFXComMessageFactory.createMessage(packetType);
-
+    static void basicBoundaryCheck(PacketType packetType, RFXComMessage message) throws RFXComException {
         // This is a place where its easy to make mistakes in coding, and can result in errors, normally
         // array bounds errors
-        byte[] message = intf.decodeMessage();
-        assertEquals("Wrong packet length", message[0], message.length - 1);
-        assertEquals("Wrong packet type", packetType.toByte(), message[1]);
+        byte[] binaryMessage = message.decodeMessage();
+        assertEquals("Wrong packet length", binaryMessage[0], binaryMessage.length - 1);
+        assertEquals("Wrong packet type", packetType.toByte(), binaryMessage[1]);
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class RFXComThermostat1MessageTest {
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "0940001B6B1816150270";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComThermostat1Message msg = (RFXComThermostat1Message) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -19,7 +19,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComThermostat2MessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.THERMOSTAT2);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
@@ -11,7 +11,7 @@ package org.openhab.binding.rfxcom.internal.messages;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
  * Test for RFXCom-binding
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
  * @since 1.9.0
  */
 public class RFXComThermostat3MessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(THERMOSTAT3);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
@@ -8,9 +8,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT4;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
  * Test for RFXCom-binding
@@ -18,11 +19,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @author Martin van Wingerden
  * @since 1.9.0
  */
-public class RFXComBarometricMessageTest {
-
+public class RFXComThermostat4MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+        RFXComMessageFactory.createMessage(THERMOSTAT4);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
@@ -8,10 +8,16 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.Response.ACK;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.SubType.RESPONSE;
+
+import javax.xml.bind.DatatypeConverter;
+
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
+import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.Response;
+import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.SubType;
 
 /**
  * Test for RFXCom-binding
@@ -20,15 +26,20 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComTransmitterMessageTest {
-    @Test
-    public void checkForSupportTest() throws RFXComException, RFXComNotImpException {
-        RFXComMessageFactory.createMessage(PacketType.TRANSMITTER_MESSAGE);
+    private void testMessage(String hexMsg, Response response, SubType subType, int seqNbr) throws RFXComException {
+        final RFXComTransmitterMessage msg = (RFXComTransmitterMessage) RFXComMessageFactory
+                .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
+        assertEquals("SubType", subType, msg.subType);
+        assertEquals("Response", response, msg.response);
+        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
+
+        byte[] decoded = msg.decodeMessage();
+
+        assertEquals("Message converted back", hexMsg, DatatypeConverter.printHexBinary(decoded));
     }
 
     @Test
-    public void basicBoundaryCheck() throws RFXComException, RFXComNotImpException {
-        RFXComTestHelper.basicBoundaryCheck(PacketType.TRANSMITTER_MESSAGE);
+    public void testSomeMessages() throws RFXComException {
+        testMessage("0402014300", ACK, RESPONSE, 67);
     }
-
-    // TODO please add tests for real messages
 }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -19,7 +19,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComUVMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.UV);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
@@ -15,7 +15,6 @@ import javax.xml.bind.DatatypeConverter;
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageTooLongException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -28,7 +27,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 public class RFXComUndecodedRFMessageTest {
 
     private void testMessage(String hexMsg, RFXComUndecodedRFMessage.SubType subType, int seqNbr, String rawPayload)
-            throws RFXComException, RFXComNotImpException {
+            throws RFXComException {
         final RFXComUndecodedRFMessage msg = (RFXComUndecodedRFMessage) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
         assertEquals("SubType", subType, msg.subType);
@@ -42,12 +41,12 @@ public class RFXComUndecodedRFMessageTest {
     }
 
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         testMessage("070301271356ECC0", RFXComUndecodedRFMessage.SubType.ARC, 0x27, "1356ECC0");
     }
 
     @Test(expected = RFXComMessageTooLongException.class)
-    public void testLongMessage() throws RFXComException, RFXComNotImpException {
+    public void testLongMessage() throws RFXComException {
         RFXComUndecodedRFMessage msg = (RFXComUndecodedRFMessage) RFXComMessageFactory
                 .createMessage(PacketType.UNDECODED_RF_MESSAGE);
         msg.subType = RFXComUndecodedRFMessage.SubType.ARC;

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -20,7 +20,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 public class RFXComWaterMessageTest {
 
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         RFXComMessageFactory.createMessage(PacketType.WATER);
     }

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 /**
@@ -19,7 +19,7 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComWeightMessageTest {
-    @Test(expected = RFXComNotImpException.class)
+    @Test(expected = RFXComMessageNotImplementedException.class)
     public void checkNotImplemented() throws Exception {
         // TODO Note that this message is supported in the 1.9 binding
         RFXComMessageFactory.createMessage(PacketType.WEIGHT);

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComWindMessage.SubType.WIND1;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComWindMessage.SubType.WIND1;
+import org.junit.Test;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -25,7 +24,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComWindMessage.Sub
  */
 public class RFXComWindMessageTest {
     @Test
-    public void testSomeMessages() throws RFXComException, RFXComNotImpException {
+    public void testSomeMessages() throws RFXComException {
         String hexMessage = "105601122F000087000000140000000079";
         byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
         RFXComWindMessage msg = (RFXComWindMessage) RFXComMessageFactory.createMessage(message);

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -8,13 +8,14 @@
  */
 package org.openhab.binding.rfxcom;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * The {@link RFXComBindingConstants} class defines common constants, which are
@@ -98,61 +99,66 @@ public class RFXComBindingConstants {
     public static final String CHANNEL_DATE_TIME = "dateTime";
 
     // List of all Thing Type UIDs
-    public final static ThingTypeUID THING_TYPE_UNDECODED = new ThingTypeUID(BINDING_ID, "undecoded");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING1 = new ThingTypeUID(BINDING_ID, "lighting1");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING2 = new ThingTypeUID(BINDING_ID, "lighting2");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING3 = new ThingTypeUID(BINDING_ID, "lighting3");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING4 = new ThingTypeUID(BINDING_ID, "lighting4");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING5 = new ThingTypeUID(BINDING_ID, "lighting5");
-    public final static ThingTypeUID THING_TYPE_LIGHTNING6 = new ThingTypeUID(BINDING_ID, "lighting6");
-    public final static ThingTypeUID THING_TYPE_CHIME = new ThingTypeUID(BINDING_ID, "chime");
-    public final static ThingTypeUID THING_TYPE_FAN = new ThingTypeUID(BINDING_ID, "fan");
-    public final static ThingTypeUID THING_TYPE_CURTAIN1 = new ThingTypeUID(BINDING_ID, "curtain1");
-    public final static ThingTypeUID THING_TYPE_BLINDS1 = new ThingTypeUID(BINDING_ID, "blinds1");
-    public final static ThingTypeUID THING_TYPE_SECURITY1 = new ThingTypeUID(BINDING_ID, "security1");
-    public final static ThingTypeUID THING_TYPE_CAMERA1 = new ThingTypeUID(BINDING_ID, "camera1");
-    public final static ThingTypeUID THING_TYPE_REMOTE_CONTROL = new ThingTypeUID(BINDING_ID, "remotecontrol");
-    public final static ThingTypeUID THING_TYPE_THERMOSTAT1 = new ThingTypeUID(BINDING_ID, "thermostat1");
-    public final static ThingTypeUID THING_TYPE_THERMOSTAT2 = new ThingTypeUID(BINDING_ID, "thermostat2");
-    public final static ThingTypeUID THING_TYPE_THERMOSTAT3 = new ThingTypeUID(BINDING_ID, "thermostat3");
-    public final static ThingTypeUID THING_TYPE_BBQ_TEMPERATURE = new ThingTypeUID(BINDING_ID, "bbqtemperature");
-    public final static ThingTypeUID THING_TYPE_TEMPERATURE_RAIN = new ThingTypeUID(BINDING_ID, "temperaturerain");
-    public final static ThingTypeUID THING_TYPE_TEMPERATURE = new ThingTypeUID(BINDING_ID, "temperature");
-    public final static ThingTypeUID THING_TYPE_HUMIDITY = new ThingTypeUID(BINDING_ID, "humidity");
-    public final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY = new ThingTypeUID(BINDING_ID,
+    private final static ThingTypeUID THING_TYPE_BAROMETRIC = new ThingTypeUID(BINDING_ID, "barometric");
+    private final static ThingTypeUID THING_TYPE_BBQ_TEMPERATURE = new ThingTypeUID(BINDING_ID, "bbqtemperature");
+    private final static ThingTypeUID THING_TYPE_BLINDS1 = new ThingTypeUID(BINDING_ID, "blinds1");
+    private final static ThingTypeUID THING_TYPE_CAMERA1 = new ThingTypeUID(BINDING_ID, "camera1");
+    private final static ThingTypeUID THING_TYPE_CHIME = new ThingTypeUID(BINDING_ID, "chime");
+    private final static ThingTypeUID THING_TYPE_CURRENT = new ThingTypeUID(BINDING_ID, "current");
+    private final static ThingTypeUID THING_TYPE_CURRENT_ENERGY = new ThingTypeUID(BINDING_ID, "currentenergy");
+    private final static ThingTypeUID THING_TYPE_CURTAIN1 = new ThingTypeUID(BINDING_ID, "curtain1");
+    private final static ThingTypeUID THING_TYPE_DATE_TIME = new ThingTypeUID(BINDING_ID, "datetime");
+    private final static ThingTypeUID THING_TYPE_ENERGY = new ThingTypeUID(BINDING_ID, "energy");
+    private final static ThingTypeUID THING_TYPE_FAN = new ThingTypeUID(BINDING_ID, "fan");
+    private final static ThingTypeUID THING_TYPE_FS20 = new ThingTypeUID(BINDING_ID, "fs20");
+    private final static ThingTypeUID THING_TYPE_GAS_USAGE = new ThingTypeUID(BINDING_ID, "gasusage");
+    private final static ThingTypeUID THING_TYPE_HOME_CONFORT = new ThingTypeUID(BINDING_ID, "homeconfort");
+    private final static ThingTypeUID THING_TYPE_HUMIDITY = new ThingTypeUID(BINDING_ID, "humidity");
+    private final static ThingTypeUID THING_TYPE_IO_LINES = new ThingTypeUID(BINDING_ID, "iolines");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING1 = new ThingTypeUID(BINDING_ID, "lighting1");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING2 = new ThingTypeUID(BINDING_ID, "lighting2");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING3 = new ThingTypeUID(BINDING_ID, "lighting3");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING4 = new ThingTypeUID(BINDING_ID, "lighting4");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING5 = new ThingTypeUID(BINDING_ID, "lighting5");
+    private final static ThingTypeUID THING_TYPE_LIGHTNING6 = new ThingTypeUID(BINDING_ID, "lighting6");
+    private final static ThingTypeUID THING_TYPE_POWER = new ThingTypeUID(BINDING_ID, "power");
+    private final static ThingTypeUID THING_TYPE_RADIATOR1 = new ThingTypeUID(BINDING_ID, "radiator1");
+    private final static ThingTypeUID THING_TYPE_RAIN = new ThingTypeUID(BINDING_ID, "rain");
+    private final static ThingTypeUID THING_TYPE_REMOTE_CONTROL = new ThingTypeUID(BINDING_ID, "remotecontrol");
+    private final static ThingTypeUID THING_TYPE_RFX_METER = new ThingTypeUID(BINDING_ID, "rfxmeter");
+    private final static ThingTypeUID THING_TYPE_RFX_SENSOR = new ThingTypeUID(BINDING_ID, "rfxsensor");
+    private final static ThingTypeUID THING_TYPE_RFY = new ThingTypeUID(BINDING_ID, "rfy");
+    private final static ThingTypeUID THING_TYPE_SECURITY1 = new ThingTypeUID(BINDING_ID, "security1");
+    private final static ThingTypeUID THING_TYPE_SECURITY2 = new ThingTypeUID(BINDING_ID, "security2");
+    private final static ThingTypeUID THING_TYPE_TEMPERATURE = new ThingTypeUID(BINDING_ID, "temperature");
+    private final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY = new ThingTypeUID(BINDING_ID,
             "temperaturehumidity");
-    public final static ThingTypeUID THING_TYPE_BAROMETRIC = new ThingTypeUID(BINDING_ID, "barometric");
-    public final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC = new ThingTypeUID(BINDING_ID,
+    private final static ThingTypeUID THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC = new ThingTypeUID(BINDING_ID,
             "temperaturehumiditybarometric");
-    public final static ThingTypeUID THING_TYPE_RAIN = new ThingTypeUID(BINDING_ID, "rain");
-    public final static ThingTypeUID THING_TYPE_WIND = new ThingTypeUID(BINDING_ID, "wind");
-    public final static ThingTypeUID THING_TYPE_UV = new ThingTypeUID(BINDING_ID, "uv");
-    public final static ThingTypeUID THING_TYPE_DATE_TIME = new ThingTypeUID(BINDING_ID, "datetime");
-    public final static ThingTypeUID THING_TYPE_CURRENT = new ThingTypeUID(BINDING_ID, "current");
-    public final static ThingTypeUID THING_TYPE_ENERGY = new ThingTypeUID(BINDING_ID, "energy");
-    public final static ThingTypeUID THING_TYPE_CURRENT_ENERGY = new ThingTypeUID(BINDING_ID, "currentenergy");
-    public final static ThingTypeUID THING_TYPE_POWER = new ThingTypeUID(BINDING_ID, "power");
-    public final static ThingTypeUID THING_TYPE_WEIGHTING_SCALE = new ThingTypeUID(BINDING_ID, "weightingscale");
-    public final static ThingTypeUID THING_TYPE_GAS_USAGE = new ThingTypeUID(BINDING_ID, "gasusage");
-    public final static ThingTypeUID THING_TYPE_WATER_USAGE = new ThingTypeUID(BINDING_ID, "waterusage");
-    public final static ThingTypeUID THING_TYPE_RFX_SENSOR = new ThingTypeUID(BINDING_ID, "rfxsensor");
-    public final static ThingTypeUID THING_TYPE_RFX_METER = new ThingTypeUID(BINDING_ID, "rfxmeter");
-    public final static ThingTypeUID THING_TYPE_FS20 = new ThingTypeUID(BINDING_ID, "fs20");
-    public final static ThingTypeUID THING_TYPE_RFY = new ThingTypeUID(BINDING_ID, "rfy");
+    private final static ThingTypeUID THING_TYPE_TEMPERATURE_RAIN = new ThingTypeUID(BINDING_ID, "temperaturerain");
+    private final static ThingTypeUID THING_TYPE_THERMOSTAT1 = new ThingTypeUID(BINDING_ID, "thermostat1");
+    private final static ThingTypeUID THING_TYPE_THERMOSTAT2 = new ThingTypeUID(BINDING_ID, "thermostat2");
+    private final static ThingTypeUID THING_TYPE_THERMOSTAT3 = new ThingTypeUID(BINDING_ID, "thermostat3");
+    private final static ThingTypeUID THING_TYPE_UNDECODED = new ThingTypeUID(BINDING_ID, "undecoded");
+    private final static ThingTypeUID THING_TYPE_UV = new ThingTypeUID(BINDING_ID, "uv");
+    private final static ThingTypeUID THING_TYPE_WATER_USAGE = new ThingTypeUID(BINDING_ID, "waterusage");
+    private final static ThingTypeUID THING_TYPE_WEIGHTING_SCALE = new ThingTypeUID(BINDING_ID, "weightingscale");
+    private final static ThingTypeUID THING_TYPE_WIND = new ThingTypeUID(BINDING_ID, "wind");
 
     /**
      * Presents all supported Thing types by RFXCOM binding.
      */
-    public final static Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_UNDECODED,
+    public final static Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_BAROMETRIC,
+            THING_TYPE_BBQ_TEMPERATURE, THING_TYPE_BLINDS1, THING_TYPE_CAMERA1, THING_TYPE_CHIME, THING_TYPE_CURRENT,
+            THING_TYPE_CURRENT_ENERGY, THING_TYPE_CURTAIN1, THING_TYPE_DATE_TIME, THING_TYPE_ENERGY, THING_TYPE_FAN,
+            THING_TYPE_FS20, THING_TYPE_GAS_USAGE, THING_TYPE_HOME_CONFORT, THING_TYPE_HUMIDITY, THING_TYPE_IO_LINES,
             THING_TYPE_LIGHTNING1, THING_TYPE_LIGHTNING2, THING_TYPE_LIGHTNING3, THING_TYPE_LIGHTNING4,
-            THING_TYPE_LIGHTNING5, THING_TYPE_LIGHTNING6, THING_TYPE_CHIME, THING_TYPE_FAN, THING_TYPE_CURTAIN1,
-            THING_TYPE_BLINDS1, THING_TYPE_SECURITY1, THING_TYPE_CAMERA1, THING_TYPE_REMOTE_CONTROL,
-            THING_TYPE_THERMOSTAT1, THING_TYPE_THERMOSTAT2, THING_TYPE_THERMOSTAT3, THING_TYPE_BBQ_TEMPERATURE,
-            THING_TYPE_TEMPERATURE_RAIN, THING_TYPE_TEMPERATURE, THING_TYPE_HUMIDITY, THING_TYPE_TEMPERATURE_HUMIDITY,
-            THING_TYPE_BAROMETRIC, THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC, THING_TYPE_RAIN, THING_TYPE_WIND,
-            THING_TYPE_UV, THING_TYPE_DATE_TIME, THING_TYPE_CURRENT, THING_TYPE_ENERGY, THING_TYPE_CURRENT_ENERGY,
-            THING_TYPE_POWER, THING_TYPE_WEIGHTING_SCALE, THING_TYPE_GAS_USAGE, THING_TYPE_WATER_USAGE,
-            THING_TYPE_RFX_SENSOR, THING_TYPE_RFX_METER, THING_TYPE_FS20, THING_TYPE_RFY);
+            THING_TYPE_LIGHTNING5, THING_TYPE_LIGHTNING6, THING_TYPE_POWER, THING_TYPE_RADIATOR1, THING_TYPE_RAIN,
+            THING_TYPE_REMOTE_CONTROL, THING_TYPE_RFX_METER, THING_TYPE_RFX_SENSOR, THING_TYPE_RFY,
+            THING_TYPE_SECURITY1, THING_TYPE_SECURITY2, THING_TYPE_TEMPERATURE, THING_TYPE_TEMPERATURE_HUMIDITY,
+            THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC, THING_TYPE_TEMPERATURE_RAIN, THING_TYPE_THERMOSTAT1,
+            THING_TYPE_THERMOSTAT2, THING_TYPE_THERMOSTAT3, THING_TYPE_UNDECODED, THING_TYPE_UV, THING_TYPE_WATER_USAGE,
+            THING_TYPE_WEIGHTING_SCALE, THING_TYPE_WIND);
 
     /**
      * Map RFXCOM packet types to RFXCOM Thing types and vice versa.
@@ -172,7 +178,9 @@ public class RFXComBindingConstants {
             .put(PacketType.FAN, RFXComBindingConstants.THING_TYPE_FAN)
             .put(PacketType.FS20, RFXComBindingConstants.THING_TYPE_FS20)
             .put(PacketType.GAS, RFXComBindingConstants.THING_TYPE_GAS_USAGE)
+            .put(PacketType.HOME_CONFORT, RFXComBindingConstants.THING_TYPE_HOME_CONFORT)
             .put(PacketType.HUMIDITY, RFXComBindingConstants.THING_TYPE_HUMIDITY)
+            .put(PacketType.IO_LINES, RFXComBindingConstants.THING_TYPE_IO_LINES)
             .put(PacketType.LIGHTING1, RFXComBindingConstants.THING_TYPE_LIGHTNING1)
             .put(PacketType.LIGHTING2, RFXComBindingConstants.THING_TYPE_LIGHTNING2)
             .put(PacketType.LIGHTING3, RFXComBindingConstants.THING_TYPE_LIGHTNING3)
@@ -180,11 +188,14 @@ public class RFXComBindingConstants {
             .put(PacketType.LIGHTING5, RFXComBindingConstants.THING_TYPE_LIGHTNING5)
             .put(PacketType.LIGHTING6, RFXComBindingConstants.THING_TYPE_LIGHTNING6)
             .put(PacketType.POWER, RFXComBindingConstants.THING_TYPE_POWER)
+            .put(PacketType.RADIATOR1, RFXComBindingConstants.THING_TYPE_RADIATOR1)
             .put(PacketType.RAIN, RFXComBindingConstants.THING_TYPE_RAIN)
             .put(PacketType.REMOTE_CONTROL, RFXComBindingConstants.THING_TYPE_REMOTE_CONTROL)
             .put(PacketType.RFXMETER, RFXComBindingConstants.THING_TYPE_RFX_METER)
             .put(PacketType.RFXSENSOR, RFXComBindingConstants.THING_TYPE_RFX_SENSOR)
+            .put(PacketType.RFY, RFXComBindingConstants.THING_TYPE_RFY)
             .put(PacketType.SECURITY1, RFXComBindingConstants.THING_TYPE_SECURITY1)
+            .put(PacketType.SECURITY2, RFXComBindingConstants.THING_TYPE_SECURITY2)
             .put(PacketType.TEMPERATURE, RFXComBindingConstants.THING_TYPE_TEMPERATURE)
             .put(PacketType.TEMPERATURE_HUMIDITY, RFXComBindingConstants.THING_TYPE_TEMPERATURE_HUMIDITY)
             .put(PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC,

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.rfxcom;
 
+import java.io.InvalidClassException;
+
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.items.ContactItem;
 import org.eclipse.smarthome.core.library.items.DateTimeItem;
@@ -16,8 +18,6 @@ import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.items.StringItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
-
-import java.io.InvalidClassException;
 
 /**
  * Represents all valid value selectors which could be processed by RFXCOM

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
@@ -31,7 +31,7 @@ import org.openhab.binding.rfxcom.internal.connector.RFXComJD2XXConnector;
 import org.openhab.binding.rfxcom.internal.connector.RFXComSerialConnector;
 import org.openhab.binding.rfxcom.internal.connector.RFXComTcpConnector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage;
 import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage;
 import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.Commands;
@@ -175,7 +175,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                 Thread.sleep(200);
 
                 if (configuration.ignoreConfig) {
-                    logger.debug("Ignoring tranceiver configuration");
+                    logger.debug("Ignoring transceiver configuration");
                 } else {
 
                     byte[] setMode = new byte[0];
@@ -185,7 +185,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
 
                     } catch (IllegalArgumentException e) {
 
-                        if (configuration.setMode != null && configuration.setMode.isEmpty() == false) {
+                        if (configuration.setMode != null && !configuration.setMode.isEmpty()) {
                             try {
                                 setMode = DatatypeConverter.parseHexBinary(configuration.setMode);
 
@@ -212,9 +212,9 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.ONLINE);
             }
         } catch (NoSuchPortException e) {
-            logger.error("Connection to RFXCOM transceiver failed: invalid port");
+            logger.error("Connection to RFXCOM transceiver failed", e);
         } catch (IOException e) {
-            logger.error("Connection to RFXCOM transceiver failed, reason: {}", e.getMessage());
+            logger.error("Connection to RFXCOM transceiver failed", e);
             if ("device not opened (3)".equalsIgnoreCase(e.getMessage())) {
                 if (connector instanceof RFXComJD2XXConnector) {
                     logger.info("Automatically Discovered RFXCOM bridges use FTDI chip driver (D2XX)."
@@ -225,7 +225,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                 }
             }
         } catch (Exception e) {
-            logger.error("Connection to RFXCOM transceiver failed, reason: {}", e.getMessage());
+            logger.error("Connection to RFXCOM transceiver failed", e);
         } catch (UnsatisfiedLinkError e) {
             logger.error("Error occurred when trying to load native library for OS '{}' version '{}', processor '{}'",
                     System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"), e);
@@ -248,7 +248,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                                 msg.transceiverType = TransceiverType._315MHZ;
                                 break;
                             default:
-                                throw new IllegalArgumentException("Illegal tranceiver type");
+                                throw new IllegalArgumentException("Illegal transceiver type");
                         }
                     }
                     break;
@@ -278,13 +278,13 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                                 msg.transceiverType = TransceiverType._315MHZ;
                                 break;
                             default:
-                                throw new IllegalArgumentException("Illegal tranceiver type");
+                                throw new IllegalArgumentException("Illegal transceiver type");
                         }
                     }
                     break;
 
                 default:
-                    throw new IllegalArgumentException("Illegal tranceiver type");
+                    throw new IllegalArgumentException("Illegal transceiver type");
             }
 
             msg.enableUndecodedPackets = configuration.enableUndecoded;
@@ -351,9 +351,6 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
 
                     case NAK:
                     case NAK_INVALID_AC_ADDRESS:
-                    case UNKNOWN:
-                        logger.error("Command transmit failed, '{}' received", resp.response);
-                        break;
                 }
             } else {
                 logger.warn("No response received from transceiver");
@@ -404,11 +401,11 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                         }
                     }
                 }
-            } catch (RFXComNotImpException e) {
+            } catch (RFXComMessageNotImplementedException e) {
                 logger.debug("Message not supported, data: {}", DatatypeConverter.printHexBinary(packet));
             } catch (RFXComException e) {
-                logger.error("Error occurred during packet receiving, data: {}, cause: {}",
-                        DatatypeConverter.printHexBinary(packet), e.getMessage());
+                logger.error("Error occured during packet receiving, data: {}",
+                        DatatypeConverter.printHexBinary(packet), e);
             }
 
             updateStatus(ThingStatus.ONLINE);

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComHandler.java
@@ -30,7 +30,7 @@ import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.DeviceMessageListener;
 import org.openhab.binding.rfxcom.internal.config.RFXComDeviceConfiguration;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 import org.openhab.binding.rfxcom.internal.messages.RFXComMessage;
@@ -91,10 +91,10 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                         logger.warn("RFXCOM doesn't support transmitting for channel '{}'", channelUID.getId());
                     }
 
-                } catch (RFXComNotImpException e) {
-                    logger.error("Message not supported: {}", e.getMessage());
+                } catch (RFXComMessageNotImplementedException e) {
+                    logger.error("Message not supported", e);
                 } catch (RFXComException e) {
-                    logger.error("Transmitting error: {}", e.getMessage());
+                    logger.error("Transmitting error", e);
                 }
             }
 
@@ -272,7 +272,7 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                 }
             }
         } catch (Exception e) {
-            logger.error("Error occurred during message receiving: {}", e.getMessage());
+            logger.error("Error occured during message receiving", e);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/exceptions/RFXComMessageNotImplementedException.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/exceptions/RFXComMessageNotImplementedException.java
@@ -13,24 +13,15 @@ package org.openhab.binding.rfxcom.internal.exceptions;
  *
  * @author Pauli Anttila - Initial contribution
  */
-public class RFXComNotImpException extends Exception {
+public class RFXComMessageNotImplementedException extends RFXComException {
 
     private static final long serialVersionUID = 5958462009164173495L;
 
-    public RFXComNotImpException() {
-        super();
-    }
-
-    public RFXComNotImpException(String message) {
-        super(message);
-    }
-
-    public RFXComNotImpException(String message, Throwable cause) {
+    public RFXComMessageNotImplementedException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public RFXComNotImpException(Throwable cause) {
-        super(cause);
+    public RFXComMessageNotImplementedException(String message) {
+        super(message);
     }
-
 }

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/exceptions/RFXComUnsupportedValueException.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/exceptions/RFXComUnsupportedValueException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.exceptions;
+
+/**
+ * Exception for when RFXCOM messages have a value that we don't understand.
+ *
+ * @author James Hewitt-Thomas - Initial contribution
+ */
+public class RFXComUnsupportedValueException extends RFXComException {
+
+    private static final long serialVersionUID = 402781611495845169L;
+
+    public RFXComUnsupportedValueException(Class<?> enumeration, String value) {
+        super("Unsupported value '" + value + "' for " + enumeration.getSimpleName());
+    }
+
+    public RFXComUnsupportedValueException(Class<?> enumeration, int value) {
+        this(enumeration, String.valueOf(value));
+    }
+}

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBaseMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBaseMessage.java
@@ -10,6 +10,9 @@ package org.openhab.binding.rfxcom.internal.messages;
 
 import javax.xml.bind.DatatypeConverter;
 
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+
 /**
  * Base class for RFXCOM data classes. All other data classes should extend this class.
  *
@@ -35,12 +38,17 @@ public abstract class RFXComBaseMessage implements RFXComMessage {
         CURTAIN1(24),
         BLINDS1(25),
         RFY(26),
+        HOME_CONFORT(27),
+        EDISIO(28),
         SECURITY1(32),
+        SECURITY2(33),
         CAMERA1(40),
         REMOTE_CONTROL(48),
         THERMOSTAT1(64),
         THERMOSTAT2(65),
         THERMOSTAT3(66),
+        THERMOSTAT4(67),
+        RADIATOR1(72),
         BBQ1(78),
         TEMPERATURE_RAIN(79),
         TEMPERATURE(80),
@@ -59,12 +67,11 @@ public abstract class RFXComBaseMessage implements RFXComMessage {
         WEIGHT(93),
         GAS(94),
         WATER(95),
+        CARTELECTRONIC(96),
         RFXSENSOR(112),
         RFXMETER(113),
         FS20(114),
-        IO_LINES(128),
-
-        UNKNOWN(255);
+        IO_LINES(128);
 
         private final int packetType;
 
@@ -72,44 +79,40 @@ public abstract class RFXComBaseMessage implements RFXComMessage {
             this.packetType = packetType;
         }
 
-        PacketType(byte packetType) {
-            this.packetType = packetType;
-        }
-
         public byte toByte() {
             return (byte) packetType;
         }
 
-        public static PacketType fromByte(int input) {
+        public static PacketType fromByte(int input) throws RFXComUnsupportedValueException {
             for (PacketType packetType : PacketType.values()) {
                 if (packetType.packetType == input) {
                     return packetType;
                 }
             }
 
-            return PacketType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(PacketType.class, input);
         }
 
     }
 
     public byte[] rawMessage;
-    public PacketType packetType = PacketType.UNKNOWN;
-    public byte packetId = 0;
-    public byte subType = 0;
-    public byte seqNbr = 0;
-    public byte id1 = 0;
-    public byte id2 = 0;
+    public PacketType packetType;
+    public byte packetId;
+    public byte subType;
+    public byte seqNbr;
+    public byte id1;
+    public byte id2;
 
     public RFXComBaseMessage() {
 
     }
 
-    public RFXComBaseMessage(byte[] data) {
+    public RFXComBaseMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         rawMessage = data;
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -19,9 +22,7 @@ import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for blinds1 message.
@@ -41,8 +42,11 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
         T6(6),
         T7(7),
         T8(8), // Chamberlain CS4330
-
-        UNKNOWN(255);
+        T9(9), // Sunpery/BTX
+        T10(10), // Dolat DLM-1, Topstar
+        T11(11), // ASP
+        T12(12), // Confexx CNF24-2435
+        T13(13); // Screenline
 
         private final int subType;
 
@@ -50,22 +54,18 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -77,9 +77,7 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
         SET_LIMIT(4), // YR1326 SET_UPPER_LIMIT(4),
         SET_LOWER_LIMIT(5), // YR1326
         DELETE_LIMITS(6), // YR1326
-        CHANGE_DIRECTON(7), // YR1326
-
-        UNKNOWN(255);
+        CHANGE_DIRECTON(7); // YR1326
 
         private final int command;
 
@@ -87,22 +85,18 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -112,18 +106,18 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.SHUTTER);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public byte unitCode;
+    public Commands command;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComBlinds1Message() {
         packetType = PacketType.BLINDS1;
     }
 
-    public RFXComBlinds1Message(byte[] data) {
+    public RFXComBlinds1Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -142,7 +136,7 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -293,11 +287,10 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComControlMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComControlMessage.java
@@ -26,7 +26,7 @@ public class RFXComControlMessage extends RFXComBaseMessage {
 
     }
 
-    public RFXComControlMessage(byte[] data) {
+    public RFXComControlMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -36,22 +36,12 @@ public class RFXComControlMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
         super.encodeMessage(data);
     }
 
     @Override
-    public String toString() {
-        String str = "";
-
-        str += super.toString();
-
-        return str;
-    }
-
-    @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
-
         throw new RFXComException("Not supported");
     }
 
@@ -67,13 +57,11 @@ public class RFXComControlMessage extends RFXComBaseMessage {
 
     @Override
     public void convertFromState(RFXComValueSelector valueSelector, Type type) throws RFXComException {
-
         throw new RFXComException("Not supported");
     }
 
     @Override
     public Object convertSubType(String subType) throws RFXComException {
-
         throw new RFXComException("Not supported");
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
@@ -8,15 +8,16 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for Current and Energy message.
@@ -25,12 +26,10 @@ import java.util.List;
  * @since 1.9.0
  */
 public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
-    private static float TOTAL_USAGE_CONVERSION_FACTOR = 223.666F;
+    private static final float TOTAL_USAGE_CONVERSION_FACTOR = 223.666F;
 
     public enum SubType {
-        ELEC4(1), // OWL - CM180i
-
-        UNKNOWN(255);
+        ELEC4(1); // OWL - CM180i
 
         private final int subType;
 
@@ -42,14 +41,14 @@ public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -59,21 +58,21 @@ public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public byte count = 0;
-    public double channel1Amps = 0.0;
-    public double channel2Amps = 0.0;
-    public double channel3Amps = 0.0;
-    public double totalUsage = 0.0;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public byte count;
+    public double channel1Amps;
+    public double channel2Amps;
+    public double channel3Amps;
+    public double totalUsage;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComCurrentEnergyMessage() {
         packetType = PacketType.CURRENT_ENERGY;
     }
 
-    public RFXComCurrentEnergyMessage(byte[] data) {
+    public RFXComCurrentEnergyMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -96,7 +95,7 @@ public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1Message.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -19,9 +22,7 @@ import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for curtain1 message. See Harrison.
@@ -32,9 +33,7 @@ import java.util.List;
 public class RFXComCurtain1Message extends RFXComBaseMessage {
 
     public enum SubType {
-        HARRISON(0),
-
-        UNKNOWN(255);
+        HARRISON(0);
 
         private final int subType;
 
@@ -42,22 +41,18 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -65,9 +60,7 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
         OPEN(0),
         CLOSE(1),
         STOP(2),
-        PROGRAM(3),
-
-        UNKNOWN(255);
+        PROGRAM(3);
 
         private final int command;
 
@@ -75,22 +68,18 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -100,18 +89,18 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.SHUTTER);
 
-    public SubType subType = SubType.UNKNOWN;
-    public char sensorId = 'A';
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public char sensorId;
+    public byte unitCode;
+    public Commands command;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComCurtain1Message() {
         packetType = PacketType.CURTAIN1;
     }
 
-    public RFXComCurtain1Message(byte[] data) {
+    public RFXComCurtain1Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -130,7 +119,7 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -264,11 +253,10 @@ public class RFXComCurtain1Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.DateTimeItem;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
@@ -16,9 +19,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for Date and Time message.
@@ -29,9 +30,7 @@ import java.util.List;
 public class RFXComDateTimeMessage extends RFXComBaseMessage {
 
     public enum SubType {
-        RTGR328N(1),
-
-        UNKNOWN(255);
+        RTGR328N(1);
 
         private final int subType;
 
@@ -39,49 +38,45 @@ public class RFXComDateTimeMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
-    private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays.asList(
-            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.DATE_TIME);
+    private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays
+            .asList(RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.DATE_TIME);
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    String dateTime = "yyyy-MM-dd'T'HH:mm:ss";
-    int yy = 0;
-    int MM = 0;
-    int dd = 0;
-    int dow = 0;
-    int HH = 0;
-    int mm = 0;
-    int ss = 0;
+    public SubType subType;
+    public int sensorId;
+    String dateTime;
+    int year;
+    int month;
+    int day;
+    int dayOfWeek;
+    int hour;
+    int minute;
+    int second;
 
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComDateTimeMessage() {
         packetType = PacketType.DATE_TIME;
     }
 
-    public RFXComDateTimeMessage(byte[] data) {
+    public RFXComDateTimeMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -100,7 +95,7 @@ public class RFXComDateTimeMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -108,15 +103,15 @@ public class RFXComDateTimeMessage extends RFXComBaseMessage {
 
         sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
 
-        yy = data[6] & 0xFF;
-        MM = data[7] & 0xFF;
-        dd = data[8] & 0xFF;
-        dow = data[9] & 0xFF;
-        HH = data[10] & 0xFF;
-        mm = data[11] & 0xFF;
-        ss = data[12] & 0xFF;
+        year = data[6] & 0xFF;
+        month = data[7] & 0xFF;
+        day = data[8] & 0xFF;
+        dayOfWeek = data[9] & 0xFF;
+        hour = data[10] & 0xFF;
+        minute = data[11] & 0xFF;
+        second = data[12] & 0xFF;
 
-        dateTime = String.format("20%02d-%02d-%02dT%02d:%02d:%02d", yy, MM, dd, HH, mm, ss);
+        dateTime = String.format("20%02d-%02d-%02dT%02d:%02d:%02d", year, month, day, hour, minute, second);
 
         signalLevel = (byte) ((data[13] & 0xF0) >> 4);
         batteryLevel = (byte) (data[13] & 0x0F);
@@ -132,13 +127,13 @@ public class RFXComDateTimeMessage extends RFXComBaseMessage {
         data[3] = seqNbr;
         data[4] = (byte) ((sensorId & 0xFF00) >> 8);
         data[5] = (byte) (sensorId & 0x00FF);
-        data[6] = (byte) (yy & 0x00FF);
-        data[7] = (byte) (MM & 0x00FF);
-        data[8] = (byte) (dd & 0x00FF);
-        data[9] = (byte) (dow & 0x00FF);
-        data[10] = (byte) (HH & 0x00FF);
-        data[11] = (byte) (mm & 0x00FF);
-        data[12] = (byte) (ss & 0x00FF);
+        data[6] = (byte) (year & 0x00FF);
+        data[7] = (byte) (month & 0x00FF);
+        data[8] = (byte) (day & 0x00FF);
+        data[9] = (byte) (dayOfWeek & 0x00FF);
+        data[10] = (byte) (hour & 0x00FF);
+        data[11] = (byte) (minute & 0x00FF);
+        data[12] = (byte) (second & 0x00FF);
         data[13] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
 
         return data;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessage.java
@@ -8,16 +8,16 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for energy message.
@@ -32,9 +32,7 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
 
     public enum SubType {
         ELEC2(1),
-        ELEC3(2),
-
-        UNKNOWN(255);
+        ELEC3(2);
 
         private final int subType;
 
@@ -42,22 +40,18 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -67,21 +61,21 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public byte count = 0;
-    public double instantAmp = 0;
-    public double totalAmpHour = 0;
-    public double instantPower = 0;
-    public double totalUsage = 0;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public byte count;
+    public double instantAmp;
+    public double totalAmpHour;
+    public double instantPower;
+    public double totalUsage;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComEnergyMessage() {
         packetType = PacketType.ENERGY;
     }
 
-    public RFXComEnergyMessage(byte[] data) {
+    public RFXComEnergyMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -104,7 +98,7 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -167,7 +161,7 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -234,11 +228,10 @@ public class RFXComEnergyMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessage.java
@@ -8,18 +8,18 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.StringItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for humidity message.
@@ -31,8 +31,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
     public enum SubType {
         HUM1(1),
         HUM2(2),
-
-        UNKNOWN(255);
+        HUM3(3);
 
         private final int subType;
 
@@ -40,22 +39,18 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -63,9 +58,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
         NORMAL(0),
         COMFORT(1),
         DRY(2),
-        WET(3),
-
-        UNKNOWN(255);
+        WET(3);
 
         private final int humidityStatus;
 
@@ -73,22 +66,18 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
             this.humidityStatus = humidityStatus;
         }
 
-        HumidityStatus(byte humidityStatus) {
-            this.humidityStatus = humidityStatus;
-        }
-
         public byte toByte() {
             return (byte) humidityStatus;
         }
 
-        public static HumidityStatus fromByte(int input) {
+        public static HumidityStatus fromByte(int input) throws RFXComUnsupportedValueException {
             for (HumidityStatus value : HumidityStatus.values()) {
                 if (value.humidityStatus == input) {
                     return value;
                 }
             }
 
-            return HumidityStatus.UNKNOWN;
+            throw new RFXComUnsupportedValueException(HumidityStatus.class, input);
         }
     }
 
@@ -98,10 +87,10 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
+    public SubType subType;
     public int sensorId = 0;
     public byte humidity = 0;
-    public HumidityStatus humidityStatus = HumidityStatus.UNKNOWN;
+    public HumidityStatus humidityStatus;
     public byte signalLevel = 0;
     public byte batteryLevel = 0;
 
@@ -109,7 +98,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
         packetType = PacketType.HUMIDITY;
     }
 
-    public RFXComHumidityMessage(byte[] data) {
+    public RFXComHumidityMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -129,7 +118,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -166,7 +155,7 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -229,11 +218,10 @@ public class RFXComHumidityMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessage.java
@@ -8,13 +8,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.io.UnsupportedEncodingException;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for interface message.
@@ -24,14 +25,13 @@ import java.util.List;
 public class RFXComInterfaceMessage extends RFXComBaseMessage {
 
     public enum SubType {
+        UNKNOWN_COMMAND(-1),
         RESPONSE(0),
         UNKNOWN_RTS_REMOTE(1),
         NO_EXTENDED_HW_PRESENT(2),
         LIST_RFY_REMOTES(3),
         LIST_ASA_REMOTES(4),
-        START_RECEIVER(7),
-
-        UNKNOWN(255);
+        START_RECEIVER(7);
 
         private final int subType;
 
@@ -47,14 +47,14 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType subType : SubType.values()) {
                 if (subType.subType == input) {
                     return subType;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -69,7 +69,7 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
         T1(8), // For internal use by RFXCOM
         T2(9), // For internal use by RFXCOM
 
-        UNKNOWN(255);
+        UNSUPPORTED_COMMAND(-1); // wrong command received from the application
 
         private final int command;
 
@@ -77,22 +77,18 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands command : Commands.values()) {
                 if (command.command == input) {
                     return command;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -107,9 +103,7 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
         _868_30MHZ_FSK(88),
         _868_35MHZ(89),
         _868_35MHZ_FSK(90),
-        _868_95MHZ_FSK(91),
-
-        UNKNOWN(255);
+        _868_95MHZ_FSK(91);
 
         private final int type;
 
@@ -125,59 +119,59 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
             return (byte) type;
         }
 
-        public static TransceiverType fromByte(int input) {
+        public static TransceiverType fromByte(int input) throws RFXComUnsupportedValueException {
             for (TransceiverType type : TransceiverType.values()) {
                 if (type.type == input) {
                     return type;
                 }
             }
 
-            return TransceiverType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(TransceiverType.class, input);
         }
     }
 
-    public SubType subType = SubType.UNKNOWN;
-    public Commands command = Commands.UNKNOWN;
+    public SubType subType;
+    public Commands command;
     public String text = "";
 
-    public TransceiverType transceiverType = TransceiverType.UNKNOWN;
-    public int firmwareVersion = 0;
+    public TransceiverType transceiverType;
+    public int firmwareVersion;
 
-    public boolean enableUndecodedPackets = false; // 0x80 - Undecoded packets
-    public boolean enableImagintronixOpusPackets = false; // 0x40 - Imagintronix/Opus (433.92)
-    public boolean enableByronSXPackets = false; // 0x20 - Byron SX (433.92)
-    public boolean enableRSLPackets = false; // 0x10 - RSL (433.92)
-    public boolean enableLighting4Packets = false; // 0x08 - Lighting4 (433.92)
-    public boolean enableFineOffsetPackets = false; // 0x04 - FineOffset / Viking (433.92)
-    public boolean enableRubicsonPackets = false; // 0x02 - Rubicson (433.92)
-    public boolean enableAEPackets = false; // 0x01 - AE (433.92)
+    public boolean enableUndecodedPackets; // 0x80 - Undecoded packets
+    public boolean enableImagintronixOpusPackets; // 0x40 - Imagintronix/Opus (433.92)
+    public boolean enableByronSXPackets; // 0x20 - Byron SX (433.92)
+    public boolean enableRSLPackets; // 0x10 - RSL (433.92)
+    public boolean enableLighting4Packets; // 0x08 - Lighting4 (433.92)
+    public boolean enableFineOffsetPackets; // 0x04 - FineOffset / Viking (433.92)
+    public boolean enableRubicsonPackets; // 0x02 - Rubicson (433.92)
+    public boolean enableAEPackets; // 0x01 - AE (433.92)
 
-    public boolean enableBlindsT1T2T3T4Packets = false; // 0x80 - BlindsT1/T2/T3/T4 (433.92)
-    public boolean enableBlindsT0Packets = false; // 0x40 - BlindsT0 (433.92)
-    public boolean enableProGuardPackets = false; // 0x20 - ProGuard (868.35 FSK)
-    public boolean enableFS20Packets = false; // 0x10 - FS20 (868.35)
-    public boolean enableLaCrossePackets = false; // 0x08 - La Crosse (433.92/868.30)
-    public boolean enableHidekiUPMPackets = false; // 0x04 - Hideki/UPM (433.92)
-    public boolean enableADPackets = false; // 0x02 - AD LightwaveRF (433.92)
-    public boolean enableMertikPackets = false; // 0x01 - Mertik (433.92)
+    public boolean enableBlindsT1T2T3T4Packets; // 0x80 - BlindsT1/T2/T3/T4 (433.92)
+    public boolean enableBlindsT0Packets; // 0x40 - BlindsT0 (433.92)
+    public boolean enableProGuardPackets; // 0x20 - ProGuard (868.35 FSK)
+    public boolean enableFS20Packets; // 0x10 - FS20 (868.35)
+    public boolean enableLaCrossePackets; // 0x08 - La Crosse (433.92/868.30)
+    public boolean enableHidekiUPMPackets; // 0x04 - Hideki/UPM (433.92)
+    public boolean enableADPackets; // 0x02 - AD LightwaveRF (433.92)
+    public boolean enableMertikPackets; // 0x01 - Mertik (433.92)
 
-    public boolean enableVisonicPackets = false; // 0x80 - Visonic (315/868.95)
-    public boolean enableATIPackets = false; // 0x40 - ATI (433.92)
-    public boolean enableOregonPackets = false; // 0x20 - Oregon Scientific (433.92)
-    public boolean enableMeiantechPackets = false; // 0x10 - Meiantech (433.92)
-    public boolean enableHomeEasyPackets = false; // 0x08 - HomeEasy EU (433.92)
-    public boolean enableACPackets = false; // 0x04 - AC (433.92)
-    public boolean enableARCPackets = false; // 0x02 - ARC (433.92)
-    public boolean enableX10Packets = false; // 0x01 - X10 (310/433.92)
+    public boolean enableVisonicPackets; // 0x80 - Visonic (315/868.95)
+    public boolean enableATIPackets; // 0x40 - ATI (433.92)
+    public boolean enableOregonPackets; // 0x20 - Oregon Scientific (433.92)
+    public boolean enableMeiantechPackets; // 0x10 - Meiantech (433.92)
+    public boolean enableHomeEasyPackets; // 0x08 - HomeEasy EU (433.92)
+    public boolean enableACPackets; // 0x04 - AC (433.92)
+    public boolean enableARCPackets; // 0x02 - ARC (433.92)
+    public boolean enableX10Packets; // 0x01 - X10 (310/433.92)
 
-    public byte hardwareVersion1 = 0;
-    public byte hardwareVersion2 = 0;
+    public byte hardwareVersion1;
+    public byte hardwareVersion2;
 
     public RFXComInterfaceMessage() {
 
     }
 
-    public RFXComInterfaceMessage(byte[] data) {
+    public RFXComInterfaceMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -228,7 +222,7 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -240,32 +234,32 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
 
             firmwareVersion = data[6] & 0xFF;
 
-            enableUndecodedPackets = (data[7] & 0x80) != 0 ? true : false;
-            enableImagintronixOpusPackets = (data[7] & 0x40) != 0 ? true : false;
-            enableByronSXPackets = (data[7] & 0x20) != 0 ? true : false;
-            enableRSLPackets = (data[7] & 0x10) != 0 ? true : false;
-            enableLighting4Packets = (data[7] & 0x08) != 0 ? true : false;
-            enableFineOffsetPackets = (data[7] & 0x04) != 0 ? true : false;
-            enableRubicsonPackets = (data[7] & 0x02) != 0 ? true : false;
-            enableAEPackets = (data[7] & 0x01) != 0 ? true : false;
+            enableUndecodedPackets = (data[7] & 0x80) != 0;
+            enableImagintronixOpusPackets = (data[7] & 0x40) != 0;
+            enableByronSXPackets = (data[7] & 0x20) != 0;
+            enableRSLPackets = (data[7] & 0x10) != 0;
+            enableLighting4Packets = (data[7] & 0x08) != 0;
+            enableFineOffsetPackets = (data[7] & 0x04) != 0;
+            enableRubicsonPackets = (data[7] & 0x02) != 0;
+            enableAEPackets = (data[7] & 0x01) != 0;
 
-            enableBlindsT1T2T3T4Packets = (data[8] & 0x80) != 0 ? true : false;
-            enableBlindsT0Packets = (data[8] & 0x40) != 0 ? true : false;
-            enableProGuardPackets = (data[8] & 0x20) != 0 ? true : false;
-            enableFS20Packets = (data[8] & 0x10) != 0 ? true : false;
-            enableLaCrossePackets = (data[8] & 0x08) != 0 ? true : false;
-            enableHidekiUPMPackets = (data[8] & 0x04) != 0 ? true : false;
-            enableADPackets = (data[8] & 0x02) != 0 ? true : false;
-            enableMertikPackets = (data[8] & 0x01) != 0 ? true : false;
+            enableBlindsT1T2T3T4Packets = (data[8] & 0x80) != 0;
+            enableBlindsT0Packets = (data[8] & 0x40) != 0;
+            enableProGuardPackets = (data[8] & 0x20) != 0;
+            enableFS20Packets = (data[8] & 0x10) != 0;
+            enableLaCrossePackets = (data[8] & 0x08) != 0;
+            enableHidekiUPMPackets = (data[8] & 0x04) != 0;
+            enableADPackets = (data[8] & 0x02) != 0;
+            enableMertikPackets = (data[8] & 0x01) != 0;
 
-            enableVisonicPackets = (data[9] & 0x80) != 0 ? true : false;
-            enableATIPackets = (data[9] & 0x40) != 0 ? true : false;
-            enableOregonPackets = (data[9] & 0x20) != 0 ? true : false;
-            enableMeiantechPackets = (data[9] & 0x10) != 0 ? true : false;
-            enableHomeEasyPackets = (data[9] & 0x08) != 0 ? true : false;
-            enableACPackets = (data[9] & 0x04) != 0 ? true : false;
-            enableARCPackets = (data[9] & 0x02) != 0 ? true : false;
-            enableX10Packets = (data[9] & 0x01) != 0 ? true : false;
+            enableVisonicPackets = (data[9] & 0x80) != 0;
+            enableATIPackets = (data[9] & 0x40) != 0;
+            enableOregonPackets = (data[9] & 0x20) != 0;
+            enableMeiantechPackets = (data[9] & 0x10) != 0;
+            enableHomeEasyPackets = (data[9] & 0x08) != 0;
+            enableACPackets = (data[9] & 0x04) != 0;
+            enableARCPackets = (data[9] & 0x02) != 0;
+            enableX10Packets = (data[9] & 0x01) != 0;
 
             hardwareVersion1 = data[10];
             hardwareVersion2 = data[11];
@@ -293,7 +287,7 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
     @Override
     public byte[] decodeMessage() {
 
-        byte[] data = new byte[13];
+        byte[] data = new byte[14];
 
         data[0] = 0x0D;
         data[1] = RFXComBaseMessage.PacketType.INTERFACE_MESSAGE.toByte();
@@ -369,11 +363,10 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
@@ -8,6 +8,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.ContactItem;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
@@ -16,12 +20,9 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for lighting1 message. See X10, ARC, etc..
@@ -43,9 +44,7 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
         ENERGENIE(8),
         ENERGENIE_5(9),
         COCO(10),
-        HQ_COCO20(11),
-
-        UNKNOWN(255);
+        HQ_COCO20(11);
 
         private final int subType;
 
@@ -53,22 +52,18 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -79,9 +74,7 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
         BRIGHT(3),
         GROUP_OFF(5),
         GROUP_ON(6),
-        CHIME(7),
-
-        UNKNOWN(255);
+        CHIME(7);
 
         private final int command;
 
@@ -89,43 +82,39 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
     private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays
             .asList(RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.COMMAND, RFXComValueSelector.CONTACT);
 
-    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
-            .asList(RFXComValueSelector.COMMAND);
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Collections
+            .singletonList(RFXComValueSelector.COMMAND);
 
-    public SubType subType = SubType.UNKNOWN;
-    public char houseCode = 'A';
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte signalLevel = 0;
-    public boolean group = false;
+    public SubType subType;
+    public char houseCode;
+    public byte unitCode;
+    public Commands command;
+    public byte signalLevel;
+    public boolean group;
 
     public RFXComLighting1Message() {
         packetType = PacketType.LIGHTING1;
     }
 
-    public RFXComLighting1Message(byte[] data) {
+    public RFXComLighting1Message(byte[] data) throws RFXComException {
 
         encodeMessage(data);
     }
@@ -144,7 +133,7 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -188,7 +177,7 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -321,11 +310,10 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
@@ -8,21 +8,29 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.eclipse.smarthome.core.library.items.*;
-import org.eclipse.smarthome.core.library.types.*;
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
-import org.openhab.binding.rfxcom.RFXComValueSelector;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING2;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting2Message.Commands.*;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING2;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting2Message.Commands.GROUP_OFF;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting2Message.Commands.GROUP_ON;
+import org.eclipse.smarthome.core.library.items.ContactItem;
+import org.eclipse.smarthome.core.library.items.DimmerItem;
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.items.RollershutterItem;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for lighting2 message.
@@ -35,9 +43,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
         AC(0),
         HOME_EASY_EU(1),
         ANSLUT(2),
-        KAMBROOK(3),
-
-        UNKNOWN(255);
+        KAMBROOK(3);
 
         private final int subType;
 
@@ -45,22 +51,18 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -70,9 +72,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
         SET_LEVEL(2),
         GROUP_OFF(3),
         GROUP_ON(4),
-        SET_GROUP_LEVEL(5),
-
-        UNKNOWN(255);
+        SET_GROUP_LEVEL(5);
 
         private final int command;
 
@@ -80,22 +80,18 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -106,19 +102,19 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.COMMAND, RFXComValueSelector.DIMMING_LEVEL);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte dimmingLevel = 0;
-    public byte signalLevel = 0;
-    public boolean group = false;
+    public SubType subType;
+    public int sensorId;
+    public byte unitCode;
+    public Commands command;
+    public byte dimmingLevel;
+    public byte signalLevel;
+    public boolean group;
 
     public RFXComLighting2Message() {
         packetType = PacketType.LIGHTING2;
     }
 
-    public RFXComLighting2Message(byte[] data) {
+    public RFXComLighting2Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -137,7 +133,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
         super.encodeMessage(data);
 
         subType = SubType.fromByte(super.subType);
@@ -196,7 +192,7 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
     /**
      * Convert a 0-15 scale value to a percent type.
      *
-     * @param pt
+     * @param value
      *            percent type to convert
      * @return converted value 0-15
      */
@@ -368,11 +364,10 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4Message.java
@@ -8,18 +8,18 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for lighting4 message.
@@ -50,9 +50,7 @@ import java.util.List;
 public class RFXComLighting4Message extends RFXComBaseMessage {
 
     public enum SubType {
-        PT2262(0),
-
-        UNKNOWN(255);
+        PT2262(0);
 
         private final int subType;
 
@@ -60,22 +58,18 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -84,9 +78,7 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
         ON(1),
         UNDEFINED_2(2),
         UNDEFINED_3(3),
-        OFF(4),
-
-        UNKNOWN(255);
+        OFF(4);
 
         private final int command;
 
@@ -94,21 +86,17 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -118,17 +106,17 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.COMMAND);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public Commands command = Commands.UNKNOWN;
-    public int pulse = 0;
-    public byte signalLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public Commands command;
+    public int pulse;
+    public byte signalLevel;
 
     public RFXComLighting4Message() {
         packetType = PacketType.LIGHTING4;
     }
 
-    public RFXComLighting4Message(byte[] data) {
+    public RFXComLighting4Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -146,7 +134,7 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -156,7 +144,7 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
         int commandID = (data[6] & 0x0F); // 4 OFF - 1 ON
         command = Commands.fromByte(commandID);
 
-        pulse = (data[7] & 0xFF) << 8 | (data[8] & 0xFF) << 0;
+        pulse = (data[7] & 0xFF) << 8 | (data[8] & 0xFF);
 
         signalLevel = (byte) ((data[9] & 0xF0) >> 4);
     }
@@ -196,35 +184,19 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
 
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
-
-        State state = UnDefType.UNDEF;
-
-        // SWITCHITEM
         if (valueSelector.getItemClass() == SwitchItem.class) {
-
             if (valueSelector == RFXComValueSelector.COMMAND) {
                 switch (command) {
                     case OFF:
-                        state = OnOffType.OFF;
-                        break;
+                        return OnOffType.OFF;
                     case ON:
-                        state = OnOffType.ON;
-                        break;
-                    default:
-                        throw new RFXComException("Can't convert value " + command + " to COMMAND SwitchItem");
+                        return OnOffType.ON;
                 }
-            } else {
                 throw new RFXComException("Can't convert " + valueSelector + " to SwitchItem: not supported");
             }
-
-            return state;
-
         } else if (valueSelector.getItemClass() == NumberItem.class) {
-
             if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
-
-                state = new DecimalType(signalLevel);
-
+                return new DecimalType(signalLevel);
             } else {
                 throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
             }
@@ -277,11 +249,10 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.ContactItem;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
@@ -16,12 +19,9 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for lighting6 message. See Blyss.
@@ -32,9 +32,7 @@ import java.util.List;
 public class RFXComLighting6Message extends RFXComBaseMessage {
 
     public enum SubType {
-        BLYSS(0),
-
-        UNKNOWN(255);
+        BLYSS(0);
 
         private final int subType;
 
@@ -42,22 +40,18 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -65,9 +59,7 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
         ON(0),
         OFF(1),
         GROUP_ON(2),
-        GROUP_OFF(3),
-
-        UNKNOWN(255);
+        GROUP_OFF(3);
 
         private final int command;
 
@@ -75,22 +67,18 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return Commands.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -100,18 +88,18 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.COMMAND);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public char groupCode = 'A';
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte signalLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public char groupCode;
+    public byte unitCode;
+    public Commands command;
+    public byte signalLevel;
 
     public RFXComLighting6Message() {
         packetType = PacketType.LIGHTING6;
     }
 
-    public RFXComLighting6Message(byte[] data) {
+    public RFXComLighting6Message(byte[] data) throws RFXComException {
 
         encodeMessage(data);
     }
@@ -130,11 +118,11 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
         super.encodeMessage(data);
 
         subType = SubType.fromByte(super.subType);
-        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF) << 0;
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
         groupCode = (char) data[6];
         unitCode = data[7];
         command = Commands.fromByte(data[8]);
@@ -173,7 +161,7 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -284,11 +272,10 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessage.java
@@ -36,7 +36,7 @@ public interface RFXComMessage {
      * @param data
      *            Raw data.
      */
-    void encodeMessage(byte[] data);
+    void encodeMessage(byte[] data) throws RFXComException;
 
     /**
      * Procedure for decode object to raw data.

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
@@ -9,12 +9,13 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComNotImpException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
 public class RFXComMessageFactory {
@@ -22,52 +23,56 @@ public class RFXComMessageFactory {
     final static String classUrl = "org.openhab.binding.rfxcom.internal.messages.";
 
     @SuppressWarnings("serial")
-    private static final Map<PacketType, String> messageClasses = Collections
-            .unmodifiableMap(new HashMap<PacketType, String>() {
+    private static final Map<PacketType, Class<? extends RFXComMessage>> messageClasses = Collections
+            .unmodifiableMap(new HashMap<PacketType, Class<? extends RFXComMessage>>() {
                 {
-                    put(PacketType.INTERFACE_CONTROL, "RFXComControlMessage");
-                    put(PacketType.INTERFACE_MESSAGE, "RFXComInterfaceMessage");
-                    put(PacketType.TRANSMITTER_MESSAGE, "RFXComTransmitterMessage");
-                    put(PacketType.UNDECODED_RF_MESSAGE, "RFXComUndecodedRFMessage");
-                    put(PacketType.LIGHTING1, "RFXComLighting1Message");
-                    put(PacketType.LIGHTING2, "RFXComLighting2Message");
-                    put(PacketType.LIGHTING3, "RFXComLighting3Message");
-                    put(PacketType.LIGHTING4, "RFXComLighting4Message");
-                    put(PacketType.LIGHTING5, "RFXComLighting5Message");
-                    put(PacketType.LIGHTING6, "RFXComLighting6Message");
-                    put(PacketType.CHIME, "RFXComChimeMessage");
-                    put(PacketType.FAN, "RFXComFanMessage");
-                    put(PacketType.CURTAIN1, "RFXComCurtain1Message");
-                    put(PacketType.BLINDS1, "RFXComBlinds1Message");
-                    put(PacketType.RFY, "RFXComRfyMessage");
-                    put(PacketType.SECURITY1, "RFXComSecurity1Message");
-                    put(PacketType.CAMERA1, "RFXComCamera1Message");
-                    put(PacketType.REMOTE_CONTROL, "RFXComRemoteControlMessage");
-                    put(PacketType.THERMOSTAT1, "RFXComThermostat1Message");
-                    put(PacketType.THERMOSTAT2, "RFXComThermostat2Message");
-                    put(PacketType.THERMOSTAT3, "RFXComThermostat3Message");
-                    put(PacketType.BBQ1, "RFXComBBQMessage");
-                    put(PacketType.TEMPERATURE_RAIN, "RFXComTemperatureRainMessage");
-                    put(PacketType.TEMPERATURE, "RFXComTemperatureMessage");
-                    put(PacketType.HUMIDITY, "RFXComHumidityMessage");
-                    put(PacketType.TEMPERATURE_HUMIDITY, "RFXComTemperatureHumidityMessage");
-                    put(PacketType.BAROMETRIC, "RFXComBarometricMessage");
-                    put(PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC, "RFXComTemperatureHumidityBarometricMessage");
-                    put(PacketType.RAIN, "RFXComRainMessage");
-                    put(PacketType.WIND, "RFXComWindMessage");
-                    put(PacketType.UV, "RFXComUVMessage");
-                    put(PacketType.DATE_TIME, "RFXComDateTimeMessage");
-                    put(PacketType.CURRENT, "RFXComCurrentMessage");
-                    put(PacketType.ENERGY, "RFXComEnergyMessage");
-                    put(PacketType.CURRENT_ENERGY, "RFXComCurrentEnergyMessage");
-                    put(PacketType.POWER, "RFXComPowerMessage");
-                    put(PacketType.WEIGHT, "RFXComWeightMessage");
-                    put(PacketType.GAS, "RFXComGasMessage");
-                    put(PacketType.WATER, "RFXComWaterMessage");
-                    put(PacketType.RFXSENSOR, "RFXComRFXSensorMessage");
-                    put(PacketType.RFXMETER, "RFXComRFXMeterMessage");
-                    put(PacketType.FS20, "RFXComFS20Message");
-                    put(PacketType.IO_LINES, "RFXComIOLinesMessage");
+                    put(PacketType.INTERFACE_CONTROL, RFXComControlMessage.class);
+                    put(PacketType.INTERFACE_MESSAGE, RFXComInterfaceMessage.class);
+                    put(PacketType.TRANSMITTER_MESSAGE, RFXComTransmitterMessage.class);
+                    put(PacketType.UNDECODED_RF_MESSAGE, RFXComUndecodedRFMessage.class);
+                    put(PacketType.LIGHTING1, RFXComLighting1Message.class);
+                    put(PacketType.LIGHTING2, RFXComLighting2Message.class);
+                    // put(PacketType.LIGHTING3, RFXComLighting3Message.class);
+                    put(PacketType.LIGHTING4, RFXComLighting4Message.class);
+                    put(PacketType.LIGHTING5, RFXComLighting5Message.class);
+                    put(PacketType.LIGHTING6, RFXComLighting6Message.class);
+                    // put(PacketType.CHIME, RFXComChimeMessage.class);
+                    // put(PacketType.FAN, RFXComFanMessage.class);
+                    put(PacketType.CURTAIN1, RFXComCurtain1Message.class);
+                    put(PacketType.BLINDS1, RFXComBlinds1Message.class);
+                    put(PacketType.RFY, RFXComRfyMessage.class);
+                    // put(PacketType.HOME_CONFORT, RFXComHomeConfort.class);
+                    put(PacketType.SECURITY1, RFXComSecurity1Message.class);
+                    // put(PacketType.SECURITY2, RFXComSecurity2Message.class);
+                    // put(PacketType.CAMERA1, RFXComCamera1Message.class);
+                    // put(PacketType.REMOTE_CONTROL, RFXComRemoteControlMessage.class);
+                    put(PacketType.THERMOSTAT1, RFXComThermostat1Message.class);
+                    // put(PacketType.THERMOSTAT2, RFXComThermostat2Message.class);
+                    // put(PacketType.THERMOSTAT3, RFXComThermostat3Message.class);
+                    // put(PacketType.RADIATOR1, RFXComRadiator1Message.class);
+                    // put(PacketType.BBQ1, RFXComBBQMessage.class);
+                    // put(PacketType.TEMPERATURE_RAIN, RFXComTemperatureRainMessage.class);
+                    put(PacketType.TEMPERATURE, RFXComTemperatureMessage.class);
+                    put(PacketType.HUMIDITY, RFXComHumidityMessage.class);
+                    put(PacketType.TEMPERATURE_HUMIDITY, RFXComTemperatureHumidityMessage.class);
+                    // put(PacketType.BAROMETRIC, RFXComBarometricMessage.class);
+                    // put(PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC,
+                    // RFXComTemperatureHumidityBarometricMessage.class);
+                    put(PacketType.RAIN, RFXComRainMessage.class);
+                    put(PacketType.WIND, RFXComWindMessage.class);
+                    // put(PacketType.UV, RFXComUVMessage.class);
+                    put(PacketType.DATE_TIME, RFXComDateTimeMessage.class);
+                    // put(PacketType.CURRENT, RFXComCurrentMessage.class);
+                    put(PacketType.ENERGY, RFXComEnergyMessage.class);
+                    put(PacketType.CURRENT_ENERGY, RFXComCurrentEnergyMessage.class);
+                    // put(PacketType.POWER, RFXComPowerMessage.class);
+                    // put(PacketType.WEIGHT, RFXComWeightMessage.class);
+                    // put(PacketType.GAS, RFXComGasMessage.class);
+                    // put(PacketType.WATER, RFXComWaterMessage.class);
+                    // put(PacketType.RFXSENSOR, RFXComRFXSensorMessage.class);
+                    // put(PacketType.RFXMETER, RFXComRFXMeterMessage.class);
+                    // put(PacketType.FS20, RFXComFS20Message.class);
+                    // put(PacketType.IO_LINES, RFXComIOLinesMessage.class);
                 }
             });
 
@@ -99,35 +104,36 @@ public class RFXComMessageFactory {
     public final static byte[] CMD_START_RECEIVER = new byte[] { 0x0D, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    public static RFXComMessage createMessage(PacketType packetType) throws RFXComException, RFXComNotImpException {
+    public static RFXComMessage createMessage(PacketType packetType) throws RFXComException {
 
         try {
-            String className = messageClasses.get(packetType);
-            Class<?> cl = Class.forName(classUrl + className);
-            return (RFXComMessage) cl.newInstance();
-
-        } catch (ClassNotFoundException e) {
-            throw new RFXComNotImpException("Message " + packetType + " not implemented", e);
-
-        } catch (Exception e) {
+            Class<? extends RFXComMessage> cl = messageClasses.get(packetType);
+            if (cl == null) {
+                throw new RFXComMessageNotImplementedException("Message " + packetType + " not implemented");
+            }
+            return cl.newInstance();
+        } catch (IllegalAccessException | InstantiationException e) {
             throw new RFXComException(e);
         }
     }
 
-    public static RFXComMessage createMessage(byte[] packet) throws RFXComException, RFXComNotImpException {
-
-        PacketType packetType = getPacketType(packet[1]);
+    public static RFXComMessage createMessage(byte[] packet) throws RFXComException {
+        PacketType packetType = PacketType.fromByte(packet[1]);
 
         try {
-            String className = messageClasses.get(packetType);
-            Class<?> cl = Class.forName(classUrl + className);
+            Class<? extends RFXComMessage> cl = messageClasses.get(packetType);
+            if (cl == null) {
+                throw new RFXComMessageNotImplementedException("Message " + packetType + " not implemented");
+            }
             Constructor<?> c = cl.getConstructor(byte[].class);
             return (RFXComMessage) c.newInstance(packet);
-
-        } catch (ClassNotFoundException e) {
-            throw new RFXComNotImpException("Message " + packetType + " not implemented, exception: ", e);
-
-        } catch (Exception e) {
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RFXComException) {
+                throw (RFXComException) e.getCause();
+            } else {
+                throw new RFXComException(e);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InstantiationException e) {
             throw new RFXComException(e);
         }
     }
@@ -141,15 +147,5 @@ public class RFXComMessageFactory {
         }
 
         throw new IllegalArgumentException("Unknown packet type " + packetType);
-    }
-
-    private static PacketType getPacketType(byte packetType) {
-        for (PacketType p : PacketType.values()) {
-            if (p.toByte() == packetType) {
-                return p;
-            }
-        }
-
-        return PacketType.UNKNOWN;
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
@@ -8,16 +8,16 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for temperature and humidity message.
@@ -34,8 +34,7 @@ public class RFXComRainMessage extends RFXComBaseMessage {
         RAIN4(4),
         RAIN5(5),
         RAIN6(6),
-
-        UNKNOWN(255);
+        RAIN7(7);
 
         private final int subType;
 
@@ -43,22 +42,18 @@ public class RFXComRainMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -68,18 +63,18 @@ public class RFXComRainMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public double rainRate = 0;
-    public double rainTotal = 0;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public double rainRate;
+    public double rainTotal;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComRainMessage() {
         packetType = PacketType.RAIN;
     }
 
-    public RFXComRainMessage(byte[] data) {
+    public RFXComRainMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -99,7 +94,7 @@ public class RFXComRainMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
         super.encodeMessage(data);
 
         subType = SubType.fromByte(super.subType);
@@ -153,7 +148,7 @@ public class RFXComRainMessage extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -210,11 +205,10 @@ public class RFXComRainMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessage.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -19,9 +22,7 @@ import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for RFY (Somfy RTS) message.
@@ -40,9 +41,7 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
         UP_2SEC(0x11),
         DOWN_2SEC(0x12),
         ENABLE_SUN_WIND_DETECTOR(0x13),
-        DISABLE_SUN_DETECTOR(0x14),
-
-        UNKNOWN(0xFF);
+        DISABLE_SUN_DETECTOR(0x14);
 
         private final int command;
 
@@ -50,22 +49,18 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
             this.command = command;
         }
 
-        Commands(byte command) {
-            this.command = command;
-        }
-
         public byte toByte() {
             return (byte) command;
         }
 
-        public static Commands fromByte(int input) {
+        public static Commands fromByte(int input) throws RFXComUnsupportedValueException {
             for (Commands c : Commands.values()) {
                 if (c.command == input) {
                     return c;
                 }
             }
 
-            return UNKNOWN;
+            throw new RFXComUnsupportedValueException(Commands.class, input);
         }
     }
 
@@ -73,9 +68,7 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
         RFY(0),
         RFY_EXT(1),
         RESERVED(2),
-        ASA(3),
-
-        UNKNOWN(255);
+        ASA(3);
 
         private final int subType;
 
@@ -83,22 +76,18 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -108,21 +97,21 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.SHUTTER);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int unitId = 0;
+    public SubType subType;
+    public int unitId;
     /**
      * valid numbers 0-4; 0 == all units
      */
-    public byte unitCode = 0;
-    public Commands command = Commands.UNKNOWN;
-    public byte signalLevel = 0xF; // maximum
+    public byte unitCode;
+    public Commands command;
+    public byte signalLevel; // maximum 0xF
 
     public RFXComRfyMessage() {
         packetType = PacketType.RFY;
 
     }
 
-    public RFXComRfyMessage(byte[] data) {
+    public RFXComRfyMessage(byte[] data) throws RFXComException {
 
         encodeMessage(data);
     }
@@ -143,7 +132,7 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
         super.encodeMessage(data);
 
         subType = SubType.values()[super.subType];
@@ -264,11 +253,10 @@ public class RFXComRfyMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1Message.java
@@ -8,16 +8,25 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.eclipse.smarthome.core.library.items.*;
-import org.eclipse.smarthome.core.library.types.*;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.items.ContactItem;
+import org.eclipse.smarthome.core.library.items.DateTimeItem;
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.items.StringItem;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for Security1 message.
@@ -38,9 +47,8 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
         VISONIC_CODESECURE(6),
         VISONIC_POWERCODE_SENSOR_AUX_CONTACT(7),
         MEIANTECH(8),
-        SA30(9),
-
-        UNKNOWN(255);
+        SA30(9), // Also SA33
+        RM174RF(10);
 
         private final int subType;
 
@@ -48,22 +56,18 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -95,9 +99,7 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
         ALARM_TAMPER(130),
         ALARM_DELAYED_TAMPER(131),
         MOTION_TAMPER(132),
-        NO_MOTION_TAMPER(133),
-
-        UNKNOWN(255);
+        NO_MOTION_TAMPER(133);
 
         private final int status;
 
@@ -105,22 +107,18 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
             this.status = status;
         }
 
-        Status(byte status) {
-            this.status = status;
-        }
-
         public byte toByte() {
             return (byte) status;
         }
 
-        public static Status fromByte(int input) {
+        public static Status fromByte(int input) throws RFXComUnsupportedValueException {
             for (Status status : Status.values()) {
                 if (status.status == input) {
                     return status;
                 }
             }
 
-            return Status.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Status.class, input);
         }
     }
 
@@ -140,10 +138,6 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
         private final int contact;
 
         Contact(int contact) {
-            this.contact = contact;
-        }
-
-        Contact(byte contact) {
             this.contact = contact;
         }
 
@@ -177,10 +171,6 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
             this.motion = motion;
         }
 
-        Motion(byte motion) {
-            this.motion = motion;
-        }
-
         public byte toByte() {
             return (byte) motion;
         }
@@ -203,19 +193,19 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays
             .asList(RFXComValueSelector.STATUS, RFXComValueSelector.CONTACT);
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public Status status = Status.UNKNOWN;
-    public byte batteryLevel = 0;
-    public byte signalLevel = 0;
-    public Contact contact = Contact.UNKNOWN;
-    public Motion motion = Motion.UNKNOWN;
+    public SubType subType;
+    public int sensorId;
+    public Status status;
+    public byte batteryLevel;
+    public byte signalLevel;
+    public Contact contact;
+    public Motion motion;
 
     public RFXComSecurity1Message() {
         packetType = PacketType.SECURITY1;
     }
 
-    public RFXComSecurity1Message(byte[] data) {
+    public RFXComSecurity1Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -234,7 +224,7 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -404,11 +394,10 @@ public class RFXComSecurity1Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessage.java
@@ -8,18 +8,19 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.StringItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for temperature and humidity message.
@@ -42,8 +43,7 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
         TH11(11),
         TH12(12),
         TH13(13),
-
-        UNKNOWN(255);
+        TH14(14);
 
         private final int subType;
 
@@ -51,22 +51,18 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -74,9 +70,7 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
         NORMAL(0),
         COMFORT(1),
         DRY(2),
-        WET(3),
-
-        UNKNOWN(255);
+        WET(3);
 
         private final int humidityStatus;
 
@@ -84,22 +78,18 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
             this.humidityStatus = humidityStatus;
         }
 
-        HumidityStatus(byte humidityStatus) {
-            this.humidityStatus = humidityStatus;
-        }
-
         public byte toByte() {
             return (byte) humidityStatus;
         }
 
-        public static HumidityStatus fromByte(int input) {
+        public static HumidityStatus fromByte(int input) throws RFXComUnsupportedValueException {
             for (HumidityStatus status : HumidityStatus.values()) {
                 if (status.humidityStatus == input) {
                     return status;
                 }
             }
 
-            return HumidityStatus.UNKNOWN;
+            throw new RFXComUnsupportedValueException(HumidityStatus.class, input);
         }
     }
 
@@ -107,21 +97,21 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
             RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.TEMPERATURE,
             RFXComValueSelector.HUMIDITY, RFXComValueSelector.HUMIDITY_STATUS);
 
-    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Collections.emptyList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public double temperature = 0;
-    public byte humidity = 0;
-    public HumidityStatus humidityStatus = HumidityStatus.UNKNOWN;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public double temperature;
+    public byte humidity;
+    public HumidityStatus humidityStatus;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComTemperatureHumidityMessage() {
         packetType = PacketType.TEMPERATURE_HUMIDITY;
     }
 
-    public RFXComTemperatureHumidityMessage(byte[] data) {
+    public RFXComTemperatureHumidityMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -142,7 +132,7 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -194,7 +184,7 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -261,11 +251,10 @@ public class RFXComTemperatureHumidityMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessage.java
@@ -8,16 +8,17 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for temperature and humidity message.
@@ -37,8 +38,7 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
         TEMP8(8),
         TEMP9(9),
         TEMP10(10),
-
-        UNKNOWN(255);
+        TEMP11(11);
 
         private final int subType;
 
@@ -46,41 +46,37 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
     private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays.asList(
             RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.TEMPERATURE);
 
-    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Collections.emptyList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public double temperature = 0;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public double temperature;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComTemperatureMessage() {
         packetType = PacketType.TEMPERATURE;
     }
 
-    public RFXComTemperatureMessage(byte[] data) {
+    public RFXComTemperatureMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -99,7 +95,7 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -146,7 +142,7 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
     @Override
     public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
 
-        State state = UnDefType.UNDEF;
+        State state;
 
         if (valueSelector.getItemClass() == NumberItem.class) {
 
@@ -200,11 +196,10 @@ public class RFXComTemperatureMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1Message.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.ContactItem;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -17,9 +20,7 @@ import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for thermostat1 message.
@@ -32,9 +33,7 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
 
     public enum SubType {
         DIGIMAX(0),
-        DIGIMAX_SHORT(1),
-
-        UNKNOWN(255);
+        DIGIMAX_SHORT(1);
 
         private final int subType;
 
@@ -42,22 +41,18 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -66,9 +61,7 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
         NO_STATUS(0),
         DEMAND(1),
         NO_DEMAND(2),
-        INITIALIZING(3),
-
-        UNKNOWN(255);
+        INITIALIZING(3);
 
         private final int status;
 
@@ -76,31 +69,25 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
             this.status = status;
         }
 
-        Status(byte status) {
-            this.status = status;
-        }
-
         public byte toByte() {
             return (byte) status;
         }
 
-        public static Status fromByte(int input) {
+        public static Status fromByte(int input) throws RFXComUnsupportedValueException {
             for (Status contact : Status.values()) {
                 if (contact.status == input) {
                     return contact;
                 }
             }
 
-            return Status.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Status.class, input);
         }
     }
 
     /* Operating mode */
     public enum Mode {
         HEATING(0),
-        COOLING(1),
-
-        UNKNOWN(255);
+        COOLING(1);
 
         private final int mode;
 
@@ -108,22 +95,18 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
             this.mode = mode;
         }
 
-        Mode(byte mode) {
-            this.mode = mode;
-        }
-
         public byte toByte() {
             return (byte) mode;
         }
 
-        public static Mode fromByte(int input) {
+        public static Mode fromByte(int input) throws RFXComUnsupportedValueException {
             for (Mode mode : Mode.values()) {
                 if (mode.mode == input) {
                     return mode;
                 }
             }
 
-            return Mode.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Mode.class, input);
         }
     }
 
@@ -133,19 +116,19 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public byte temperature = 0;
-    public byte set = 0;
-    public Mode mode = Mode.UNKNOWN;
-    public Status status = Status.UNKNOWN;
-    public byte signalLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public byte temperature;
+    public byte set;
+    public Mode mode;
+    public Status status;
+    public byte signalLevel;
 
     public RFXComThermostat1Message() {
         packetType = PacketType.THERMOSTAT1;
     }
 
-    public RFXComThermostat1Message(byte[] data) {
+    public RFXComThermostat1Message(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -166,7 +149,7 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -273,11 +256,10 @@ public class RFXComThermostat1Message extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessage.java
@@ -8,12 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.List;
+
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for transmitter message.
@@ -24,9 +25,7 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
 
     public enum SubType {
         ERROR_RECEIVER_DID_NOT_LOCK(0),
-        RESPONSE(1),
-
-        UNKNOWN(255);
+        RESPONSE(1);
 
         private final int subType;
 
@@ -34,22 +33,18 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -59,10 +54,8 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
                         // anyway with RF receive data
         NAK(2), // NAK, transmitter did not lock on the requested transmit
                 // frequency
-        NAK_INVALID_AC_ADDRESS(3), // NAK, AC address zero in id1-id4 not
+        NAK_INVALID_AC_ADDRESS(3); // NAK, AC address zero in id1-id4 not
                                    // allowed
-
-        UNKNOWN(255);
 
         private final int response;
 
@@ -70,33 +63,29 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
             this.response = response;
         }
 
-        Response(byte response) {
-            this.response = response;
-        }
-
         public byte toByte() {
             return (byte) response;
         }
 
-        public static Response fromByte(int input) {
+        public static Response fromByte(int input) throws RFXComUnsupportedValueException {
             for (Response response : Response.values()) {
                 if (response.response == input) {
                     return response;
                 }
             }
 
-            return Response.UNKNOWN;
+            throw new RFXComUnsupportedValueException(Response.class, input);
         }
     }
 
-    public SubType subType = SubType.UNKNOWN;
-    public Response response = Response.UNKNOWN;
+    public SubType subType;
+    public Response response;
 
     public RFXComTransmitterMessage() {
         packetType = PacketType.TRANSMITTER_MESSAGE;
     }
 
-    public RFXComTransmitterMessage(byte[] data) {
+    public RFXComTransmitterMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -118,7 +107,7 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -171,11 +160,10 @@ public class RFXComTransmitterMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
@@ -97,7 +97,7 @@ public class RFXComUndecodedRFMessage extends RFXComBaseMessage {
         packetType = UNDECODED_RF_MESSAGE;
     }
 
-    public RFXComUndecodedRFMessage(byte[] message) {
+    public RFXComUndecodedRFMessage(byte[] message) throws RFXComException {
         encodeMessage(message);
     }
 
@@ -115,7 +115,7 @@ public class RFXComUndecodedRFMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] message) {
+    public void encodeMessage(byte[] message) throws RFXComException {
 
         super.encodeMessage(message);
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessage.java
@@ -8,15 +8,16 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.openhab.binding.rfxcom.RFXComValueSelector;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-
-import java.util.Arrays;
-import java.util.List;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 /**
  * RFXCOM data class for temperature and humidity message.
@@ -33,9 +34,7 @@ public class RFXComWindMessage extends RFXComBaseMessage {
         WIND4(4),
         WIND5(5),
         WIND6(6),
-        WIND7(7),
-
-        UNKNOWN(255);
+        WIND7(7);
 
         private final int subType;
 
@@ -43,22 +42,18 @@ public class RFXComWindMessage extends RFXComBaseMessage {
             this.subType = subType;
         }
 
-        SubType(byte subType) {
-            this.subType = subType;
-        }
-
         public byte toByte() {
             return (byte) subType;
         }
 
-        public static SubType fromByte(int input) {
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
             for (SubType c : SubType.values()) {
                 if (c.subType == input) {
                     return c;
                 }
             }
 
-            return SubType.UNKNOWN;
+            throw new RFXComUnsupportedValueException(SubType.class, input);
         }
     }
 
@@ -68,18 +63,18 @@ public class RFXComWindMessage extends RFXComBaseMessage {
 
     private final static List<RFXComValueSelector> supportedOutputValueSelectors = Arrays.asList();
 
-    public SubType subType = SubType.UNKNOWN;
-    public int sensorId = 0;
-    public double windDirection = 0;
-    public double windSpeed = 0;
-    public byte signalLevel = 0;
-    public byte batteryLevel = 0;
+    public SubType subType;
+    public int sensorId;
+    public double windDirection;
+    public double windSpeed;
+    public byte signalLevel;
+    public byte batteryLevel;
 
     public RFXComWindMessage() {
         packetType = PacketType.WIND;
     }
 
-    public RFXComWindMessage(byte[] data) {
+    public RFXComWindMessage(byte[] data) throws RFXComException {
         encodeMessage(data);
     }
 
@@ -99,7 +94,7 @@ public class RFXComWindMessage extends RFXComBaseMessage {
     }
 
     @Override
-    public void encodeMessage(byte[] data) {
+    public void encodeMessage(byte[] data) throws RFXComException {
 
         super.encodeMessage(data);
 
@@ -201,11 +196,10 @@ public class RFXComWindMessage extends RFXComBaseMessage {
             }
         }
 
-        // try to find sub type by number
         try {
-            return SubType.values()[Integer.parseInt(subType)];
-        } catch (Exception e) {
-            throw new RFXComException("Unknown sub type " + subType);
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
         }
     }
 


### PR DESCRIPTION
Remove unknown values from enums as they can cover errors elsewhere
Removed default / unused assignments and constructors.
Added missing packegeTypes and subTypes
Adapted the exception handling to log errors as they occur
Made the mapping from enum's to implementations less errorprone

Also-By: James Hewitt-Thomas <james.hewitt@gmail.com> (github: jamstah)
Signed-off-by: Martin van Wingerden <martinvw@mtin.nl> (github: martinvw)