### PR TITLE
Removed the exported internal package from MAX tests.

### DIFF
--- a/addons/binding/org.openhab.binding.max.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max.test/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Import-Package: groovy.json,
  org.openhab.binding.max,
  org.osgi.service.device,
  org.slf4j
-Export-Package: org.openhab.binding.max.internal.message;x-internal:=true,
- org.openhab.binding.max.test;uses:="org.eclipse.smarthome.test"
+Export-Package: org.openhab.binding.max.test;uses:="org.eclipse.smarthome.test"
 
 


### PR DESCRIPTION
The static code analysis tool showed a violation in the MAX tests (https://github.com/openhab/static-code-analysis/pull/33) - an internal package is exported - `org.openhab.binding.max.internal.message`