### PR TITLE
[kodi] Improve handling of stop channel

### DIFF
--- a/addons/binding/org.openhab.binding.kodi/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.kodi/ESH-INF/thing/thing-types.xml
@@ -65,7 +65,7 @@
 	<channel-type id="stop">
 		<item-type>Switch</item-type>
 		<label>Stop</label>
-		<description>Stop the player</description>
+		<description>Stops the player. ON if the player is stopped.</description>
 	</channel-type>
 	<channel-type id="playuri" advanced="true">
 		<item-type>String</item-type>

--- a/addons/binding/org.openhab.binding.kodi/README.md
+++ b/addons/binding/org.openhab.binding.kodi/README.md
@@ -62,7 +62,7 @@ The Kodi thing supports the following channels:
 | mute                    | Switch       | Mute/unmute your playback |
 | volume                  | Dimmer       | Read or control the volume of your playback |
 | control                 | Player       | Control the Kodi player, e.g.  `PLAY`, `PAUSE`, `NEXT`, `PREVIOUS`, `FASTFORWARD`, `REWIND` |
-| stop                    | Switch       | Stops the Kodi player |
+| stop                    | Switch       | Write `ON` to this channel: Stops the Kodi player. If this channel is `ON`, the player is stopped, otherwise it is in anouther state (see control channel) |
 | title                   | String       | Title of the currently played song/movie/tv episode |
 | showtitle               | String       | Title of the currently played tv-show; empty for other types |
 | album                   | String       | Album name of the currently played song |

--- a/addons/binding/org.openhab.binding.kodi/README.md
+++ b/addons/binding/org.openhab.binding.kodi/README.md
@@ -62,7 +62,7 @@ The Kodi thing supports the following channels:
 | mute                    | Switch       | Mute/unmute your playback |
 | volume                  | Dimmer       | Read or control the volume of your playback |
 | control                 | Player       | Control the Kodi player, e.g.  `PLAY`, `PAUSE`, `NEXT`, `PREVIOUS`, `FASTFORWARD`, `REWIND` |
-| stop                    | Switch       | Write `ON` to this channel: Stops the Kodi player. If this channel is `ON`, the player is stopped, otherwise it is in anouther state (see control channel) |
+| stop                    | Switch       | Write `ON` to this channel: Stops the Kodi player. If this channel is `ON`, the player is stopped, otherwise kodi is in another state (see control channel) |
 | title                   | String       | Title of the currently played song/movie/tv episode |
 | showtitle               | String       | Title of the currently played tv-show; empty for other types |
 | album                   | String       | Album name of the currently played song |

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/handler/KodiHandler.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/handler/KodiHandler.java
@@ -124,11 +124,10 @@ public class KodiHandler extends BaseThingHandler implements KodiEventListener {
                 }
                 break;
             case CHANNEL_STOP:
-                if (command instanceof OnOffType) {
+                if (command.equals(OnOffType.ON)) {
                     connection.playerStop();
-                    updateState(CHANNEL_STOP, UnDefType.UNDEF);
                 } else if (command.equals(RefreshType.REFRESH)) {
-                    updateState(CHANNEL_STOP, UnDefType.UNDEF);
+                    connection.updatePlayerStatus();
                 }
                 break;
             case CHANNEL_PLAYURI:
@@ -280,17 +279,24 @@ public class KodiHandler extends BaseThingHandler implements KodiEventListener {
         switch (state) {
             case Play:
                 updateState(CHANNEL_CONTROL, PlayPauseType.PLAY);
+                updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
             case Pause:
+                updateState(CHANNEL_CONTROL, PlayPauseType.PAUSE);
+                updateState(CHANNEL_STOP, OnOffType.OFF);
+                break;
             case Stop:
             case End:
                 updateState(CHANNEL_CONTROL, PlayPauseType.PAUSE);
+                updateState(CHANNEL_STOP, OnOffType.ON);
                 break;
             case FastForward:
                 updateState(CHANNEL_CONTROL, RewindFastforwardType.FASTFORWARD);
+                updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
             case Rewind:
                 updateState(CHANNEL_CONTROL, RewindFastforwardType.REWIND);
+                updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
         }
     }


### PR DESCRIPTION
After this change, the stop channel can also be read: it is 'ON' if the player is stopped