### PR TITLE
[squeezebox] Add to audiosink/notification examples.

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -87,7 +87,23 @@ rule "Garage Door Open Notification"
 when
     Item GarageDoorOpenNotification received command ON
 then
+    // Play the notification on the default sink
+    say("The garage door is open!", "voicerss:enUS")
+    // Play the notification on a specific sink
     say("The garage door is open!", "voicerss:enUS", "squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510")
+end
+```
+
+And, you can play sounds from the conf/sounds directory.
+```
+rule "Play Sounds"
+when
+    Item PlaySounds received command ON
+then
+    // Play the sound on the default sink
+    playsound("doorbell.mp3")
+    // Play the sound on a specific sink
+    playsound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3")
 end
 ```
 

--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -72,16 +72,19 @@ Squeeze Players can be set up as audio sinks in openHAB.  Please follow the [ope
 You can create an item and sitemap entry in order to set the notification volume independently from the Squeeze Player's current volume setting. If the notification volume is not specified, it will use the Player's current volume setting.
 
 Item for setting notification volume.
+
 ```
 Dimmer NotificationVolume "Notification Volume [%d %%]" {channel="squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510:notificationSoundVolume"}
 ```
 
 Sitemap entry for setting notification volume.
+
 ```
 Slider item=NotificationVolume label="Notification Volume"
 ```
 
 You can play notifications from within rules.
+
 ```
 rule "Garage Door Open Notification"
 when
@@ -95,6 +98,7 @@ end
 ```
 
 And, you can play sounds from the conf/sounds directory.
+
 ```
 rule "Play Sounds"
 when


### PR DESCRIPTION
Add playsound examples to the documentation.  There were multiple questions on the forum about how to do this.  The updated example should eliminate those questions.

Signed-off-by: Mark Hilbush <mark@hilbush.com>