### PR TITLE
[onkyo] bring back Album Art URL channel

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channel-groups.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channel-groups.xml
@@ -46,6 +46,7 @@
 			<channel id="listenmode" typeId="listenmode" />
 			<channel id="playuri" typeId="playuri" />
 			<channel id="albumArt" typeId="albumArt" />
+			<channel id="albumArtUrl" typeId="albumArtUrl" />
 		</channels>
 	</channel-group-type>
 

--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channels.xml
@@ -158,6 +158,12 @@
 		<description>Image of cover art of the current song</description>
 		<state readOnly="true"></state>
 	</channel-type>
+	<channel-type id="albumArtUrl" advanced="true">
+		<item-type>String</item-type>
+		<label>Album Art Url</label>
+		<description>Url to the image of cover art of the current song</description>
+		<state readOnly="true"></state>
+	</channel-type>
 	<channel-type id="artist" advanced="true">
 		<item-type>String</item-type>
 		<label>Artist</label>

--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -110,6 +110,7 @@ The Onkyo AVR supports the following channels (some channels are model specific)
 | player#listenmode              | Number       | Current listening mode e.g. Stereo, 5.1ch Surround,..|
 | player#playuri                 | String       | Plays the URI provided to the channel |
 | player#albumArt                | Image        | Image of the current album art of the current song |
+| player#albumArtUrl             | String       | Url to the current album art of the current song |
 | netmenu#title                  | String       | Title of the current NET service |
 | netmenu#control                | String       | Control the USB/Net Menu, e.g. Up/Down/Select/Back/PageUp/PageDown/Select[0-9] 
 | netmenu#selection              | Number       | The number of the currently selected USB/Net Menu entry (0-9) 
@@ -154,5 +155,5 @@ Here after are the ID values of the input sources:
 
 ## Audio Support
 
-+All supported Onkyo AVRs are registered as an audio sink in the framework.
-+Audio streams are sent to the `playuri` channel.
++ All supported Onkyo AVRs are registered as an audio sink in the framework.
++ Audio streams are sent to the `playuri` channel.

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
@@ -105,6 +105,7 @@ public class OnkyoBindingConstants {
     public final static String CHANNEL_TITLE = "player#title";
     public final static String CHANNEL_ALBUM = "player#album";
     public static final String CHANNEL_ALBUM_ART = "player#albumArt";
+    public static final String CHANNEL_ALBUM_ART_URL = "player#albumArtUrl";
     public final static String CHANNEL_LISTENMODE = "player#listenmode";
     public static final String CHANNEL_PLAY_URI = "player#playuri";
 

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
@@ -538,6 +538,16 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
             }
             onkyoAlbumArt.clearAlbumArt();
         }
+
+        if (data.startsWith("2-")) {
+            updateState(CHANNEL_ALBUM_ART_URL, new StringType(data.substring(2, data.length())));
+        } else if (data.startsWith("n-")) {
+            updateState(CHANNEL_ALBUM_ART_URL, UnDefType.UNDEF);
+        } else {
+            logger.debug("Not supported album art URL type: {}", data.substring(0, 2));
+            updateState(CHANNEL_ALBUM_ART_URL, UnDefType.UNDEF);
+        }
+
     }
 
     private void updateNetTitle(String data) {

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/OnkyoHandler.java
@@ -263,6 +263,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                 handlePlayUri(command);
                 break;
             case CHANNEL_ALBUM_ART:
+            case CHANNEL_ALBUM_ART_URL:
                 if (command.equals(RefreshType.REFRESH)) {
                     sendCommand(EiscpCommand.NETUSB_ALBUM_ART_QUERY);
                 }


### PR DESCRIPTION
This channel got lost in the previous onkyo album art PR
To be used for UI's that don't support image Itemtype yet (basic/classic)