### PR TITLE
[rfxcom] Send commands on control channels so that switches behave as expected

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -149,15 +149,15 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                                 case CHANNEL_COMMAND:
                                 case CHANNEL_CHIME_SOUND:
                                 case CHANNEL_MOOD:
-                                    postCommand(uid, message.convertToCommand(channelId));
+                                    postNullableCommand(uid, message.convertToCommand(channelId));
                                     break;
 
                                 case CHANNEL_LOW_BATTERY:
-                                    updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
+                                    updateNullableState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
                                     break;
 
                                 default:
-                                    updateState(uid, message.convertToState(channelId));
+                                    updateNullableState(uid, message.convertToState(channelId));
                                     break;
                             }
                         } catch (RFXComException e) {
@@ -169,6 +169,22 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
         } catch (Exception e) {
             logger.error("Error occurred during message receiving", e);
         }
+    }
+
+    private void updateNullableState(ChannelUID uid, State state) {
+        if (state == null) {
+            return;
+        }
+
+        updateState(uid, state);
+    }
+
+    private void postNullableCommand(ChannelUID uid, Command command) {
+        if (command == null) {
+            return;
+        }
+
+        postCommand(uid, command);
     }
 
     /**

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -145,7 +145,9 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                         String channelId = uid.getId();
 
                         try {
-                            if (channelId.equals(CHANNEL_LOW_BATTERY)) {
+                            if (channelId.equals(CHANNEL_COMMAND)) {
+                                postCommand(uid, (Command) message.convertToState(channelId));
+                            } else if (channelId.equals(CHANNEL_LOW_BATTERY)) {
                                 updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
                             } else {
                                 State state = message.convertToState(channelId);

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -146,7 +146,7 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
 
                         try {
                             if (channelId.equals(CHANNEL_COMMAND)) {
-                                postCommand(uid, (Command) message.convertToState(channelId));
+                                postCommand(uid, message.convertToCommand(channelId));
                             } else if (channelId.equals(CHANNEL_LOW_BATTERY)) {
                                 updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
                             } else {

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -145,15 +145,20 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                         String channelId = uid.getId();
 
                         try {
-                            if (channelId.equals(CHANNEL_COMMAND)) {
-                                postCommand(uid, message.convertToCommand(channelId));
-                            } else if (channelId.equals(CHANNEL_LOW_BATTERY)) {
-                                updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
-                            } else {
-                                State state = message.convertToState(channelId);
-                                if (state != null) {
-                                    updateState(uid, state);
-                                }
+                            switch (channelId) {
+                                case CHANNEL_COMMAND:
+                                case CHANNEL_CHIME_SOUND:
+                                case CHANNEL_MOOD:
+                                    postCommand(uid, message.convertToCommand(channelId));
+                                    break;
+
+                                case CHANNEL_LOW_BATTERY:
+                                    updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
+                                    break;
+
+                                default:
+                                    updateState(uid, message.convertToState(channelId));
+                                    break;
                             }
                         } catch (RFXComException e) {
                             logger.trace("{} does not handle {}", channelId, message);

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDeviceMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDeviceMessage.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.rfxcom.internal.messages;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.rfxcom.internal.config.RFXComDeviceConfiguration;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
@@ -25,6 +26,15 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  * @author Martin van Wingerden - Simplify some code in the RFXCOM binding
  */
 public interface RFXComDeviceMessage<T> extends RFXComMessage {
+    /**
+     * Procedure for converting RFXCOM value to openHAB command.
+     *
+     * @param channelId id of the channel
+     * @return openHAB command.
+     * @throws RFXComUnsupportedChannelException if the channel is not supported
+     */
+    Command convertToCommand(String channelId) throws RFXComUnsupportedChannelException;
+
     /**
      * Procedure for converting RFXCOM value to openHAB state.
      *

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDeviceMessageImpl.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDeviceMessageImpl.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.CHANNEL
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.rfxcom.internal.config.RFXComDeviceConfiguration;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
@@ -41,6 +42,11 @@ abstract class RFXComDeviceMessageImpl<T> extends RFXComBaseMessage implements R
     public void setConfig(RFXComDeviceConfiguration config) throws RFXComException {
         this.setSubType(convertSubType(config.subType));
         this.setDeviceId(config.deviceId);
+    }
+
+    @Override
+    public Command convertToCommand(String channelId) throws RFXComUnsupportedChannelException {
+        return (Command) convertToState(channelId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
@@ -179,24 +179,19 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
                     case OFF:
                     case GROUP_OFF:
                         return OnOffType.OFF;
-                        break;
 
                     case ON:
                     case GROUP_ON:
                         return OnOffType.ON;
-                        break;
 
                     case DIM:
                         return IncreaseDecreaseType.DECREASE;
-                        break;
 
                     case BRIGHT:
                         return IncreaseDecreaseType.INCREASE;
-                        break;
 
                     case CHIME:
                         return OnOffType.ON;
-                        break;
 
                     default:
                         throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + command);

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
@@ -14,9 +14,11 @@ package org.openhab.binding.rfxcom.internal.messages;
 
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -85,6 +87,8 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
     public Commands command;
     public boolean group;
 
+    private static byte[] lastUnit = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
     public RFXComLighting1Message() {
         super(PacketType.LIGHTING1);
     }
@@ -116,8 +120,17 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
 
         if ((command == Commands.GROUP_ON) || (command == Commands.GROUP_OFF)) {
             unitCode = 0;
+        } else if ((data[5] == 0) && ((command == Commands.DIM) || (command == Commands.BRIGHT))) {
+            // SS13 switches broadcast DIM/BRIGHT to X0 and the dimmers ignore
+            // the message unless the last X<n> ON they saw was for them. So we
+            // redirect an incoming broadcast DIM/BRIGHT to the correct item
+            // based on the last X<n> we saw or sent.
+            unitCode = lastUnit[(int)houseCode - (int)'A'];
         } else {
             unitCode = data[5];
+            if (command == Commands.ON) {
+                lastUnit[(int)houseCode - (int)'A'] = unitCode;
+            }
         }
 
         signalLevel = (byte) ((data[7] & 0xF0) >> 4);
@@ -135,7 +148,18 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
         data[2] = subType.toByte();
         data[3] = seqNbr;
         data[4] = (byte) houseCode;
-        data[5] = unitCode;
+        // When an SS13 sends a DIM/BRIGHT it broadcasts to the all-units code (X0)
+        // and it is up to the dimmers to ignore the message if the last X<n> they
+        // saw wasn't for them. Sending to an actual X<n> may or may not work.
+        // It is untested against _any_ dimmer never mind all so we stick to doing
+        // the same as an SS13. At least for now. Using an explicit X<n> would be
+        // better (if it works) because X10 RF and PLM are lossy and different
+        // modules may have seen different traffic.
+        if ((command == Commands.DIM) || (command == Commands.BRIGHT)) {
+            data[5] = 0;
+        } else {
+            data[5] = unitCode;
+        }
         data[6] = command.toByte();
         data[7] = (byte) ((signalLevel & 0x0F) << 4);
 
@@ -148,6 +172,41 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
     }
 
     @Override
+    public Command convertToCommand(String channelId) throws RFXComUnsupportedChannelException {
+        switch (channelId) {
+            case CHANNEL_COMMAND:
+                switch (command) {
+                    case OFF:
+                    case GROUP_OFF:
+                        return OnOffType.OFF;
+                        break;
+
+                    case ON:
+                    case GROUP_ON:
+                        return OnOffType.ON;
+                        break;
+
+                    case DIM:
+                        return IncreaseDecreaseType.DECREASE;
+                        break;
+
+                    case BRIGHT:
+                        return IncreaseDecreaseType.INCREASE;
+                        break;
+
+                    case CHIME:
+                        return OnOffType.ON;
+                        break;
+
+                    default:
+                        throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + command);
+                }
+
+            default:
+                return super.convertToCommand(channelId);
+        }
+    }
+
     public State convertToState(String channelId) throws RFXComUnsupportedChannelException {
         switch (channelId) {
             case CHANNEL_COMMAND:
@@ -164,7 +223,7 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
                         return OnOffType.ON;
 
                     default:
-                        throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
+                        throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + command);
                 }
 
             case CHANNEL_COMMAND_STRING:
@@ -184,11 +243,11 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
                         return OpenClosedType.OPEN;
 
                     default:
-                        throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
+                        throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + command);
                 }
 
             default:
-                return super.convertToState(channelId);
+                throw new RFXComUnsupportedChannelException("Channel " + channelId + " is not relevant here");
         }
     }
 


### PR DESCRIPTION
Sends commands on control channels so that switches behave as expected. Maps X10 SS13 bright/dim to openHAB INCREASE/DECREASE. Fixes the update/command distribution loop so it doesn't abort as soon as an inappropriate channel is seen but checks the others as well (this makes LWRF mood buttons work, quite possibly other things too).

Fixes #2102