### PR TITLE
[squeezebox] Add duration channel for now playing track

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
@@ -1,246 +1,249 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="squeezebox"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="squeezebox" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <bridge-type id="squeezeboxserver">
-        <label>SqueezeBox Server</label>
-        <description>This is a SqueezeBox Server instance.
+	<bridge-type id="squeezeboxserver">
+		<label>SqueezeBox Server</label>
+		<description>This is a SqueezeBox Server instance.
         </description>
-        <config-description>
-            <parameter name="ipAddress" type="text" required="true">
-                <label>IP or Host Name</label>
-                <description>The IP or host name of the SqueezeServer
+		<config-description>
+			<parameter name="ipAddress" type="text" required="true">
+				<label>IP or Host Name</label>
+				<description>The IP or host name of the SqueezeServer
                 </description>
-            </parameter>
-            <parameter name="webport" type="integer" required="true"
-                min="1" max="65335">
-                <label>SqueezeServer Web Port</label>
-                <description>Webport interface of the SqueezeServer</description>
-                <default>9000</default>
-            </parameter>
-            <parameter name="cliport" type="integer" required="true"
-                min="1" max="65335">
-                <label>SqueezeServer CLI Port</label>
-                <description>Port of the CLI interface of the SqueezeServer</description>
-                <default>9090</default>
-            </parameter>
-            <parameter name="language" type="text" required="false">
-                <label>Language</label>
-                <description>Language to use when using Google speech</description>
-                <default>en</default>
-            </parameter>
-        </config-description>
-    </bridge-type>
+			</parameter>
+			<parameter name="webport" type="integer" required="true" min="1" max="65335">
+				<label>SqueezeServer Web Port</label>
+				<description>Webport interface of the SqueezeServer</description>
+				<default>9000</default>
+			</parameter>
+			<parameter name="cliport" type="integer" required="true" min="1" max="65335">
+				<label>SqueezeServer CLI Port</label>
+				<description>Port of the CLI interface of the SqueezeServer</description>
+				<default>9090</default>
+			</parameter>
+			<parameter name="language" type="text" required="false">
+				<label>Language</label>
+				<description>Language to use when using Google speech</description>
+				<default>en</default>
+			</parameter>
+		</config-description>
+	</bridge-type>
 
-    <thing-type id="squeezeboxplayer">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="squeezeboxserver" />
-        </supported-bridge-type-refs>
-        <label>SqueezeBox Player</label>
-        <description>This is a SqueezeBox Player instance</description>
-        <channels>
-            <channel id="power" typeId="power" />
-            <channel id="mute" typeId="mute" />
-            <channel id="volume" typeId="volume" />
-            <channel id="stop" typeId="stop" />
-            <channel id="playPause" typeId="playPause" />
-            <channel id="next" typeId="next" />
-            <channel id="prev" typeId="prev" />
-            <channel id="control" typeId="control" />
-            <channel id="stream" typeId="stream" />
-            <channel id="sync" typeId="sync" />
-            <channel id="unsync" typeId="unsync" />
-            <channel id="playListIndex" typeId="playListIndex" />
-            <channel id="currentPlayingTime" typeId="currentPlayingTime" />
-            <channel id="currentPlaylistShuffle" typeId="currentPlaylistShuffle" />
-            <channel id="currentPlaylistRepeat" typeId="currentPlaylistRepeat" />
-            <channel id="title" typeId="title" />
-            <channel id="remotetitle" typeId="remotetitle" />
-            <channel id="album" typeId="album" />
-            <channel id="artist" typeId="artist" />
-            <channel id="year" typeId="year" />
-            <channel id="genre" typeId="genre" />
-            <channel id="coverartdata" typeId="coverartdata" />
-            <channel id="ircode" typeId="ircode" />
-            <channel id="numberPlaylistTracks" typeId="numberPlaylistTracks" />
-            <channel id="notificationSoundVolume" typeId="notificationVolume" />
-        </channels>
-        <properties>
-               <property name="vendor">Logitech</property>
-               <property name="modelId"></property>
-               <property name="name"></property>
-               <property name="uid"></property>
-               <property name="ip"></property>
-        </properties>
-        <config-description>
-            <parameter name="mac" type="text" required="true">
-                <label>MAC Address</label>
-                <description>SqueezeBox Players are identified by their MAC address</description>
-            </parameter>
-        </config-description>
-    </thing-type>
+	<thing-type id="squeezeboxplayer">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="squeezeboxserver" />
+		</supported-bridge-type-refs>
+		<label>SqueezeBox Player</label>
+		<description>This is a SqueezeBox Player instance</description>
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="mute" typeId="mute" />
+			<channel id="volume" typeId="volume" />
+			<channel id="stop" typeId="stop" />
+			<channel id="playPause" typeId="playPause" />
+			<channel id="next" typeId="next" />
+			<channel id="prev" typeId="prev" />
+			<channel id="control" typeId="control" />
+			<channel id="stream" typeId="stream" />
+			<channel id="sync" typeId="sync" />
+			<channel id="unsync" typeId="unsync" />
+			<channel id="playListIndex" typeId="playListIndex" />
+			<channel id="currentPlayingTime" typeId="currentPlayingTime" />
+			<channel id="duration" typeId="duration" />
+			<channel id="currentPlaylistShuffle" typeId="currentPlaylistShuffle" />
+			<channel id="currentPlaylistRepeat" typeId="currentPlaylistRepeat" />
+			<channel id="title" typeId="title" />
+			<channel id="remotetitle" typeId="remotetitle" />
+			<channel id="album" typeId="album" />
+			<channel id="artist" typeId="artist" />
+			<channel id="year" typeId="year" />
+			<channel id="genre" typeId="genre" />
+			<channel id="coverartdata" typeId="coverartdata" />
+			<channel id="ircode" typeId="ircode" />
+			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks" />
+			<channel id="notificationSoundVolume" typeId="notificationVolume" />
+		</channels>
+		<properties>
+			<property name="vendor">Logitech</property>
+			<property name="modelId"></property>
+			<property name="name"></property>
+			<property name="uid"></property>
+			<property name="ip"></property>
+		</properties>
+		<config-description>
+			<parameter name="mac" type="text" required="true">
+				<label>MAC Address</label>
+				<description>SqueezeBox Players are identified by their MAC address</description>
+			</parameter>
+		</config-description>
+	</thing-type>
 
-    <!-- Commands -->
-    <channel-type id="power" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Power</label>
-        <description>Power on/off your device</description>
-    </channel-type>
-    <channel-type id="mute" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Mute</label>
-        <description>Mute/unmute your device</description>
-    </channel-type>
-    <channel-type id="volume">
-        <item-type>Dimmer</item-type>
-        <label>Volume</label>
-        <description>Volume of your device</description>
-        <state min="0" max="100" step="1" pattern="%d %%">
-        </state>
-    </channel-type>
-    <channel-type id="stop" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Stop</label>
-        <description>Stop the current title</description>
-    </channel-type>
-    <channel-type id="playPause" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Play/Pause</label>
-        <description>Plays (on) or pauses (off) the player</description>
-    </channel-type>
-        <channel-type id="pause" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Pause</label>
-        <description>Send a pause command to the player</description>
-    </channel-type>
-        <channel-type id="next" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Next</label>
-        <description>Send a next command to the player</description>
-    </channel-type>
-        <channel-type id="prev" advanced="true">
-        <item-type>Switch</item-type>
-        <label>Previous</label>
-        <description>Send a previous command to the player</description>
-    </channel-type>
-    <channel-type id="control">
-        <item-type>Player</item-type>
-        <label>Control</label>
-        <description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
-        <category>Player</category>
-    </channel-type>
-    <channel-type id="stream" advanced="true">
-        <item-type>String</item-type>
-        <label>Stream URL</label>
-        <description>Play the given HTTP or file stream (file:// or http://). </description>
-    </channel-type>
-    <channel-type id="sync" advanced="true">
-        <item-type>String</item-type>
-        <label>Sync Player</label>
-        <description>Add another player to your device for synchronized playback (other player mac address)</description>
-    </channel-type>
-    <channel-type id="unsync" advanced="true">
-        <item-type>Switch</item-type>
-        <label>UnSync Player</label>
-        <description>Remove this device from synchronization</description>
-    </channel-type>
-    <channel-type id="playListIndex" advanced="true">
-        <item-type>Number</item-type>
-        <label>Playlist Index</label>
-        <description>Playlist index</description>
-    </channel-type>
-    <channel-type id="currentPlayingTime">
-        <item-type>Number</item-type>
-        <label>Current Playing Time</label>
-        <description>Current Playing Time</description>
-    </channel-type>
-    <channel-type id="currentPlaylistShuffle">
-        <item-type>Number</item-type>
-        <label>Shuffle Mode</label>
-        <description>Current playlist shuffle mode</description>
-                <state>
-            <options>
-                <option value="0">No Shuffle</option>
-                <option value="1">Shuffle Songs</option>
-                <option value="2">Shuffle Albums</option>
-            </options>
-        </state>
-    </channel-type>
-    <channel-type id="currentPlaylistRepeat">
-        <item-type>Number</item-type>
-        <label>Repeat Mode</label>
-        <description>Current playlist repeat Mode</description>
-        <state>
-            <options>
-                <option value="0">No Repeat</option>
-                <option value="1">Repeat Song</option>
-                <option value="2">Repeat Playlist</option>
-            </options>
-        </state>
-    </channel-type>
+	<!-- Commands -->
+	<channel-type id="power" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Power</label>
+		<description>Power on/off your device</description>
+	</channel-type>
+	<channel-type id="mute" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Mute</label>
+		<description>Mute/unmute your device</description>
+	</channel-type>
+	<channel-type id="volume">
+		<item-type>Dimmer</item-type>
+		<label>Volume</label>
+		<description>Volume of your device</description>
+		<state min="0" max="100" step="1" pattern="%d %%">
+		</state>
+	</channel-type>
+	<channel-type id="stop" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Stop</label>
+		<description>Stop the current title</description>
+	</channel-type>
+	<channel-type id="playPause" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Play/Pause</label>
+		<description>Plays (on) or pauses (off) the player</description>
+	</channel-type>
+	<channel-type id="pause" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Pause</label>
+		<description>Send a pause command to the player</description>
+	</channel-type>
+	<channel-type id="next" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Next</label>
+		<description>Send a next command to the player</description>
+	</channel-type>
+	<channel-type id="prev" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Previous</label>
+		<description>Send a previous command to the player</description>
+	</channel-type>
+	<channel-type id="control">
+		<item-type>Player</item-type>
+		<label>Control</label>
+		<description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
+		<category>Player</category>
+	</channel-type>
+	<channel-type id="stream" advanced="true">
+		<item-type>String</item-type>
+		<label>Stream URL</label>
+		<description>Play the given HTTP or file stream (file:// or http://). </description>
+	</channel-type>
+	<channel-type id="sync" advanced="true">
+		<item-type>String</item-type>
+		<label>Sync Player</label>
+		<description>Add another player to your device for synchronized playback (other player mac address)</description>
+	</channel-type>
+	<channel-type id="unsync" advanced="true">
+		<item-type>Switch</item-type>
+		<label>UnSync Player</label>
+		<description>Remove this device from synchronization</description>
+	</channel-type>
+	<channel-type id="playListIndex" advanced="true">
+		<item-type>Number</item-type>
+		<label>Playlist Index</label>
+		<description>Playlist index</description>
+	</channel-type>
+	<channel-type id="currentPlayingTime">
+		<item-type>Number</item-type>
+		<label>Current Playing Time</label>
+		<description>Current Playing Time</description>
+	</channel-type>
+	<channel-type id="duration">
+		<item-type>Number</item-type>
+		<label>Track Duration</label>
+		<description>Duration of Current Track (in seconds)</description>
+	</channel-type>
+	<channel-type id="currentPlaylistShuffle">
+		<item-type>Number</item-type>
+		<label>Shuffle Mode</label>
+		<description>Current playlist shuffle mode</description>
+		<state>
+			<options>
+				<option value="0">No Shuffle</option>
+				<option value="1">Shuffle Songs</option>
+				<option value="2">Shuffle Albums</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="currentPlaylistRepeat">
+		<item-type>Number</item-type>
+		<label>Repeat Mode</label>
+		<description>Current playlist repeat Mode</description>
+		<state>
+			<options>
+				<option value="0">No Repeat</option>
+				<option value="1">Repeat Song</option>
+				<option value="2">Repeat Playlist</option>
+			</options>
+		</state>
+	</channel-type>
 
-    <!-- Squeezebox variables -->
-    <channel-type id="title">
-        <item-type>String</item-type>
-        <label>Title</label>
-        <description>Title of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="remotetitle" advanced="true">
-        <item-type>String</item-type>
-        <label>Remote Title</label>
-        <description>Remote Title (Radio) of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="album">
-        <item-type>String</item-type>
-        <label>Album</label>
-        <description>Album name of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="artist">
-        <item-type>String</item-type>
-        <label>Artist</label>
-        <description>Artist name of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="year" advanced="true">
-        <item-type>String</item-type>
-        <label>Year</label>
-        <description>Release year of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="genre" advanced="true">
-        <item-type>String</item-type>
-        <label>Genre</label>
-        <description>Genre name of the current song</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-    <channel-type id="coverartdata">
-        <item-type>Image</item-type>
-        <label>Cover Art</label>
-        <description>Image data of cover art of the current song</description>
-        <state readOnly="true"></state>
-    </channel-type>
-    <channel-type id="ircode" advanced="true">
-        <item-type>String</item-type>
-        <label>IR Code</label>
-        <description>String of the cached IR code</description>
-        <state readOnly="true" pattern="%s"></state>
-    </channel-type>
-        <channel-type id="numberPlaylistTracks" advanced="true">
-        <item-type>Number</item-type>
-        <label>Number of Playlist Tracks</label>
-        <description>Number of playlist tracks</description>
-        <state readOnly="true" pattern="%d"></state>
-    </channel-type>
-    <channel-type id="notificationVolume">
-        <item-type>Dimmer</item-type>
-        <label>Notification Volume</label>
-        <description>Volume of notifications</description>
-        <state min="0" max="100" step="1" pattern="%d %%">
-        </state>
-    </channel-type>
+	<!-- Squeezebox variables -->
+	<channel-type id="title">
+		<item-type>String</item-type>
+		<label>Title</label>
+		<description>Title of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="remotetitle" advanced="true">
+		<item-type>String</item-type>
+		<label>Remote Title</label>
+		<description>Remote Title (Radio) of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="album">
+		<item-type>String</item-type>
+		<label>Album</label>
+		<description>Album name of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="artist">
+		<item-type>String</item-type>
+		<label>Artist</label>
+		<description>Artist name of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="year" advanced="true">
+		<item-type>String</item-type>
+		<label>Year</label>
+		<description>Release year of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="genre" advanced="true">
+		<item-type>String</item-type>
+		<label>Genre</label>
+		<description>Genre name of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="coverartdata">
+		<item-type>Image</item-type>
+		<label>Cover Art</label>
+		<description>Image data of cover art of the current song</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="ircode" advanced="true">
+		<item-type>String</item-type>
+		<label>IR Code</label>
+		<description>String of the cached IR code</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="numberPlaylistTracks" advanced="true">
+		<item-type>Number</item-type>
+		<label>Number of Playlist Tracks</label>
+		<description>Number of playlist tracks</description>
+		<state readOnly="true" pattern="%d"></state>
+	</channel-type>
+	<channel-type id="notificationVolume">
+		<item-type>Dimmer</item-type>
+		<label>Notification Volume</label>
+		<description>Volume of notifications</description>
+		<state min="0" max="100" step="1" pattern="%d %%">
+		</state>
+	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
@@ -15,6 +15,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * across the whole binding.
  *
  * @author Dan Cunningham - Initial contribution
+ * @author Mark Hilbush - Added duration channel
  */
 public class SqueezeBoxBindingConstants {
 
@@ -38,6 +39,7 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_UNSYNC = "unsync";
     public static final String CHANNEL_PLAYLIST_INDEX = "playListIndex";
     public static final String CHANNEL_CURRENT_PLAYING_TIME = "currentPlayingTime";
+    public static final String CHANNEL_DURATION = "duration";
     public static final String CHANNEL_NUMBER_PLAYLIST_TRACKS = "numberPlaylistTracks";
     public static final String CHANNEL_CURRENT_PLAYLIST_SHUFFLE = "currentPlaylistShuffle";
     public static final String CHANNEL_CURRENT_PLAYLIST_REPEAT = "currentPlaylistRepeat";

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dan Cunningham
  * @author Mark Hilbush - added method to cancel request player job, and to set thing properties
+ * @author Mark Hilbush - Added duration channel
  *
  */
 public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryService
@@ -112,7 +113,7 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
                 squeezeBoxServerHandler.requestPlayers();
             }
         };
-        
+
         logger.debug("request player job scheduled to run every {} seconds", TTL);
         requestPlayerJob = scheduler.scheduleWithFixedDelay(runnable, 10, TTL, TimeUnit.SECONDS);
     }
@@ -140,6 +141,10 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
 
     @Override
     public void currentPlayingTimeEvent(String mac, int time) {
+    }
+
+    @Override
+    public void durationEvent(String mac, int duration) {
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
@@ -132,6 +132,10 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
     public void currentPlayingTimeEvent(String mac, int time) {
     }
 
+    @Override
+    public void durationEvent(String mac, int duration) {
+    }
+
     /*
      * Monitor for when the playlist is updated
      */

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
@@ -12,6 +12,7 @@ package org.openhab.binding.squeezebox.handler;
  * @author Markus Wolters
  * @author Ben Jones
  * @author Dan Cunningham (OH2 Port)
+ * @author Mark Hilbush added durationEvent
  */
 public interface SqueezeBoxPlayerEventListener {
 
@@ -28,6 +29,8 @@ public interface SqueezeBoxPlayerEventListener {
     void currentPlaylistIndexEvent(String mac, int index);
 
     void currentPlayingTimeEvent(String mac, int time);
+
+    void durationEvent(String mac, int duration);
 
     void numberPlaylistTracksEvent(String mac, int track);
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author Dan Cunningham - Initial contribution
  * @author Mark Hilbush - Improved handling of player status, prevent REFRESH from causing exception
  * @author Mark Hilbush - Implement AudioSink and notifications
+ * @author Mark Hilbush - Added duration channel
  */
 public class SqueezeBoxPlayerHandler extends BaseThingHandler implements SqueezeBoxPlayerEventListener {
 
@@ -318,6 +319,15 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         if (isMe(mac)) {
             currentTime = time;
         }
+    }
+
+    @Override
+    public void durationEvent(String mac, int duration) {
+        if (getThing().getChannel(CHANNEL_DURATION) == null) {
+            logger.debug("Channel 'duration' does not exist.  Delete and readd player thing to pick up channel.");
+            return;
+        }
+        updateChannel(mac, CHANNEL_DURATION, new DecimalType(duration));
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Daniel Walters - Fix player discovery when player name contains spaces
  * @author Mark Hilbush - Improve reconnect logic. Improve player status updates.
  * @author Mark Hilbush - Implement AudioSink and notifications
+ * @author Mark Hilbush - Added duration channel
  */
 public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
@@ -566,6 +567,17 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                         }
                     });
                 }
+                // Parameter duration
+                else if (messagePart.startsWith("duration%3A")) {
+                    String value = messagePart.substring("duration%3A".length());
+                    final int duration = (int) Double.parseDouble(value);
+                    updatePlayer(new PlayerUpdateEvent() {
+                        @Override
+                        public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                            listener.durationEvent(mac, duration);
+                        }
+                    });
+                }
                 // Parameter Playing Playlist Index
                 else if (messagePart.startsWith("playlist_cur_index%3A")) {
                     String value = messagePart.substring("playlist_cur_index%3A".length());
@@ -700,6 +712,13 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             String mode;
             if (action.equals("newsong")) {
                 mode = "play";
+                // Set the track duration to 0
+                updatePlayer(new PlayerUpdateEvent() {
+                    @Override
+                    public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                        listener.durationEvent(mac, 0);
+                    }
+                });
             } else if (action.equals("pause")) {
                 mode = messageParts[3].equals("0") ? "play" : "pause";
             } else if (action.equals("stop")) {


### PR DESCRIPTION
Adds new duration channel; sets duration of now playing track.  Gracefully handles condition when duration channel doesn't exist (for existing things).

Ran autoformatter on thing-types.xml, hence it shows many changes.

Closes #2124

Signed-off-by: Mark Hilbush <mark@hilbush.com>
