### PR TITLE
activate static analysis checks by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,9 +309,14 @@
             </build>
         </profile>
 
-	<!-- static code analysis profiles -->
+    <!-- static code analysis profiles -->
     <profile>
       <id>check</id>
+      <activation>
+        <property>
+          <name>!skipChecks</name>
+        </property>
+      </activation>   
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>