### PR TITLE
Fixed mediator lookup, using the OGSI dependency injection.

### DIFF
--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/META-INF/MANIFEST.MF
@@ -8,12 +8,13 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,
  org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
- org.eclipse.smarthome.config.discovery,
  org.osgi.framework,
+ org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.silvercrestwifisocket,

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketDiscovery.xml
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketDiscovery.xml
@@ -14,4 +14,6 @@
    <service>
       <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryService"/>
    </service>
+   <reference interface="org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator" 
+       name="mediator" policy="static" bind="setMediator" cardinality="1..1" unbind="unsetMediator"/>
 </scr:component>

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketHandlerFactory.xml
@@ -16,5 +16,6 @@
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
    </service>
-
+   <reference interface="org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator" 
+       name="mediator" policy="static" bind="setMediator" cardinality="1..1" unbind="unsetMediator"/>
 </scr:component>

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketMediator.xml
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/OSGI-INF/SilvercrestWifiSocketMediator.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator">
+   <implementation class="org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediatorImpl"/>
+   <service>
+      <provide interface="org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/discovery/SilvercrestWifiSocketDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/discovery/SilvercrestWifiSocketDiscoveryService.java
@@ -32,7 +32,29 @@ import org.slf4j.LoggerFactory;
 public class SilvercrestWifiSocketDiscoveryService extends AbstractDiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(SilvercrestWifiSocketDiscoveryService.class);
-    private final SilvercrestWifiSocketMediator mediator;
+    private SilvercrestWifiSocketMediator mediator;
+
+    /**
+     * Used by OSGI to inject the mediator in the discovery service.
+     *
+     * @param mediator the mediator
+     */
+    public void setMediator(final SilvercrestWifiSocketMediator mediator) {
+        logger.debug("Mediator has been injected on discovery service.");
+        this.mediator = mediator;
+        mediator.setDiscoveryService(this);
+    }
+
+    /**
+     * Used by OSGI to unset the mediator in the discovery service.
+     *
+     * @param mediator the mediator
+     */
+    public void unsetMediator(final SilvercrestWifiSocketMediator mitsubishiMediator) {
+        logger.debug("Mediator has been unsetted from discovery service.");
+        this.mediator.setDiscoveryService(null);
+        this.mediator = null;
+    }
 
     /**
      * Constructor of the discovery service.
@@ -42,8 +64,6 @@ public class SilvercrestWifiSocketDiscoveryService extends AbstractDiscoveryServ
     public SilvercrestWifiSocketDiscoveryService() throws IllegalArgumentException {
         super(SilvercrestWifiSocketBindingConstants.SUPPORTED_THING_TYPES_UIDS,
                 SilvercrestWifiSocketBindingConstants.DISCOVERY_TIMEOUT_SECONDS);
-        logger.debug("SilvercrestWifiSocketMediator is not initialized yet will create one mediator...");
-        this.mediator = new SilvercrestWifiSocketMediator(this);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/handler/SilvercrestWifiSocketMediator.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/handler/SilvercrestWifiSocketMediator.java
@@ -8,18 +8,12 @@
  */
 package org.openhab.binding.silvercrestwifisocket.handler;
 
-import java.net.SocketException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.silvercrestwifisocket.SilvercrestWifiSocketBindingConstants;
 import org.openhab.binding.silvercrestwifisocket.discovery.SilvercrestWifiSocketDiscoveryService;
 import org.openhab.binding.silvercrestwifisocket.internal.entities.SilvercrestWifiSocketResponse;
 import org.openhab.binding.silvercrestwifisocket.internal.runnable.SilvercrestWifiSocketUpdateReceiverRunnable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link SilvercrestWifiSocketMediator} is responsible for receiving all the UDP packets and route correctly to
@@ -27,27 +21,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jaime Vaz - Initial contribution
  */
-public class SilvercrestWifiSocketMediator {
-
-    private final Logger logger = LoggerFactory.getLogger(SilvercrestWifiSocketMediator.class);
-
-    private final Map<Thing, SilvercrestWifiSocketHandler> handlersRegisteredByThing = new HashMap<>();
-
-    private SilvercrestWifiSocketUpdateReceiverRunnable receiver;
-    private Thread receiverThread;
-
-    private final SilvercrestWifiSocketDiscoveryService silvercrestDiscoveryService;
-
-    /**
-     * Constructor of the mediator. The discovery service must be passed for notify when one new wifi socket has been
-     * found.
-     *
-     * @param silvercrestDiscoveryService the {@link SilvercrestWifiSocketDiscoveryService}
-     */
-    public SilvercrestWifiSocketMediator(final SilvercrestWifiSocketDiscoveryService silvercrestDiscoveryService) {
-        this.silvercrestDiscoveryService = silvercrestDiscoveryService;
-        this.initMediatorWifiSocketUpdateReceiverRunnable();
-    }
+public interface SilvercrestWifiSocketMediator {
 
     /**
      * This method is called by the {@link SilvercrestWifiSocketUpdateReceiverRunnable}, when one new message has been
@@ -55,24 +29,7 @@ public class SilvercrestWifiSocketMediator {
      *
      * @param receivedMessage the {@link SilvercrestWifiSocketResponse} message.
      */
-    public void processReceivedPacket(final SilvercrestWifiSocketResponse receivedMessage) {
-        logger.debug("Received packet from: {} with content: [{}]", receivedMessage.getHostAddress(),
-                receivedMessage.getType());
-
-        SilvercrestWifiSocketHandler handler = this.getHandlerRegistredByMac(receivedMessage.getMacAddress());
-
-        if (handler != null) {
-            // deliver message to handler.
-            handler.newReceivedResponseMessage(receivedMessage);
-            logger.debug("Received message delivered with success to handler of mac {}",
-                    receivedMessage.getMacAddress());
-        } else {
-            logger.debug("There is no handler registered for mac address: {}", receivedMessage.getMacAddress());
-            // notify discovery service of thing found!
-            this.silvercrestDiscoveryService.discoveredWifiSocket(receivedMessage.getMacAddress(),
-                    receivedMessage.getHostAddress());
-        }
-    }
+    void processReceivedPacket(final SilvercrestWifiSocketResponse receivedMessage);
 
     /**
      * Registers a new {@link Thing} and the corresponding {@link SilvercrestWifiSocketHandler}.
@@ -80,67 +37,26 @@ public class SilvercrestWifiSocketMediator {
      * @param thing the {@link Thing}.
      * @param handler the {@link SilvercrestWifiSocketHandler}.
      */
-    public void registerThingAndWifiSocketHandler(final Thing thing, final SilvercrestWifiSocketHandler handler) {
-        this.handlersRegisteredByThing.put(thing, handler);
-    }
+    void registerThingAndWifiSocketHandler(final Thing thing, final SilvercrestWifiSocketHandler handler);
 
     /**
      * Unregisters a {@link SilvercrestWifiSocketHandler} by the corresponding {@link Thing}.
      *
      * @param thing the {@link Thing}.
      */
-    public void unregisterWifiSocketHandlerByThing(final Thing thing) {
-        SilvercrestWifiSocketHandler handler = this.handlersRegisteredByThing.get(thing);
-        if (handler != null) {
-            this.handlersRegisteredByThing.remove(thing);
-        }
-
-    }
-
-    /**
-     * Utilitary method to get the registered thing handler in mediator by the mac address.
-     *
-     * @param macAddress the mac address of the thing of the handler.
-     * @return {@link SilvercrestWifiSocketHandler} if found.
-     */
-    private SilvercrestWifiSocketHandler getHandlerRegistredByMac(final String macAddress) {
-        SilvercrestWifiSocketHandler searchedHandler = null;
-        for (SilvercrestWifiSocketHandler handler : this.handlersRegisteredByThing.values()) {
-            if (macAddress.equals(handler.getMacAddress())) {
-                searchedHandler = handler;
-                // don't spend more computation. Found the handler.
-                break;
-            }
-        }
-        return searchedHandler;
-    }
-
-    /**
-     * Inits the mediator WifiSocketUpdateReceiverRunnable thread. This thread is responsible to receive all
-     * packets from Wifi Socket devices, and redirect the messages to mediator.
-     */
-    private void initMediatorWifiSocketUpdateReceiverRunnable() {
-        // try with handler port if is null
-        if ((this.receiver == null) || ((this.receiverThread != null)
-                && (this.receiverThread.isInterrupted() || !this.receiverThread.isAlive()))) {
-            try {
-                this.receiver = new SilvercrestWifiSocketUpdateReceiverRunnable(this,
-                        SilvercrestWifiSocketBindingConstants.WIFI_SOCKET_DEFAULT_UDP_PORT);
-                this.receiverThread = new Thread(this.receiver);
-                this.receiverThread.start();
-                logger.debug("Invoked the start of receiver thread.");
-            } catch (SocketException e) {
-                logger.debug("Cannot start the socket with default port...");
-            }
-        }
-    }
+    void unregisterWifiSocketHandlerByThing(final Thing thing);
 
     /**
      * Returns all the {@link Thing} registered.
      *
      * @returns all the {@link Thing}.
      */
-    public Set<Thing> getAllThingsRegistered() {
-        return this.handlersRegisteredByThing.keySet();
-    }
+    Set<Thing> getAllThingsRegistred();
+
+    /**
+     * Sets the discovery service to inform the when one new thing has been found.
+     *
+     * @param discoveryService the discovery service.
+     */
+    void setDiscoveryService(SilvercrestWifiSocketDiscoveryService discoveryService);
 }

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/handler/SilvercrestWifiSocketMediatorImpl.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/handler/SilvercrestWifiSocketMediatorImpl.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.silvercrestwifisocket.handler;
+
+import java.net.SocketException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.silvercrestwifisocket.SilvercrestWifiSocketBindingConstants;
+import org.openhab.binding.silvercrestwifisocket.discovery.SilvercrestWifiSocketDiscoveryService;
+import org.openhab.binding.silvercrestwifisocket.internal.entities.SilvercrestWifiSocketResponse;
+import org.openhab.binding.silvercrestwifisocket.internal.runnable.SilvercrestWifiSocketUpdateReceiverRunnable;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SilvercrestWifiSocketMediatorImpl} is responsible for receiving all the UDP packets and route correctly to
+ * each handler.
+ *
+ * @author Jaime Vaz - Initial contribution
+ */
+public class SilvercrestWifiSocketMediatorImpl implements SilvercrestWifiSocketMediator {
+
+    private final Logger logger = LoggerFactory.getLogger(SilvercrestWifiSocketMediatorImpl.class);
+
+    private final Map<Thing, SilvercrestWifiSocketHandler> handlersRegistredByThing = new HashMap<>();
+
+    private SilvercrestWifiSocketUpdateReceiverRunnable receiver;
+    private Thread receiverThread;
+
+    private SilvercrestWifiSocketDiscoveryService silvercrestDiscoveryService;
+
+    /**
+     * Called at the service activation.
+     *
+     * @param componentContext the componentContext
+     */
+    protected void activate(final ComponentContext componentContext) {
+        logger.debug("Mediator has been activated by OSGI.");
+        this.initMediatorWifiSocketUpdateReceiverRunnable();
+    }
+
+    /**
+     * Called at the service deactivation.
+     *
+     * @param componentContext the componentContext
+     */
+    protected void deactivate(final ComponentContext componentContext) {
+        if (this.receiver != null) {
+            this.receiver.shutdown();
+        }
+    }
+
+    /**
+     * This method is called by the {@link SilvercrestWifiSocketUpdateReceiverRunnable}, when one new message has been
+     * received.
+     *
+     * @param receivedMessage the {@link SilvercrestWifiSocketResponse} message.
+     */
+    @Override
+    public void processReceivedPacket(final SilvercrestWifiSocketResponse receivedMessage) {
+        logger.debug("Received packet from: {} with content: [{}]", receivedMessage.getHostAddress(),
+                receivedMessage.getType());
+
+        SilvercrestWifiSocketHandler handler = this.getHandlerRegistredByMac(receivedMessage.getMacAddress());
+
+        if (handler != null) {
+            // deliver message to handler.
+            handler.newReceivedResponseMessage(receivedMessage);
+            logger.debug("Received message delivered with success to handler of mac {}",
+                    receivedMessage.getMacAddress());
+        } else {
+            logger.debug("There is no handler registered for mac address:{}", receivedMessage.getMacAddress());
+            // notify discovery service of thing found!
+            this.silvercrestDiscoveryService.discoveredWifiSocket(receivedMessage.getMacAddress(),
+                    receivedMessage.getHostAddress());
+        }
+    }
+
+    /**
+     * Regists one new {@link Thing} and the corresponding {@link SilvercrestWifiSocketHandler}.
+     *
+     * @param thing the {@link Thing}.
+     * @param handler the {@link SilvercrestWifiSocketHandler}.
+     */
+    @Override
+    public void registerThingAndWifiSocketHandler(final Thing thing, final SilvercrestWifiSocketHandler handler) {
+        this.handlersRegistredByThing.put(thing, handler);
+    }
+
+    /**
+     * Unregists one {@link SilvercrestWifiSocketHandler} by the corresponding {@link Thing}.
+     *
+     * @param thing the {@link Thing}.
+     */
+    @Override
+    public void unregisterWifiSocketHandlerByThing(final Thing thing) {
+        SilvercrestWifiSocketHandler handler = this.handlersRegistredByThing.get(thing);
+        if (handler != null) {
+            this.handlersRegistredByThing.remove(thing);
+        }
+
+    }
+
+    /**
+     * Utilitary method to get the registered thing handler in mediator by the mac address.
+     *
+     * @param macAddress the mac address of the thing of the handler.
+     * @return {@link SilvercrestWifiSocketHandler} if found.
+     */
+    private SilvercrestWifiSocketHandler getHandlerRegistredByMac(final String macAddress) {
+        SilvercrestWifiSocketHandler searchedHandler = null;
+        for (SilvercrestWifiSocketHandler handler : this.handlersRegistredByThing.values()) {
+            if (macAddress.equals(handler.getMacAddress())) {
+                searchedHandler = handler;
+                // don't spend more computation. Found the handler.
+                break;
+            }
+        }
+        return searchedHandler;
+    }
+
+    /**
+     * Inits the mediator WifiSocketUpdateReceiverRunnable thread. This thread is responsible to receive all
+     * packets from Wifi Socket devices, and redirect the messages to mediator.
+     */
+    private void initMediatorWifiSocketUpdateReceiverRunnable() {
+        // try with handler port if is null
+        if ((this.receiver == null) || ((this.receiverThread != null)
+                && (this.receiverThread.isInterrupted() || !this.receiverThread.isAlive()))) {
+            try {
+                this.receiver = new SilvercrestWifiSocketUpdateReceiverRunnable(this,
+                        SilvercrestWifiSocketBindingConstants.WIFI_SOCKET_DEFAULT_UDP_PORT);
+                this.receiverThread = new Thread(this.receiver);
+                this.receiverThread.start();
+                logger.debug("Invoked the start of receiver thread.");
+            } catch (SocketException e) {
+                logger.debug("Cannot start the socket with default port...");
+            }
+        }
+    }
+
+    /**
+     * Returns all the {@link Thing} registered.
+     *
+     * @returns all the {@link Thing}.
+     */
+    @Override
+    public Set<Thing> getAllThingsRegistred() {
+        return this.handlersRegistredByThing.keySet();
+    }
+
+    @Override
+    public void setDiscoveryService(final SilvercrestWifiSocketDiscoveryService discoveryService) {
+        this.silvercrestDiscoveryService = discoveryService;
+
+    }
+}

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/internal/SilvercrestWifiSocketHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/internal/SilvercrestWifiSocketHandlerFactory.java
@@ -11,18 +11,14 @@ package org.openhab.binding.silvercrestwifisocket.internal;
 import java.util.Collections;
 import java.util.Set;
 
-import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.openhab.binding.silvercrestwifisocket.SilvercrestWifiSocketBindingConstants;
-import org.openhab.binding.silvercrestwifisocket.discovery.SilvercrestWifiSocketDiscoveryService;
 import org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketHandler;
 import org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator;
 import org.openhab.binding.silvercrestwifisocket.internal.exceptions.MacAddressNotValidException;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +37,26 @@ public class SilvercrestWifiSocketHandlerFactory extends BaseThingHandlerFactory
 
     private SilvercrestWifiSocketMediator mediator;
 
+    /**
+     * Used by OSGI to inject the mediator in the handler factory.
+     *
+     * @param mediator the mediator
+     */
+    public void setMediator(final SilvercrestWifiSocketMediator mediator) {
+        logger.debug("Mediator has been injected on handler factory service.");
+        this.mediator = mediator;
+    }
+
+    /**
+     * Used by OSGI to unsets the mediator from the handler factory.
+     *
+     * @param mediator the mediator
+     */
+    public void unsetMediator(final SilvercrestWifiSocketMediator mitsubishiMediator) {
+        logger.debug("Mediator has been unsetted from discovery service.");
+        this.mediator = null;
+    }
+
     @Override
     public boolean supportsThingType(final ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -57,7 +73,13 @@ public class SilvercrestWifiSocketHandlerFactory extends BaseThingHandlerFactory
             try {
                 handler = new SilvercrestWifiSocketHandler(thing);
                 logger.debug("SilvercrestWifiSocketMediator will register the handler.");
-                this.getMediator().registerThingAndWifiSocketHandler(thing, handler);
+                if (this.mediator != null) {
+                    this.mediator.registerThingAndWifiSocketHandler(thing, handler);
+                } else {
+                    logger.error(
+                            "The mediator is missing on Handler factory. Without one mediator the handler cannot work!");
+                    return null;
+                }
                 return handler;
             } catch (MacAddressNotValidException e) {
                 logger.debug("The mac address passed to WifiSocketHandler by configurations is not valid.");
@@ -69,39 +91,10 @@ public class SilvercrestWifiSocketHandlerFactory extends BaseThingHandlerFactory
 
     @Override
     public void unregisterHandler(final Thing thing) {
-        this.getMediator().unregisterWifiSocketHandlerByThing(thing);
-        super.unregisterHandler(thing);
-    }
-
-    /**
-     * Looks up for the the {@link SilvercrestWifiSocketDiscoveryService} and gets the
-     * {@link SilvercrestWifiSocketMediator}.
-     *
-     * @return the {@link SilvercrestWifiSocketMediator}.
-     */
-    private SilvercrestWifiSocketMediator getMediator() {
-        if (this.mediator == null) {
-            try {
-                // LOOKUP FOR SilvercrestDiscoveryService
-                ServiceReference<?>[] references = this.bundleContext
-                        .getAllServiceReferences(DiscoveryService.class.getName(), null);
-                if (references != null) {
-                    for (ServiceReference<?> reference : references) {
-                        if (this.bundleContext.getServiceObjects(reference)
-                                .getService() instanceof SilvercrestWifiSocketDiscoveryService) {
-                            SilvercrestWifiSocketDiscoveryService discoveryService = (SilvercrestWifiSocketDiscoveryService) this.bundleContext
-                                    .getServiceObjects(reference).getService();
-                            this.mediator = discoveryService.getMediator();
-                            break;
-                        }
-                    }
-                }
-            } catch (InvalidSyntaxException e) {
-                logger.debug("Error looking up for SilvercrestDiscoveryService to get the WifiSocketMediator: {}",
-                        e.getMessage());
-            }
+        if (this.mediator != null) {
+            this.mediator.unregisterWifiSocketHandlerByThing(thing);
         }
-        return this.mediator;
+        super.unregisterHandler(thing);
     }
 
 }


### PR DESCRIPTION
This pull request fix some nullpointer exceptions on the OH 2.1.0 snapshot.
Now the injection of the mediator is done using dependency injection of OSGI instead looking up on bundle context by the service reference. 
I appreciate  the merge ASAP because the binding is unusable after one restart in the last snapshot version.

Signed-off-by: Jaime Vaz <Jaime Vaz>