### PR TITLE
[Lutron] Ignore "extra" GNET> prompts

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
@@ -301,7 +301,7 @@ public class IPBridgeHandler extends BaseBridgeHandler {
 
             Matcher matcher = STATUS_REGEX.matcher(line);
 
-            if (matcher.matches()) {
+            if (matcher.find()) {
                 LutronCommandType type = LutronCommandType.valueOf(matcher.group(1));
 
                 if (type == LutronCommandType.SYSTEM) {


### PR DESCRIPTION
Under operational conditions, a Smart Bridge PRO has been observed to
return multiple "GNET>" prompts to the handler.  These cause the regex
to fail to match and properly extract the content from the stream.

This changes a full-string regex match to a "contains" match
allowing the content to be extracted when there are multiple,
leading prompts.  It is not robust to _trailing_ prompts,
but such a case has not yet been observed.

Resolves https://github.com/openhab/openhab2-addons/issues/2028

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com> (github: jeffsf)

as per http://docs.openhab.org/developers/contributing/contributing.html
retrieved on 2017-03-16