### PR TITLE
Fixed the incorrect about.html files

### DIFF
--- a/addons/binding/org.openhab.binding.allplay/about.html
+++ b/addons/binding/org.openhab.binding.allplay/about.html
@@ -11,7 +11,7 @@
 <p>&lt;<em>December 11, 2016</em>&gt;</p>	
 <h3>License</h3>
 
-<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
 indicated below, the Content is provided to you under the terms and conditions of the
 Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
 at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.

--- a/addons/binding/org.openhab.binding.boschindego/about.html
+++ b/addons/binding/org.openhab.binding.boschindego/about.html
@@ -7,6 +7,23 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
+
+<p>March 30, 2017</p>	
+<h3>License</h3>
+
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
 <h3>Third Party Content</h3>
 <ul>
     <li><a href="https://github.com/zazaz-de/iot-device-bosch-indego-controller/">API for Bosch Indego Connect</a>: Controller application and API for Bosch Indego Connect, under Apache 2.0 license</li>

--- a/addons/io/org.openhab.io.homekit/about.html
+++ b/addons/io/org.openhab.io.homekit/about.html
@@ -7,6 +7,23 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
+
+<p>March 30, 2017</p>	
+<h3>License</h3>
+
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
 <h3>Third Party Content</h3>
 <ul>
     <li><a href="https://github.com/beowulfe/HAP-Java">HAP-Java</a>: Homekit protocol implementation, under MIT license</li>

--- a/addons/voice/org.openhab.voice.marytts/about.html
+++ b/addons/voice/org.openhab.voice.marytts/about.html
@@ -7,6 +7,23 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
+
+<p>March 30, 2017</p>	
+<h3>License</h3>
+
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
 <h3>Third Party Content</h3>
 <ul>
     <li><a href="http://mary.dfki.de/">MaryTTS</a>: A TTS implementation, under LGPL license</li>

--- a/src/etc/about.html
+++ b/src/etc/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>March 30, 2017</p>	
+<h3>License</h3>
+
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
+</body>
+</html>


### PR DESCRIPTION
The static code analysis tool found four about.html files that violate the rules (https://github.com/openhab/static-code-analysis/pull/34).

Also, I have added a sample `about.html` file in `src/etc`.

Signed-off-by: Petar Valchev <petar.valchev@musala.com>