### PR TITLE
Use OSGI-INF/*.xml Everywhere in the MANIFEST.MF of the Addons

### DIFF
--- a/addons/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
@@ -27,6 +27,6 @@ Import-Package: com.google.common.collect,
  org.quartz.impl.matchers,
  org.quartz.utils,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.astro,
  org.openhab.binding.astro.handler

--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -32,6 +32,6 @@ Import-Package: com.google.common.base,
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.osgi.framework,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.freebox,
  org.openhab.binding.freebox.handler

--- a/addons/binding/org.openhab.binding.kostalinverter/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.kostalinverter/META-INF/MANIFEST.MF
@@ -16,4 +16,4 @@ Import-Package: org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Import-Package: com.google.common.base;version="10.0.1",
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.max
 
 

--- a/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.model.script.actions,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.network,
  org.openhab.binding.network.handler

--- a/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
@@ -14,6 +14,6 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.smaenergymeter,
  org.openhab.binding.smaenergymeter.handler

--- a/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
@@ -25,6 +25,6 @@ Import-Package: com.google.common.collect,
  org.osgi.framework,
  org.osgi.service.component,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.yamahareceiver,
  org.openhab.binding.yamahareceiver.handler


### PR DESCRIPTION
All the Serivce-Component Headers in the MANIFEST.MF files of the openHAB addons, that use OSGI-INF/* are now using the recommended OSGI-INF/*.xml

All the problems are found by using the Service Component Manifest Check from the static analysis tool https://github.com/openhab/static-code-analysis/pull/50

Signed-off-by: Dimitar Ivanov <dstivanov@gmail.com>