### PR TITLE
Fix for 'Onkyo binding floods log with "no route to host"'

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
@@ -33,6 +33,12 @@
 			<default>100</default>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="connectionErrorLogging" type="boolean">
+            <label>Connection error logging</label>
+            <description>Enable/disable error logging when connection fails to receiver. This is usable when receiver is fully without power e.g. powered off by external socket switch.</description>
+            <default>true</default>
+            <advanced>true</advanced>
+        </parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
@@ -21,6 +21,7 @@ public class OnkyoDeviceConfiguration {
     public String udn;
     public int refreshInterval;
     public int volumeLimit;
+    public boolean connectionErrorLogging;
 
     @Override
     public String toString() {
@@ -31,6 +32,7 @@ public class OnkyoDeviceConfiguration {
         str += ", udn = " + udn;
         str += ", refreshInterval = " + refreshInterval;
         str += ", volumeLimit = " + volumeLimit;
+        str += ", connectionErrorLogging = " + connectionErrorLogging;
 
         return str;
     }


### PR DESCRIPTION
Introduced functionality to Onkyo binding which prevent binding to flood
error messages to the log when receiver is fully powered off.

This resolve #1787


Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>