### PR TITLE
[maryTTS] use sample rate from audioFormat

### DIFF
--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
@@ -89,7 +89,7 @@ class MaryTTSAudioStream extends FixedLengthAudioStream {
         byte format = 0x10; // PCM
         byte bits = 16;
         byte channel = 1;
-        long srate = (this.audioFormat != null) ? this.audioFormat.getFrequency() : 16000l;
+        long srate = (this.audioFormat != null) ? this.audioFormat.getFrequency() : 48000l;
         long rawLength = length - 36;
         long bitrate = srate * channel * bits;
 

--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
@@ -89,7 +89,7 @@ class MaryTTSAudioStream extends FixedLengthAudioStream {
         byte format = 0x10; // PCM
         byte bits = 16;
         byte channel = 1;
-        int srate = 48000;
+        long srate = (this.audioFormat != null) ? this.audioFormat.getFrequency() : 16000l;
         long rawLength = length - 36;
         long bitrate = srate * channel * bits;
 


### PR DESCRIPTION
This fixes the issue #1715 with the wrong sample rate for german voices, because the result is in 16kHz (other than en_US).
I discovered that the audioFormat is always set for real audio samples. But after changing the voice or after startup there is always a request audioFormat == null, so the null check is necessary. 

see also https://community.openhab.org/t/sonos-audio-sink-say/15576/87

closes #1715