### PR TITLE
[dlinkupnpcamera] D-Link UPnP Cameras Binding initial contribution

### DIFF
--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/binding/binding.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="dlinkupnpcamera"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>DlinkUpnpCamera Binding</name>
+    <description>This is the binding for DlinkUpnpCamera.</description>
+    <author>Law Christopher</author>
+
+</binding:binding>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/i18n/dlinkupnpcamera_xx_XX.properties
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/i18n/dlinkupnpcamera_xx_XX.properties
@@ -1,0 +1,11 @@
+# binding
+binding.dlinkupnpcamera.name = <Your localized Binding name>
+binding.dlinkupnpcamera.description = <Your localized Binding description>
+
+# thing types
+thing-type.dlinkupnpcamera.sample.label = <Your localized Thing label>
+thing-type.dlinkupnpcamera.sample.description = <Your localized Thing description>
+
+# channel types
+channel-type.dlinkupnpcamera.sample-channel.label = <Your localized Channel label>
+channel-type.dlinkupnpcamera.sample-channel.description = <Your localized Channel description>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="dlinkupnpcamera"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Sample Thing Type -->
+    <thing-type id="camera">
+        <label>Dlink Upnp Camera</label>
+        <description>Dlink Upnp camera represents a discovered camera</description>
+
+        <channels>
+            <channel id="pan" typeId="pan"/>
+            <channel id="tilt" typeId="tilt"/>
+            <channel id="image" typeId="image"/>
+        </channels>
+        
+        <config-description>
+            <parameter name="udn" type="text">
+                <label>Unique Device Name</label>
+                <description>The UDN identifies the camera.</description>
+                <required>true</required>
+            </parameter>
+
+            <parameter name="connectionRefresh" type="integer">
+                <label>Connection refresh</label>
+                <description>Specifies the refresh interval in seconds</description>
+                <default>30</default>
+            </parameter>
+            
+            <parameter name="username" type="text">
+                <label>Username</label>
+                <description>The username for authentication to camera</description>
+                <required>true</required>
+            </parameter>
+            
+            <parameter name="password" type="text">
+                <label>Password</label>
+                <description>The password for authentication to camera</description>
+                <required>true</required>
+            </parameter>
+            
+            <parameter name="commandRequest" type="text">
+                <label>Command request URL repertory</label>
+                <description>Link for command request in URL</description>
+                <default>/cgi/ptdc.cgi?command</default>
+            </parameter>
+            
+            <parameter name="imageRequest" type="text">
+                                <label>Image request URL repertory</label>
+                <description>Link for image request in URL</description>
+                <default>/image/jpeg.cgi</default>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+    <channel-type id="pan">
+        <item-type>Player</item-type>
+        <label>Pan</label>
+        <description>Rotate the camera to left or right</description>
+    </channel-type>
+    
+    <channel-type id="tilt">
+        <item-type>Player</item-type>
+        <label>Tilt</label>
+        <description>Tilt</description>
+    </channel-type>
+
+    <channel-type id="image">
+        <item-type>Image</item-type>
+        <label>Image</label>
+        <description>Display an image from camera</description>
+    </channel-type>
+    
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/META-INF/MANIFEST.MF
@@ -1,0 +1,36 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: dlinkupnpcamera Binding
+Bundle-SymbolicName: org.openhab.binding.dlinkupnpcamera;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: 
+ com.google.common.collect,
+ org.apache.commons.lang,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.config.discovery.inbox.events,
+ org.eclipse.smarthome.core.common.registry,
+ org.eclipse.smarthome.core.events,
+ org.eclipse.smarthome.core.items.events,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.net.http,
+ org.eclipse.smarthome.io.transport.upnp,
+ org.jupnp,
+ org.jupnp.model,
+ org.jupnp.model.meta,
+ org.jupnp.model.types,
+ org.openhab.io.net.actions,
+ org.osgi.service.component;version="1.2.2",
+ org.slf4j,
+ org.xml.sax,
+ org.xml.sax.helpers
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.dlinkupnpcamera,
+ org.openhab.binding.dlinkupnpcamera.handler
+Bundle-ActivationPolicy: lazy

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/OSGI-INF/DlinkUpnpCameraDiscovery.xml
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/OSGI-INF/DlinkUpnpCameraDiscovery.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2014-2017 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.dlinkupnpcamera.discovery.DlinkUpnpCameraDiscoveryParticipant">
+   <implementation class="org.openhab.binding.dlinkupnpcamera.discovery.DlinkUpnpCameraDiscoveryParticipant"/>
+   <service> 
+      <provide interface="org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant"/>
+   </service>
+</scr:component>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/OSGI-INF/DlinkUpnpCameraHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/OSGI-INF/DlinkUpnpCameraHandlerFactory.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2017 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.dlinkupnpcamera">
+
+   <implementation class="org.openhab.binding.dlinkupnpcamera.internal.DlinkUpnpCameraHandlerFactory"/>
+   <reference bind="setUpnpIOService" cardinality="1..1" interface="org.eclipse.smarthome.io.transport.upnp.UpnpIOService" name="UpnpIOService" policy="static" unbind="unsetUpnpIOService"/>
+   <reference bind="setDiscoveryServiceRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry" name="DiscoveryServiceRegistry" policy="static" unbind="unsetDiscoveryServiceRegistry"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/README.md
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/README.md
@@ -1,0 +1,49 @@
+# DlinkUpnpCamera Binding
+
+This is an openHAB2 binding that can discover D-Link cameras present in a network.
+the cameras can then be added as a thing in openHAB2 in order to be used later.
+
+## Discovery
+
+The cameras are discovered through UPnP in the local network and are put in the inbox.
+
+## Supported Things
+
+The binding supports a single type of Thing which is the camera Thing.
+
+## Binding Configuration
+
+The binding does not require any specific configuration.
+
+## Thing Configuration
+
+A camera Thing requires an UDN which is the Unique Device Name used in UPnP protocol.
+Moreover, the camera Thing needs to be configured with the following parameters:
+ - a parameter for the status and image update, connection refresh
+ - an username which is a required parameter, used for authentication to the camera
+ - a password also required, used for authentication.
+ - a command request URL repertory, which is used to build the HTTP request needed to command the camera
+ - an image request URL repertory to build the URL used for retrieving an image from the camera
+
+## Channels
+
+Depending of the camera model, some channels are not supported.
+Overall, a camera Thing supports the following channels:
+
+| Channel Type ID | Item Type    | Description  |
+|-----------------|------------------------|--------------|----------------- |------------- |
+| Pan | Player       | Pan control and patrol mode of the camera, NEXT command pans the camera to the right, PREVIOUS command pans the camera to the left. PLAY command starts the patrol mode if available and PAUSE command stops the patrol mode. |
+| Tilt | Player       | Tilt control and patrol mode of the camera, NEXT command tilts the camera up, PREVIOUS command tilts the camera down. PLAY command starts the patrol mode if available and PAUSE command stops the patrol mode. |
+| Image | Image       | The image from the camera is updated if a REFRESH command is given. It is updated every time a status update is done. |
+
+## Example to display video from the camera
+
+demo.sitemap:
+
+```
+sitemap default label="Main Menu" {
+    Text label="UPnP Camera display" {
+     Webview url="http://192.168.0.48/video/mjpg.cgi" height=10
+    }
+}
+```

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/build.properties
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/pom.xml
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.dlinkupnpcamera</artifactId>
+  <version>2.1.0-SNAPSHOT</version>
+
+  <name>DlinkUpnpCamera Binding</name>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/DlinkUpnpCameraBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/DlinkUpnpCameraBindingConstants.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinkupnpcamera;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+import com.google.common.collect.Sets;
+
+/**
+ * The {@link DlinkUpnpCameraBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Yacine Ndiaye
+ * @author Antoine Blanc
+ * @author Christopher Law
+ */
+public class DlinkUpnpCameraBindingConstants {
+
+    public static final String BINDING_ID = "dlinkupnpcamera";
+
+    // List of all Thing Type UIDs
+    public final static ThingTypeUID CAMERA_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "camera");
+
+    public static final Set<ThingTypeUID> SUPPORTED_KNOWN_THING_TYPES_UIDS = Sets.newHashSet(CAMERA_THING_TYPE_UID);
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
+            SUPPORTED_KNOWN_THING_TYPES_UIDS);
+
+    // List of all Channel ids
+    public final static String PAN = "pan";
+    public final static String TILT = "tilt";
+    public final static String IMAGE = "image";
+
+}

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/config/DlinkUpnpCameraConfiguration.java
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/config/DlinkUpnpCameraConfiguration.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinkupnpcamera.config;
+
+/**
+ * The {@link DlinkUpnpCameraConfiguration} contains parameters for the configuration of a camera.
+ *
+ * @author Yacine Ndiaye
+ * @author Antoine Blanc
+ * @author Christopher Law
+ */
+public class DlinkUpnpCameraConfiguration {
+
+    public static final String UDN = "udn";
+    public static final String IP = "ip";
+    public static final String NAME = "name";
+
+    public String udn;
+    public String username;
+    public String password;
+    public String commandRequest;
+    public String imageRequest;
+    public Integer connectionRefresh;
+
+}

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/discovery/DlinkUpnpCameraDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/discovery/DlinkUpnpCameraDiscoveryParticipant.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinkupnpcamera.discovery;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.binding.dlinkupnpcamera.DlinkUpnpCameraBindingConstants;
+import org.openhab.binding.dlinkupnpcamera.config.DlinkUpnpCameraConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link DlinkUpnpCameraDiscoveryParticipant} is responsible processing the
+ * results of searches for UPNP devices
+ *
+ * @author Yacine Ndiaye
+ * @author Antoine Blanc
+ * @author Christopher Law
+ */
+public class DlinkUpnpCameraDiscoveryParticipant implements UpnpDiscoveryParticipant {
+    private Logger logger = LoggerFactory.getLogger(DlinkUpnpCameraDiscoveryParticipant.class);
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return DlinkUpnpCameraBindingConstants.SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override // discover the camera
+    public DiscoveryResult createResult(RemoteDevice device) {
+        ThingUID uid = getThingUID(device);
+        if (uid != null) {
+            Map<String, Object> properties = new HashMap<>(3);
+            String label = "camera device";
+            try {
+                label = device.getDetails().getModelDetails().getModelName();
+            } catch (Exception e) {
+                // ignore and use default label
+            }
+            // add the properties of the cameras to the properties of the thing
+            properties.put(DlinkUpnpCameraConfiguration.UDN, device.getIdentity().getUdn().getIdentifierString());
+            properties.put(DlinkUpnpCameraConfiguration.IP, device.getIdentity().getDescriptorURL().getHost());
+            properties.put(DlinkUpnpCameraConfiguration.NAME, label);
+
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
+                    .build();
+            logger.debug("Result {}", result.toString());
+            logger.debug("Created a DiscoveryResult for device '{}' with UDN '{}'",
+                    device.getDetails().getFriendlyName(), device.getIdentity().getUdn().getIdentifierString());
+            // returning the result
+            return result;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public ThingUID getThingUID(RemoteDevice device) {
+        if (device != null) {
+            if (device.getDetails().getManufacturerDetails().getManufacturer() != null) {// detect all the D-Link
+                                                                                         // cameras
+                if (device.getDetails().getManufacturerDetails().getManufacturer().toUpperCase().contains("D-LINK")) {
+                    logger.debug("Discovered a camera thing with UDN '{}'",
+                            device.getIdentity().getUdn().getIdentifierString());
+
+                    return new ThingUID(DlinkUpnpCameraBindingConstants.CAMERA_THING_TYPE_UID,
+                            device.getIdentity().getUdn().getIdentifierString());
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/handler/DlinkUpnpCameraHandler.java
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/handler/DlinkUpnpCameraHandler.java
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinkupnpcamera.handler;
+
+import static org.openhab.binding.dlinkupnpcamera.DlinkUpnpCameraBindingConstants.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry;
+import org.eclipse.smarthome.core.library.types.NextPreviousType;
+import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.RawType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
+import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
+import org.openhab.binding.dlinkupnpcamera.config.DlinkUpnpCameraConfiguration;
+import org.openhab.io.net.actions.Ping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link DlinkUpnpCameraHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Yacine Ndiaye
+ * @author Antoine Blanc
+ * @author Christopher Law
+ */
+public class DlinkUpnpCameraHandler extends BaseThingHandler implements UpnpIOParticipant {
+
+    private static final int DEFAULT_REFRESH_INTERVAL = 30;
+    private static final int PING_TIMEOUT = 20;
+
+    private String hostname;
+
+    private Logger logger = LoggerFactory.getLogger(DlinkUpnpCameraHandler.class);
+
+    private UpnpIOService service;
+    private ScheduledFuture<?> pollingJob;
+
+    private Runnable pollingRunnable = new Runnable() {
+
+        @Override
+        public void run() {
+            try {
+                logger.debug("Polling...");
+
+                // First check if the camera is set in the UPnP service registry
+                // If not, set the thing state to OFFLINE and wait for the next poll
+                if (!isUpnpDeviceRegistered()) {
+                    logger.debug("UPnP device {} not yet registered", getUDN());
+                    updateStatus(ThingStatus.OFFLINE);
+                    return;
+                }
+
+                // Check if the camera can be joined
+                // If not, set the thing state to OFFLINE and do nothing else
+                updatePlayerState();
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Exception during poll : {}", e);
+            }
+        }
+    };
+
+    @Override
+    public void initialize() {
+
+        logger.debug("initializing handler for thing {}", getThing().getUID());
+
+        if (getUDN() != null) {
+            updateStatus(ThingStatus.ONLINE);
+            onUpdate();
+            hostname = getThing().getProperties().get(DlinkUpnpCameraConfiguration.IP);
+            super.initialize();
+            logger.debug("Camera initialized.");
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+            logger.warn("Cannot initalize the camera. UDN not set.");
+        }
+    }
+
+    private boolean isUpnpDeviceRegistered() {
+        return service.isRegistered(this);
+    }
+
+    public DlinkUpnpCameraHandler(Thing thing, UpnpIOService upnpIOService,
+            DiscoveryServiceRegistry discoveryServiceRegistry) {
+        super(thing);
+
+        logger.debug("Creating a DlinkUpnpCameraHandler for thing '{}'", getThing().getUID());
+        if (upnpIOService != null) {
+            this.service = upnpIOService;
+        }
+    }
+
+    @Override
+    public String getUDN() {
+        return getConfigAs(DlinkUpnpCameraConfiguration.class).udn;
+    }
+
+    private String getUsername() {
+        return getConfigAs(DlinkUpnpCameraConfiguration.class).username;
+    }
+
+    private String getPassword() {
+        return getConfigAs(DlinkUpnpCameraConfiguration.class).password;
+    }
+
+    private String getCommandRequest() {
+        return getConfigAs(DlinkUpnpCameraConfiguration.class).commandRequest;
+    }
+
+    private String getImageRequest() {
+        return getConfigAs(DlinkUpnpCameraConfiguration.class).imageRequest;
+    }
+
+    private void updatePlayerState() {
+        try {
+            refreshImage();
+            boolean isAlive = Ping.checkVitality(hostname, 0, PING_TIMEOUT);
+            if (isAlive) {
+                if (!ThingStatus.ONLINE.equals(getThing().getStatus())) {
+                    logger.debug("Camera {} is connected to local network", getUDN());
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            } else {
+                if (!ThingStatus.OFFLINE.equals(getThing().getStatus())) {
+                    logger.debug("Camera {} is disconnected from local network", getUDN());
+                    updateStatus(ThingStatus.OFFLINE);
+                }
+            }
+        } catch (IOException e) {
+            logger.debug("couldn't establish network connection [host '{}']", new Object[] { hostname });
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        switch (channelUID.getId()) {
+            case IMAGE:
+                refreshImage(command);
+                break;
+            case PAN:
+                try {
+                    sendControlCommand(command, 20, 0);
+                } catch (FileNotFoundException e) {
+                    logger.debug("Command not supported by the camera");
+                }
+                break;
+            case TILT:
+                try {
+                    sendControlCommand(command, 0, 10);
+                } catch (FileNotFoundException e) {
+                    logger.debug("Command not supported by the camera");
+                }
+                break;
+            default:
+                // Nothing is done
+        }
+    }
+
+    private void sendControlCommand(Command command, int x, int y) throws FileNotFoundException {
+        if (command instanceof NextPreviousType || command instanceof PlayPauseType) {
+            switch (command.toString()) {
+                case "NEXT":
+                    sendHttpRequest(buildCommandUrl(hostname, x, y));
+                    break;
+                case "PREVIOUS":
+                    sendHttpRequest(buildCommandUrl(hostname, -x, -y));
+                    break;
+                case "PLAY":
+                    sendHttpRequest(buildPatrolUrl(hostname));
+                    break;
+                case "PAUSE":
+                    sendHttpRequest(buildStopUrl(hostname));
+                    break;
+                default:
+                    // Nothing is done
+            }
+        }
+    }
+
+    private void refreshImage() {
+        URL url = null;
+        try {
+            url = new URL(buildImageUrl(hostname));
+        } catch (MalformedURLException e) {
+            logger.debug("Can't create the URL");
+        }
+        try {
+            updateState(IMAGE, new RawType(readImage(url).toByteArray()));
+        } catch (IOException e) {
+            logger.debug("Can't update the image");
+        }
+    }
+
+    private void refreshImage(Command command) {
+        if (command instanceof RefreshType) {
+            refreshImage();
+        }
+    }
+
+    private ByteArrayOutputStream readImage(URL url) throws IOException {
+        // authentication for network connection
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(getUsername(), getPassword().toCharArray());
+            }
+        });
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        InputStream is = null;
+
+        is = url.openStream();
+        byte[] byteArray = new byte[4096];
+        int bytesRead;
+        while ((bytesRead = is.read(byteArray)) > 0) {
+            baos.write(byteArray, 0, bytesRead);
+        }
+        if (is != null) {
+            is.close();
+        }
+
+        return baos;
+    }
+
+    private void onUpdate() {
+        if (pollingJob == null || pollingJob.isCancelled()) {
+            DlinkUpnpCameraConfiguration config = getConfigAs(DlinkUpnpCameraConfiguration.class);
+            // use default if not specified
+            int refreshInterval = DEFAULT_REFRESH_INTERVAL;
+            if (config.connectionRefresh != null) {
+                refreshInterval = config.connectionRefresh.intValue();
+            }
+            pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, 0, refreshInterval, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("Handler disposed for thing {}", getThing().getUID());
+
+        if (pollingJob != null && !pollingJob.isCancelled()) {
+            pollingJob.cancel(true);
+            pollingJob = null;
+        }
+    }
+
+    @Override
+    public void onValueReceived(String variable, String value, String service) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void onStatusChanged(boolean status) {
+        // TODO Auto-generated method stub
+
+    }
+
+    private void sendHttpRequest(String string_url) {
+        // authentication for network connection
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(getUsername(), getPassword().toCharArray());
+            }
+        });
+
+        URL url = null;
+        try {
+            url = new URL(String.format(string_url));
+            HttpURLConnection connection = null;
+            connection = (HttpURLConnection) url.openConnection();
+            connection.getInputStream();
+        } catch (IOException e) {
+            logger.debug("Request failed");
+        }
+    }
+
+    private String buildCommandUrl(String hostname, int x, int y) {
+        return "http://" + hostname + getCommandRequest() + "=set_relative_pos&posX=" + x + "&posY=" + y;
+    }
+
+    private String buildPatrolUrl(String hostname) {
+        return "http://" + hostname + getCommandRequest() + "=pan_patrol";
+    }
+
+    private String buildStopUrl(String hostname) {
+        return "http://" + hostname + getCommandRequest() + "=stop";
+    }
+
+    private String buildImageUrl(String hostname) {
+        return "http://" + hostname + getImageRequest();
+    }
+}

--- a/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/internal/DlinkUpnpCameraHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.dlinkupnpcamera/src/main/java/org/openhab/binding/dlinkupnpcamera/internal/DlinkUpnpCameraHandlerFactory.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.dlinkupnpcamera.internal;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
+import org.openhab.binding.dlinkupnpcamera.DlinkUpnpCameraBindingConstants;
+import org.openhab.binding.dlinkupnpcamera.config.DlinkUpnpCameraConfiguration;
+import org.openhab.binding.dlinkupnpcamera.handler.DlinkUpnpCameraHandler;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link upnpcameraHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Yacine Ndiaye
+ * @author Antoine Blanc
+ * @author Christopher Law
+ */
+public class DlinkUpnpCameraHandlerFactory extends BaseThingHandlerFactory {
+    private Logger logger = LoggerFactory.getLogger(DlinkUpnpCameraHandlerFactory.class);
+
+    private UpnpIOService upnpIOService;
+    private DiscoveryServiceRegistry discoveryServiceRegistry;
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+
+        return DlinkUpnpCameraBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(Thing thing) {
+        logger.debug("ThingHandler createHandler");
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(DlinkUpnpCameraBindingConstants.CAMERA_THING_TYPE_UID)) {
+            return new DlinkUpnpCameraHandler(thing, upnpIOService, discoveryServiceRegistry);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected void activate(ComponentContext componentContext) {
+        super.activate(componentContext);
+        logger.debug("activate upnpcameraHandler");
+    };
+
+    @Override
+    public Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration, ThingUID thingUID,
+            ThingUID bridgeUID) {
+        if (DlinkUpnpCameraBindingConstants.CAMERA_THING_TYPE_UID.equals(thingTypeUID)) {
+            ThingUID cameraUID = getCameraUID(thingTypeUID, thingUID, configuration);
+            logger.debug("Creating a Camera thing with ID '{}'", cameraUID);
+            return super.createThing(thingTypeUID, configuration, cameraUID, null);
+        }
+        throw new IllegalArgumentException(
+                "The thing type " + thingTypeUID + " is not supported by the DlinkUpnpCamera binding.");
+    }
+
+    private ThingUID getCameraUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
+        String udn = (String) configuration.get(DlinkUpnpCameraConfiguration.UDN);
+
+        if (thingUID == null) {
+            thingUID = new ThingUID(thingTypeUID, udn);
+        }
+
+        return thingUID;
+    }
+
+    protected void setUpnpIOService(UpnpIOService upnpIOService) {
+        this.upnpIOService = upnpIOService;
+    }
+
+    protected void unsetUpnpIOService(UpnpIOService upnpIOService) {
+        this.upnpIOService = null;
+    }
+
+    protected void setDiscoveryServiceRegistry(DiscoveryServiceRegistry discoveryServiceRegistry) {
+        this.discoveryServiceRegistry = discoveryServiceRegistry;
+    }
+
+    protected void unsetDiscoveryServiceRegistry(DiscoveryServiceRegistry discoveryServiceRegistry) {
+        this.discoveryServiceRegistry = null;
+    }
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -26,6 +26,7 @@
     <module>org.openhab.binding.boschindego</module>
     <module>org.openhab.binding.chromecast</module>
     <module>org.openhab.binding.coolmasternet</module>
+    <module>org.openhab.binding.dlinkupnpcamera</module>
     <module>org.openhab.binding.dscalarm</module>
     <module>org.openhab.binding.exec</module>
     <module>org.openhab.binding.feed</module>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -68,6 +68,12 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.coolmasternet/${project.version}</bundle>
     </feature>
 
+    <feature name="openhab-binding-dlinkupnpcamera" description="DlinkUpnpCamera Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-upnp</feature>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.dlinkupnpcamera/${project.version}</bundle>
+    </feature>
+
     <feature name="openhab-binding-dscalarm" description="DSCAlarm Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>


### PR DESCRIPTION
Hi, this is the initial contribution of the DLink UPnP camera binding. 
This binding discovers on the local network D-Link cameras with the UPnP protocol.
Once added as Things, they can be controlled remotely and provide data.

Currently, this binding covers two models : the DCS-5222L and the DCS-932L. However, it might work for other models from D-Link if they are controlled the same way.

As it is our first binding for openHAB, it will probably need improvements. That is why, any suggestion is welcome. Thank you.

Also-by: Yacine Ndiaye <yacinenana@gmail.com> (github: yacinend)
Also-by: Antoine Blanc <antoineblanc269@gmail.com> (github: AntoineBL)
Signed-off-by: Christopher Law <law.christopher38@gmail.com> (github: lawchris)