### PR TITLE
Logging: loggers should be used for logging

### DIFF
--- a/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/handler/BoschIndegoHandler.java
+++ b/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/handler/BoschIndegoHandler.java
@@ -157,11 +157,12 @@ public class BoschIndegoHandler extends BaseThingHandler {
             updateState(TEXTUAL_STATE, new StringType(statusWithMessage.getMessage()));
 
         } catch (IndegoAuthenticationException e) {
-            e.printStackTrace();
+            String message = "The login credentials are wrong or another client connected to your Indego account";
+            logger.warn(message, e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "The login credentials are wrong or another client connected to your Indego account");
+                    message);
         } catch (IndegoException e) {
-            e.printStackTrace();
+            logger.warn("An error occurred", e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         }
     }

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/handler/ChromecastHandler.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/handler/ChromecastHandler.java
@@ -102,7 +102,7 @@ public class ChromecastHandler extends BaseThingHandler implements ChromeCastSpo
             chromecast = new ChromeCast(address, port);
             chromecast.registerListener(this);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.warn("An error occurred", e);
         }
     }
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
@@ -31,71 +31,66 @@ public class MessageProcessorTest {
         this.processor = new MessageProcessor();
     }
 
-    private void commonMessageTest(String line, Message expectedMessage) {
-        try {
-            Assert.assertTrue(this.processor.addReceivedLine(line));
-            Assert.assertTrue(this.processor.isMessageAvailable());
-            Message message = this.processor.pull();
-            Assert.assertNotNull(message);
-            Assert.assertEquals(message.getClass().getName(), expectedMessage.getClass().getName());
-            Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
-        }
+    private void commonMessageTest(String line, Message expectedMessage) throws Exception {
+        Assert.assertTrue(this.processor.addReceivedLine(line));
+        Assert.assertTrue(this.processor.isMessageAvailable());
+        Message message = this.processor.pull();
+        Assert.assertNotNull(message);
+        Assert.assertEquals(message.getClass().getName(), expectedMessage.getClass().getName());
+        Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
     }
 
     @Test
-    public void testS_Message() {
+    public void testS_Message() throws Exception {
         String rawData = "S:03,0,30";
         S_Message expectedMessage = new S_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testN_Message() {
+    public void testN_Message() throws Exception {
         String rawData = "N:Aw4VzExFUTAwMTUzNDD/";
         N_Message expectedMessage = new N_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testA_Message() {
+    public void testA_Message() throws Exception {
         String rawData = "A:";
         A_Message expectedMessage = new A_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testC_Message() {
+    public void testC_Message() throws Exception {
         String rawData = "C:0ff1bc,EQ/xvAQJEAJMRVEwNzk0MDA3";
         C_Message expectedMessage = new C_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testL_Message() {
+    public void testL_Message() throws Exception {
         String rawData = "L:Bg/xvAkAAA==";
         L_Message expectedMessage = new L_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testH_Message() {
+    public void testH_Message() throws Exception {
         String rawData = "H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
         H_Message expectedMessage = new H_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testSingleM_Message() {
+    public void testSingleM_Message() throws Exception {
         String rawData = "M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
         M_Message expectedMessage = new M_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
     }
 
     @Test
-    public void testMultilineM_Message() {
+    public void testMultilineM_Message() throws Exception {
         String line1_part1 = "M:00,02,";
         String line1_part2 = "VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
         String line1 = line1_part1 + line1_part2;
@@ -106,21 +101,17 @@ public class MessageProcessorTest {
 
         String expectedString = line1 + line2_part2;
         M_Message expectedMessage = new M_Message(expectedString);
-        try {
-            Assert.assertFalse(this.processor.addReceivedLine(line1));
-            Assert.assertTrue(this.processor.addReceivedLine(line2));
-            Message message = this.processor.pull();
-            Assert.assertNotNull(message);
-            Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
-            Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
-        }
+
+        Assert.assertFalse(this.processor.addReceivedLine(line1));
+        Assert.assertTrue(this.processor.addReceivedLine(line2));
+        Message message = this.processor.pull();
+        Assert.assertNotNull(message);
+        Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
+        Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
     }
 
     @Test
-    public void testWrongIndexOfMultilineM_Message() {
+    public void testWrongIndexOfMultilineM_Message() throws Exception {
         String line1 = "M:00,02,VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
         String line2 = "M:02,02,AxBV8ExFUTA5ODI2ODUOV2FuZHRoZXJtb3N0YXQJBA/v50xFUTA3OTQ0NzcNQmFsa29uZmVuc3RlcgkBD4lXTEVRMTAwNDYyMRZIZWl6dW5nIHVudGVybSBGZW5zdGVyCQQP8llMRVEwNzkzODUwDkZlbnN0ZXIgcmVjaHRzCQQP8bxMRVEwNzk0MDA3DUZlbnN0ZXIgbGlua3MJAQ+JOExFUTEwMDQ1OTAOSGVpenVuZyBCYWxrb24JBA/yLExFUTA3OTM4OTUKQmFsa29udMO8cgkED++zTEVRMDc5NDUyOQhGbHVydMO8cgkB";
 
@@ -129,9 +120,6 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (IncorrectMultilineIndexException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
 
         try {
@@ -141,14 +129,11 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (IncorrectMultilineIndexException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
     }
 
     @Test
-    public void testPullBeforeNewLine() {
+    public void testPullBeforeNewLine() throws Exception {
         String line1 = "H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
         String line2 = "M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
 
@@ -158,27 +143,19 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (MessageIsWaitingException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
 
-        try {
-            Message message = this.processor.pull();
-            Assert.assertNotNull(message);
-            Assert.assertEquals(message.getClass().getName(), H_Message.class.getName());
-            this.processor.addReceivedLine(line2);
-            message = this.processor.pull();
-            Assert.assertNotNull(message);
-            Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
-        }
+        Message message = this.processor.pull();
+        Assert.assertNotNull(message);
+        Assert.assertEquals(message.getClass().getName(), H_Message.class.getName());
+        this.processor.addReceivedLine(line2);
+        message = this.processor.pull();
+        Assert.assertNotNull(message);
+        Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
     }
 
     @Test
-    public void testWrongIndicatorWhileMultilineProcessing() {
+    public void testWrongIndicatorWhileMultilineProcessing() throws Exception {
         String line1 = "M:00,02,VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
         String line2 = "H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
 
@@ -188,14 +165,11 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (IncompleteMessageException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
     }
 
     @Test
-    public void testUnknownMessageIndicator() {
+    public void testUnknownMessageIndicator() throws Exception {
         String rawData = "X:0ff1bc,EQ/xvAQJEAJMRVEwNzk0MDA3";
 
         try {
@@ -203,14 +177,11 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (UnsupportedMessageTypeException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
     }
 
     @Test
-    public void testNoMessageAvailable() {
+    public void testNoMessageAvailable() throws Exception {
         String rawData = "M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
         M_Message expectedMessage = new M_Message(rawData);
         commonMessageTest(rawData, expectedMessage);
@@ -224,7 +195,7 @@ public class MessageProcessorTest {
     }
 
     @Test
-    public void testUnprocessableMessage() {
+    public void testUnprocessableMessage() throws Exception {
         String line1 = "M:00"; // Some information are missing.
 
         try {
@@ -232,9 +203,6 @@ public class MessageProcessorTest {
             Assert.fail("Expected exception was not thrown.");
         } catch (UnprocessableMessageException e) {
             // OK, correct Exception was thrown
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected error");
         }
     }
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/Utils.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/Utils.java
@@ -182,18 +182,4 @@ public final class Utils {
         hex.delete(hex.length() - 1, hex.length());
         return hex.toString();
     }
-
-    /**
-     * Retrieves the stacktrace of an exception as string.
-     *
-     * @param e
-     *            the exception to resolve the stacktrace from
-     * @return the stacktrace from the exception provided
-     */
-    public static String getStackTrace(Exception e) {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter printWriter = new PrintWriter(stringWriter);
-        e.printStackTrace(printWriter);
-        return stringWriter.toString();
-    }
 }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/AbstractMilightBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/AbstractMilightBridgeHandler.java
@@ -137,7 +137,7 @@ public abstract class AbstractMilightBridgeHandler extends BaseBridgeHandler {
             try {
                 com.setAddress(InetAddress.getByName(host_config));
             } catch (UnknownHostException e) {
-                e.printStackTrace();
+                logger.warn("Unknown host {}", host_config, e);
             }
         }
 

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/TestDiscovery.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/test/TestDiscovery.java
@@ -10,6 +10,8 @@ package org.openhab.binding.milight.test;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.openhab.binding.milight.MilightBindingConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simple discovery service that will make the emulated V6 bridge visible to the Inbox of OH.
@@ -19,6 +21,8 @@ import org.openhab.binding.milight.MilightBindingConstants;
  * @since 2.1
  */
 public class TestDiscovery extends AbstractDiscoveryService {
+    private final Logger logger = LoggerFactory.getLogger(TestDiscovery.class);
+
     @SuppressWarnings("unused")
     private EmulatedV6Bridge server;
 
@@ -27,7 +31,7 @@ public class TestDiscovery extends AbstractDiscoveryService {
         try {
             server = new EmulatedV6Bridge();
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.warn("An error occurred", e);
         }
     }
 

--- a/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/protocol/TokenRequest.java
+++ b/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/protocol/TokenRequest.java
@@ -19,6 +19,8 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.openhab.binding.tesla.TeslaBindingConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link TokenRequest} is a datastructure to capture
@@ -29,6 +31,7 @@ import org.openhab.binding.tesla.TeslaBindingConstants;
  * @author Nicolai Grødum - Adding token based auth
  */
 public abstract class TokenRequest {
+    private final Logger logger = LoggerFactory.getLogger(TokenRequest.class);
 
     private String client_id;
     private String client_secret;
@@ -66,7 +69,7 @@ public abstract class TokenRequest {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException
                 | InvalidKeyException | ShortBufferException
                 | IllegalBlockSizeException | BadPaddingException e) {
-            e.printStackTrace();
+            logger.warn("An error occurred", e);
         }
     }
 

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/FadingWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/FadingWiFiLEDDriver.java
@@ -179,12 +179,11 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
                         currentTargetState = fadeState;
                     }
                 } catch (NoRouteToHostException e) {
-                    e.printStackTrace();
+                    logger.warn("No route to host {}:{}", host, port, e);
                 } catch (SocketException e) {
-                    e.printStackTrace();
                     logger.warn("SocketException", e);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    logger.warn("An error occurred", e);
                 }
             }, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Throwable.printStackTrace(...) prints a Throwable and its stack trace to some stream. By default that stream System.Err, which could inadvertently expose sensitive information.

Loggers should be used instead to print Throwables, as they have many advantages:

Users are able to easily retrieve the logs.
The format of log messages is uniform and allow users to browse the logs easily.

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>