### PR TITLE
Remove Jekyll preambles from README.md files

### DIFF
--- a/addons/binding/org.openhab.binding.airquality/README.md
+++ b/addons/binding/org.openhab.binding.airquality/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # Air Quality Binding
 
 This binding uses the [AQIcn.org service](http://aqicn.org) for providing air quality information for any location worldwide.

--- a/addons/binding/org.openhab.binding.hdpowerview/README.md
+++ b/addons/binding/org.openhab.binding.hdpowerview/README.md
@@ -1,9 +1,11 @@
 # Hunter Douglas PowerView Binding
+
 This is an openHAB binding for the [Hunter Douglas PowerView Motorized Shades](http://www.hunterdouglas.com/operating-systems/powerview-motorization/support) via the PowerView Hub.
 
 PowerView shades have motorization control for their vertical position, as well as vane controls on the shade's slats. Make sure your Shades are visible in the dedicated PowerView app before attempting discovery. This binding also supports Scenes that are defined via the PowerView app. This helps to work around a limitation of the Hub - commands are executed serially with a several second delay between executions. By using a Scene to control multiple shades at once, the shades will all begin moving at the same time.
 
 ## Supported Things
+
 <table>
  <tr>
   <td><b>Thing</b></td>
@@ -23,10 +25,13 @@ PowerView shades have motorization control for their vertical position, as well 
 </table>
 
 ## Discovery
+
 The PowerView Hub is discovered via a NetBios query. This is the same method used by the dedicated PowerView app. After the Hub is added, Shades and Scenes will be discovered by querying the Hub.
 
 ## Thing Configuration
+
 PowerView things should be configured via discovery - it would be difficult to configure manually as the IDs of the shades and scenes are not exposed via the dedicated app. However, the configuration parameters are described below:
+
 <table>
  <tr>
   <td><b>Thing</b></td>
@@ -52,7 +57,9 @@ PowerView things should be configured via discovery - it would be difficult to c
 </table>
 
 ## Channels
+
 ### PowerView Shade
+
 <table>
  <tr>
   <td><b>Channel</b></td>
@@ -78,7 +85,9 @@ PowerView things should be configured via discovery - it would be difficult to c
 
 
 ### PowerView Scene
+
 Scenes channels are added to the Hub as they are discovered.
+
 <table>
  <tr>
   <td><b>Channel</b></td>

--- a/addons/binding/org.openhab.binding.kostalinverter/README.md
+++ b/addons/binding/org.openhab.binding.kostalinverter/README.md
@@ -1,10 +1,4 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
-# Kostal inverter Binding
+# Kostal Inverter Binding
 
 Scrapes the web interface of the inverter for the metrics of the supported channels below.
 

--- a/addons/binding/org.openhab.binding.miele/README.md
+++ b/addons/binding/org.openhab.binding.miele/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # Miele@home Binding
 
 This binding integrates Miele@home appliances. Miele@home is a Zigbee based network to interconnect and control Miele appliances that are equipped with special modules. See [www.miele.de](http://www.miele.de) for the list of available appliances.

--- a/addons/binding/org.openhab.binding.milight/README.md
+++ b/addons/binding/org.openhab.binding.milight/README.md
@@ -1,12 +1,15 @@
 # Milight Binding
+
 The openHAB2 Milight binding allows to send commands to multiple Milight bridges.
 
 [![openHAB Milight](http://img.youtube.com/vi/zNe9AkQbfmc/0.jpg)](http://www.youtube.com/watch?v=zNe9AkQbfmc)
 
 ## Supported Things
+
 The Milight Binding supports White, and RGB(W) bulbs.
 
 ## Discovery
+
 Version 3+ bridges can be discovered by triggering a search in openHAB's inbox. Found bridges
 will show up an can easily be added as things.
 After a bridge has been added, all possible bridge supported devices will appear
@@ -15,10 +18,12 @@ no real auto detection for single milight leds but only for the briges possible.
 Add the leds you actually configured and hide the rest of the detected things.
 
 ## Binding Configuration
+
 When manually adding an older bridge Type (3-), you have to add configuration information for
 the bridge IP-Address and the listening port.
 
 ## Thing Configuration
+
 Besides adding bridges through Paper-UI, you can also add them manually in your Thing
 configuration file.
 
@@ -44,6 +49,7 @@ The group number corresponds to the bulbs/channels on your bridge, where 0 refle
 1-4 white bulb channels and 5 all rgb bulbs.
 
 ## Features
+
 For white bulbs these channels are supported:
 
     ledbrightness       controls the brightness of your bulbs
@@ -135,6 +141,7 @@ The rgb bulbs do not support changing their saturation, so the colorpicker will 
     end
   
 ## Authors
+
  * David Gräff <david.graeff@tu-dortmund.de>, 2016
  * Hans-Joerg Merk
  * Kai Kreuzer

--- a/addons/binding/org.openhab.binding.netatmo/README.md
+++ b/addons/binding/org.openhab.binding.netatmo/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # Netatmo Binding
  
 The Netatmo binding integrates the following Netatmo products:

--- a/addons/binding/org.openhab.binding.toon/README.md
+++ b/addons/binding/org.openhab.binding.toon/README.md
@@ -1,13 +1,7 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # Toon Binding
+
 The Toon bindings shows among others current room temperature, setpoint, energy and gas usage information.
 It can control the setpoint and current program. Connected smart plugs can also be controlled.
-
 
 ## Supported Things
 

--- a/addons/ui/org.openhab.ui.cometvisu/README.md
+++ b/addons/ui/org.openhab.ui.cometvisu/README.md
@@ -1,4 +1,4 @@
-Documentation of the CometVisu Backend for openHAB2
+# CometVisu Backend for openHAB2
 
 ## Introduction
 

--- a/addons/voice/org.openhab.voice.marytts/README.md
+++ b/addons/voice/org.openhab.voice.marytts/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # Mary Text-to-Speech
 
 ## Overview


### PR DESCRIPTION
The Jekyll front matter and include conflict with the documentation build process, which applies its own correct preamble.

Signed-off-by: John Cocula <john@cocula.com>