### PR TITLE
[Lutron] Implement INCREASE/DECREASE/STOP for dimmers

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/DimmerHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/DimmerHandler.java
@@ -12,8 +12,10 @@ import static org.openhab.binding.lutron.LutronBindingConstants.CHANNEL_LIGHTLEV
 
 import java.math.BigDecimal;
 
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -31,6 +33,9 @@ import org.slf4j.LoggerFactory;
  */
 public class DimmerHandler extends LutronHandler {
     private static final Integer ACTION_ZONELEVEL = 1;
+    private static final Integer ACTION_START_RAISING = 2;
+    private static final Integer ACTION_START_LOWERING = 3;
+    private static final Integer ACTION_STOP_RAISING_LOWERING = 4;
 
     private Logger logger = LoggerFactory.getLogger(DimmerHandler.class);
 
@@ -88,6 +93,14 @@ public class DimmerHandler extends LutronHandler {
                 output(ACTION_ZONELEVEL, 100, this.config.getFadeInTime());
             } else if (command.equals(OnOffType.OFF)) {
                 output(ACTION_ZONELEVEL, 0, this.config.getFadeOutTime());
+
+            } else if (command.equals(IncreaseDecreaseType.INCREASE)) {
+                output(ACTION_START_RAISING);
+            } else if (command.equals(IncreaseDecreaseType.DECREASE)) {
+                output(ACTION_START_LOWERING);
+            } else if (command.equals(StopMoveType.STOP)) {
+                output(ACTION_STOP_RAISING_LOWERING);
+
             }
         }
     }


### PR DESCRIPTION
Caseta and at least Maestro dimmers support up/down dimming
from the unit or a remote, like a Pico

Add the new command codes to the dimmer handler to allow this
dimming to be controlled from within openHAB

Documentation of commands from publicly available
http://www.lutron.com/TechnicalDocumentLibrary/040249.pdf
(revision T 12 January 2017)

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com> (github: jeffsf)

as per http://docs.openhab.org/developers/contributing/contributing.html
retrieved on 2017-03-16