### PR TITLE
[RFXCom] Ported the support for the TemperatureRain message type

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2010-2016 by the respective copyright holders.
- * <p>
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,9 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.Assert.assertEquals;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureRainMessage.SubType.WS1200;
+
+import javax.xml.bind.DatatypeConverter;
+
 import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
-import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**
  * Test for RFXCom-binding
@@ -19,10 +23,20 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * @since 1.9.0
  */
 public class RFXComTemperatureRainMessageTest {
+    @Test
+    public void testSomeMessages() throws RFXComException {
+        String hexMessage = "0A4F01CCF001004F03B759";
+        byte[] message = DatatypeConverter.parseHexBinary(hexMessage);
+        RFXComTemperatureRainMessage msg = (RFXComTemperatureRainMessage) RFXComMessageFactory.createMessage(message);
+        assertEquals("SubType", WS1200, msg.subType);
+        assertEquals("Seq Number", 204, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Sensor Id", "61441", msg.getDeviceId());
+        assertEquals("Temperature", 7.9, msg.temperature, 0.001);
+        assertEquals("Rain total", 95.1, msg.rainTotal, 0.001);
+        assertEquals("Signal Level", (byte) 5, msg.signalLevel);
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(PacketType.TEMPERATURE_RAIN);
+        byte[] decoded = msg.decodeMessage();
+
+        assertEquals("Message converted back", hexMessage, DatatypeConverter.printHexBinary(decoded));
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/channels.xml
@@ -81,7 +81,7 @@
 		<item-type>Number</item-type>
 		<label>Rain Total</label>
 		<description>Total rain in millimeters</description>
-		<state pattern="%d mm" readOnly="true"></state>
+		<state pattern="%.1f mm" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="shutter">

--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturerain.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/temperaturerain.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+                          xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="temperaturerain">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+            <bridge-type-ref id="tcpbridge" />
+            <bridge-type-ref id="RFXtrx433" />
+            <bridge-type-ref id="RFXrec433" />
+        </supported-bridge-type-refs>
+
+        <label>RFXCOM Temperature-Rain Sensor</label>
+        <description>A Temperature-Rain device.</description>
+
+        <channels>
+            <channel id="temperature" typeId="temperature" />
+            <channel id="rainTotal" typeId="raintotal" />
+            <channel id="signalLevel" typeId="system.signal-strength" />
+            <channel id="batteryLevel" typeId="system.battery-level" />
+            <channel id="lowBattery" typeId="system.low-battery" />
+        </channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>Device Id</label>
+                <description>Sensor Id. Example 56923</description>
+            </parameter>
+            <parameter name="subType" type="text" required="true">
+                <label>Sub Type</label>
+                <description>Specifies device sub type.</description>
+                <options>
+                    <option value="WS1200">WS1200</option>
+                </options>
+            </parameter>
+        </config-description>
+
+    </thing-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -200,7 +200,7 @@ public class RFXComBindingConstants {
             .put(PacketType.TEMPERATURE_HUMIDITY, RFXComBindingConstants.THING_TYPE_TEMPERATURE_HUMIDITY)
             .put(PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC,
                     RFXComBindingConstants.THING_TYPE_TEMPERATURE_HUMIDITY_BAROMETRIC)
-            .put(PacketType.TEMPERATURE_RAIN, RFXComBindingConstants.THING_TYPE_RAIN)
+            .put(PacketType.TEMPERATURE_RAIN, RFXComBindingConstants.THING_TYPE_TEMPERATURE_RAIN)
             .put(PacketType.THERMOSTAT1, RFXComBindingConstants.THING_TYPE_THERMOSTAT1)
             .put(PacketType.THERMOSTAT2, RFXComBindingConstants.THING_TYPE_THERMOSTAT2)
             .put(PacketType.THERMOSTAT3, RFXComBindingConstants.THING_TYPE_THERMOSTAT3)

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
@@ -20,8 +20,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 
 public class RFXComMessageFactory {
 
-    final static String classUrl = "org.openhab.binding.rfxcom.internal.messages.";
-
     @SuppressWarnings("serial")
     private static final Map<PacketType, Class<? extends RFXComMessage>> messageClasses = Collections
             .unmodifiableMap(new HashMap<PacketType, Class<? extends RFXComMessage>>() {
@@ -51,7 +49,7 @@ public class RFXComMessageFactory {
                     // put(PacketType.THERMOSTAT3, RFXComThermostat3Message.class);
                     // put(PacketType.RADIATOR1, RFXComRadiator1Message.class);
                     // put(PacketType.BBQ1, RFXComBBQMessage.class);
-                    // put(PacketType.TEMPERATURE_RAIN, RFXComTemperatureRainMessage.class);
+                    put(PacketType.TEMPERATURE_RAIN, RFXComTemperatureRainMessage.class);
                     put(PacketType.TEMPERATURE, RFXComTemperatureMessage.class);
                     put(PacketType.HUMIDITY, RFXComHumidityMessage.class);
                     put(PacketType.TEMPERATURE_HUMIDITY, RFXComTemperatureHumidityMessage.class);

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import static org.openhab.binding.rfxcom.RFXComValueSelector.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+
+/**
+ * RFXCOM data class for Temperature and Rain message.
+ *
+ * @author Damien Servant
+ * @author Martin van Wingerden - ported to openHAB 2.0
+ * @since 1.9.0
+ */
+public class RFXComTemperatureRainMessage extends RFXComBaseMessage {
+
+    public enum SubType {
+        WS1200(1);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+
+        public static SubType fromByte(int input) throws RFXComUnsupportedValueException {
+            for (SubType c : SubType.values()) {
+                if (c.subType == input) {
+                    return c;
+                }
+            }
+
+            throw new RFXComUnsupportedValueException(SubType.class, input);
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedInputValueSelectors = Arrays.asList(SIGNAL_LEVEL,
+            BATTERY_LEVEL, TEMPERATURE, RAIN_TOTAL);
+
+    private final static List<RFXComValueSelector> supportedOutputValueSelectors = Collections.emptyList();
+
+    public SubType subType;
+    public int sensorId;
+    public double temperature;
+    public double rainTotal;
+    public byte signalLevel;
+    public byte batteryLevel;
+
+    public RFXComTemperatureRainMessage() {
+        packetType = PacketType.TEMPERATURE_RAIN;
+    }
+
+    public RFXComTemperatureRainMessage(byte[] data) throws RFXComException {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = super.toString();
+        str += ", - Sub type = " + subType;
+        str += ", - Id = " + sensorId;
+        str += ", - Temperature = " + temperature;
+        str += ", - Rain total = " + rainTotal;
+        str += ", - Signal level = " + signalLevel;
+        str += ", - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public String getDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) throws RFXComException {
+
+        super.encodeMessage(data);
+
+        subType = SubType.fromByte(super.subType);
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+        temperature = ((data[6] & 0x7F) << 8 | (data[7] & 0xFF)) * 0.1;
+        if ((data[6] & 0x80) != 0) {
+            temperature = -temperature;
+        }
+        rainTotal = ((data[8] & 0xFF) << 8 | (data[9] & 0xFF)) * 0.1;
+        signalLevel = (byte) ((data[10] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[10] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[11];
+
+        data[0] = (byte) (data.length - 1);
+        data[1] = RFXComBaseMessage.PacketType.TEMPERATURE_RAIN.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+
+        short temp = (short) Math.abs(temperature * 10);
+        data[6] = (byte) ((temp >> 8) & 0xFF);
+        data[7] = (byte) (temp & 0xFF);
+        if (temperature < 0) {
+            data[6] |= 0x80;
+        }
+
+        short rainT = (short) Math.abs(rainTotal * 10);
+        data[8] = (byte) ((rainT >> 8) & 0xFF);
+        data[9] = (byte) (rainT & 0xFF);
+        data[10] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+        State state;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+            if (valueSelector == SIGNAL_LEVEL) {
+                state = new DecimalType(signalLevel);
+            } else if (valueSelector == BATTERY_LEVEL) {
+                state = new DecimalType(batteryLevel);
+            } else if (valueSelector == TEMPERATURE) {
+                state = new DecimalType(temperature);
+            } else if (valueSelector == RAIN_TOTAL) {
+                state = new DecimalType(rainTotal);
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+        } else {
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+        }
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, Type type) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        // try to find sub type by number
+        try {
+            return SubType.fromByte(Integer.parseInt(subType));
+        } catch (NumberFormatException e) {
+            throw new RFXComUnsupportedValueException(SubType.class, subType);
+        }
+    }
+
+    @Override
+    public void setSubType(Object subType) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public void setDeviceId(String deviceId) throws RFXComException {
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedInputValueSelectors() throws RFXComException {
+        return supportedInputValueSelectors;
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedOutputValueSelectors() throws RFXComException {
+        return supportedOutputValueSelectors;
+    }
+}


### PR DESCRIPTION
As originally developed in https://github.com/openhab/openhab1-addons/pull/3956

As discussed and tested in https://community.openhab.org/t/rfxcom-binding-does-not-decode-temperature-rain-alecto-ws-1200-message/6484/11