### PR TITLE
replaced "kostalpico.kostalpico" with "kostalinverter.kostalinverter"

### DIFF
--- a/addons/binding/org.openhab.binding.kostalinverter/README.md
+++ b/addons/binding/org.openhab.binding.kostalinverter/README.md
@@ -30,7 +30,7 @@ None
 demo.things
 
 ```
-Thing kostalpico:kostalpico:inverter [ url="http://192.168.0.128" ]
+Thing kostalinverter:kostalinverter:inverter [ url="http://192.168.0.128" ]
 ```
 
 If the thing goes online then the connection to the web interface is successful. In case
@@ -41,9 +41,9 @@ it is offline you should see an error message.
 demo.items:
 
 ```
-Number SolarPower "Solar power [%.2f Watt]" <energy> (gGF) { channel="kostalpico:kostalpico:inverter:acPower" }
-Number SolarEnergyDay "Solar day energy[%.2f kwh]" <energy> (gGF)  { channel="kostalpico:kostalpico:inverter:dayEnergy" }
-Number SolarTotalEnergy "Solar total energy[%.2f kwh]" <energy> (gGF) { channel="kostalpico:kostalpico:inverter:totalEnergy" }
-String SolarStatus "Solar status [%s]" <energy> (gGF) { channel="kostalpico:kostalpico:inverter:status" }
+Number SolarPower "Solar power [%.2f Watt]" <energy> (gGF) { channel="kostalinverter:kostalinverter:inverter:acPower" }
+Number SolarEnergyDay "Solar day energy[%.2f kwh]" <energy> (gGF)  { channel="kostalinverter:kostalinverter:inverter:dayEnergy" }
+Number SolarTotalEnergy "Solar total energy[%.2f kwh]" <energy> (gGF) { channel="kostalinverter:kostalinverter:inverter:totalEnergy" }
+String SolarStatus "Solar status [%s]" <energy> (gGF) { channel="kostalinverter:kostalinverter:inverter:status" }
 ```
 


### PR DESCRIPTION
documentation had wrong syntax