### PR TITLE
Fix Onkyo binding connection supervisor issue.

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoConnection.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoConnection.java
@@ -377,11 +377,9 @@ public class OnkyoConnection {
         class Task extends TimerTask {
             @Override
             public void run() {
-                if (connected) {
-                    logger.debug("Test connection to {}:{}", ip, port);
-                    sendCommand(new EiscpMessage.MessageBuilder().command(EiscpCommand.POWER_QUERY.getCommand())
-                            .value(EiscpCommand.POWER_QUERY.getValue()).build());
-                }
+                logger.debug("Test connection to {}:{}", ip, port);
+                sendCommand(new EiscpMessage.MessageBuilder().command(EiscpCommand.POWER_QUERY.getCommand())
+                        .value(EiscpCommand.POWER_QUERY.getValue()).build());
             }
         }
     }


### PR DESCRIPTION
Connection supervisor should always send message to receiver. Otherwise
connection will never be opened if connection failed during
initialization.


Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>