### PR TITLE
Milight: Make v6 bridges keep alive interval configurable

### DIFF
--- a/addons/binding/org.openhab.binding.milight/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.milight/ESH-INF/thing/thing-types.xml
@@ -43,7 +43,6 @@
                 </description>
                 <advanced>true</advanced>
             </parameter>
-
             <parameter name="REFRESH_IN_SEC" type="integer" min="5" max="300">
                 <label>Refresh interval</label>
                 <description>Interval in seconds to check for device presence. The Bridge ID is used to check if the IP is still the right one.
@@ -109,6 +108,13 @@
                 does not respond with the correct Bride ID and a re-detection is started. Useful for DHCP environments where
                 IPs may change over time, after power outage etc. Will be resolved by discovery if auto configured.
                 </description>
+                <advanced>true</advanced>
+            </parameter>
+            <parameter name="REFRESH_IN_SEC" type="integer" min="5" max="300">
+                <label>Keep alive interval</label>
+                <description>Interval in seconds to send a keep alive ping. If a session expires and need to be reestablished, the bridge and all devices could go offline for a few seconds.
+                </description>
+                <default>5</default>
                 <advanced>true</advanced>
             </parameter>
         </config-description>

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/AbstractMilightBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/AbstractMilightBridgeHandler.java
@@ -43,7 +43,7 @@ public abstract class AbstractMilightBridgeHandler extends BaseBridgeHandler {
     protected String bridgeid;
     protected ThingDiscoveryService thingDiscoveryService;
     private ScheduledFuture<?> keepAliveTimer;
-    protected int refrehIntervalSec;
+    protected int refrehIntervalSec = 5;
 
     public AbstractMilightBridgeHandler(Bridge bridge) {
         super(bridge);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
@@ -31,7 +31,6 @@ import org.openhab.binding.milight.internal.protocol.MilightV6SessionManager.Ses
  */
 public class MilightBridgeV6Handler extends AbstractMilightBridgeHandler implements ISessionState {
     private MilightV6SessionManager session;
-    private static final int v6IntervalSec = 5;
 
     public MilightBridgeV6Handler(Bridge bridge) {
         super(bridge);
@@ -162,7 +161,9 @@ public class MilightBridgeV6Handler extends AbstractMilightBridgeHandler impleme
             case SESSION_VALID:
                 updateStatus(ThingStatus.ONLINE);
                 // Setup the keep alive timer as soon as we have established a valid session
-                setupRefreshTimer(v6IntervalSec);
+                BigDecimal refresh_sec = (BigDecimal) thing.getConfiguration()
+                        .get(MilightBindingConstants.CONFIG_REFRESH_SEC);
+                setupRefreshTimer(refresh_sec == null ? refrehIntervalSec : refresh_sec.intValue());
                 addBulbsToDiscovery();
                 // As soon as the session is valid, update the user visible configuration of the host IP.
                 Configuration c = editConfiguration();


### PR DESCRIPTION
For some users the default interval of 5 sec is not frequent enough to keep the session to a v6 bridge established.