### PR TITLE
Issue with zones being added as main zone

### DIFF
--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/discovery/YamahaDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/discovery/YamahaDiscoveryParticipant.java
@@ -53,10 +53,9 @@ public class YamahaDiscoveryParticipant implements UpnpDiscoveryParticipant {
         } catch (Exception e) {
             // ignore and use the default label
         }
-        properties.put((String) YamahaReceiverBindingConstants.CONFIG_HOST_NAME,
+        properties.put(YamahaReceiverBindingConstants.CONFIG_HOST_NAME,
                 device.getIdentity().getDescriptorURL().getHost());
-        properties.put((String) YamahaReceiverBindingConstants.CONFIG_ZONE,
-                YamahaReceiverCommunication.Zone.Main_Zone.name());
+        properties.put(YamahaReceiverBindingConstants.CONFIG_ZONE, YamahaReceiverCommunication.Zone.Main_Zone.name());
 
         DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label).build();
 

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaReceiverHandler.java
@@ -112,11 +112,22 @@ public class YamahaReceiverHandler extends BaseThingHandler {
             relativeVolumeChangeFactor = relVolumeChange.floatValue();
         }
 
-        // Determine the zone of this thing
+        // Determine the zone of this thing from configuration
         String zoneName = (String) thing.getConfiguration().get(YamahaReceiverBindingConstants.CONFIG_ZONE);
+
+        // If no zone was found in configuration, check properties
         if (zoneName == null) {
-            zoneName = YamahaReceiverCommunication.Zone.Main_Zone.name();
+            zoneName = thing.getProperties().get(YamahaReceiverBindingConstants.CONFIG_ZONE);
+
+            // If no zone is still found, assume main zone
+            if (zoneName == null) {
+                zoneName = YamahaReceiverCommunication.Zone.Main_Zone.name();
+            } else {
+                zoneName = YamahaReceiverCommunication.Zone.valueOf(zoneName).name();
+            }
         }
+
+        logger.info("Zone found to be: " + zoneName);
 
         Zone zone = YamahaReceiverCommunication.Zone.valueOf(zoneName);
 


### PR DESCRIPTION
Fixed issue where when an additional zone was added, it was marked as Main_zone instead of the appropriate zone.

This caused every zone added to add a zone to itself.
This resulted in an infinite loop of the same zone being added.

In addition to this, all additional zones were only controlling the main
zone.