### PR TITLE
Z-Way: Add last update channel.

### DIFF
--- a/addons/binding/org.openhab.binding.zway/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/thing/channels.xml
@@ -216,7 +216,7 @@
         <category>Temperature</category>
         <state readOnly="false" />
     </channel-type>
-    
+        
     <!-- Special channel types -->
     
     <channel-type id="actions">

--- a/addons/binding/org.openhab.binding.zway/README.md
+++ b/addons/binding/org.openhab.binding.zway/README.md
@@ -114,7 +114,6 @@ The following channels are currently supported.
 
 Currently unsupported Z-Way probe types:
 
-- SwitchMultilevel: motor (selection criterion for rollershutter - will be implemented soon)
 - SensorBinary: cooling, all alarm types (resulting from Z-Wave command class AlarmSensor(deprecated) and Alarm)
 - SensorMultilevel: meterElectric_pulse_count, meterElectric_voltage, meterElectric_ampere, meterElectric_power_factor
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
@@ -103,6 +103,7 @@ public class ZWayBindingConstants {
     public static final String DEVICE_PROP_DEVICE_TYPE = "deviceType";
     public static final String DEVICE_PROP_ZDDXMLFILE = "zddxmlfile";
     public static final String DEVICE_PROP_SDK = "SDK";
+    public static final String DEVICE_PROP_LAST_UPDATE = "lastUpdate";
 
     /* Bridge properties */
     public final static String BRIDGE_PROP_SOFTWARE_REVISION_VERSION = "softwareRevisionVersion";

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
@@ -8,8 +8,11 @@
  */
 package org.openhab.binding.zway.handler;
 
-import static org.openhab.binding.zway.ZWayBindingConstants.THING_TYPE_VIRTUAL_DEVICE;
+import static org.openhab.binding.zway.ZWayBindingConstants.*;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
@@ -68,7 +71,7 @@ public class ZWayZAutomationDeviceHandler extends ZWayDeviceHandler {
 
                             addDeviceAsChannel(device);
 
-                            // starts polling job and register all linked items
+                            // Starts polling job and register all linked items
                             completeInitialization();
                         } else {
                             logger.warn("Initializing Z-Way device handler failed (virtual device not found): {}",
@@ -152,5 +155,37 @@ public class ZWayZAutomationDeviceHandler extends ZWayDeviceHandler {
         }
 
         super.dispose();
+    }
+
+    @Override
+    protected void refreshLastUpdate() {
+        logger.debug("Refresh last update for virtual device");
+
+        // Check Z-Way bridge handler
+        ZWayBridgeHandler zwayBridgeHandler = getZWayBridgeHandler();
+        if (zwayBridgeHandler == null || !zwayBridgeHandler.getThing().getStatus().equals(ThingStatus.ONLINE)) {
+            logger.debug("Z-Way bridge handler not found or not ONLINE.");
+            return;
+        }
+
+        // Load and check device from Z-Way server
+        DeviceList deviceList = zwayBridgeHandler.getZWayApi().getDevices();
+        if (deviceList != null) {
+            Device device = deviceList.getDeviceById(mConfig.getDeviceId());
+            if (device == null) {
+                logger.debug("ZAutomation device not found.");
+                return;
+            }
+
+            Calendar lastUpdateOfDevice = Calendar.getInstance();
+            lastUpdateOfDevice.setTimeInMillis(new Long(device.getUpdateTime()) * 1000);
+
+            if (lastUpdate == null || (lastUpdate != null && lastUpdateOfDevice.after(lastUpdate))) {
+                lastUpdate = lastUpdateOfDevice;
+            }
+
+            DateFormat formatter = new SimpleDateFormat("dd.MM.yyyy hh:mm:ss");
+            updateProperty(DEVICE_PROP_LAST_UPDATE, formatter.format(lastUpdate.getTime()));
+        }
     }
 }


### PR DESCRIPTION
I added a channel to display the last update. This is useful for battery powered devices that report changes only at a certain interval or at a specific offset.

New version for testing: [org.openhab.binding.zway-2.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab2-addons/files/760867/org.openhab.binding.zway-2.1.0-SNAPSHOT.zip)

Signed-off-by: Patrick Hecker <pah111kg@fh-zwickau.de> (github: pathec)