### PR TITLE
Logging: loggers should be non-static, whenever possible

### DIFF
--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/handler/AmazonDashButtonHandler.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/handler/AmazonDashButtonHandler.java
@@ -34,10 +34,6 @@ import org.slf4j.LoggerFactory;
  * @author Oliver Libutzki - Initial contribution
  */
 public class AmazonDashButtonHandler extends BaseThingHandler implements PcapNetworkInterfaceListener {
-
-    @SuppressWarnings("unused")
-    private static final Logger logger = LoggerFactory.getLogger(AmazonDashButtonHandler.class);
-
     private PacketCapturingService packetCapturingService;
 
     private long lastCommandHandled = 0;

--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/capturing/PacketCapturingService.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/capturing/PacketCapturingService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PacketCapturingService {
 
-    private static final Logger logger = LoggerFactory.getLogger(PacketCapturingService.class);
+    private final Logger logger = LoggerFactory.getLogger(PacketCapturingService.class);
 
     private static final int READ_TIMEOUT = 10; // [ms]
     private static final int SNAPLEN = 65536; // [bytes]

--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/discovery/AmazonDashButtonDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/discovery/AmazonDashButtonDiscoveryService.java
@@ -50,7 +50,7 @@ public class AmazonDashButtonDiscoveryService extends AbstractDiscoveryService i
 
     private static final int DISCOVER_TIMEOUT_SECONDS = 30;
 
-    private static final Logger logger = LoggerFactory.getLogger(AmazonDashButtonDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(AmazonDashButtonDiscoveryService.class);
 
     /**
      * The Amazon Dash button vendor prefixes

--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/pcap/PcapNetworkInterfaceService.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/pcap/PcapNetworkInterfaceService.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Sets.SetView;
  */
 public class PcapNetworkInterfaceService {
 
-    private static final Logger logger = LoggerFactory.getLogger(PcapNetworkInterfaceService.class);
+    private final Logger logger = LoggerFactory.getLogger(PcapNetworkInterfaceService.class);
 
     private static PcapNetworkInterfaceService instance = null;
     private static final String THREADPOOL_NAME = "pcapNetworkInterfaceService";

--- a/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/discovery/AstroDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/discovery/AstroDiscoveryService.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Gerhard Riegler
  */
 public class AstroDiscoveryService extends AbstractDiscoveryService {
-    private static final Logger logger = LoggerFactory.getLogger(AstroDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(AstroDiscoveryService.class);
     private static final int DISCOVER_TIMEOUT_SECONDS = 30;
 
     /**

--- a/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/handler/AstroThingHandler.java
+++ b/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/handler/AstroThingHandler.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AstroThingHandler extends BaseThingHandler {
-    private static final Logger logger = LoggerFactory.getLogger(AstroThingHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(AstroThingHandler.class);
     private Scheduler quartzScheduler;
     private ScheduledFuture<?> schedulerFuture;
     private int linkedPositionalChannels = 0;

--- a/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/AbstractBaseJob.java
+++ b/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/AbstractBaseJob.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AbstractBaseJob implements Job {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractBaseJob.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractBaseJob.class);
     public static final String KEY_THING_UID = "thingUid";
     public static final String KEY_CHANNEL_ID = "channelId";
     public static final String KEY_JOB_NAME = "jobName";

--- a/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/AbstractDailyJob.java
+++ b/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/AbstractDailyJob.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AbstractDailyJob extends AbstractBaseJob {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractDailyJob.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractDailyJob.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/net/SocketChannelSession.java
+++ b/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/net/SocketChannelSession.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts
  */
 public class SocketChannelSession implements SocketSession {
-    private Logger _logger = LoggerFactory.getLogger(SocketChannelSession.class);
+    private final Logger logger = LoggerFactory.getLogger(SocketChannelSession.class);
 
     /**
      * The host/ip address to connect to
@@ -113,10 +113,10 @@ public class SocketChannelSession implements SocketSession {
         final SocketChannel channel = SocketChannel.open();
         channel.configureBlocking(true);
 
-        _logger.debug("Connecting to {}:{}", _host, _port);
+        logger.debug("Connecting to {}:{}", _host, _port);
         channel.connect(new InetSocketAddress(_host, _port));
 
-        _logger.debug("Waiting for connect");
+        logger.debug("Waiting for connect");
         while (!channel.finishConnect()) {
             try {
                 Thread.sleep(250);
@@ -132,7 +132,7 @@ public class SocketChannelSession implements SocketSession {
     @Override
     public void disconnect() throws IOException {
         if (isConnected()) {
-            _logger.debug("Disconnecting from {}:{}", _host, _port);
+            logger.debug("Disconnecting from {}:{}", _host, _port);
 
             final SocketChannel channel = _socketChannel.getAndSet(null);
             channel.close();
@@ -164,9 +164,9 @@ public class SocketChannelSession implements SocketSession {
 
         final SocketChannel channel = _socketChannel.get();
         if (channel == null) {
-            _logger.debug("Cannot send command '{}' - socket channel was closed", command);
+            logger.debug("Cannot send command '{}' - socket channel was closed", command);
         } else {
-            _logger.debug("Sending Command: '{}'", command);
+            logger.debug("Sending Command: '{}'", command);
             channel.write(toSend);
         }
     }
@@ -197,7 +197,7 @@ public class SocketChannelSession implements SocketSession {
             if (_isRunning.getAndSet(false)) {
                 try {
                     if (!_running.await(5, TimeUnit.SECONDS)) {
-                        _logger.warn("Waited too long for response reader to finish");
+                        logger.warn("Waited too long for response reader to finish");
                     }
                 } catch (InterruptedException e) {
                     // Do nothing
@@ -314,7 +314,7 @@ public class SocketChannelSession implements SocketSession {
                 if (processingThread != null && Thread.currentThread() != processingThread) {
                     try {
                         if (!_running.await(5, TimeUnit.SECONDS)) {
-                            _logger.warn("Waited too long for dispatcher to finish");
+                            logger.warn("Waited too long for dispatcher to finish");
                         }
                     } catch (InterruptedException e) {
                         // do nothing
@@ -345,29 +345,29 @@ public class SocketChannelSession implements SocketSession {
                     if (response != null) {
                         if (response instanceof String) {
                             try {
-                                _logger.debug("Dispatching response: {}", response);
+                                logger.debug("Dispatching response: {}", response);
                                 final SocketSessionListener[] listeners = _listeners
                                         .toArray(new SocketSessionListener[0]);
                                 for (SocketSessionListener listener : listeners) {
                                     listener.responseReceived((String) response);
                                 }
                             } catch (Exception e) {
-                                _logger.warn("Exception occurred processing the response '{}': {}", response, e);
+                                logger.warn("Exception occurred processing the response '{}': {}", response, e);
                             }
                         } else if (response instanceof Exception) {
-                            _logger.debug("Dispatching exception: {}", response);
+                            logger.debug("Dispatching exception: {}", response);
                             final SocketSessionListener[] listeners = _listeners.toArray(new SocketSessionListener[0]);
                             for (SocketSessionListener listener : listeners) {
                                 listener.responseException((Exception) response);
                             }
                         } else {
-                            _logger.warn("Unknown response class: {}", response);
+                            logger.warn("Unknown response class: {}", response);
                         }
                     }
                 } catch (InterruptedException e) {
                     // Do nothing
                 } catch (Exception e) {
-                    _logger.debug("Uncaught exception {}", e.getMessage(), e);
+                    logger.debug("Uncaught exception {}", e.getMessage(), e);
                     break;
                 }
             }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -46,7 +46,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     /**
      * the refresh interval which is used to poll values from the fritzaha.
      * server (optional, defaults to 15 s)

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -46,7 +46,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Ip of PL546E in standalone mode

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceListPolling.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceListPolling.java
@@ -19,7 +19,7 @@ public class DeviceListPolling implements Runnable {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     /**
      * Handler for delegation to callbacks.
      */

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/HandlerFactory.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/HandlerFactory.java
@@ -39,7 +39,7 @@ public class HandlerFactory extends BaseThingHandlerFactory {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     /**
      * Service registration map
      */

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AvmDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AvmDiscoveryService.java
@@ -38,7 +38,7 @@ public class AvmDiscoveryService extends AbstractDiscoveryService {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Maximum time to search for devices.

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AvmUpnpDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AvmUpnpDiscoveryParticipant.java
@@ -37,7 +37,7 @@ public class AvmUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Provide supported thing type uid's

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaContentExchange.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaContentExchange.java
@@ -30,7 +30,7 @@ public class FritzahaContentExchange extends BufferingResponseListener
     /**
      * logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Callback to execute on complete response

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
@@ -59,7 +59,7 @@ public class FritzahaWebInterface {
      */
     protected IFritzHandler fbHandler;
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     // Uses RegEx to handle bad FritzBox XML
     /**
      * RegEx Pattern to grab the session ID from a login XML response

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaDiscoveryCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaDiscoveryCallback.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class FritzAhaDiscoveryCallback extends FritzAhaReauthCallback {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private AvmDiscoveryService service;
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetSwitchCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetSwitchCallback.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class FritzAhaSetSwitchCallback extends FritzAhaReauthCallback {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     /**
      * Item to update
      */

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
@@ -34,7 +34,7 @@ public class FritzAhaUpdateXmlCallback extends FritzAhaReauthCallback {
     /**
      * logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Handler to update

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/ControllerHandler.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/ControllerHandler.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ControllerHandler extends BaseBridgeHandler {
     private static final int SOCKET_TIMEOUT = 2000;
-    private static final Logger logger = LoggerFactory.getLogger(ControllerHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(ControllerHandler.class);
     private String host;
     private int port;
     private Socket socket;

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DSCAlarmMessage {
 
-    private static final Logger logger = LoggerFactory.getLogger(DSCAlarmMessage.class);
+    private final Logger logger = LoggerFactory.getLogger(DSCAlarmMessage.class);
 
     private static final EnumMap<DSCAlarmCode, MessageParameters> dscAlarmMessageParameters = new EnumMap<>(
             DSCAlarmCode.class);

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
-    private static final Logger logger = LoggerFactory.getLogger(DSCAlarmBridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(DSCAlarmBridgeDiscovery.class);
 
     private EnvisalinkBridgeDiscovery envisalinkBridgeDiscovery = new EnvisalinkBridgeDiscovery(this);
     private IT100BridgeDiscovery it100BridgeDiscovery = new IT100BridgeDiscovery(this);

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmDiscoveryService.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DSCAlarmDiscoveryService extends AbstractDiscoveryService {
 
-    private static final Logger logger = LoggerFactory.getLogger(DSCAlarmDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(DSCAlarmDiscoveryService.class);
 
     /**
      * DSC Alarm Bridge handler.

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/EnvisalinkBridgeDiscovery.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class EnvisalinkBridgeDiscovery {
-    private static final Logger logger = LoggerFactory.getLogger(EnvisalinkBridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(EnvisalinkBridgeDiscovery.class);
 
     static final int ENVISALINK_BRIDGE_PORT = 4025;
     static final int CONNECTION_TIMEOUT = 10;

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/IT100BridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/IT100BridgeDiscovery.java
@@ -32,7 +32,7 @@ import gnu.io.UnsupportedCommOperationException;
  *
  */
 public class IT100BridgeDiscovery {
-    private static final Logger logger = LoggerFactory.getLogger(IT100BridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(IT100BridgeDiscovery.class);
 
     static final int BAUD_RATE = 9600;
     static final int RECEIVE_TIMEOUT = 15000;

--- a/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/discovery/FreeboxDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/discovery/FreeboxDiscoveryService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FreeboxDiscoveryService extends AbstractDiscoveryService implements FreeboxDataListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(FreeboxDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(FreeboxDiscoveryService.class);
 
     private static final int SEARCH_TIME = 10;
 

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/discovery/GardenaDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/discovery/GardenaDeviceDiscoveryService.java
@@ -37,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
  */
 public class GardenaDeviceDiscoveryService extends AbstractDiscoveryService {
 
-    private static final Logger logger = LoggerFactory.getLogger(GardenaDeviceDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(GardenaDeviceDiscoveryService.class);
     private static final int DISCOVER_TIMEOUT_SECONDS = 30;
 
     private GardenaAccountHandler accountHandler;

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/GlobalCacheDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/GlobalCacheDiscoveryService.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Initial contribution
  */
 public class GlobalCacheDiscoveryService extends AbstractDiscoveryService implements ExtendedDiscoveryService {
-    private static final Logger logger = LoggerFactory.getLogger(GlobalCacheDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(GlobalCacheDiscoveryService.class);
 
     private ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> gcDiscoveryJob;

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/MulticastListener.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/MulticastListener.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Initial contribution
  */
 public class MulticastListener {
-    private static final Logger logger = LoggerFactory.getLogger(MulticastListener.class);
+    private final Logger logger = LoggerFactory.getLogger(MulticastListener.class);
 
     private MulticastSocket socket;
 

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/AbstractHubbedThingHandler.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/AbstractHubbedThingHandler.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 abstract class AbstractHubbedThingHandler extends BaseThingHandler {
 
-    protected Logger logger = LoggerFactory.getLogger(AbstractHubbedThingHandler.class);
+    private Logger logger = LoggerFactory.getLogger(AbstractHubbedThingHandler.class);
 
     public AbstractHubbedThingHandler(Thing thing) {
         super(thing);

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/converter/type/AbstractTypeConverter.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/converter/type/AbstractTypeConverter.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AbstractTypeConverter<T extends State> implements TypeConverter<T> {
-    private static final Logger logger = LoggerFactory.getLogger(TypeConverter.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractTypeConverter.class);
 
     /**
      * Defines all devices where the state datapoint must be inverted.

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/converter/type/PercentTypeConverter.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/converter/type/PercentTypeConverter.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class PercentTypeConverter extends AbstractTypeConverter<PercentType> {
-    private static final Logger logger = LoggerFactory.getLogger(PercentTypeConverter.class);
+    private final Logger logger = LoggerFactory.getLogger(PercentTypeConverter.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/discovery/HomegearDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/discovery/HomegearDiscoveryParticipant.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class HomegearDiscoveryParticipant implements UpnpDiscoveryParticipant {
-    private static final Logger logger = LoggerFactory.getLogger(HomegearDiscoveryParticipant.class);
+    private final Logger logger = LoggerFactory.getLogger(HomegearDiscoveryParticipant.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/discovery/HomematicDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/discovery/HomematicDeviceDiscoveryService.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Gerhard Riegler - Initial contribution
  */
 public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
-    private static final Logger logger = LoggerFactory.getLogger(HomematicDeviceDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(HomematicDeviceDiscoveryService.class);
     private static final int DISCOVER_TIMEOUT_SECONDS = 300;
 
     private HomematicBridgeHandler bridgeHandler;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class HomematicBridgeHandler extends BaseBridgeHandler implements HomematicGatewayListener {
-    private static final Logger logger = LoggerFactory.getLogger(HomematicBridgeHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(HomematicBridgeHandler.class);
     private static final long REINITIALIZE_DELAY_SECONDS = 10;
     private static SimplePortPool portPool = new SimplePortPool();
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AbstractHomematicGateway implements RpcEventListener, HomematicGateway, VirtualGateway {
-    private static final Logger logger = LoggerFactory.getLogger(HomematicGateway.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractHomematicGateway.class);
     public static final double DEFAULT_DISABLE_DELAY = 2.0;
     private static final long CONNECTION_TRACKER_INTERVAL_SECONDS = 15;
     private static final String GATEWAY_POOL_NAME = "homematicGateway";

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -49,7 +49,7 @@ import com.thoughtworks.xstream.io.xml.StaxDriver;
  * @author Gerhard Riegler - Initial contribution
  */
 public class CcuGateway extends AbstractHomematicGateway {
-    private static final Logger logger = LoggerFactory.getLogger(CcuGateway.class);
+    private final Logger logger = LoggerFactory.getLogger(CcuGateway.class);
 
     private Map<String, String> tclregaScripts;
     private HttpClient httpClient;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class BinRpcClient extends RpcClient {
-    private static final Logger logger = LoggerFactory.getLogger(BinRpcClient.class);
+    private final Logger logger = LoggerFactory.getLogger(BinRpcClient.class);
 
     private SocketHandler socketHandler;
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class RpcClient {
-    private static final Logger logger = LoggerFactory.getLogger(RpcClient.class);
+    private final Logger logger = LoggerFactory.getLogger(RpcClient.class);
     protected static final int MAX_RPC_RETRY = 1;
 
     protected HomematicConfig config;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class SocketHandler {
-    private static final Logger logger = LoggerFactory.getLogger(SocketHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(SocketHandler.class);
 
     private Map<Integer, SocketInfo> socketsPerPort = new HashMap<Integer, SocketInfo>();
     private HomematicConfig config;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class XmlRpcClient extends RpcClient {
-    private static final Logger logger = LoggerFactory.getLogger(XmlRpcClient.class);
+    private final Logger logger = LoggerFactory.getLogger(XmlRpcClient.class);
     private HttpClient httpClient;
 
     public XmlRpcClient(HomematicConfig config) throws IOException {

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class BinRpcMessage implements RpcRequest, RpcResponse {
-    private static final Logger logger = LoggerFactory.getLogger(BinRpcMessage.class);
+    private final Logger logger = LoggerFactory.getLogger(BinRpcMessage.class);
 
     public enum TYPE {
         REQUEST,

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuValueParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuValueParser.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class CcuValueParser extends CommonRpcParser<TclScriptDataList, Void> {
-    private static final Logger logger = LoggerFactory.getLogger(CcuValueParser.class);
+    private final Logger logger = LoggerFactory.getLogger(CcuValueParser.class);
 
     private HmChannel channel;
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 
 public class DisplayOptionsParser extends CommonRpcParser<Object, Void> {
-    private static final Logger logger = LoggerFactory.getLogger(DisplayOptionsParser.class);
+    private final Logger logger = LoggerFactory.getLogger(DisplayOptionsParser.class);
     private static final String[] onOff = new String[] { "ON", "OFF" };
 
     private HmChannel channel;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
-    private static final Logger logger = LoggerFactory.getLogger(GetParamsetParser.class);
+    private final Logger logger = LoggerFactory.getLogger(GetParamsetParser.class);
 
     private HmChannel channel;
     private HmParamsetType paramsetType;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcCallbackHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcCallbackHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class BinRpcCallbackHandler implements Runnable {
-    private static final Logger logger = LoggerFactory.getLogger(BinRpcCallbackHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(BinRpcCallbackHandler.class);
 
     private static final byte BIN_EMPTY_STRING[] = { 'B', 'i', 'n', 1, 0, 0, 0, 8, 0, 0, 0, 3, 0, 0, 0, 0 };
     private static final byte BIN_EMPTY_ARRAY[] = { 'B', 'i', 'n', 1, 0, 0, 0, 8, 0, 0, 1, 0, 0, 0, 0, 0 };

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcServer.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcServer.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class BinRpcServer implements RpcServer {
-    private static final Logger logger = LoggerFactory.getLogger(BinRpcServer.class);
+    private final Logger logger = LoggerFactory.getLogger(BinRpcServer.class);
 
     private Thread networkServiceThread;
     private BinRpcNetworkService networkService;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
@@ -41,7 +41,7 @@ import org.xml.sax.SAXException;
  * @author Gerhard Riegler - Initial contribution
  */
 public class XmlRpcServer implements RpcServer {
-    private static final Logger logger = LoggerFactory.getLogger(XmlRpcServer.class);
+    private final Logger logger = LoggerFactory.getLogger(XmlRpcServer.class);
 
     private static final String XML_EMPTY_STRING = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<methodResponse><params><param><value></value></param></params></methodResponse>";
     private static final String XML_EMPTY_ARRAY = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<methodResponse><params><param><value><array><data></data></array></value></param></params></methodResponse>";

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/AbstractVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/AbstractVirtualDatapointHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public abstract class AbstractVirtualDatapointHandler implements VirtualDatapointHandler {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractVirtualDatapointHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractVirtualDatapointHandler.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class BatteryTypeVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
-    private static final Logger logger = LoggerFactory.getLogger(BatteryTypeVirtualDatapointHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(BatteryTypeVirtualDatapointHandler.class);
 
     private static final Properties batteries = new Properties();
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceVirtualDatapointHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class DeleteDeviceVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
-    private static final Logger logger = LoggerFactory.getLogger(DeleteDeviceVirtualDatapointHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(DeleteDeviceVirtualDatapointHandler.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class OnTimeAutomaticVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
-    private static final Logger logger = LoggerFactory.getLogger(OnTimeAutomaticVirtualDatapointHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(OnTimeAutomaticVirtualDatapointHandler.class);
 
     /**
      * {@inheritDoc}

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/DelayedExecuter.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/DelayedExecuter.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class DelayedExecuter {
-    private static final Logger logger = LoggerFactory.getLogger(DelayedExecuter.class);
+    private final Logger logger = LoggerFactory.getLogger(DelayedExecuter.class);
 
     private Map<HmDatapointInfo, Timer> delayedEvents = new HashMap<HmDatapointInfo, Timer>();
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/type/HomematicTypeGeneratorImpl.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/type/HomematicTypeGeneratorImpl.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  */
 public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(HomematicTypeGeneratorImpl.class);
+    private final Logger logger = LoggerFactory.getLogger(HomematicTypeGeneratorImpl.class);
     private static URI configDescriptionUriChannel;
 
     private HomematicThingTypeProvider thingTypeProvider;

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiClientSocket.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiClientSocket.java
@@ -36,7 +36,7 @@ import com.google.gson.JsonParser;
  *
  */
 public class KodiClientSocket {
-    private static final Logger logger = LoggerFactory.getLogger(KodiClientSocket.class);
+    private final Logger logger = LoggerFactory.getLogger(KodiClientSocket.class);
 
     private final ScheduledExecutorService scheduler;
     private static final int REQUEST_TIMEOUT_MS = 60000;

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonPrimitive;
  */
 public class KodiConnection implements KodiClientSocketEventListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(KodiConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(KodiConnection.class);
 
     private static final int VOLUMESTEP = 10;
 

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/SocketSession.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/SocketSession.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts
  */
 public class SocketSession {
-    private Logger _logger = LoggerFactory.getLogger(SocketSession.class);
+    private final Logger logger = LoggerFactory.getLogger(SocketSession.class);
 
     /**
      * The host/ip address to connect to
@@ -125,7 +125,7 @@ public class SocketSession {
         _client.setKeepAlive(true);
         _client.setSoTimeout(1000); // allow reader to check to see if it should stop every 1 second
 
-        _logger.debug("Connecting to {}:{}", _host, _port);
+        logger.debug("Connecting to {}:{}", _host, _port);
         _writer = new PrintStream(_client.getOutputStream());
         _reader = new BufferedReader(new InputStreamReader(_client.getInputStream()));
 
@@ -143,7 +143,7 @@ public class SocketSession {
      */
     public void disconnect() throws IOException {
         if (isConnected()) {
-            _logger.debug("Disconnecting from {}:{}", _host, _port);
+            logger.debug("Disconnecting from {}:{}", _host, _port);
 
             _dispatcher.stopRunning();
             _responseReader.stopRunning();
@@ -186,7 +186,7 @@ public class SocketSession {
             throw new IOException("Cannot send message - disconnected");
         }
 
-        _logger.debug("Sending Command: '{}'", command);
+        logger.debug("Sending Command: '{}'", command);
         _writer.println(command + "\n"); // as pre spec - each command must have a newline
         _writer.flush();
 
@@ -221,7 +221,7 @@ public class SocketSession {
             try {
                 if (_isRunning.getAndSet(false)) {
                     if (!_running.await(5, TimeUnit.SECONDS)) {
-                        _logger.warn("Waited too long for dispatcher to finish");
+                        logger.warn("Waited too long for dispatcher to finish");
                     }
                 }
             } catch (InterruptedException e) {
@@ -265,11 +265,11 @@ public class SocketSession {
                         if (str.endsWith("\r\n") || str.endsWith("login: ")) {
                             sb.setLength(0);
                             final String response = str.substring(0, str.length() - 2);
-                            _logger.debug("Received response: {}", response);
+                            logger.debug("Received response: {}", response);
                             _responses.put(response);
                         }
                     }
-                    // _logger.debug(">>> reading: " + sb + ":" + (int) ch);
+                    // logger.debug(">>> reading: " + sb + ":" + (int) ch);
                 } catch (SocketTimeoutException e) {
                     // do nothing - we expect this (setSOTimeout) to check the _isReading
                 } catch (InterruptedException e) {
@@ -324,7 +324,7 @@ public class SocketSession {
             try {
                 if (_isRunning.getAndSet(false)) {
                     if (!_running.await(5, TimeUnit.SECONDS)) {
-                        _logger.warn("Waited too long for dispatcher to finish");
+                        logger.warn("Waited too long for dispatcher to finish");
                     }
                 }
             } catch (InterruptedException e) {
@@ -356,16 +356,16 @@ public class SocketSession {
                     if (response != null) {
                         if (response instanceof String) {
                             try {
-                                _logger.debug("Dispatching response: {}", response);
+                                logger.debug("Dispatching response: {}", response);
                                 callback.responseReceived((String) response);
                             } catch (Exception e) {
-                                _logger.warn("Exception occurred processing the response '{}': {}", response, e);
+                                logger.warn("Exception occurred processing the response '{}': {}", response, e);
                             }
                         } else if (response instanceof Exception) {
-                            _logger.debug("Dispatching exception: {}", response);
+                            logger.debug("Dispatching exception: {}", response);
                             callback.responseException((Exception) response);
                         } else {
-                            _logger.error("Unknown response class: {}", response);
+                            logger.error("Unknown response class: {}", response);
                         }
                     }
                 } catch (InterruptedException e) {

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
@@ -20,8 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class CubeCommand {
 
-    protected final Logger logger = LoggerFactory.getLogger(CubeCommand.class);
-
     /**
      * @return the String to be send to the MAX! Cube
      */

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/M_Command.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/M_Command.java
@@ -19,6 +19,8 @@ import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.RoomInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link M_Command} Creates the MAX! Cube the room & device name information update message.
@@ -28,6 +30,8 @@ import org.openhab.binding.max.internal.device.RoomInformation;
  */
 
 public class M_Command extends CubeCommand {
+    private final Logger logger = LoggerFactory.getLogger(M_Command.class);
+
     private static byte MAGIC_NR = 86;
     private static byte M_VERSION = 2;
     private static int MAX_NAME_LENGTH = 32;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/A_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/A_Message.java
@@ -20,8 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class A_Message extends Message {
 
-    Logger logger = LoggerFactory.getLogger(MaxBinding.class);
-
     public A_Message(String raw) {
         super(raw);
     }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/F_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/F_Message.java
@@ -24,12 +24,10 @@ public final class F_Message extends Message {
     private String ntpServer1 = "";
     private String ntpServer2 = "";
 
-    Logger logger = LoggerFactory.getLogger(MaxBinding.class);
-
     /**
      * The {@link: F_Message} contains information about the Cube NTP Configuration
      *
-     * @param String with raw message
+     * @param raw String with raw message
      */
     public F_Message(String raw) {
         super(raw);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/M_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/M_Message.java
@@ -27,11 +27,11 @@ import org.slf4j.LoggerFactory;
  * @since 1.4.0
  */
 public final class M_Message extends Message {
+    private final Logger logger = LoggerFactory.getLogger(M_Message.class);
 
     public ArrayList<RoomInformation> rooms;
     public ArrayList<DeviceInformation> devices;
     private Boolean hasConfiguration;
-    Logger logger = LoggerFactory.getLogger(MaxBinding.class);
 
     public M_Message(String raw) {
         super(raw);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/N_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/N_Message.java
@@ -23,18 +23,17 @@ import org.slf4j.LoggerFactory;
  * @since 2.0.0
  */
 public final class N_Message extends Message {
+    private final Logger logger = LoggerFactory.getLogger(N_Message.class);
 
     private String decodedPayload;
     private DeviceType deviceType = null;
     private String rfAddress = null;
     private String serialnr = null;
 
-    Logger logger = LoggerFactory.getLogger(MaxBinding.class);
-
     /**
      * The {@link: N_Message} contains information about a newly discovered Device
      *
-     * @param String with raw message
+     * @param raw String with raw message
      */
     public N_Message(String raw) {
         super(raw);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/S_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/S_Message.java
@@ -20,12 +20,11 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 public final class S_Message extends Message {
+    private final Logger logger = LoggerFactory.getLogger(S_Message.class);
 
     private int dutyCycle;
     private int freeMemorySlots;
     private boolean commandDiscarded = false;
-
-    Logger logger = LoggerFactory.getLogger(MaxBinding.class);
 
     public S_Message(String raw) {
         super(raw);

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/DishWasherHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/DishWasherHandler.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonElement;
  */
 public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(DishWasherHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(DishWasherHandler.class);
 
     public DishWasherHandler(Thing thing) {
         super(thing, DishwasherChannelSelector.class, "Dishwasher");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/DishwasherChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/DishwasherChannelSelector.java
@@ -116,14 +116,12 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     },
     SWITCH(null, "switch", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(DishwasherChannelSelector.class);
-
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private DishwasherChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    DishwasherChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeChannelSelector.java
@@ -66,14 +66,14 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     },
     START(null, "start", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(FridgeChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(FridgeChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private FridgeChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    FridgeChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeFreezerChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeFreezerChannelSelector.java
@@ -82,14 +82,14 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     },
     START(null, "start", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(FridgeFreezerChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(FridgeFreezerChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private FridgeFreezerChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    FridgeFreezerChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeFreezerHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeFreezerHandler.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonElement;
  */
 public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(FridgeFreezerHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(FridgeFreezerHandler.class);
 
     public FridgeFreezerHandler(Thing thing) {
         super(thing, FridgeFreezerChannelSelector.class, "FridgeFreezer");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/FridgeHandler.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonElement;
  */
 public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(FridgeHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(FridgeHandler.class);
 
     public FridgeHandler(Thing thing) {
         super(thing, FridgeChannelSelector.class, "Fridge");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HobChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HobChannelSelector.java
@@ -53,7 +53,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE6_HEAT("plate6RemainingHeat", "plate6heat", DecimalType.class, false),
     PLATE6_TIME("plate6RemainingTime", "plate6time", StringType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(OvenChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(HobChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HobHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HobHandler.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
  */
 public class HobHandler extends MieleApplianceHandler<HobChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(HobHandler.class);
-
     public HobHandler(Thing thing) {
         super(thing, HobChannelSelector.class, "Hob");
     }

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HoodChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HoodChannelSelector.java
@@ -53,14 +53,14 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
     },
     STOP(null, "stop", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(HoodChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(HoodChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private HoodChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    HoodChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HoodHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/HoodHandler.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonElement;
  */
 public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(HoodHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(HoodHandler.class);
 
     public HoodHandler(Thing thing) {
         super(thing, HoodChannelSelector.class, "Hood");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleApplianceHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleApplianceHandler.java
@@ -51,12 +51,13 @@ import com.google.gson.JsonParser;
 public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannelSelector> extends BaseThingHandler
         implements ApplianceStatusListener {
 
+    private final Logger logger = LoggerFactory.getLogger(MieleApplianceHandler.class);
+
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(THING_TYPE_DISHWASHER,
             THING_TYPE_OVEN, THING_TYPE_FRIDGE, THING_TYPE_DRYER, THING_TYPE_HOB, THING_TYPE_FRIDGEFREEZER,
             THING_TYPE_HOOD, THING_TYPE_WASHINGMACHINE);
 
     protected Gson gson = new Gson();
-    protected Logger logger = LoggerFactory.getLogger(MieleApplianceHandler.class);
 
     protected String UID;
     protected MieleBridgeHandler bridgeHandler;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleBridgeHandler.java
@@ -79,7 +79,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
 
     protected Random rand = new Random();
     protected Gson gson = new Gson();
-    protected Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
 
     protected List<ApplianceStatusListener> applianceStatusListeners = new CopyOnWriteArrayList<>();
     protected ScheduledFuture<?> pollingJob;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/OvenChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/OvenChannelSelector.java
@@ -141,14 +141,14 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     STOP(null, "stop", OnOffType.class, false),
     SWITCH(null, "switch", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(OvenChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(OvenChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private OvenChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    OvenChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/OvenHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/OvenHandler.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonElement;
  */
 public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(OvenHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(OvenHandler.class);
 
     public OvenHandler(Thing thing) {
         super(thing, OvenChannelSelector.class, "Oven");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/TumbleDryerChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/TumbleDryerChannelSelector.java
@@ -123,7 +123,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     },
     SWITCH(null, "switch", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(TumbleDryerChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(TumbleDryerChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/TumbleDryerHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/TumbleDryerHandler.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonElement;
  */
 public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(TumbleDryerHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(TumbleDryerHandler.class);
 
     public TumbleDryerHandler(Thing thing) {
         super(thing, TumbleDryerChannelSelector.class, "TumbleDryer");

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/WashingMachineChannelSelector.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/WashingMachineChannelSelector.java
@@ -136,14 +136,14 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     SWITCH(null, "switch", OnOffType.class, false);
 
-    protected Logger logger = LoggerFactory.getLogger(WashingMachineChannelSelector.class);
+    private final Logger logger = LoggerFactory.getLogger(WashingMachineChannelSelector.class);
 
     private final String mieleID;
     private final String channelID;
     private final Class<? extends Type> typeClass;
     private final boolean isProperty;
 
-    private WashingMachineChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
+    WashingMachineChannelSelector(String propertyID, String channelID, Class<? extends Type> typeClass,
             boolean isProperty) {
         this.mieleID = propertyID;
         this.channelID = channelID;

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/WashingMachineHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/WashingMachineHandler.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonElement;
  */
 public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineChannelSelector> {
 
-    protected Logger logger = LoggerFactory.getLogger(WashingMachineHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(WashingMachineHandler.class);
 
     public WashingMachineHandler(Thing thing) {
         super(thing, WashingMachineChannelSelector.class, "WashingMachine");

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV2RGB.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV2RGB.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class MilightV2RGB extends AbstractBulbInterface {
-    protected static final Logger logger = LoggerFactory.getLogger(MilightV2RGB.class);
+    protected final Logger logger = LoggerFactory.getLogger(MilightV2RGB.class);
     protected static final int brLevels = 9;
 
     public MilightV2RGB(QueuedSend sendQueue, int zone) {

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class MilightV3 extends AbstractBulbInterface {
     public static final int MAX_ANIM_MODES = 10;
-    protected static final Logger logger = LoggerFactory.getLogger(MilightV3.class);
+    protected final Logger logger = LoggerFactory.getLogger(MilightV3.class);
 
     public MilightV3(int type_offset, QueuedSend sendQueue, int zone) {
         super(type_offset, sendQueue, zone);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  * @since 2.1
  */
 public abstract class MilightV6 extends AbstractBulbInterface {
-    protected static final Logger logger = LoggerFactory.getLogger(MilightV6.class);
+    protected final Logger logger = LoggerFactory.getLogger(MilightV6.class);
 
     protected static final int MAX_BR = 100; // Maximum brightness (0x64)
     protected static final int MAX_SAT = 100; // Maximum saturation (0x64)

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * @since 2.1
  */
 public class MilightV6SessionManager implements Runnable {
-    protected static final Logger logger = LoggerFactory.getLogger(MilightV6SessionManager.class);
+    protected final Logger logger = LoggerFactory.getLogger(MilightV6SessionManager.class);
 
     // The used sequence number for a command will be present in the response of the iBox. This
     // allows us to identify failed command deliveries.

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
@@ -32,10 +32,11 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class QueuedSend implements Runnable {
+    private final Logger logger = LoggerFactory.getLogger(QueuedSend.class);
+
     BlockingQueue<QueueItem> queue = new LinkedBlockingQueue<>(20);
     protected final DatagramPacket packet;
     protected final DatagramSocket datagramSocket;
-    private static final Logger logger = LoggerFactory.getLogger(QueuedSend.class);
     private int delay_between_commands = 100;
     private int repeat_commands = 1;
     private boolean willbeclosed = false;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/EmulatedV6Bridge.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/EmulatedV6Bridge.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class EmulatedV6Bridge {
-    protected static final Logger logger = LoggerFactory.getLogger(EmulatedV6Bridge.class);
+    protected final Logger logger = LoggerFactory.getLogger(EmulatedV6Bridge.class);
     private boolean willbeclosed = false;
     private byte SID1 = (byte) 0xed;
     private byte SID2 = (byte) 0xab;

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/MinecraftSocketHandler.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/MinecraftSocketHandler.java
@@ -36,7 +36,7 @@ import rx.subjects.BehaviorSubject;
  */
 public class MinecraftSocketHandler implements WebSocketEventHandler {
 
-    private Logger logger = LoggerFactory.getLogger(MinecraftServerHandler.class);
+    private Logger logger = LoggerFactory.getLogger(MinecraftSocketHandler.class);
 
     private BehaviorSubject<ServerData> serverRx = BehaviorSubject.create();
     private BehaviorSubject<List<SignData>> signsRx = BehaviorSubject.<List<SignData>>create();

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/ServerConnection.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/handler/server/ServerConnection.java
@@ -35,7 +35,7 @@ import rx.subscriptions.Subscriptions;
  */
 public class ServerConnection {
 
-    private static final Logger logger = LoggerFactory.getLogger(MinecraftDiscoveryService.class);
+    private static final Logger logger = LoggerFactory.getLogger(ServerConnection.class);
 
     private String host;
     private int port;

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/MinecraftHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/MinecraftHandlerFactory.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MinecraftHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(MinecraftDiscoveryService.class);
+    private static final Logger logger = LoggerFactory.getLogger(MinecraftHandlerFactory.class);
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>();
 

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/AbstractNetatmoThingHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/AbstractNetatmoThingHandler.java
@@ -39,7 +39,7 @@ import io.swagger.client.model.NAMeasureResponse;
  *
  */
 abstract class AbstractNetatmoThingHandler<X extends NetatmoThingConfiguration> extends BaseThingHandler {
-    private static Logger logger = LoggerFactory.getLogger(AbstractNetatmoThingHandler.class);
+    private Logger logger = LoggerFactory.getLogger(AbstractNetatmoThingHandler.class);
     private List<Integer> signalThresholds = null;
     protected List<String> measuredChannels = new ArrayList<String>();
     protected NAMeasureResponse measures = null;

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoBridgeHandler.java
@@ -41,7 +41,7 @@ import retrofit.RetrofitError;
  *
  */
 public class NetatmoBridgeHandler extends BaseBridgeHandler {
-    private static Logger logger = LoggerFactory.getLogger(NetatmoBridgeHandler.class);
+    private Logger logger = LoggerFactory.getLogger(NetatmoBridgeHandler.class);
     private NetatmoBridgeConfiguration configuration;
     private ApiClient apiClient;
     private StationApi stationApi = null;

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
@@ -41,7 +41,7 @@ public abstract class NetatmoDeviceHandler<X extends NetatmoDeviceConfiguration>
         extends AbstractNetatmoThingHandler<X> {
 
     protected NADeviceAdapter<?> device;
-    private static Logger logger = LoggerFactory.getLogger(NetatmoDeviceHandler.class);
+    private Logger logger = LoggerFactory.getLogger(NetatmoDeviceHandler.class);
     private ScheduledFuture<?> refreshJob;
 
     public NetatmoDeviceHandler(Thing thing, Class<X> configurationClass) {

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class NetatmoModuleHandler<X extends NetatmoModuleConfiguration>
         extends AbstractNetatmoThingHandler<X> {
-    private static Logger logger = LoggerFactory.getLogger(NetatmoModuleHandler.class);
+    private Logger logger = LoggerFactory.getLogger(NetatmoModuleHandler.class);
     private int batteryMin = 0;
     private int batteryLow = 0;
     private int batteryMax = 1;

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/service/NetworkService.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NetworkService {
 
-    private static Logger logger = LoggerFactory.getLogger(NetworkService.class);
+    private Logger logger = LoggerFactory.getLogger(NetworkService.class);
 
     private ScheduledFuture<?> refreshJob;
 

--- a/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/OceanicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/OceanicBindingConstants.java
@@ -236,8 +236,6 @@ public class OceanicBindingConstants {
         getINR("incompleteregenerations", DecimalType.class, ValueSelectorType.GET, false),
         getTOR("allregenerations", DecimalType.class, ValueSelectorType.GET, false);
 
-        static final Logger logger = LoggerFactory.getLogger(OceanicChannelSelector.class);
-
         private final String text;
         private Class<? extends Type> typeClass;
         private ValueSelectorType typeValue;

--- a/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/handler/OceanicThingHandler.java
+++ b/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/handler/OceanicThingHandler.java
@@ -58,7 +58,7 @@ public class OceanicThingHandler extends BaseThingHandler {
     public static final String BAUD_RATE = "baud";
     public static final String BUFFER_SIZE = "buffer";
 
-    private static Logger logger = LoggerFactory.getLogger(OceanicThingHandler.class);
+    private Logger logger = LoggerFactory.getLogger(OceanicThingHandler.class);
 
     private SerialPort serialPort;
     private CommPortIdentifier portId;

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoConnection.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoConnection.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OnkyoConnection {
 
-    private static Logger logger = LoggerFactory.getLogger(OnkyoConnection.class);
+    private Logger logger = LoggerFactory.getLogger(OnkyoConnection.class);
 
     /** default eISCP port. **/
     public static final int DEFAULT_EISCP_PORT = 60128;

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHTTPHandler.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHTTPHandler.java
@@ -21,6 +21,8 @@ import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.opensprinkler.OpenSprinklerBindingConstants.Station;
 import org.openhab.binding.opensprinkler.config.OpenSprinklerConfig;
 import org.openhab.binding.opensprinkler.internal.api.OpenSprinklerApiFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link OpenSprinklerHTTPHandler} is responsible for handling commands, which are
@@ -29,6 +31,8 @@ import org.openhab.binding.opensprinkler.internal.api.OpenSprinklerApiFactory;
  * @author Chris Graham - Initial contribution
  */
 public class OpenSprinklerHTTPHandler extends OpenSprinklerHandler {
+    private final Logger logger = LoggerFactory.getLogger(OpenSprinklerHTTPHandler.class);
+
     private OpenSprinklerConfig openSprinklerConfig = null;
 
     public OpenSprinklerHTTPHandler(Thing thing) {

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHandler.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Chris Graham - Initial contribution
  */
 public abstract class OpenSprinklerHandler extends BaseThingHandler {
-    protected Logger logger = LoggerFactory.getLogger(OpenSprinklerHTTPHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(OpenSprinklerHandler.class);
 
     protected ScheduledFuture<?> pollingJob;
 

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerPiHandler.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/handler/OpenSprinklerPiHandler.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.opensprinkler.OpenSprinklerBindingConstants.Station;
 import org.openhab.binding.opensprinkler.config.OpenSprinklerPiConfig;
 import org.openhab.binding.opensprinkler.internal.api.OpenSprinklerApiFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link OpenSprinklerPiHandler} is responsible for handling commands, which are
@@ -28,6 +30,8 @@ import org.openhab.binding.opensprinkler.internal.api.OpenSprinklerApiFactory;
  * @author Chris Graham - Initial contribution
  */
 public class OpenSprinklerPiHandler extends OpenSprinklerHandler {
+    private final Logger logger = LoggerFactory.getLogger(OpenSprinklerPiHandler.class);
+
     private OpenSprinklerPiConfig openSprinklerConfig = null;
 
     public OpenSprinklerPiHandler(Thing thing) {

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/DisplayInformation.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/DisplayInformation.java
@@ -23,9 +23,9 @@ public class DisplayInformation {
 
     Boolean volumeDisplay; // 1-light, 0-OFF
     Boolean guidIcon; // 1-light, 0-OFF
-    String infoText = new String(""); // the actual display text
+    String infoText = ""; // the actual display text
 
-    private static final Logger logger = LoggerFactory.getLogger(DisplayInformation.class);
+    private final Logger logger = LoggerFactory.getLogger(DisplayInformation.class);
 
     /**
      * parse the display status text send from the receiver

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class StreamAvrConnection implements AvrConnection {
 
-    private static final Logger logger = LoggerFactory.getLogger(StreamAvrConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(StreamAvrConnection.class);
 
     // The maximum time to wait incoming messages.
     private static final Integer READ_TIMEOUT = 1000;

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ip/IpAvrConnection.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ip/IpAvrConnection.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IpAvrConnection extends StreamAvrConnection {
 
-    private static final Logger logger = LoggerFactory.getLogger(IpAvrConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(IpAvrConnection.class);
 
     /** default port for IP communication **/
     public static final int DEFAULT_IPCONTROL_PORT = 8102;

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/serial/SerialAvrConnection.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/serial/SerialAvrConnection.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SerialAvrConnection extends StreamAvrConnection {
 
-    private static final Logger logger = LoggerFactory.getLogger(SerialAvrConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(SerialAvrConnection.class);
 
     private static final Integer LINK_SPEED = 9600;
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PulseaudioClient {
 
-    private static final Logger logger = LoggerFactory.getLogger(PulseaudioClient.class);
+    private final Logger logger = LoggerFactory.getLogger(PulseaudioClient.class);
 
     private String host;
     private int port;

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDeviceDiscoveryService.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PulseaudioDeviceDiscoveryService extends AbstractDiscoveryService implements DeviceStatusListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(PulseaudioDeviceDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(PulseaudioDeviceDiscoveryService.class);
 
     private PulseaudioBridgeHandler pulseaudioBridgeHandler;
 

--- a/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/net/SocketChannelSession.java
+++ b/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/net/SocketChannelSession.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts
  */
 public class SocketChannelSession implements SocketSession {
-    private Logger _logger = LoggerFactory.getLogger(SocketChannelSession.class);
+    private final Logger logger = LoggerFactory.getLogger(SocketChannelSession.class);
 
     /**
      * The host/ip address to connect to
@@ -137,10 +137,10 @@ public class SocketChannelSession implements SocketSession {
         final SocketChannel channel = SocketChannel.open();
         channel.configureBlocking(true);
 
-        _logger.debug("Connecting to {}:{}", _host, _port);
+        logger.debug("Connecting to {}:{}", _host, _port);
         channel.connect(new InetSocketAddress(_host, _port));
 
-        _logger.debug("Waiting for connect");
+        logger.debug("Waiting for connect");
         while (!channel.finishConnect()) {
             try {
                 Thread.sleep(250);
@@ -161,7 +161,7 @@ public class SocketChannelSession implements SocketSession {
     @Override
     public void disconnect() throws IOException {
         if (isConnected()) {
-            _logger.debug("Disconnecting from {}:{}", _host, _port);
+            logger.debug("Disconnecting from {}:{}", _host, _port);
 
             final SocketChannel channel = _socketChannel.getAndSet(null);
             channel.close();
@@ -207,9 +207,9 @@ public class SocketChannelSession implements SocketSession {
 
         final SocketChannel channel = _socketChannel.get();
         if (channel == null) {
-            _logger.debug("Cannot send command '{}' - socket channel was closed", command);
+            logger.debug("Cannot send command '{}' - socket channel was closed", command);
         } else {
-            _logger.debug("Sending Command: '{}'", command);
+            logger.debug("Sending Command: '{}'", command);
             channel.write(toSend);
         }
     }
@@ -240,7 +240,7 @@ public class SocketChannelSession implements SocketSession {
             if (_isRunning.getAndSet(false)) {
                 try {
                     if (!_running.await(5, TimeUnit.SECONDS)) {
-                        _logger.warn("Waited too long for response reader to finish");
+                        logger.warn("Waited too long for response reader to finish");
                     }
                 } catch (InterruptedException e) {
                     // Do nothing
@@ -356,7 +356,7 @@ public class SocketChannelSession implements SocketSession {
                 if (!_isProcessing.get()) {
                     try {
                         if (!_running.await(5, TimeUnit.SECONDS)) {
-                            _logger.warn("Waited too long for dispatcher to finish");
+                            logger.warn("Waited too long for dispatcher to finish");
                         }
                     } catch (InterruptedException e) {
                         // do nothing
@@ -386,7 +386,7 @@ public class SocketChannelSession implements SocketSession {
                     if (response != null) {
                         if (response instanceof String) {
                             try {
-                                _logger.debug("Dispatching response: {}", response);
+                                logger.debug("Dispatching response: {}", response);
                                 try {
                                     _isProcessing.set(true);
                                     for (SocketSessionListener listener : listeners) {
@@ -396,10 +396,10 @@ public class SocketChannelSession implements SocketSession {
                                     _isProcessing.set(false);
                                 }
                             } catch (Exception e) {
-                                _logger.warn("Exception occurred processing the response '{}': {}", response, e);
+                                logger.warn("Exception occurred processing the response '{}': {}", response, e);
                             }
                         } else if (response instanceof Exception) {
-                            _logger.debug("Dispatching exception: {}", response);
+                            logger.debug("Dispatching exception: {}", response);
                             try {
                                 _isProcessing.set(true);
                                 for (SocketSessionListener listener : listeners) {
@@ -409,13 +409,13 @@ public class SocketChannelSession implements SocketSession {
                                 _isProcessing.set(false);
                             }
                         } else {
-                            _logger.warn("Unknown response class: {}", response);
+                            logger.warn("Unknown response class: {}", response);
                         }
                     }
                 } catch (InterruptedException e) {
                     // Do nothing
                 } catch (Exception e) {
-                    _logger.debug("Uncaught exception {}: {}", e.getMessage(), e);
+                    logger.debug("Uncaught exception {}: {}", e.getMessage(), e);
                     break;
                 }
             }

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SMAEnergyMeterDiscoveryService extends AbstractDiscoveryService {
 
-    private static final Logger logger = LoggerFactory.getLogger(SMAEnergyMeterDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(SMAEnergyMeterDiscoveryService.class);
 
     public SMAEnergyMeterDiscoveryService() {
         super(SUPPORTED_THING_TYPES_UIDS, 15, true);

--- a/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/discovery/SysteminfoDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/discovery/SysteminfoDiscoveryService.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Svilen Valkanov
  */
 public class SysteminfoDiscoveryService extends AbstractDiscoveryService {
-    private static final Logger logger = LoggerFactory.getLogger(SysteminfoDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(SysteminfoDiscoveryService.class);
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_COMPUTER);
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreDeviceController.java
@@ -42,7 +42,7 @@ import org.tellstick.device.iface.SwitchableDevice;
  *
  */
 public class TelldusCoreDeviceController implements DeviceChangeListener, SensorListener, TelldusDeviceController {
-    private static final Logger logger = LoggerFactory.getLogger(TelldusCoreBridgeHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(TelldusCoreDeviceController.class);
     private long lastSend = 0;
     long resendInterval = 100;
     public static final long DEFAULT_INTERVAL_BETWEEN_SEND = 250;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveBridgeHandler.java
@@ -49,7 +49,7 @@ import org.tellstick.device.iface.Device;
  */
 public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements TelldusBridgeHandler {
 
-    static final Logger logger = LoggerFactory.getLogger(TelldusLiveBridgeHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(TelldusLiveBridgeHandler.class);
 
     private TellstickNetDevices deviceList = null;
     private TellstickNetSensors sensorList = null;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveDeviceController.java
@@ -58,7 +58,7 @@ import org.tellstick.device.iface.SwitchableDevice;
  */
 
 public class TelldusLiveDeviceController implements DeviceChangeListener, SensorListener, TelldusDeviceController {
-    private static final Logger logger = LoggerFactory.getLogger(TelldusLiveDeviceController.class);
+    private final Logger logger = LoggerFactory.getLogger(TelldusLiveDeviceController.class);
     private long lastSend = 0;
     public static final long DEFAULT_INTERVAL_BETWEEN_SEND = 250;
     static final int REQUEST_TIMEOUT_MS = 5000;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickHandlerFactory.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Jarle Hjortland - Initial contribution
  */
 public class TellstickHandlerFactory extends BaseThingHandlerFactory {
-    private static final Logger logger = LoggerFactory.getLogger(TellstickHandlerFactory.class);
+    private final Logger logger = LoggerFactory.getLogger(TellstickHandlerFactory.class);
     private TellstickDiscoveryService discoveryService = null;
 
     @Override

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickBridgeDiscovery.java
@@ -31,7 +31,7 @@ import org.tellstick.device.TellstickController;
  */
 public class TellstickBridgeDiscovery extends AbstractDiscoveryService {
 
-    private static final Logger logger = LoggerFactory.getLogger(TellstickBridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(TellstickBridgeDiscovery.class);
 
     static boolean discoveryRunning = false;
     static boolean initilized = false;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
@@ -46,7 +46,7 @@ public class TellstickDiscoveryService extends AbstractDiscoveryService
         super(timeout);
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(TellstickDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(TellstickDiscoveryService.class);
 
     private List<TelldusBridgeHandler> telldusBridgeHandlers = new Vector<TelldusBridgeHandler>();
 

--- a/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/internal/discovery/VitotronicBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/internal/discovery/VitotronicBridgeDiscovery.java
@@ -33,7 +33,7 @@ public class VitotronicBridgeDiscovery extends AbstractDiscoveryService {
 
     int adapterPort = 31113;
 
-    private static final Logger logger = LoggerFactory.getLogger(VitotronicBridgeDiscovery.class);
+    private final Logger logger = LoggerFactory.getLogger(VitotronicBridgeDiscovery.class);
 
     public VitotronicBridgeDiscovery() throws IllegalArgumentException {
         super(VitotronicBindingConstants.SUPPORTED_BRIDGE_THING_TYPES_UIDS, 15, false);

--- a/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/handler/ZoneMinderServerBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/handler/ZoneMinderServerBridgeHandler.java
@@ -79,7 +79,7 @@ public class ZoneMinderServerBridgeHandler extends BaseBridgeHandler implements 
     /**
      * Logger
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private ZoneMinderDiscoveryService discoveryService = null;
     private ServiceRegistration discoveryRegistration = null;

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayBridgeHandler.java
@@ -74,7 +74,7 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
 
     public static final ThingTypeUID SUPPORTED_THING_TYPE = THING_TYPE_BRIDGE;
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private BridgePolling bridgePolling;
     private ScheduledFuture<?> pollingJob;

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
@@ -69,7 +69,7 @@ import de.fh_zwickau.informatik.sensor.model.zwaveapi.devices.ZWaveDevice;
  * @author Patrick Hecker - Initial contribution
  */
 public abstract class ZWayDeviceHandler extends BaseThingHandler {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private Logger logger = LoggerFactory.getLogger(getClass());
 
     private DevicePolling devicePolling;
     private ScheduledFuture<?> pollingJob;

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
@@ -37,7 +37,7 @@ import de.fh_zwickau.informatik.sensor.model.devices.DeviceList;
 public class ZWayZAutomationDeviceHandler extends ZWayDeviceHandler {
     public static final ThingTypeUID SUPPORTED_THING_TYPE = THING_TYPE_VIRTUAL_DEVICE;
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private Logger logger = LoggerFactory.getLogger(getClass());
 
     private ZWayZAutomationDeviceConfiguration mConfig = null;
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZWaveDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZWaveDeviceHandler.java
@@ -39,7 +39,7 @@ import de.fh_zwickau.informatik.sensor.model.zwaveapi.devices.ZWaveDevice;
 public class ZWayZWaveDeviceHandler extends ZWayDeviceHandler {
     public static final ThingTypeUID SUPPORTED_THING_TYPE = THING_TYPE_DEVICE;
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private Logger logger = LoggerFactory.getLogger(getClass());
 
     private ZWayZWaveDeviceConfiguration mConfig = null;
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayBridgeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayBridgeDiscoveryService.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ZWayBridgeDiscoveryService extends AbstractDiscoveryService {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final int SEARCH_TIME = 240;
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
@@ -36,7 +36,7 @@ import de.fh_zwickau.informatik.sensor.model.zwaveapi.devices.ZWaveDevice;
  */
 public class ZWayDeviceDiscoveryService extends AbstractDiscoveryService {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final int SEARCH_TIME = 60;
     private static final int INITIAL_DELAY = 15;

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
@@ -29,13 +29,13 @@ import com.beowulfe.hap.HomekitServer;
  * @author Andy Lintner
  */
 public class HomekitAuthInfoImpl implements HomekitAuthInfo {
+    private final Logger logger = LoggerFactory.getLogger(HomekitAuthInfoImpl.class);
 
     private final Storage<String> storage;
     private final String mac;
     private final BigInteger salt;
     private final byte[] privateKey;
     private final String pin;
-    private Logger logger = LoggerFactory.getLogger(HomekitImpl.class);
 
     public HomekitAuthInfoImpl(StorageService storageService, String pin) throws InvalidAlgorithmParameterException {
         storage = storageService.getStorage("homekit");

--- a/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -64,7 +64,7 @@ public class CloudClient {
     /*
      * Logger for this class
      */
-    private static Logger logger = LoggerFactory.getLogger(CloudClient.class);
+    private Logger logger = LoggerFactory.getLogger(CloudClient.class);
     /*
      * This constant defines maximum number of HTTP connections per peer
      * address for HTTP client which performs local connections to openHAB

--- a/addons/ui/org.openhab.ui.cometvisu.php/src/main/java/org/openhab/ui/cometvisu/servlet/quercus/PHProviderImpl.java
+++ b/addons/ui/org.openhab.ui.cometvisu.php/src/main/java/org/openhab/ui/cometvisu/servlet/quercus/PHProviderImpl.java
@@ -60,7 +60,7 @@ import com.caucho.vfs.WriteStream;
  */
 public class PHProviderImpl implements PHProvider {
 
-    private static final Logger logger = LoggerFactory.getLogger(PHProviderImpl.class);
+    private final Logger logger = LoggerFactory.getLogger(PHProviderImpl.class);
     private static final L10N L = new L10N(PHProviderImpl.class);
 
     protected QuercusEngine engine;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ChartResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ChartResource.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_CHART_ALIAS)
 public class ChartResource implements RESTResource {
-    private static final Logger logger = LoggerFactory.getLogger(ChartResource.class);
+    private final Logger logger = LoggerFactory.getLogger(ChartResource.class);
 
     // pattern RRDTool uses to format doubles in XML files
     static final String PATTERN = "0.0000000000E00";

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/LoginResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/LoginResource.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_LOGIN_ALIAS)
 public class LoginResource implements RESTResource {
-    private static final Logger logger = LoggerFactory.getLogger(LoginResource.class);
-
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
     public Response getLogin(@Context UriInfo uriInfo, @Context HttpHeaders headers, @QueryParam("u") String user,

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ReadResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/ReadResource.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_READ_ALIAS)
 public class ReadResource implements EventBroadcaster, RESTResource {
-    private static final Logger logger = LoggerFactory.getLogger(ReadResource.class);
+    private final Logger logger = LoggerFactory.getLogger(ReadResource.class);
 
     private SseBroadcaster broadcaster = new SseBroadcaster();
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/WriteResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/backend/WriteResource.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_WRITE_ALIAS)
 public class WriteResource implements RESTResource {
-    private static final Logger logger = LoggerFactory.getLogger(WriteResource.class);
+    private final Logger logger = LoggerFactory.getLogger(WriteResource.class);
 
     private ItemRegistry itemRegistry;
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/CvActivator.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/CvActivator.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CvActivator implements BundleActivator {
 
-    private static final Logger logger = LoggerFactory.getLogger(CvActivator.class);
+    private final Logger logger = LoggerFactory.getLogger(CvActivator.class);
 
     private static BundleContext context;
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/StateBeanMessageBodyWriter.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/StateBeanMessageBodyWriter.java
@@ -37,8 +37,6 @@ import org.openhab.ui.cometvisu.backend.beans.StateBean;
 @Produces(MediaType.APPLICATION_JSON)
 public class StateBeanMessageBodyWriter implements MessageBodyWriter<Object> {
 
-    // private static final Logger logger = LoggerFactory.getLogger(StateBeanMessageBodyWriter.class);
-
     @Override
     public long getSize(Object arg0, Class<?> arg1, Type arg2, Annotation[] arg3, MediaType arg4) {
         // deprecated by JAX-RS 2.0 and ignored by Jersey runtime

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/ItemRegistryEventListener.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/ItemRegistryEventListener.java
@@ -23,8 +23,6 @@ import org.openhab.ui.cometvisu.backend.EventBroadcaster;
  * @since 2.0.0
  */
 public class ItemRegistryEventListener implements ItemRegistryChangeListener {
-    // private static final Logger logger = LoggerFactory.getLogger(ItemRegistryEventListener.class);
-
     private ItemRegistry itemRegistry;
 
     private EventBroadcaster eventBroadcaster;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuApp.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuApp.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CometVisuApp {
 
-    private static final Logger logger = LoggerFactory.getLogger(CometVisuApp.class);
+    private final Logger logger = LoggerFactory.getLogger(CometVisuApp.class);
 
     protected HttpService httpService;
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuServlet.java
@@ -73,11 +73,8 @@ import com.google.gson.Gson;
  * @author Tobias Bräutigam
  */
 public class CometVisuServlet extends HttpServlet {
-    /**
-     *
-     */
     private static final long serialVersionUID = 4448918908615003303L;
-    private static final Logger logger = LoggerFactory.getLogger(CometVisuServlet.class);
+    private final Logger logger = LoggerFactory.getLogger(CometVisuServlet.class);
 
     private static final int DEFAULT_BUFFER_SIZE = 10240; // ..bytes = 10KB.
     private static final long DEFAULT_EXPIRE_TIME = 604800000L; // ..ms = 1


### PR DESCRIPTION
E1. As we are in a dynamic OSGi environment, loggers should be non-static, whenever possible and have the name logger.

IMHO they should also refer to the correct class and preferably be private & final, 

PS: I don't like (but tolerate ;-) ) using it with getClass but if we do let's leave out the this...
PS2: this is the most complex PR I can do while being half asleep with a baby on my lap
PS3: the remaining static ones (12 of them) are being called from static scopes removing them requires to stop using static scopes at all...

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>