### PR TITLE
Homematic: small updates

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/README.md
+++ b/addons/binding/org.openhab.binding.homematic/README.md
@@ -48,7 +48,7 @@ All devices connected to a Homematic gateway. All required openHAB metadata are 
 Gateway discovery is only available for Homegear, you need at least 0.6.x for gateway discovery. For all other gateways you have to manually add a bridge in a things file.  
 Device discovery is supported for all gateways.
 
-The binding has a gateway type autodetection, but sometimes a gateway does not clearly notify the type. If you are using a LXCCU for example, you have to manually set the gateway type in the bride configuration to CCU.  
+The binding has a gateway type autodetection, but sometimes a gateway does not clearly notify the type. If you are using a YAHM for example, you have to manually set the gateway type in the bride configuration to CCU.  
 
 If autodetection can not identify the gateway, the binding uses the default gateway implementation. The difference is, that variables, scripts and device names are not supported, everything else is the same.
 
@@ -281,6 +281,14 @@ If a button is still not working and you do not see any PRESS_LONG / SHORT in yo
 A device may return this failure while fetching the datapoint values. I've tested pretty much but i did not found the reason. The HM-ES-TX-WM device for example always returns this failure, it's impossible with the current CCU2 firmware (2.17.15) to fetch the values. I've implemented two workarounds, if a device returns the failure, workaround one is executed, if the device still returns the failure, workaround two is executed. This always works in my tests, but you may see a OFFLINE, ONLINE cycle for the device.  
 Fetching values is only done at startup or if you trigger a REFRESH. I hope this will be fixed in one of the next CCU firmwares.  
 With [Homegear](https://www.homegear.eu) everything works as expected.
+
+**No variables and scripts in GATEWAY-EXTRAS**  
+
+The gateway autodetection of the binding can not clearly identify the gateway and falls back to the default implementation. Use the ```gatewayType=ccu``` config to force the binding to use the CCU implementation.
+
+**Variables out of sync**  
+
+The CCU only sends a event if a datapoint of a device has changed. There is (currently) no way to receive a event automatically when a variable has changed. To reload all variables, send a REFRESH command to any variable.
 
 ### Debugging and Tracing
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
@@ -214,7 +214,7 @@ public class HomematicThingHandler extends BaseThingHandler {
             if (dp.getParamsetType() == HmParamsetType.MASTER) {
                 // update configuration
                 Configuration config = editConfiguration();
-                config.put(MetadataUtils.getParameterName(dp), dp.getValue());
+                config.put(MetadataUtils.getParameterName(dp), dp.isEnumType() ? dp.getOptionValue() : dp.getValue());
                 updateConfiguration(config);
             } else if (!HomematicTypeGeneratorImpl.isIgnoredDatapoint(dp)) {
                 // update channel


### PR DESCRIPTION
@kaikreuzer 
I just saw, that the Thing configuration parameters no longer work. There is always a error message in PaperUI:
value: 0,4 (Double)
Input should satisfy expression %.2f

value: 6 (Integer)
Input should satisfy expression %d

Is this a binding or a PaperUI issue?

What is the correct way to add/remove Thing channels at runtime. Is it enough to add/remove a channel from the getThing().getChannels() list or do i have to use editThing() ?
