### PR TITLE
[OpenSprinkler] Avoid NPE in case missing config

### DIFF
--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHTTPHandler.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHTTPHandler.java
@@ -39,16 +39,15 @@ public class OpenSprinklerHTTPHandler extends OpenSprinklerHandler {
     public void initialize() {
         openSprinklerConfig = getConfig().as(OpenSprinklerConfig.class);
 
-        logger.debug("Initializing OpenSprinkler with config (Hostname: {}, Port: {}, Password: {}, Refresh: {}).",
-                openSprinklerConfig.hostname, openSprinklerConfig.port, openSprinklerConfig.password,
-                openSprinklerConfig.refresh);
-
         if (openSprinklerConfig == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "Could not parse the config for the OpenSprinkler.");
-
             return;
         }
+
+        logger.debug("Initializing OpenSprinkler with config (Hostname: {}, Port: {}, Password: {}, Refresh: {}).",
+                openSprinklerConfig.hostname, openSprinklerConfig.port, openSprinklerConfig.password,
+                openSprinklerConfig.refresh);
 
         try {
             openSprinklerDevice = OpenSprinklerApiFactory.getHttpApi(openSprinklerConfig.hostname,

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerPiHandler.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerPiHandler.java
@@ -38,14 +38,14 @@ public class OpenSprinklerPiHandler extends OpenSprinklerHandler {
     public void initialize() {
         openSprinklerConfig = getConfig().as(OpenSprinklerPiConfig.class);
 
-        logger.debug("Initializing OpenSprinkler with config (Refresh: {}).", openSprinklerConfig.refresh);
-
         if (openSprinklerConfig == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "Could not parse the config for the OpenSprinkler.");
 
             return;
         }
+
+        logger.debug("Initializing OpenSprinkler with config (Refresh: {}).", openSprinklerConfig.refresh);
 
         try {
             openSprinklerDevice = OpenSprinklerApiFactory.getGpioApi(openSprinklerConfig.stations);


### PR DESCRIPTION
Note. not clear why GH sees the whole class as changed. 
Only change made was to move the log message (L42) after the following null check

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>