### PR TITLE
[Onkyo] albumArt header issue workaround

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoAlbumArt.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoAlbumArt.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Arrays;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -148,11 +149,25 @@ public class OnkyoAlbumArt {
                     break;
                 case URL:
                     data = downloadAlbumArt(coverArtUrl);
+                    //Workaround firmware bug providing incorrect headers causing them to be seen as body instead.
+                    if (data != null) {
+                        int bodyLength = data.length;
+                        int i = new String(data).indexOf("image/");
+                        while (i < bodyLength && data[i] != '\r') {
+                            i++;
+                        }
+                        while (i < bodyLength && (data[i] == '\r' || data[i] == '\n')) {
+                            i++;
+                        }
+                        if (i > 0) {
+                            data = Arrays.copyOfRange(data, i, bodyLength);
+                            logger.trace("Onkyo fixed picture data @ {}: {} ", i, new String(data));
+                        }
+                    }
                     break;
                 case NONE:
                 default:
             }
-
             return data;
         }
 


### PR DESCRIPTION
This is a workaround for Onkyo receivers firmware bug that is providing
html headers in the html body for album art.

This prevents album art from being displayed properly
This code strips the headers from the body so the real body remains

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>