### PR TITLE
[Chromecast] Added support for Audio groups fixes #1853

### DIFF
--- a/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
@@ -4,6 +4,34 @@
         xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
         xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
+    <!-- Chromecast Audio Group Thing Type -->
+    <thing-type id="audiogroup">
+        <label>Chromecast Audio Group</label>
+        <description>A Google Chromecast Audio Group device</description>
+
+        <channels>
+            <channel id="control" typeId="control"/>
+            <channel id="volume" typeId="volume"/>
+            <channel id="mute" typeId="mute"/>
+            <channel id="playuri" typeId="playuri"/>
+        </channels>
+
+        <config-description>
+            <parameter name="ipAddress" type="text">
+                <context>network-address</context>
+                <label>Network Address</label>
+                <description>Network address of the Chromecast device.</description>
+                <required>true</required>
+            </parameter>
+            <parameter name="port" type="integer">
+                <context>network-port</context>
+                <label>Network Port</label>
+                <description>Network port of the Chromecast device.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+    
     <!-- Chromecast Audio Thing Type -->
     <thing-type id="audio">
         <label>Chromecast Audio</label>
@@ -23,9 +51,14 @@
                 <description>Network address of the Chromecast device.</description>
                 <required>true</required>
             </parameter>
+            <parameter name="port" type="integer">
+                <context>network-port</context>
+                <label>Network Port</label>
+                <description>Network port of the Chromecast device.</description>
+                <required>true</required>
+            </parameter>
         </config-description>
     </thing-type>
-
     <!-- Chromecast HDMI dongle Thing Type -->
     <thing-type id="chromecast">
         <label>Chromecast</label>
@@ -43,6 +76,12 @@
                 <context>network-address</context>
                 <label>Network Address</label>
                 <description>Network address of the Chromecast device.</description>
+                <required>true</required>
+            </parameter>
+            <parameter name="port" type="integer">
+                <context>network-port</context>
+                <label>Network Port</label>
+                <description>Network port of the Chromecast device.</description>
                 <required>true</required>
             </parameter>
         </config-description>

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/ChromecastBindingConstants.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/ChromecastBindingConstants.java
@@ -25,11 +25,13 @@ public class ChromecastBindingConstants {
 
     public static final ThingTypeUID THING_TYPE_CHROMECAST = new ThingTypeUID(BINDING_ID, "chromecast");
     public static final ThingTypeUID THING_TYPE_AUDIO = new ThingTypeUID(BINDING_ID, "audio");
+    public static final ThingTypeUID THING_TYPE_AUDIOGROUP = new ThingTypeUID(BINDING_ID, "audiogroup");
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();
 
     static {
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_AUDIO);
+        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_AUDIOGROUP);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CHROMECAST);
     }
 
@@ -41,6 +43,7 @@ public class ChromecastBindingConstants {
 
     // config parameters
     public static final String HOST = "ipAddress";
+    public static final String PORT = "port";
 
     // properties
     public static final String SERIAL_NUMBER = "serialNumber";

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastDiscoveryParticipant.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
 import org.openhab.binding.chromecast.ChromecastBindingConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link ChromecastDiscoveryParticipant} is responsible for discovering Chromecast devices through UPnP.
@@ -31,6 +33,7 @@ import org.openhab.binding.chromecast.ChromecastBindingConstants;
 public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant {
 
     private static final String SERVICE_TYPE = "_googlecast._tcp.local.";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
@@ -53,7 +56,9 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
         final Map<String, Object> properties = new HashMap<>(2);
         String host = service.getHostAddresses()[0];
         properties.put(ChromecastBindingConstants.HOST, host);
-
+        int port = service.getPort();
+        properties.put(ChromecastBindingConstants.PORT, port);
+        logger.debug("Chromecast Found: {} {}", host, port);
         String friendlyName = service.getPropertyString("fn"); // friendly name;
 
         final DiscoveryResult result = DiscoveryResultBuilder.create(uid).withThingType(getThingType(service))
@@ -64,11 +69,14 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     private ThingTypeUID getThingType(final ServiceInfo service) {
         String model = service.getPropertyString("md"); // model
+        logger.debug("Chromecast Type: {}", model);
         if (model == null) {
             return null;
         }
         if (model.equals("Chromecast Audio")) {
             return ChromecastBindingConstants.THING_TYPE_AUDIO;
+        } else if (model.equals("Google Cast Group")) {
+            return ChromecastBindingConstants.THING_TYPE_AUDIOGROUP;
         } else {
             return ChromecastBindingConstants.THING_TYPE_CHROMECAST;
         }


### PR DESCRIPTION
Creates additional THING_TYPE for Audio Groups. Adds discovered network
port number to device configuration rather than relying on assumed port
number of 8009.
Signed-off-by: Sean McGuire <mcguiresean@hotmail.com> (github: mcguiresean)