### PR TITLE
Minecraft: Allow commands to be sent to minecraft server.

### DIFF
--- a/addons/binding/org.openhab.binding.minecraft/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.minecraft/ESH-INF/thing/thing-types.xml
@@ -47,6 +47,7 @@
 			<channel id="playerHealth" typeId="playerHealth" />
 			<channel id="playerWalkSpeed" typeId="playerWalkSpeed" />
 			<channel id="playerLocation" typeId="location" />
+			<channel id="playerGameMode" typeId="playerGameMode" />
 
 		</channels>
 
@@ -109,24 +110,22 @@
 		<item-type>Location</item-type>
 		<label>Location</label>
 		<description>The location of the player.</description>
-		<state readOnly="true" />
 	</channel-type>
 
 	<channel-type id="playerLevel">
 		<item-type>Number</item-type>
 		<label>Level</label>
 		<description>The players current level.</description>
-		<state readOnly="true" />
 	</channel-type>
 
-	<channel-type id="playerTotalExperience">
+	<channel-type id="playerTotalExperience" advanced="true">
 		<item-type>Number</item-type>
 		<label>Total Experience</label>
 		<description>The total experience of the player.</description>
 		<state readOnly="true" />
 	</channel-type>
 
-	<channel-type id="playerExperiencePercentage">
+	<channel-type id="playerExperiencePercentage" advanced="true">
 		<item-type>Number</item-type>
 		<label>Experience</label>
 		<description>Percentage of the experience bar filled for the next level.</description>
@@ -137,22 +136,34 @@
 		<item-type>Number</item-type>
 		<label>Health</label>
 		<description>The health of player.</description>
-		<state readOnly="true" />
 	</channel-type>
 
-	<channel-type id="playerWalkSpeed">
+	<channel-type id="playerWalkSpeed" advanced="true">
 		<item-type>Number</item-type>
 		<label>Speed</label>
 		<description>The speed of player.</description>
-		<state readOnly="true" />
+		<state min="0" max="1" step="0.05" pattern="%.2f" />
 	</channel-type>
+	
+	<channel-type id="playerGameMode" advanced="true">
+        <item-type>String</item-type>
+        <label>Game Mode</label>
+        <description>The players current game mode.</description>
+        <state readOnly="false">
+            <options>
+                <option value="CREATIVE">creative</option>
+                <option value="SURVIVAL">survival</option>
+                <option value="ADVENTURE">adventure</option>
+                <option value="SPECTATOR">spectator</option>
+            </options>
+        </state>
+    </channel-type>
 
 	<channel-type id="signActive">
 		<item-type>Switch</item-type>
 		<label>Online</label>
 		<description>Shows if the sign has powered redstone below it.</description>
 		<category>Switch</category>
-		<state readOnly="true" />
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.minecraft/README.md
+++ b/addons/binding/org.openhab.binding.minecraft/README.md
@@ -12,7 +12,7 @@ The binding allows reading of server and player data. It furthermore keeps track
 
 ## Discovery
 
-The Minecraft binding automatically finds all Minecraft servers running [this plugin](https://github.com/ibaton/bukkit-openhab-plugin/releases/download/1.5/OHMinecraft.jar) on the local network. Servers can be added manually if they are not found automatically. 
+The Minecraft binding automatically finds all Minecraft servers running [this plugin](https://github.com/ibaton/bukkit-openhab-plugin/releases/download/1.9/OHMinecraft.jar) on the local network. Servers can be added manually if they are not found automatically. 
 
 ## Channels
 
@@ -41,10 +41,17 @@ Depending on the thing type, different channels are provided:
 | playerHealth | Number | The health of the player |
 | playerWalkSpeed | Number | The speed of the player |
 | playerLocation | Location | The player location |
+| playerGameMode | Number | The players game mode |
 
 ### Sign
 
 | Channel Type ID | Item Type    | Description  |
 |------------------|------------------------|--------------|
 | signActive | Switch | Does the sign have powered redstone below it |
+
+Active switch (Controllable from openHAB)
+<a href="https://drive.google.com/uc?export=view&id=0B3UO0c11-Q6hMkNZSjJidGk4b28"><img src="https://drive.google.com/uc?export=view&id=0B3UO0c11-Q6hMkNZSjJidGk4b28" style="width: 500px; max-width: 100%; height: auto" title="Click for the larger version." /></a>
+
+Passive sensor
+<a href="https://drive.google.com/uc?export=view&id=0B3UO0c11-Q6hUG1wd3h0MDUzUzQ"><img src="https://drive.google.com/uc?export=view&id=0B3UO0c11-Q6hUG1wd3h0MDUzUzQ" style="width: 500px; max-width: 100%; height: auto" title="Click for the larger version." /></a>
 

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/MinecraftBindingConstants.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/MinecraftBindingConstants.java
@@ -40,6 +40,7 @@ public class MinecraftBindingConstants {
     public final static String CHANNEL_PLAYER_HEALTH = "playerHealth";
     public final static String CHANNEL_PLAYER_WALK_SPEED = "playerWalkSpeed";
     public final static String CHANNEL_PLAYER_LOCATION = "playerLocation";
+    public final static String CHANNEL_PLAYER_GAME_MODE = "playerGameMode";
 
     public final static String CHANNEL_SIGN_ACTIVE = "signActive";
 

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/discovery/MinecraftMDNSDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/discovery/MinecraftMDNSDiscoveryParticipant.java
@@ -74,7 +74,8 @@ public class MinecraftMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
 
     @Override
     public ThingUID getThingUID(ServiceInfo service) {
-        if (isMinecraftServer(service)) {
+
+        if (isMinecraftServer(service) && service.getInetAddresses().length > 0) {
             String host = service.getInetAddresses()[0].getHostAddress();
             host = host.replace('.', '_');
 

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftPlayerHandler.java
@@ -8,11 +8,10 @@
  */
 package org.openhab.binding.minecraft.handler;
 
-import java.util.List;
-
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PointType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -24,13 +23,18 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.minecraft.MinecraftBindingConstants;
 import org.openhab.binding.minecraft.config.PlayerConfig;
+import org.openhab.binding.minecraft.message.OHMessage;
 import org.openhab.binding.minecraft.message.data.PlayerData;
+import org.openhab.binding.minecraft.message.data.commands.PlayerCommandData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+
 import rx.Observable;
 import rx.Subscription;
-import rx.functions.Action1;
 
 /**
  * The {@link MinecraftPlayerHandler} is responsible for handling commands, which are
@@ -45,6 +49,7 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
     private Subscription playerSubscription;
     private MinecraftServerHandler bridgeHandler;
     private PlayerConfig config;
+    private Gson gson = new GsonBuilder().create();
 
     public MinecraftPlayerHandler(Thing thing) {
         super(thing);
@@ -74,19 +79,17 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
     }
 
     private void hookupListeners(MinecraftServerHandler bridgeHandler) {
-        playerSubscription = bridgeHandler.getPlayerRx().doOnNext(players -> {        
-                    boolean playerOnline = false;
-                    for (PlayerData player : players) {
-                        if (config.getName().equals(player.getName())) {
-                            playerOnline = true;
-                            break;
-                        }
-                    }
-                    State onlineState = playerOnline ? OnOffType.ON : OnOffType.OFF;
-                    updateState(MinecraftBindingConstants.CHANNEL_PLAYER_ONLINE, onlineState);
-                })
-                .flatMap(players -> Observable.from(players))
-                .filter(player -> config.getName().equals(player.getName()))
+        playerSubscription = bridgeHandler.getPlayerRx().doOnNext(players -> {
+            boolean playerOnline = false;
+            for (PlayerData player : players) {
+                if (config.getName().equals(player.getName())) {
+                    playerOnline = true;
+                    break;
+                }
+            }
+            State onlineState = playerOnline ? OnOffType.ON : OnOffType.OFF;
+            updateState(MinecraftBindingConstants.CHANNEL_PLAYER_ONLINE, onlineState);
+        }).flatMap(players -> Observable.from(players)).filter(player -> config.getName().equals(player.getName()))
                 .subscribe(player -> updatePlayerState(player));
     }
 
@@ -105,6 +108,7 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
         DecimalType latitude = new DecimalType(player.getLocation().getY());
         DecimalType altitude = new DecimalType(player.getLocation().getY());
         State playerLocation = new PointType(latitude, longitude, altitude);
+        State playerGameMode = new StringType(player.getGameMode());
 
         updateState(MinecraftBindingConstants.CHANNEL_PLAYER_LEVEL_PERCENTAGE, playerLevelPercentage);
         updateState(MinecraftBindingConstants.CHANNEL_PLAYER_TOTAL_EXPERIENCE, playerTotalExperience);
@@ -112,6 +116,11 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
         updateState(MinecraftBindingConstants.CHANNEL_PLAYER_HEALTH, playerHealth);
         updateState(MinecraftBindingConstants.CHANNEL_PLAYER_WALK_SPEED, playerWalkSpeed);
         updateState(MinecraftBindingConstants.CHANNEL_PLAYER_LOCATION, playerLocation);
+        updateState(MinecraftBindingConstants.CHANNEL_PLAYER_GAME_MODE, playerGameMode);
+    }
+
+    private String getPlayerName() {
+        return config.getName();
     }
 
     private synchronized MinecraftServerHandler getBridgeHandler() {
@@ -146,7 +155,40 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
         updateState(channelUID, state);
     }
 
+    /**
+     * Send a player command to server.
+     *
+     * @param type the type of command to send
+     * @param playerName the name of the player to target
+     * @param value the related to command
+     */
+    private void sendPlayerCommand(String type, String playerName, String value) {
+        PlayerCommandData playerCommand = new PlayerCommandData(type, playerName, value);
+        JsonElement serializedCommand = gson.toJsonTree(playerCommand);
+        logger.debug("Command: " + serializedCommand);
+        bridgeHandler.sendMessage(new OHMessage(OHMessage.MESSAGE_TYPE_PLAYER_COMMANDS, serializedCommand));
+    }
+
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        switch (channelUID.getId()) {
+            case MinecraftBindingConstants.CHANNEL_PLAYER_HEALTH:
+                sendPlayerCommand(PlayerCommandData.COMMAND_PLAYER_HEALTH, getPlayerName(), command.toString());
+                break;
+            case MinecraftBindingConstants.CHANNEL_PLAYER_LEVEL:
+                sendPlayerCommand(PlayerCommandData.COMMAND_PLAYER_LEVEL, getPlayerName(), command.toString());
+                break;
+            case MinecraftBindingConstants.CHANNEL_PLAYER_WALK_SPEED:
+                sendPlayerCommand(PlayerCommandData.COMMAND_PLAYER_WALK_SPEED, getPlayerName(), command.toString());
+                break;
+            case MinecraftBindingConstants.CHANNEL_PLAYER_GAME_MODE:
+                sendPlayerCommand(PlayerCommandData.COMMAND_PLAYER_GAME_MODE, getPlayerName(), command.toString());
+                break;
+            case MinecraftBindingConstants.CHANNEL_PLAYER_LOCATION:
+                sendPlayerCommand(PlayerCommandData.COMMAND_PLAYER_LOCATION, getPlayerName(), command.toString());
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftServerHandler.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftServerHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.minecraft.MinecraftBindingConstants;
 import org.openhab.binding.minecraft.config.ServerConfig;
 import org.openhab.binding.minecraft.handler.server.ServerConnection;
+import org.openhab.binding.minecraft.message.OHMessage;
 import org.openhab.binding.minecraft.message.data.PlayerData;
 import org.openhab.binding.minecraft.message.data.ServerData;
 import org.openhab.binding.minecraft.message.data.SignData;
@@ -45,7 +46,8 @@ public class MinecraftServerHandler extends BaseBridgeHandler {
     private ServerConfig config;
 
     private Observable<ServerConnection> serverConnectionRX;
-    private Subscription subscription;
+    private ServerConnection connection;
+    private CompositeSubscription subscription;
 
     public MinecraftServerHandler(Bridge bridge) {
         super(bridge);
@@ -53,10 +55,11 @@ public class MinecraftServerHandler extends BaseBridgeHandler {
 
     @Override
     public void initialize() {
-        super.initialize();
+        subscription = new CompositeSubscription();
         config = getConfigAs(ServerConfig.class);
         logger.info("Initializing MinecraftHandler");
         connectToServer();
+        super.initialize();
     }
 
     /**
@@ -76,22 +79,28 @@ public class MinecraftServerHandler extends BaseBridgeHandler {
         String host = config.getHostname();
         int port = config.getPort();
 
-        subscription = new CompositeSubscription();
-
         serverConnectionRX = ServerConnection.create(getThing().getUID(), host, port)
                 .doOnNext(item -> updateOnlineState(true)).doOnError(e -> updateOnlineState(false))
                 .retryWhen(new RetryWithDelay(1, TimeUnit.MINUTES)).repeat().replay(1).refCount();
 
-        subscription = serverConnectionRX.flatMap(connection -> connection.getSocketHandler().getServerRx())
+        Subscription serverUpdateSubscription = serverConnectionRX
+                .flatMap(connection -> connection.getSocketHandler().getServerRx())
                 .subscribe(serverData -> updateServerState(serverData));
+
+        Subscription serverConnectionSubscription = serverConnectionRX.subscribe(connection -> {
+            this.connection = connection;
+        });
+
+        subscription.add(serverUpdateSubscription);
+        subscription.add(serverConnectionSubscription);
     }
 
     public Observable<List<SignData>> getSignsRx() {
-        return serverConnectionRX.flatMap(connection -> connection.getSocketHandler().getSignsRx());
+        return serverConnectionRX.switchMap(connection -> connection.getSocketHandler().getSignsRx());
     }
 
     public Observable<List<PlayerData>> getPlayerRx() {
-        return serverConnectionRX.flatMap(connection -> connection.getSocketHandler().getPlayersRx());
+        return serverConnectionRX.switchMap(connection -> connection.getSocketHandler().getPlayersRx());
     }
 
     /**
@@ -117,10 +126,28 @@ public class MinecraftServerHandler extends BaseBridgeHandler {
         updateState(MinecraftBindingConstants.CHANNEL_MAX_PLAYERS, maxPlayersState);
     }
 
+    /**
+     * Send message to server.
+     * Does nothing if no connection is established.
+     *
+     * @param message the message to send
+     * @return true if message was sent.
+     */
+    public boolean sendMessage(OHMessage message) {
+        if (connection != null) {
+            connection.sendMessage(message);
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public void dispose() {
-        logger.info("Disposing minecraft server thing");
-        subscription.unsubscribe();
+        logger.debug("Disposing minecraft server thing");
+
+        if (subscription != null) {
+            subscription.unsubscribe();
+        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftSignHandler.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/MinecraftSignHandler.java
@@ -20,9 +20,15 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.minecraft.MinecraftBindingConstants;
 import org.openhab.binding.minecraft.config.SignConfig;
+import org.openhab.binding.minecraft.message.OHMessage;
 import org.openhab.binding.minecraft.message.data.SignData;
+import org.openhab.binding.minecraft.message.data.commands.SignCommandData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 
 import rx.Observable;
 import rx.Subscription;
@@ -40,6 +46,8 @@ public class MinecraftSignHandler extends BaseThingHandler {
     private MinecraftServerHandler bridgeHandler;
     private Subscription signSubscription;
     private SignConfig config;
+
+    private Gson gson = new GsonBuilder().create();
 
     public MinecraftSignHandler(Thing thing) {
         super(thing);
@@ -66,6 +74,10 @@ public class MinecraftSignHandler extends BaseThingHandler {
         if (!signSubscription.isUnsubscribed()) {
             signSubscription.unsubscribe();
         }
+    }
+
+    private String getSignName() {
+        return config.getName();
     }
 
     private void hookupListeners(MinecraftServerHandler bridgeHandler) {
@@ -114,7 +126,25 @@ public class MinecraftSignHandler extends BaseThingHandler {
         updateState(channelUID, state);
     }
 
+    /**
+     * Send a sign command to server.
+     *
+     * @param type the type of command to send
+     * @param signName the sign that the command targets
+     * @param value the value related to command
+     */
+    private void sendSignCommand(String type, String signName, String value) {
+        SignCommandData signCommand = new SignCommandData(type, signName, value);
+        JsonElement serializedCommand = gson.toJsonTree(signCommand);
+        bridgeHandler.sendMessage(new OHMessage(OHMessage.MESSAGE_TYPE_SIGN_COMMANDS, serializedCommand));
+    }
+
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        switch (channelUID.getId()) {
+            case MinecraftBindingConstants.CHANNEL_SIGN_ACTIVE:
+                Boolean activeState = command == OnOffType.ON ? true : false;
+                sendSignCommand(SignCommandData.COMMAND_SIGN_ACTIVE, getSignName(), activeState.toString());
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/ServerConnection.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/ServerConnection.java
@@ -13,11 +13,14 @@ import java.net.URISyntaxException;
 
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.minecraft.discovery.MinecraftDiscoveryService;
+import org.openhab.binding.minecraft.message.OHMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.firebase.tubesock.WebSocket;
 import com.firebase.tubesock.WebSocketException;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
@@ -37,8 +40,11 @@ public class ServerConnection {
     private String host;
     private int port;
     private ThingUID thingUID;
+    private Gson gson = new GsonBuilder().create();
 
     private MinecraftSocketHandler socketHandler;
+
+    private WebSocket webSocket;
 
     private ServerConnection(ThingUID thingUID, String host, int port) {
         this.host = host;
@@ -85,6 +91,11 @@ public class ServerConnection {
         return thingUID;
     }
 
+    public void sendMessage(OHMessage message) {
+        String serializedMessage = gson.toJson(message);
+        webSocket.send(serializedMessage);
+    }
+
     /**
      * Add the handler used to handle messages state updates web socket.
      *
@@ -92,6 +103,10 @@ public class ServerConnection {
      */
     private void setSocketHandler(MinecraftSocketHandler handler) {
         socketHandler = handler;
+    }
+
+    private void setWebSocket(WebSocket webSocket) {
+        this.webSocket = webSocket;
     }
 
     /**
@@ -111,7 +126,7 @@ public class ServerConnection {
 
         final String serverUrl = String.format("ws://%s:%d/stream", host, port);
 
-        return Observable.<ServerConnection>create(new OnSubscribe<ServerConnection>() {
+        return Observable.<ServerConnection> create(new OnSubscribe<ServerConnection>() {
 
             @Override
             public void call(final Subscriber<? super ServerConnection> subscriber) {
@@ -132,8 +147,6 @@ public class ServerConnection {
                             subscriber.onCompleted();
                         };
                     };
-                    serverConnection.setSocketHandler(socketHandler);
-                    subscriber.onNext(serverConnection);
 
                     URI destUri = null;
                     try {
@@ -144,6 +157,10 @@ public class ServerConnection {
                     final WebSocket websocket = new WebSocket(destUri);
                     websocket.setEventHandler(socketHandler);
                     websocket.connect();
+
+                    serverConnection.setSocketHandler(socketHandler);
+                    serverConnection.setWebSocket(websocket);
+                    subscriber.onNext(serverConnection);
 
                     subscriber.add(Subscriptions.create(new Action0() {
                         @Override

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/OHMessage.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/OHMessage.java
@@ -20,8 +20,9 @@ public class OHMessage {
 
     public static final int MESSAGE_TYPE_PLAYERS = 1;
     public static final int MESSAGE_TYPE_SERVERS = 2;
-    public static final int MESSAGE_TYPE_COMMANDS = 3;
     public static final int MESSAGE_TYPE_SIGNS = 4;
+    public static final int MESSAGE_TYPE_PLAYER_COMMANDS = 3;
+    public static final int MESSAGE_TYPE_SIGN_COMMANDS = 5;
 
     private int messageType;
     private JsonElement message;
@@ -56,7 +57,7 @@ public class OHMessage {
     }
 
     /**
-     * Get messsage dagta.
+     * Get messsage data.
      *
      * @return
      */

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/PlayerData.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/PlayerData.java
@@ -23,6 +23,7 @@ public class PlayerData {
     protected double health;
     protected float walkSpeed;
     protected LocationData location;
+    protected String gameMode;
 
     /**
      * Get the display name of player.
@@ -79,9 +80,9 @@ public class PlayerData {
     }
 
     /**
-     * Get the walkspeed of player
+     * Get the walk speed of player.
      *
-     * @return walkspeed of player.
+     * @return walk speed of player
      */
     public float getWalkSpeed() {
         return walkSpeed;
@@ -94,6 +95,15 @@ public class PlayerData {
      */
     public LocationData getLocation() {
         return location;
+    }
+
+    /**
+     * Get the players game mode.
+     *
+     * @return game mode
+     */
+    public String getGameMode() {
+        return gameMode;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/commands/PlayerCommandData.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/commands/PlayerCommandData.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.minecraft.message.data.commands;
+
+/**
+ * Object representing Minecraft server.
+ *
+ * @author Mattias Markehed
+ */
+public class PlayerCommandData {
+
+    public static String COMMAND_PLAYER_HEALTH = "PLAYER_HEALTH";
+    public static String COMMAND_PLAYER_LEVEL = "PLAYER_LEVEL";
+    public static String COMMAND_PLAYER_WALK_SPEED = "PLAYER_WALK_SPEED";
+    public static String COMMAND_PLAYER_GAME_MODE = "PLAYER_GAME_MODE";
+    public static String COMMAND_PLAYER_LOCATION = "PLAYER_LOCATION";
+
+    String type;
+    String playerName;
+    String value;
+
+    public PlayerCommandData() {
+    }
+
+    public PlayerCommandData(String type, String playerName, String value) {
+        this.type = type;
+        this.playerName = playerName;
+        this.value = value;
+    }
+
+    /**
+     * Get the type of command.
+     *
+     * @return the type of command.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * The name of the player that the command targets.
+     *
+     * @return name of player
+     */
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    /**
+     * The command value sent.
+     *
+     * @return command value.
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/commands/SignCommandData.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/message/data/commands/SignCommandData.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.minecraft.message.data.commands;
+
+/**
+ * A command that targets a sign.
+ *
+ * @author Mattias Markehed
+ */
+public class SignCommandData {
+
+    public static String COMMAND_SIGN_ACTIVE = "COMMAND_SIGN_ACTIVE";
+
+    String type;
+    String signName;
+    String value;
+
+    public SignCommandData() {
+    }
+
+    public SignCommandData(String type, String signName, String value) {
+        this.type = type;
+        this.signName = signName;
+        this.value = value;
+    }
+
+    /**
+     * Get the type of command.
+     *
+     * @return the type of command.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * The name of the sign that the command targets.
+     *
+     * @return name of sign
+     */
+    public String getSignName() {
+        return signName;
+    }
+
+    /**
+     * The command value sent.
+     *
+     * @return command value.
+     */
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
Minecraft: Allow commands to be sent to minecraft server.
Fixed problem with uninitialized player on startup.

Signed-off-by: Mattias Markehed <mattias.markehed@gmail.com>