### PR TITLE
Remove the "Require-Bundle" header 

### DIFF
--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -34,5 +34,3 @@ Import-Package: com.google.common.base,
 Service-Component: OSGI-INF/*
 Export-Package: org.openhab.binding.freebox,
  org.openhab.binding.freebox.handler
-Require-Bundle: org.apache.commons.io,
- org.apache.commons.codec

--- a/addons/binding/org.openhab.binding.max.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max.test/META-INF/MANIFEST.MF
@@ -17,10 +17,13 @@ Import-Package: groovy.json,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
+ org.junit.runner,
+ org.junit.runners,
  org.openhab.binding.max,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Export-Package: org.openhab.binding.max.internal.message;x-internal:=true,
  org.openhab.binding.max.test;uses:="org.eclipse.smarthome.test"
+
 

--- a/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
  org.apache.commons.net.util,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
@@ -19,4 +20,3 @@ Import-Package: com.google.common.collect,
 Service-Component: OSGI-INF/*
 Export-Package: org.openhab.binding.network,
  org.openhab.binding.network.handler
-Require-Bundle: org.apache.commons.lang

--- a/addons/binding/org.openhab.binding.rfxcom.test/.classpath
+++ b/addons/binding/org.openhab.binding.rfxcom.test/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.config.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core.thing"/>

--- a/addons/binding/org.openhab.binding.rfxcom.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.rfxcom.test/META-INF/MANIFEST.MF
@@ -13,6 +13,8 @@ Import-Package: org.slf4j,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
+ org.junit.runner,
+ org.junit.runners,
  org.openhab.binding.rfxcom,
  org.osgi.service.device
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/addons/binding/org.openhab.binding.vitotronic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.vitotronic/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,
  org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
@@ -18,4 +19,3 @@ Import-Package: com.google.common.collect,
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.vitotronic,
  org.openhab.binding.vitotronic.handler
-Require-Bundle: org.eclipse.smarthome.config.discovery

--- a/addons/ui/org.openhab.ui.cometvisu.php/META-INF/MANIFEST.MF
+++ b/addons/ui/org.openhab.ui.cometvisu.php/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Import-Package:
  com.caucho.vfs;version="[4.0,5)",
  javax.servlet;version="[3.1,4)",
  javax.servlet.http;version="[3.1,4)",
+ org.openhab.ui.cometvisu.php,
  org.slf4j;version="[1.7,2)"
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
-Require-Bundle: org.openhab.ui.cometvisu


### PR DESCRIPTION
My colleagues and I are developing a static-code-analysis tool (https://github.com/openhab/static-code-analysis). One of the checks that we are doing verifies that the `MANIFEST.MF` file does not contain any `Require-Bundle` header (https://github.com/openhab/static-code-analysis/pull/19), as it is written in the openHab coding guidelines - http://docs.openhab.org/developers/development/guidelines.html. I found some bundles that do not follow that rule. IMHO, they can be changed in a way that they don't contain a `Require-Bundle` header.