### PR TITLE
Z-Way: Change channel definition of multilevel switches.

### DIFF
--- a/addons/binding/org.openhab.binding.zway/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/thing/channels.xml
@@ -169,7 +169,7 @@
     </channel-type>
     
     <channel-type id="switchMultilevel">
-        <item-type>Number</item-type>
+        <item-type>Dimmer</item-type>
         <label>Switch multilevel</label>
         <description>This channel represents a universal channel if no further device information is available.</description>
         <state readOnly="false" />

--- a/addons/binding/org.openhab.binding.zway/README.md
+++ b/addons/binding/org.openhab.binding.zway/README.md
@@ -129,7 +129,7 @@ The following channels represent universial channels if no further device inform
 | sensorBinary      | Switch | Switch       | SensorBinary |
 | sensorMultilevel  | Number | -            | SensorMultilevel |
 | switchBinary      | Switch | Switch       | SwitchBinary |
-| switchMultilevel  | Number | -            | SwitchMultilevel |
+| switchMultilevel  | Dimmer | -            | SwitchMultilevel |
 | switchColor       | Color  | ColorLight   | SwitchRGBW |
 | switchControl     | Switch | Switch       | SwitchControl |
 | thermostat        | Number | Temperature  | Thermostat |

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.thing.Bridge;
@@ -512,9 +513,9 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                             }
                         } else if (device instanceof SwitchMultilevel) {
                             // possible commands: update(), on(), up(), off(), down(), min(), max(), upMax(),
-                            // increase(),
-                            // decrease(), exact(level), exactSmooth(level, duration), stop(), startUp(), startDown()
-                            if (command instanceof DecimalType) {
+                            // increase(), decrease(), exact(level), exactSmooth(level, duration), stop(), startUp(),
+                            // startDown()
+                            if (command instanceof DecimalType || command instanceof PercentType) {
                                 logger.debug("Handle command: DecimalType");
 
                                 device.exact(command.toString());
@@ -528,14 +529,19 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
 
                                     device.startDown();
                                 }
-                            } else {
-                                if (command instanceof StopMoveType) {
-                                    logger.debug("Handle command: StopMoveType");
+                            } else if (command instanceof StopMoveType) {
+                                logger.debug("Handle command: StopMoveType");
 
-                                    device.stop();
+                                device.stop();
+                            } else if (command instanceof OnOffType) {
+                                logger.debug("Handle command: OnOffType");
+
+                                if (command.equals(OnOffType.ON)) {
+                                    device.on();
+                                } else if (command.equals(OnOffType.OFF)) {
+                                    device.off();
                                 }
                             }
-
                         } else if (device instanceof SwitchRGBW) {
                             // possible commands: on(), off(), exact(red, green, blue)
                             if (command instanceof HSBType) {
@@ -646,7 +652,7 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                 acceptedItemType = "Switch";
             } else if (device instanceof SwitchMultilevel) {
                 id = SWITCH_MULTILEVEL_CHANNEL;
-                acceptedItemType = "Number";
+                acceptedItemType = "Dimmer";
             } else if (device instanceof SwitchToggle) {
                 // ?
             } else if (device instanceof SwitchRGBW) {

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/converter/ZWayDeviceStateConverter.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/converter/ZWayDeviceStateConverter.java
@@ -57,7 +57,8 @@ public class ZWayDeviceStateConverter {
         } else if (device instanceof SwitchBinary) {
             return getBinaryState(level.toLowerCase());
         } else if (device instanceof SwitchMultilevel) {
-            if (channel.getAcceptedItemType().equals("Rollershutter")) {
+            if (channel.getAcceptedItemType().equals("Rollershutter")
+                    || channel.getAcceptedItemType().equals("Dimmer")) {
                 return getPercentState(level);
             } else {
                 return getMultilevelState(level);


### PR DESCRIPTION
- Change item type of multilevel switch device type from number to dimmer to use a slider.
- Add On/Off command handling for multilevel switch device type, resulting in 0 for Off and 99 for On in Z-Way.

New version for testing: [org.openhab.binding.zway-2.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab2-addons/files/807121/org.openhab.binding.zway-2.1.0-SNAPSHOT.zip)

Signed-off-by: Patrick Hecker <pah111kg@fh-zwickau.de> (github: pathec)