### PR TITLE
Synchronized classes like eg StringBuffer should not be used anymore

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
@@ -328,7 +328,7 @@ public class DSCAlarmMessage {
      */
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         sb.append("Code: \"");
         sb.append(codeReceived);

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/handler/GlobalCacheHandler.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/handler/GlobalCacheHandler.java
@@ -317,7 +317,7 @@ public class GlobalCacheHandler extends BaseThingHandler {
 
         // sequenceLength2 (hexCodeArray[3]) is not used
 
-        StringBuffer gcCode = new StringBuffer();
+        StringBuilder gcCode = new StringBuilder();
         gcCode.append(frequency);
         gcCode.append(",");
         gcCode.append(REPEAT);
@@ -524,7 +524,7 @@ public class GlobalCacheHandler extends BaseThingHandler {
         }
 
         private String getAsHexString(byte[] b) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
 
             for (int j = 0; j < b.length; j++) {
                 String s = String.format("%02x ", b[j] & 0xff);

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
@@ -408,7 +408,7 @@ public class DisplayTextVirtualDatapoint extends AbstractVirtualDatapointHandler
      */
     private String encodeText(String text) {
         final byte[] bytes = text.getBytes(StandardCharsets.ISO_8859_1);
-        StringBuffer sb = new StringBuffer(bytes.length * 2);
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
         for (byte b : bytes) {
             sb.append("0x");
             String hexValue = String.format("%02x", b);

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeConfig.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeConfig.java
@@ -114,7 +114,7 @@ public class GrafikEyeConfig {
      * @returna non-null, non-empty comma delimited list of shade zones
      */
     public String getShadeZones() {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int z = 0; z < shades.length; z++) {
             if (shades[z]) {
                 if (sb.length() > 0) {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgProtocolHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgProtocolHandler.java
@@ -601,7 +601,7 @@ class PrgProtocolHandler {
         final String hexFade = convertFade(fade);
         final String hexIntensity = convertIntensity(controlUnit, zone, intensity);
 
-        final StringBuffer sb = new StringBuffer(16);
+        final StringBuilder sb = new StringBuilder(16);
         for (int z = 1; z <= 8; z++) {
             sb.append(' ');
             sb.append(zone == z ? hexIntensity : "*");
@@ -1041,7 +1041,7 @@ class PrgProtocolHandler {
                 controlUnit = Integer.parseInt(m.group(1));
 
                 final String q4 = m.group(8);
-                final String q4bits = new StringBuffer(Integer.toBinaryString(Integer.parseInt(q4, 16))).reverse()
+                final String q4bits = new StringBuilder(Integer.toBinaryString(Integer.parseInt(q4, 16))).reverse()
                         .toString();
                 // final boolean seqType = (q4bits.length() > 0 ? q4bits.charAt(0) : '0') == '1';
                 final boolean seqMode = (q4bits.length() > 1 ? q4bits.charAt(1) : '0') == '1';

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
@@ -385,7 +385,7 @@ public class MilightV6SessionManager implements Runnable {
     }
 
     private void logUnknownPacket(byte[] data, int len, String reason) {
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         for (int i = 0; i < len; ++i) {
             s.append(String.format("%02X ", data[i]));
         }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
@@ -116,7 +116,7 @@ public class QueuedSend implements Runnable {
                     datagramSocket.send(packet);
 
                     if (logger.isDebugEnabled()) {
-                        StringBuffer s = new StringBuffer();
+                        StringBuilder s = new StringBuilder();
                         for (int c = 0; c < item.data.length; ++c) {
                             s.append(String.format("%02X ", item.data[c]));
                         }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/EmulatedV6Bridge.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/EmulatedV6Bridge.java
@@ -285,7 +285,7 @@ public class EmulatedV6Bridge {
                                 continue;
                             }
 
-                            StringBuffer debugStr = new StringBuffer();
+                            StringBuilder debugStr = new StringBuilder();
                             if (buffer[13] == 0x08) {
                                 debugStr.append("RGBWW ");
                             } else if (buffer[13] == 0x07) {
@@ -321,7 +321,7 @@ public class EmulatedV6Bridge {
     }
 
     protected void logUnknownPacket(byte[] data, int len, String reason) {
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         for (int i = 0; i < len; ++i) {
             s.append(String.format("%02X ", data[i]));
         }
@@ -339,7 +339,7 @@ public class EmulatedV6Bridge {
     }
 
     private void debug_session_send(byte buffer[], InetAddress address) {
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         for (int i = 0; i < buffer.length; ++i) {
             s.append(String.format("%02X ", buffer[i]));
         }

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/util/Http.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/util/Http.java
@@ -58,7 +58,7 @@ public class Http {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         String inputLine;
-        StringBuffer response = new StringBuffer();
+        StringBuilder response = new StringBuilder();
 
         while ((inputLine = in.readLine()) != null) {
             response.append(inputLine);
@@ -99,7 +99,7 @@ public class Http {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         String inputLine;
-        StringBuffer response = new StringBuffer();
+        StringBuilder response = new StringBuilder();
 
         while ((inputLine = in.readLine()) != null) {
             response.append(inputLine);

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
@@ -278,7 +278,7 @@ public class YamahaReceiverCommunication {
             InputStream is = connection.getInputStream();
             BufferedReader rd = new BufferedReader(new InputStreamReader(is));
             String line;
-            StringBuffer response = new StringBuffer();
+            StringBuilder response = new StringBuilder();
             while ((line = rd.readLine()) != null) {
                 response.append(line);
                 response.append('\r');


### PR DESCRIPTION
I replaced all occurences of StringBuffer by StringBuilder this is safe drop-in replacement.

Some background:

Early classes of the Java API, such as Vector, Hashtable and StringBuffer, were synchronized to make them thread-safe. Unfortunately, synchronization has a big negative impact on performance, even when using these collections from a single thread.

It is better to use their new unsynchronized replacements:

- ArrayList or LinkedList instead of Vector
- Deque instead of Stack
- HashMap instead of Hashtable
- StringBuilder instead of StringBuffer

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>