### PR TITLE
Fix access matcher comparsion with ==

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
@@ -118,7 +118,7 @@ public class FritzahaWebInterface {
 		sid = sidmatch.group(1);
 		Matcher accmatch = ACCESS_PATTERN.matcher(loginXml);
 		if (accmatch.find()) {
-			if (accmatch.group(1) == "2") {
+			if ("2".equals(accmatch.group(1))) {
 				this.fbHandler.setStatusInfo(
 						ThingStatus.ONLINE, 
 						ThingStatusDetail.NONE, 
@@ -165,7 +165,7 @@ public class FritzahaWebInterface {
 		sid = sidmatch.group(1);
 		accmatch = ACCESS_PATTERN.matcher(loginXml);
 		if (accmatch.find()) {
-			if (accmatch.group(1) == "2") {
+			if ("2".equals(accmatch.group(1))) {
 				this.fbHandler.setStatusInfo(
 						ThingStatus.ONLINE, 
 						ThingStatusDetail.NONE, 


### PR DESCRIPTION
== compares the objects, which doesn't return that, what we really want to check, Use equals instead to compare strings.

This fixes the problem, that the binding says, that the user does not have access to the home automation part of the FritzBox, even
if the user is valid and has access.