### PR TITLE
[RFXCOM] Fixes to shutdown and packet reading thread

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/handler/RFXComBridgeHandler.java
@@ -78,7 +78,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
     }
 
     @Override
-    public void dispose() {
+    public synchronized void dispose() {
         logger.debug("Handler disposed.");
 
         for (DeviceMessageListener deviceStatusListener : deviceStatusListeners) {
@@ -139,7 +139,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
         responseMessage = respMessage;
     }
 
-    private void connect() {
+    private synchronized void connect() {
         logger.debug("Connecting to RFXCOM transceiver");
 
         try {

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComJD2XXConnector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComJD2XXConnector.java
@@ -67,6 +67,9 @@ public class RFXComJD2XXConnector extends RFXComBaseConnector {
         if (readerThread != null) {
             logger.debug("Interrupt serial listener");
             readerThread.interrupt();
+            try {
+                readerThread.join();
+            } catch (InterruptedException e) {}
         }
 
         if (out != null) {
@@ -82,18 +85,18 @@ public class RFXComJD2XXConnector extends RFXComBaseConnector {
             logger.debug("Close serial port");
             try {
                 serialPort.close();
-
-                readerThread = null;
-                serialPort = null;
-                out = null;
-                in = null;
-
-                logger.debug("Closed");
-
             } catch (IOException e) {
                 logger.warn("Serial port closing error", e);
             }
         }
+
+        readerThread = null;
+        serialPort = null;
+        out = null;
+        in = null;
+
+        logger.debug("Closed");
+
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComSerialConnector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComSerialConnector.java
@@ -53,7 +53,7 @@ public class RFXComSerialConnector extends RFXComBaseConnector implements Serial
         serialPort = (SerialPort) commPort;
         serialPort.setSerialPortParams(38400, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
         serialPort.enableReceiveThreshold(1);
-        serialPort.disableReceiveTimeout();
+        serialPort.enableReceiveTimeout(100); // In ms. Small values mean faster shutdown but more cpu usage.
 
         in = serialPort.getInputStream();
         out = serialPort.getOutputStream();
@@ -88,6 +88,9 @@ public class RFXComSerialConnector extends RFXComBaseConnector implements Serial
         if (readerThread != null) {
             logger.debug("Interrupt serial listener");
             readerThread.interrupt();
+            try {
+                readerThread.join();
+            } catch (InterruptedException e) {}
         }
 
         if (out != null) {

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComStreamReader.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComStreamReader.java
@@ -10,10 +10,7 @@ package org.openhab.binding.rfxcom.internal.connector;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.util.Arrays;
-
-import javax.xml.bind.DatatypeConverter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,13 +18,13 @@ import org.slf4j.LoggerFactory;
 /**
  * RFXCOM stream reader to parse RFXCOM output into messages.
  *
+ * @author Mike Jagdis - Interruptible read loop
  * @author James Hewitt-Thomas - New class
  * @author Pauli Anttila - Original read loop
  */
 public class RFXComStreamReader extends Thread {
     private final Logger logger = LoggerFactory.getLogger(RFXComStreamReader.class);
 
-    private boolean interrupted = false;
     private RFXComBaseConnector connector;
     private InputStream in;
 
@@ -37,89 +34,49 @@ public class RFXComStreamReader extends Thread {
     }
 
     @Override
-    public void interrupt() {
-        interrupted = true;
-        super.interrupt();
-        try {
-            in.close();
-        } catch (IOException ignore) {
-            // quietly close
-        }
-    }
-
-    @Override
     public void run() {
-        final int dataBufferMaxLen = Byte.MAX_VALUE;
-
-        byte[] dataBuffer = new byte[dataBufferMaxLen];
-
-        int msgLen = 0;
-        int index = 0;
-        boolean startFound = false;
-
         logger.debug("Data listener started");
 
+        final int MAX_READ_TIMEOUTS = 4;
+        byte[] buf = new byte[Byte.MAX_VALUE];
+
+        // The stream has (or SHOULD have) a read timeout set. Taking a
+        // read timeout (read returns 0) between packets gives us a chance
+        // to check if we've been interrupted. Read interrupts during a
+        // packet are ignored but if too many timeouts occur we take it as
+        // meaning the RFXCOM has become missing presumed dead.
         try {
+start_packet:
+            while (!Thread.interrupted()) {
+                // First byte tells us how long the packet is
+                int bytesRead = in.read(buf, 0, 1);
+                int packetLength = buf[0];
 
-            byte[] tmpData = new byte[20];
-            int len = -1;
+                if (bytesRead > 0 && packetLength > 0) {
+                    // Now read the rest of the packet
+                    int bufferIndex = 1;
+                    int readTimeoutCount = 1;
 
-            while (!interrupted) {
+                    while (bufferIndex <= packetLength) {
+                        int bytesRemaining = packetLength - bufferIndex + 1;
+                        bytesRead = in.read(buf, bufferIndex, bytesRemaining);
 
-                if ((len = in.read(tmpData)) > 0) {
-
-                    byte[] logData = Arrays.copyOf(tmpData, len);
-                    logger.trace("Received data (len={}): {}", len, DatatypeConverter.printHexBinary(logData));
-
-                    for (int i = 0; i < len; i++) {
-
-                        if (index > dataBufferMaxLen) {
-                            // too many bytes received, try to find new
-                            // start
-                            startFound = false;
-                        }
-
-                        if (!startFound && tmpData[i] > 0) {
-
-                            startFound = true;
-                            index = 0;
-                            dataBuffer[index++] = tmpData[i];
-                            msgLen = tmpData[i] + 1;
-
-                        } else if (startFound) {
-
-                            dataBuffer[index++] = tmpData[i];
-
-                            if (index == msgLen) {
-                                sendMessage(dataBuffer, msgLen);
-
-                                // find new start
-                                startFound = false;
-                            }
+                        if (bytesRead > 0) {
+                            bufferIndex += bytesRead;
+                            readTimeoutCount = 1;
+                        } else if (readTimeoutCount++ == MAX_READ_TIMEOUTS) {
+                            connector.sendErrorToListeners("Timeout during packet read");
+                            break start_packet;
                         }
                     }
-                } else {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException ignore) {
-                    }
+
+                    connector.sendMsgToListeners(Arrays.copyOfRange(buf, 0, packetLength + 1));
                 }
             }
-        } catch (InterruptedIOException e) {
-            Thread.currentThread().interrupt();
-            logger.error("Interrupted via InterruptedIOException");
-        } catch (IOException e) {
-            logger.error("Reading from serial port failed", e);
-            connector.sendErrorToListeners(e.getMessage());
+        } catch (IOException ioe) {
+            connector.sendErrorToListeners(ioe.getMessage());
         }
 
         logger.debug("Data listener stopped");
-    }
-
-    private void sendMessage(byte[] dataBuffer, int msgLen) {
-        byte[] msg = new byte[msgLen];
-        System.arraycopy(dataBuffer, 0, msg, 0, msgLen);
-
-        connector.sendMsgToListeners(msg);
     }
 }

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComTcpConnector.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComTcpConnector.java
@@ -39,6 +39,7 @@ public class RFXComTcpConnector extends RFXComBaseConnector {
     public void connect(RFXComBridgeConfiguration device) throws IOException {
         logger.info("Connecting to RFXCOM at {}:{} over TCP/IP", device.host, device.port);
         socket = new Socket(device.host, device.port);
+        socket.setSoTimeout(100); // In ms. Small values mean faster shutdown but more cpu usage.
         in = socket.getInputStream();
         out = socket.getOutputStream();
 
@@ -58,6 +59,9 @@ public class RFXComTcpConnector extends RFXComBaseConnector {
         if (readerThread != null) {
             logger.debug("Interrupt stream listener");
             readerThread.interrupt();
+            try {
+                readerThread.join();
+            } catch (InterruptedException e) {}
         }
 
         if (out != null) {


### PR DESCRIPTION
We MUST set read timeouts on the input streams because the reads
themselves are not interruptible. We SHOULD wait for the read thread
to handle the interrupt and exit before completing the shutdown.

The packet reading loop SHOULD NOT handle an interrupt and shutdown
in the middle of a packet - only between packets. In the unlikely
(but possible) event that the RFXCOM is unplugged mid-packet a
timeout is used while reading packet data and the connection
abandoned if it is reached.

Closes #2100

Signed-off-by: Mike Jagdis <mjagdis@eris-associates.co.uk> (github: mjagdis)