### PR TITLE
Read minimum and maximum temperature from configuration

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -58,11 +58,11 @@ public class HomekitSettings {
         }
         Object minimumTemperature = properties.get("minimumTemperature");
         if (minimumTemperature != null) {
-            this.minimumTemperature = (double) minimumTemperature;
+            this.minimumTemperature = Double.parseDouble(minimumTemperature.toString());
         }
         Object maximumTemperature = properties.get("maximumTemperature");
         if (maximumTemperature != null) {
-            this.maximumTemperature = (double) maximumTemperature;
+            this.maximumTemperature = Double.parseDouble(maximumTemperature.toString());
         }
         this.thermostatHeatMode = (String) properties.get("thermostatHeatMode");
         this.thermostatCoolMode = (String) properties.get("thermostatCoolMode");


### PR DESCRIPTION
[![Review](https://codenvy.io/factory/resources/codenvy-review.svg)](https://codenvy.io/f?id=factoryu291ginlghqkebhg)

Fix to read the minimum and maximum temperatures from the configuration of the homekit bridge.