### PR TITLE
D-Link Smart Home device binding

### DIFF
--- a/addons/binding/org.openhab.binding.dlinksmarthome/.classpath
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/.project
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.dlinksmarthome</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/binding/binding.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="dlinksmarthome"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>D-Link Smart Home Binding</name>
+    <description>This is the binding for D-Link Smart Home devices</description>
+    <author>Mike Major</author>
+
+</binding:binding>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="dlinksmarthome"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Motion Sensor DCH-S150 Thing Type -->
+    <thing-type id="DCH-S150">
+        <label>Motion Sensor</label>
+        <description>D-Link DCH-S150 WiFi motion sensor</description>
+
+        <channels>
+            <channel id="motion" typeId="system.trigger">
+                <label>Motion Detected</label>
+                <description>Triggered when the sensor detects motion</description>
+            </channel>
+        </channels>
+        <config-description>
+            <parameter name="ipAddress" type="text" required="true">
+                <context>network-address</context>
+                <label>Hostname or IP</label>
+                <description>Hostname or IP of the device.</description>
+            </parameter>
+            <parameter name="pin" type="text" required="true">
+                <context>password</context>
+                <label>PIN Code</label>
+                <description>PIN code from the back of the device.</description>
+            </parameter>
+            <parameter name="rebootTime" type="text" required="false">
+                <context>time</context>
+                <default>03:00</default>
+                <advanced>true</advanced>
+                <label>Reboot Time</label>
+                <description>Time that the device will be first rebooted each day (device must be rebooted periodically to ensure that it remains responsive).</description>
+            </parameter>
+            <parameter name="rebootInterval" type="integer" min="0" max="24" required="false">
+                <advanced>true</advanced>
+                <label>Reboot Interval</label>
+                <description>Number of hours before device needs rebooting (a value of 0 disables reboot).</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/ESH-INF/thing/thing-types.xml
@@ -26,18 +26,6 @@
                 <label>PIN Code</label>
                 <description>PIN code from the back of the device.</description>
             </parameter>
-            <parameter name="rebootTime" type="text" required="false">
-                <context>time</context>
-                <default>03:00</default>
-                <advanced>true</advanced>
-                <label>Reboot Time</label>
-                <description>Time that the device will be first rebooted each day (device must be rebooted periodically to ensure that it remains responsive).</description>
-            </parameter>
-            <parameter name="rebootInterval" type="integer" min="0" max="24" required="false">
-                <advanced>true</advanced>
-                <label>Reboot Interval</label>
-                <description>Number of hours before device needs rebooting (a value of 0 disables reboot).</description>
-            </parameter>
         </config-description>
     </thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/META-INF/MANIFEST.MF
@@ -1,0 +1,25 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: D-Link Smart Home Binding
+Bundle-SymbolicName: org.openhab.binding.dlinksmarthome;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: 
+ javax.jmdns,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.transport.mdns.discovery,
+ org.openhab.binding.dlinksmarthome,
+ org.openhab.binding.dlinksmarthome.handler,
+ org.slf4j
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.dlinksmarthome,
+ org.openhab.binding.dlinksmarthome.handler

--- a/addons/binding/org.openhab.binding.dlinksmarthome/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/META-INF/MANIFEST.MF
@@ -8,6 +8,11 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: 
  javax.jmdns,
+ org.eclipse.jetty.client,
+ org.eclipse.jetty.client.api,
+ org.eclipse.jetty.client.util,
+ org.eclipse.jetty.http,
+ org.eclipse.jetty.util.component,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.library.types,

--- a/addons/binding/org.openhab.binding.dlinksmarthome/OSGI-INF/DLinkSmartHomeDiscoveryParticipant.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/OSGI-INF/DLinkSmartHomeDiscoveryParticipant.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.dlinksmarthome">
+   <implementation class="org.openhab.binding.dlinksmarthome.internal.DLinkSmartHomeDiscoveryParticipant"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/OSGI-INF/DLinkSmartHomeHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/OSGI-INF/DLinkSmartHomeHandlerFactory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.dlinksmarthome">
+
+   <implementation class="org.openhab.binding.dlinksmarthome.internal.DLinkSmartHomeHandlerFactory"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/README.md
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/README.md
@@ -8,12 +8,6 @@ A binding for D-Link Smart Home devices.
 
 The binding has been tested with hardware revisions A1 and A2 running firmware version 1.22.
 
-The binding must periodically reboot the device as it eventually becomes unresponsive: 
-
-* Hardware revision A1 devices require rebooting every 4 hours
-* Hardware revision A2 devices require rebooting every 24 hours
-
-
 ## Discovery
 
 The binding can automatically discover devices that have already been added to the Wifi network. Please refer to your mydlink Home app for instructions on how to add your device to your Wifi network.
@@ -30,8 +24,6 @@ It is recommended to let the binding discover and add devices. Once added the co
 
 * **ipAddress** - Hostname or IP of the device
 * **pin** - PIN code from the back of the device
-* **rebootTime** (default 03:00) - Time that the device will be first rebooted each day (device must be rebooted periodically to ensure that it remains responsive)
-* **rebootInterval** (default 24) - Number of hours before device needs rebooting (a value of 0 disables reboot)
  
 To manually configure a DCH-S150 Thing you must specify its IP address and PIN code. 
  

--- a/addons/binding/org.openhab.binding.dlinksmarthome/README.md
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/README.md
@@ -1,0 +1,61 @@
+# D-Link Smart Home Binding
+
+A binding for D-Link Smart Home devices.
+
+## Supported Things
+
+### DCH-S150 (WiFi motion sensor)
+
+The binding has been tested with hardware revisions A1 and A2 running firmware version 1.22.
+
+The binding must periodically reboot the device as it eventually becomes unresponsive: 
+
+* Hardware revision A1 devices require rebooting every 4 hours
+* Hardware revision A2 devices require rebooting every 24 hours
+
+
+## Discovery
+
+The binding can automatically discover devices that have already been added to the Wifi network. Please refer to your mydlink Home app for instructions on how to add your device to your Wifi network.
+
+## Binding Configuration
+
+The binding does not require any special configuration.
+
+## Thing Configuration
+
+It is recommended to let the binding discover and add devices. Once added the configuration must be updated to specify the PIN code located on the back of the device.
+
+### DCH-S150
+
+* **ipAddress** - Hostname or IP of the device
+* **pin** - PIN code from the back of the device
+* **rebootTime** (default 03:00) - Time that the device will be first rebooted each day (device must be rebooted periodically to ensure that it remains responsive)
+* **rebootInterval** (default 24) - Number of hours before device needs rebooting (a value of 0 disables reboot)
+ 
+To manually configure a DCH-S150 Thing you must specify its IP address and PIN code. 
+ 
+In the thing file, this looks like e.g.
+
+```
+  Thing dlinksmarthome:DCH-S150:mysensor [ ipAddress="192.168.2.132" pin="1234" ]
+```
+
+## Channels
+
+### DCH-S150
+
+* **motion** - Triggered when the sensor detects motion.
+
+## Example usage
+
+### DCH-S150
+
+```
+  rule "Landing motion"
+  when
+      Channel "dlinksmarthome:DCH-S150:90-8D-78-XX-XX-XX:motion" triggered
+  then
+      println("Motion has been detected")
+  end
+```

--- a/addons/binding/org.openhab.binding.dlinksmarthome/about.html
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>March 12, 2017</p> 
+<h3>License</h3>
+
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
+</body>
+</html>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/build.properties
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/build.properties
@@ -1,0 +1,7 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/,\
+               about.html

--- a/addons/binding/org.openhab.binding.dlinksmarthome/pom.xml
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.dlinksmarthome</artifactId>
+  <version>2.1.0-SNAPSHOT</version>
+
+  <name>D-Link Smart Home Binding</name>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/DLinkSmartHomeBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/DLinkSmartHomeBindingConstants.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link DLinkSmartHomeBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Mike Major - Initial contribution
+ */
+public class DLinkSmartHomeBindingConstants {
+
+    public static final String BINDING_ID = "dlinksmarthome";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_DCHS150 = new ThingTypeUID(BINDING_ID, "DCH-S150");
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_DCHS150);
+
+    // Motion trigger channel
+    public static final String MOTION = "motion";
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
@@ -9,9 +9,7 @@
 package org.openhab.binding.dlinksmarthome.handler;
 
 import static org.openhab.binding.dlinksmarthome.DLinkSmartHomeBindingConstants.MOTION;
-import static org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig.*;
 
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -47,16 +45,6 @@ public class DLinkMotionSensorHandler extends BaseThingHandler implements DLinkM
 
     @Override
     public void initialize() {
-        if (getConfig().get(REBOOT_INTERVAL) == null) {
-            final Configuration configuration = editConfiguration();
-            if ("A1".equals(getThing().getProperties().get(HARDWARE_VERSION))) {
-                configuration.put(REBOOT_INTERVAL, 4);
-            } else {
-                configuration.put(REBOOT_INTERVAL, 24);
-            }
-            updateConfiguration(configuration);
-        }
-
         final DLinkMotionSensorConfig config = getConfigAs(DLinkMotionSensorConfig.class);
         motionSensor = new DLinkMotionSensorCommunication(config, this, scheduler);
     }
@@ -72,18 +60,11 @@ public class DLinkMotionSensorHandler extends BaseThingHandler implements DLinkM
             case ONLINE:
                 updateStatus(ThingStatus.ONLINE);
                 break;
-            case REBOOTING:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE, "Device rebooting");
-                break;
             case COMMUNICATION_ERROR:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 break;
             case INVALID_PIN:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid pin code");
-                break;
-            case INVALID_TIME:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Invalid reboot time or interval");
                 break;
             case INTERNAL_ERROR:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "System error");

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
@@ -67,10 +67,10 @@ public class DLinkMotionSensorHandler extends BaseThingHandler implements DLinkM
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid pin code");
                 break;
             case INTERNAL_ERROR:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "System error");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "System error");
                 break;
             case UNSUPPORTED_FIRMWARE:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "Unsupported firmware");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Unsupported firmware");
                 break;
             default:
                 break;
@@ -79,7 +79,9 @@ public class DLinkMotionSensorHandler extends BaseThingHandler implements DLinkM
 
     @Override
     public void dispose() {
-        motionSensor.dispose();
+        if (motionSensor != null) {
+            motionSensor.dispose();
+        }
         super.dispose();
     }
 }

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/handler/DLinkMotionSensorHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.handler;
+
+import static org.openhab.binding.dlinksmarthome.DLinkSmartHomeBindingConstants.MOTION;
+import static org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig.*;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorCommunication;
+import org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorCommunication.DeviceStatus;
+import org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig;
+import org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorListener;
+
+/**
+ * The {@link DLinkMotionSensorHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Mike Major - Initial contribution
+ */
+public class DLinkMotionSensorHandler extends BaseThingHandler implements DLinkMotionSensorListener {
+
+    private DLinkMotionSensorCommunication motionSensor;
+
+    private final ChannelUID motionChannel;
+
+    public DLinkMotionSensorHandler(final Thing thing) {
+        super(thing);
+        motionChannel = new ChannelUID(getThing().getUID(), MOTION);
+    }
+
+    @Override
+    public void handleCommand(final ChannelUID channelUID, final Command command) {
+        // Does not support commands
+    }
+
+    @Override
+    public void initialize() {
+        if (getConfig().get(REBOOT_INTERVAL) == null) {
+            final Configuration configuration = editConfiguration();
+            if ("A1".equals(getThing().getProperties().get(HARDWARE_VERSION))) {
+                configuration.put(REBOOT_INTERVAL, 4);
+            } else {
+                configuration.put(REBOOT_INTERVAL, 24);
+            }
+            updateConfiguration(configuration);
+        }
+
+        final DLinkMotionSensorConfig config = getConfigAs(DLinkMotionSensorConfig.class);
+        motionSensor = new DLinkMotionSensorCommunication(config, this, scheduler);
+    }
+
+    @Override
+    public void motionDetected() {
+        triggerChannel(motionChannel);
+    }
+
+    @Override
+    public void sensorStatus(final DeviceStatus status) {
+        switch (status) {
+            case ONLINE:
+                updateStatus(ThingStatus.ONLINE);
+                break;
+            case REBOOTING:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE, "Device rebooting");
+                break;
+            case COMMUNICATION_ERROR:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+                break;
+            case INVALID_PIN:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid pin code");
+                break;
+            case INVALID_TIME:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Invalid reboot time or interval");
+                break;
+            case INTERNAL_ERROR:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "System error");
+                break;
+            case UNSUPPORTED_FIRMWARE:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "Unsupported firmware");
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void dispose() {
+        motionSensor.dispose();
+        super.dispose();
+    }
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkHNAPCommunication.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkHNAPCommunication.java
@@ -1,0 +1,440 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.MimeHeader;
+import javax.xml.soap.MimeHeaders;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+/**
+ * The {@link DLinkHNAPCommunication} is responsible for communicating with D-Link
+ * Smart Home devices using the HNAP interface.
+ *
+ * This abstract class handles login and authentication which is common between devices.
+ *
+ * Reverse engineered from Login.html and soapclient.js retrieved from the device.
+ *
+ * @author Mike Major - Initial contribution
+ */
+public abstract class DLinkHNAPCommunication {
+
+    // SOAP actions
+    private static final String LOGIN_ACTION = "\"http://purenetworks.com/HNAP1/LOGIN\"";
+
+    // Strings used more than once
+    private static final String LOGIN = "LOGIN";
+    private static final String ACTION = "Action";
+    private static final String USERNAME = "Username";
+    private static final String LOGINPASSWORD = "LoginPassword";
+    private static final String CAPTCHA = "Captcha";
+    private static final String ADMIN = "Admin";
+    private static final String LOGINRESULT = "LOGINResult";
+    private static final String COOKIE = "Cookie";
+
+    /**
+     * HNAP XMLNS
+     */
+    protected static final String HNAP_XMLNS = "http://purenetworks.com/HNAP1";
+    /**
+     * The SOAP action HTML header
+     */
+    protected static final String SOAPACTION = "SOAPAction";
+    /**
+     * OK represents a successful action
+     */
+    protected static final String OK = "OK";
+
+    /**
+     * Use to log connection issues
+     */
+    private final Logger logger = LoggerFactory.getLogger(DLinkHNAPCommunication.class);
+
+    private URL url;
+    private final String pin;
+    private String privateKey;
+
+    private DocumentBuilder parser;
+    private SOAPMessage requestAction;
+    private SOAPMessage loginAction;
+
+    private HNAPStatus status = HNAPStatus.INITIALISED;
+
+    /**
+     * Indicates the status of the HNAP interface
+     *
+     */
+    protected enum HNAPStatus {
+        /**
+         * Ready to start communication with device
+         */
+        INITIALISED,
+        /**
+         * Successfully logged in to device
+         */
+        LOGGED_IN,
+        /**
+         * Problem communicating with device
+         */
+        COMMUNICATION_ERROR,
+        /**
+         * Internal error
+         */
+        INTERNAL_ERROR,
+        /**
+         * Error due to unsupported firmware
+         */
+        UNSUPPORTED_FIRMWARE,
+        /**
+         * Error due to invalid pin code
+         */
+        INVALID_PIN
+    }
+
+    /**
+     * Use {@link #getHNAPStatus()} to determine the status of the HNAP connection
+     * after construction.
+     *
+     * @param ipAddress
+     * @param pin
+     */
+    public DLinkHNAPCommunication(final String ipAddress, final String pin) {
+        this.pin = pin;
+
+        try {
+            url = new URL(null, "http://" + ipAddress + "/HNAP1");
+
+            parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+            final MessageFactory messageFactory = MessageFactory.newInstance();
+            requestAction = messageFactory.createMessage();
+            loginAction = messageFactory.createMessage();
+
+            buildRequestAction();
+            buildLoginAction();
+
+        } catch (final SOAPException e) {
+            logger.debug("DLinkHNAPCommunication - Internal error", e);
+            status = HNAPStatus.INTERNAL_ERROR;
+        } catch (final MalformedURLException e) {
+            logger.debug("DLinkHNAPCommunication - Internal error", e);
+            status = HNAPStatus.INTERNAL_ERROR;
+        } catch (final ParserConfigurationException e) {
+            logger.debug("DLinkHNAPCommunication - Internal error", e);
+            status = HNAPStatus.INTERNAL_ERROR;
+        }
+    }
+
+    /**
+     * This is the first SOAP message used in the login process and is used to retrieve
+     * the cookie, challenge and public key used for authentication.
+     *
+     * @throws SOAPException
+     */
+    private void buildRequestAction() throws SOAPException {
+        requestAction.getSOAPHeader().detachNode();
+        final SOAPBody soapBody = requestAction.getSOAPBody();
+        final SOAPElement soapBodyElem = soapBody.addChildElement(LOGIN, "", HNAP_XMLNS);
+        soapBodyElem.addChildElement(ACTION).addTextNode("request");
+        soapBodyElem.addChildElement(USERNAME).addTextNode(ADMIN);
+        soapBodyElem.addChildElement(LOGINPASSWORD);
+        soapBodyElem.addChildElement(CAPTCHA);
+
+        final MimeHeaders headers = requestAction.getMimeHeaders();
+        headers.addHeader(SOAPACTION, LOGIN_ACTION);
+
+        requestAction.saveChanges();
+    }
+
+    /**
+     * This is the second SOAP message used in the login process and uses a password derived
+     * from the challenge, public key and the device's pin code.
+     *
+     * @throws SOAPException
+     */
+    private void buildLoginAction() throws SOAPException {
+        loginAction.getSOAPHeader().detachNode();
+        final SOAPBody soapBody = loginAction.getSOAPBody();
+        final SOAPElement soapBodyElem = soapBody.addChildElement(LOGIN, "", HNAP_XMLNS);
+        soapBodyElem.addChildElement(ACTION).addTextNode("login");
+        soapBodyElem.addChildElement(USERNAME).addTextNode(ADMIN);
+        soapBodyElem.addChildElement(LOGINPASSWORD);
+        soapBodyElem.addChildElement(CAPTCHA);
+
+        final MimeHeaders headers = loginAction.getMimeHeaders();
+        headers.addHeader(SOAPACTION, LOGIN_ACTION);
+    }
+
+    /**
+     * Sets the password for the second login message based on the data received from the
+     * first login message. Also sets the private key used to generate the authentication header.
+     *
+     * @param challenge
+     * @param cookie
+     * @param publicKey
+     * @throws SOAPException
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     */
+    private void setAuthenticationData(final String challenge, final String cookie, final String publicKey)
+            throws SOAPException, InvalidKeyException, NoSuchAlgorithmException {
+        final MimeHeaders loginHeaders = loginAction.getMimeHeaders();
+        loginHeaders.setHeader(COOKIE, "uid=" + cookie);
+
+        privateKey = hash(challenge, publicKey + pin);
+
+        final String password = hash(challenge, privateKey);
+
+        loginAction.getSOAPBody().getElementsByTagName(LOGINPASSWORD).item(0).setTextContent(password);
+        loginAction.saveChanges();
+    }
+
+    /**
+     * Used to hash the authentication data such as the login password and the authentication header
+     * for the detection message.
+     *
+     * @param data
+     * @param key
+     * @return The hashed data
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     */
+    private String hash(final String data, final String key) throws NoSuchAlgorithmException, InvalidKeyException {
+        final Mac mac = Mac.getInstance("HMACMD5");
+        final SecretKeySpec sKey = new SecretKeySpec(key.getBytes(), "ASCII");
+
+        mac.init(sKey);
+        final byte[] bytes = mac.doFinal(data.getBytes());
+
+        final StringBuilder hashBuf = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            final String hex = Integer.toHexString(0xFF & bytes[i]).toUpperCase();
+            if (hex.length() == 1) {
+                hashBuf.append('0');
+            }
+            hashBuf.append(hex);
+        }
+
+        return hashBuf.toString();
+    }
+
+    /**
+     * Output unexpected responses to the debug log and sets the FIRMWARE error.
+     *
+     * @param message
+     * @param soapResponse
+     */
+    private void unexpectedResult(final String message, final Document soapResponse) {
+        logUnexpectedResult(message, soapResponse);
+
+        // Best guess when receiving unexpected responses
+        status = HNAPStatus.UNSUPPORTED_FIRMWARE;
+    }
+
+    /**
+     * Get the status of the HNAP interface
+     *
+     * @return the HNAP status
+     */
+    protected HNAPStatus getHNAPStatus() {
+        return status;
+    }
+
+    /**
+     * Sends the two login messages and stores the private key used to generate the
+     * authentication header required for actions.
+     *
+     * Use {@link #getHNAPStatus()} to determine the status of the HNAP connection
+     * after calling this method.
+     *
+     * @param timeout - Connection timeout in milliseconds
+     */
+    protected void login(final int timeout) {
+        if (status != HNAPStatus.INTERNAL_ERROR) {
+            try {
+                Document soapResponse = sendReceive(requestAction, timeout);
+
+                Node result = soapResponse.getElementsByTagName(LOGINRESULT).item(0);
+
+                if (result != null && OK.equals(result.getTextContent())) {
+                    final Node challengeNode = soapResponse.getElementsByTagName("Challenge").item(0);
+                    final Node cookieNode = soapResponse.getElementsByTagName(COOKIE).item(0);
+                    final Node publicKeyNode = soapResponse.getElementsByTagName("PublicKey").item(0);
+
+                    if (challengeNode != null && cookieNode != null && publicKeyNode != null) {
+                        setAuthenticationData(challengeNode.getTextContent(), cookieNode.getTextContent(),
+                                publicKeyNode.getTextContent());
+
+                        soapResponse = sendReceive(loginAction, timeout);
+                        result = soapResponse.getElementsByTagName(LOGINRESULT).item(0);
+
+                        if (result != null) {
+                            if ("success".equals(result.getTextContent())) {
+                                status = HNAPStatus.LOGGED_IN;
+                            } else {
+                                logger.debug("login - Check pin is correct");
+                                // Assume pin code problem rather than a firmware change
+                                status = HNAPStatus.INVALID_PIN;
+                            }
+                        } else {
+                            unexpectedResult("login - Unexpected login response", soapResponse);
+                        }
+                    } else {
+                        unexpectedResult("login - Unexpected request response", soapResponse);
+                    }
+                } else {
+                    unexpectedResult("login - Unexpected request response", soapResponse);
+                }
+            } catch (final InvalidKeyException e) {
+                logger.debug("login - Internal error", e);
+                status = HNAPStatus.INTERNAL_ERROR;
+            } catch (final NoSuchAlgorithmException e) {
+                logger.debug("login - Internal error", e);
+                status = HNAPStatus.INTERNAL_ERROR;
+            } catch (final Exception e) {
+                // Assume there has been some problem trying to send one of the messages
+                if (status != HNAPStatus.COMMUNICATION_ERROR) {
+                    logger.debug("login - Communication error", e);
+                    status = HNAPStatus.COMMUNICATION_ERROR;
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the authentication headers for the action message. This should only be called
+     * after a successful login.
+     *
+     * Use {@link #getHNAPStatus()} to determine the status of the HNAP connection
+     * after calling this method.
+     *
+     * @param action - SOAP Action to add headers
+     */
+    protected void setAuthenticationHeaders(final SOAPMessage action) {
+        if (status == HNAPStatus.LOGGED_IN) {
+            try {
+                final MimeHeaders loginHeaders = loginAction.getMimeHeaders();
+                final MimeHeaders actionHeaders = action.getMimeHeaders();
+
+                actionHeaders.setHeader(COOKIE, loginHeaders.getHeader(COOKIE)[0]);
+
+                final String timeStamp = String.valueOf(System.currentTimeMillis() / 1000);
+                final String auth = hash(timeStamp + actionHeaders.getHeader(SOAPACTION)[0], privateKey) + " "
+                        + timeStamp;
+                actionHeaders.setHeader("HNAP_AUTH", auth);
+
+                action.saveChanges();
+            } catch (final InvalidKeyException e) {
+                logger.debug("setAuthenticationHeaders - Internal error", e);
+                status = HNAPStatus.INTERNAL_ERROR;
+            } catch (final NoSuchAlgorithmException e) {
+                logger.debug("setAuthenticationHeaders - Internal error", e);
+                status = HNAPStatus.INTERNAL_ERROR;
+            } catch (final SOAPException e) {
+                // No communication happening so assume system error
+                logger.debug("setAuthenticationHeaders - Internal error", e);
+                status = HNAPStatus.INTERNAL_ERROR;
+            }
+        }
+    }
+
+    /**
+     * Send the SOAP message using a HttpURLConnection and parse the result using DocumentBuilder.
+     * This is used in preference to SOAPConnection and SOAPMessage as these tend to fill
+     * the log file with messages when things go wrong.
+     *
+     * @param action - SOAP Action to send
+     * @param timeout - Connection timeout in milliseconds
+     * @return The result which may be null
+     * @throws IOException
+     * @throws SOAPException
+     * @throws SAXException
+     */
+    protected Document sendReceive(final SOAPMessage action, final int timeout)
+            throws IOException, SOAPException, SAXException {
+
+        Document result = null;
+
+        final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        connection.setConnectTimeout(timeout);
+        connection.setReadTimeout(timeout);
+
+        connection.setDoOutput(true);
+        final Iterator<?> it = action.getMimeHeaders().getAllHeaders();
+        while (it.hasNext()) {
+            final MimeHeader header = (MimeHeader) it.next();
+            connection.setRequestProperty(header.getName(), header.getValue());
+        }
+
+        try (final OutputStream os = connection.getOutputStream()) {
+            action.writeTo(os);
+        }
+
+        try (final InputStream is = connection.getInputStream()) {
+            result = parser.parse(is);
+        }
+
+        return result;
+    }
+
+    /**
+     * Output unexpected responses to the debug log.
+     *
+     * @param message
+     * @param soapResponse
+     */
+    protected void logUnexpectedResult(final String message, final Document soapResponse) {
+
+        // No point formatting for output if debug logging is not enabled
+        if (logger.isDebugEnabled()) {
+            try {
+                final TransformerFactory transFactory = TransformerFactory.newInstance();
+                final Transformer transformer = transFactory.newTransformer();
+                final StringWriter buffer = new StringWriter();
+                transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                transformer.transform(new DOMSource(soapResponse), new StreamResult(buffer));
+                logger.debug("{} : {}", message, buffer);
+            } catch (final TransformerException e) {
+                logger.debug("{}", message);
+            }
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeDiscoveryParticipant.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.dlinksmarthome.internal;
 
 import static org.openhab.binding.dlinksmarthome.DLinkSmartHomeBindingConstants.*;
-import static org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig.*;
+import static org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig.IP_ADDRESS;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -93,11 +93,9 @@ public class DLinkSmartHomeDiscoveryParticipant implements MDNSDiscoveryParticip
 
         final String host = serviceInfo.getHostAddresses()[0];
         final String mac = serviceInfo.getPropertyString("mac");
-        final String hardwareVersion = serviceInfo.getPropertyString("hardware_ver");
 
         final Map<String, Object> properties = new HashMap<>();
         properties.put(IP_ADDRESS, host);
-        properties.put(HARDWARE_VERSION, hardwareVersion);
 
         logger.debug("DCH-S150 found: {}", host);
 

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeDiscoveryParticipant.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.internal;
+
+import static org.openhab.binding.dlinksmarthome.DLinkSmartHomeBindingConstants.*;
+import static org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorConfig.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link DLinkSmartHomeDiscoveryParticipant} is responsible for discovering devices through UPnP.
+ *
+ * @author Mike Major - Initial contribution
+ *
+ */
+public class DLinkSmartHomeDiscoveryParticipant implements MDNSDiscoveryParticipant {
+
+    private static final String SERVICE_TYPE = "_dhnap._tcp.local.";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    public String getServiceType() {
+        return SERVICE_TYPE;
+    }
+
+    @Override
+    public DiscoveryResult createResult(final ServiceInfo serviceInfo) {
+        final ThingUID thingUID = getThingUID(serviceInfo);
+
+        if (thingUID == null) {
+            return null;
+        }
+
+        final ThingTypeUID thingTypeUID = getThingType(serviceInfo);
+
+        if (THING_TYPE_DCHS150.equals(thingTypeUID)) {
+            return createMotionSensor(thingUID, thingTypeUID, serviceInfo);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public ThingUID getThingUID(final ServiceInfo serviceInfo) {
+        final ThingTypeUID thingTypeUID = getThingType(serviceInfo);
+
+        if (thingTypeUID != null) {
+            final String mac = serviceInfo.getPropertyString("mac").replace(":", "").toLowerCase();
+            return new ThingUID(thingTypeUID, mac);
+        } else {
+            return null;
+        }
+    }
+
+    private ThingTypeUID getThingType(final ServiceInfo serviceInfo) {
+        final String model = serviceInfo.getPropertyString("model_number");
+
+        if (model == null) {
+            return null;
+        } else if (model.equals("DCH-S150")) {
+            return THING_TYPE_DCHS150;
+        } else {
+            logger.debug("D-Link HNAP Type: {}", model);
+            return null;
+        }
+    }
+
+    private DiscoveryResult createMotionSensor(final ThingUID thingUID, final ThingTypeUID thingType,
+            final ServiceInfo serviceInfo) {
+
+        final String host = serviceInfo.getHostAddresses()[0];
+        final String mac = serviceInfo.getPropertyString("mac");
+        final String hardwareVersion = serviceInfo.getPropertyString("hardware_ver");
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(IP_ADDRESS, host);
+        properties.put(HARDWARE_VERSION, hardwareVersion);
+
+        logger.debug("DCH-S150 found: {}", host);
+
+        return DiscoveryResultBuilder.create(thingUID).withThingType(thingType).withProperties(properties)
+                .withLabel("Motion Sensor (" + mac + ")").build();
+    }
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeHandlerFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.internal;
+
+import static org.openhab.binding.dlinksmarthome.DLinkSmartHomeBindingConstants.*;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.dlinksmarthome.handler.DLinkMotionSensorHandler;
+
+/**
+ * The {@link DLinkSmartHomeHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Mike Major - Initial contribution
+ */
+public class DLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
+
+    @Override
+    public boolean supportsThingType(final ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(final Thing thing) {
+
+        final ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(THING_TYPE_DCHS150)) {
+            return new DLinkMotionSensorHandler(thing);
+        }
+
+        return null;
+    }
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorConfig.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorConfig.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.internal.motionsensor;
+
+/**
+ * The {@link DLinkMotionSensorConfig} provides configuration data
+ *
+ * @author Mike Major - Initial contribution
+ */
+public class DLinkMotionSensorConfig {
+
+    /**
+     * Hardware version found during discovery
+     */
+    public static final String HARDWARE_VERSION = "hardwareVersion";
+
+    /**
+     * Constants representing the configuration strings
+     */
+    public static final String IP_ADDRESS = "ipAddress";
+    public static final String PIN = "pin";
+    public static final String REBOOT_TIME = "rebootTime";
+    public static final String REBOOT_INTERVAL = "rebootInterval";
+
+    /**
+     * The IP address of the device
+     */
+    public String ipAddress;
+
+    /**
+     * The pin code of the device
+     */
+    public String pin;
+
+    /**
+     * The time the device will be rebooted for the first time each day
+     */
+    public String rebootTime;
+
+    /**
+     * The number of hours after which the device will be rebooted
+     */
+    public Integer rebootInterval;
+}

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorConfig.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorConfig.java
@@ -16,17 +16,10 @@ package org.openhab.binding.dlinksmarthome.internal.motionsensor;
 public class DLinkMotionSensorConfig {
 
     /**
-     * Hardware version found during discovery
-     */
-    public static final String HARDWARE_VERSION = "hardwareVersion";
-
-    /**
      * Constants representing the configuration strings
      */
     public static final String IP_ADDRESS = "ipAddress";
     public static final String PIN = "pin";
-    public static final String REBOOT_TIME = "rebootTime";
-    public static final String REBOOT_INTERVAL = "rebootInterval";
 
     /**
      * The IP address of the device
@@ -37,14 +30,4 @@ public class DLinkMotionSensorConfig {
      * The pin code of the device
      */
     public String pin;
-
-    /**
-     * The time the device will be rebooted for the first time each day
-     */
-    public String rebootTime;
-
-    /**
-     * The number of hours after which the device will be rebooted
-     */
-    public Integer rebootInterval;
 }

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorListener.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/motionsensor/DLinkMotionSensorListener.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinksmarthome.internal.motionsensor;
+
+import org.openhab.binding.dlinksmarthome.internal.motionsensor.DLinkMotionSensorCommunication.DeviceStatus;
+
+/**
+ * The {@link DLinkMotionSensorListener} provides callbacks for motion detection
+ * and device status changes.
+ *
+ * @author Mike Major - Initial contribution
+ */
+public interface DLinkMotionSensorListener {
+
+    /**
+     * Callback to indicate motion has been detected
+     */
+    void motionDetected();
+
+    /**
+     * Callback to indicate a change in the device status
+     */
+    void sensorStatus(final DeviceStatus status);
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -26,6 +26,7 @@
     <module>org.openhab.binding.boschindego</module>
     <module>org.openhab.binding.chromecast</module>
     <module>org.openhab.binding.coolmasternet</module>
+    <module>org.openhab.binding.dlinksmarthome</module>
     <module>org.openhab.binding.dscalarm</module>
     <module>org.openhab.binding.exec</module>
     <module>org.openhab.binding.feed</module>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -67,6 +67,12 @@
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.coolmasternet/${project.version}</bundle>
     </feature>
+    
+    <feature name="openhab-binding-dlinksmarthome" description="D-Link Smart Home Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-mdns</feature>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.dlinksmarthome/${project.version}</bundle>
+    </feature>
 
     <feature name="openhab-binding-dscalarm" description="DSCAlarm Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>


### PR DESCRIPTION
This is a binding for D-Link Smart Home devices such as the DCH-S150 motion sensor and DSP-W215 smart plug.

The binding is intended to support D-Link Smart Home devices which provide a HNAP interface over WiFi.

The binding does not require the use of the cloud and for the motion sensor is about 2-3 seconds faster in response time compared to using IFTTT/myopenHAB.

Currently supported Things:
**DCH-S150** - The binding provides auto discovery and a trigger channel.

Signed-off-by: Mike Major <mike_j_major@hotmail.com> (github: MikeJMajor)