### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/handler/AirQualityHandler.java
+++ b/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/handler/AirQualityHandler.java
@@ -266,7 +266,7 @@ public class AirQualityHandler extends BaseThingHandler {
         }
 
         // Update the thing status
-        if (resultOk && result != null) {
+        if (resultOk) {
             String attributions = result.getData().getAttributions();
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, attributions);
         } else {

--- a/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/SunPhaseJob.java
+++ b/addons/binding/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/SunPhaseJob.java
@@ -30,11 +30,13 @@ public class SunPhaseJob extends AbstractBaseJob {
     @Override
     protected void executeJob(String thingUid, JobDataMap jobDataMap) {
         AstroThingHandler astroHandler = AstroHandlerFactory.getHandler(thingUid);
-        Channel phaseNameChannel = astroHandler.getThing().getChannel(CHANNEL_ID_SUN_PHASE_NAME);
-        if (astroHandler != null && phaseNameChannel != null) {
-            SunPhaseName phaseName = (SunPhaseName) jobDataMap.get(KEY_PHASE_NAME);
-            ((Sun) astroHandler.getPlanet()).getPhase().setName(phaseName);
-            astroHandler.publishChannelIfLinked(phaseNameChannel.getUID());
+        if (astroHandler != null) {
+            Channel phaseNameChannel = astroHandler.getThing().getChannel(CHANNEL_ID_SUN_PHASE_NAME);
+            if (phaseNameChannel != null) {
+                SunPhaseName phaseName = (SunPhaseName) jobDataMap.get(KEY_PHASE_NAME);
+                ((Sun) astroHandler.getPlanet()).getPhase().setName(phaseName);
+                astroHandler.publishChannelIfLinked(phaseNameChannel.getUID());
+            }
         }
     }
 }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.dscalarm.DSCAlarmBindingConstants;
@@ -76,15 +75,10 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
         try {
             ThingUID thingUID = new ThingUID(DSCAlarmBindingConstants.ENVISALINKBRIDGE_THING_TYPE, bridgeID);
 
-            if (thingUID != null) {
+            thingDiscovered(DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                    .withLabel("EyezOn Envisalink Bridge - " + ipAddress).build());
 
-                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties) // .withProperty(EnvisalinkBridgeConfiguration.IP_ADDRESS,
-                                                                                                            // ipAddress)
-                        .withLabel("EyezOn Envisalink Bridge - " + ipAddress).build();
-                thingDiscovered(result);
-
-                logger.trace("addBridge(): '{}' was added to Smarthome inbox.", result.getThingUID());
-            }
+            logger.trace("addBridge(): '{}' was added to Smarthome inbox.", thingUID);
         } catch (Exception e) {
             logger.error("addBridge(): Error: {}", e);
         }
@@ -117,14 +111,10 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
         try {
             ThingUID thingUID = new ThingUID(DSCAlarmBindingConstants.IT100BRIDGE_THING_TYPE, bridgeID);
 
-            if (thingUID != null) {
+            thingDiscovered(DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                    .withLabel("DSC IT-100 Bridge - " + port).build());
 
-                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                        .withLabel("DSC IT-100 Bridge - " + port).build();
-                thingDiscovered(result);
-
-                logger.trace("addBridge(): '{}' was added to Smarthome inbox.", result.getThingUID());
-            }
+            logger.trace("addBridge(): '{}' was added to Smarthome inbox.", thingUID);
         } catch (Exception e) {
             logger.error("addBridge(): Error: {}", e);
         }

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/GlobalCacheDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/discovery/GlobalCacheDiscoveryService.java
@@ -160,20 +160,19 @@ public class GlobalCacheDiscoveryService extends AbstractDiscoveryService implem
                 ThingTypeUID typeUID = gcMulticastListener.getThingTypeUID();
                 if (typeUID != null) {
                     ThingUID uid = new ThingUID(typeUID, gcMulticastListener.getSerialNumber());
-                    if (uid != null) {
-                        // If there's not a thing and it's not in the inbox, create the discovery result
-                        if (discoveryServiceCallback != null
-                                && discoveryServiceCallback.getExistingDiscoveryResult(uid) == null
-                                && discoveryServiceCallback.getExistingThing(uid) == null) {
 
-                            logger.trace("Creating discovery result for: {}, type={}, IP={}", uid,
-                                    gcMulticastListener.getModel(), gcMulticastListener.getIPAddress());
+                    // If there's not a thing and it's not in the inbox, create the discovery result
+                    if (discoveryServiceCallback != null
+                            && discoveryServiceCallback.getExistingDiscoveryResult(uid) == null
+                            && discoveryServiceCallback.getExistingThing(uid) == null) {
 
-                            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                                    .withLabel("GlobalCache " + gcMulticastListener.getModel()).build();
+                        logger.trace("Creating discovery result for: {}, type={}, IP={}", uid,
+                                gcMulticastListener.getModel(), gcMulticastListener.getIPAddress());
 
-                            thingDiscovered(result);
-                        }
+                        thingDiscovered(DiscoveryResultBuilder.create(uid)
+                                .withProperties(properties)
+                                .withLabel("GlobalCache " + gcMulticastListener.getModel())
+                                .build());
                     }
                 }
             }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/discovery/HarmonyHubDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/discovery/HarmonyHubDiscoveryService.java
@@ -286,10 +286,9 @@ public class HarmonyHubDiscoveryService extends AbstractDiscoveryService {
 
         ThingUID uid = new ThingUID(HarmonyHubBindingConstants.HARMONY_HUB_THING_TYPE,
                 id.replaceAll("[^A-Za-z0-9\\-_]", ""));
-        if (uid != null) {
-            DiscoveryResult discoResult = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel("HarmonyHub " + friendlyName).build();
-            thingDiscovered(discoResult);
-        }
+        thingDiscovered(DiscoveryResultBuilder.create(uid)
+                .withProperties(properties)
+                .withLabel("HarmonyHub " + friendlyName)
+                .build());
     }
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/RssiVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/RssiVirtualDatapointHandler.java
@@ -75,7 +75,7 @@ public class RssiVirtualDatapointHandler extends AbstractVirtualDatapointHandler
         Integer deviceValue = getDatapointValue(dpRssiDevice);
         Integer peerValue = getDatapointValue(dpRssiPeer);
 
-        if ((deviceValue == null || (deviceValue != null && deviceValue == 0)) && peerValue != null) {
+        if ((deviceValue == null || deviceValue == 0) && peerValue != null) {
             return peerValue;
         }
         return deviceValue;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/type/generator/CcuMetadataExtractor.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/type/generator/CcuMetadataExtractor.java
@@ -218,7 +218,7 @@ public class CcuMetadataExtractor {
                         includeLine = false;
                     }
                 }
-                if ((includeLine == null || (startLine != null && includeLine)) && StringUtils.isNotBlank(line)) {
+                if ((includeLine == null || includeLine) && StringUtils.isNotBlank(line)) {
                     line(line);
                 }
             }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -186,12 +185,9 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
             properties.put(MaxBinding.PROPERTY_SERIAL_NUMBER, cubeSerialNumber);
             properties.put(MaxBinding.PROPERTY_RFADDRESS, rfAddress);
             ThingUID uid = new ThingUID(MaxBinding.CUBEBRIDGE_THING_TYPE, cubeSerialNumber);
-            if (uid != null) {
-                DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withRepresentationProperty(MaxBinding.PROPERTY_SERIAL_NUMBER)
-                        .withThingType(CUBEBRIDGE_THING_TYPE).withLabel("MAX! Cube LAN Gateway").build();
-                thingDiscovered(result);
-            }
+            thingDiscovered(DiscoveryResultBuilder.create(uid).withProperties(properties)
+                    .withRepresentationProperty(MaxBinding.PROPERTY_SERIAL_NUMBER).withThingType(CUBEBRIDGE_THING_TYPE)
+                    .withLabel("MAX! Cube LAN Gateway").build());
         }
     }
 

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleApplianceHandler.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/handler/MieleApplianceHandler.java
@@ -203,35 +203,33 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                     metaDataCache.put(new StringBuilder().append(dp.Name).toString().trim(), metadata);
                 }
 
-                if (dp != null) {
-                    ApplianceChannelSelector selector = null;
-                    try {
-                        selector = getValueSelectorFromMieleID(dp.Name);
-                    } catch (Exception h) {
-                        logger.trace("{} is not a valid channel for a {}", dp.Name, modelID);
-                    }
+                ApplianceChannelSelector selector = null;
+                try {
+                    selector = getValueSelectorFromMieleID(dp.Name);
+                } catch (Exception h) {
+                    logger.trace("{} is not a valid channel for a {}", dp.Name, modelID);
+                }
 
-                    if (selector != null && !selector.isProperty()) {
-                        ChannelUID theChannelUID = new ChannelUID(getThing().getUID(), selector.getChannelID());
-                        logger.trace("Update state of {} with '{}'",
-                                new Object[] { theChannelUID.toString(), dpValue });
+                if (selector != null && !selector.isProperty()) {
+                    ChannelUID theChannelUID = new ChannelUID(getThing().getUID(), selector.getChannelID());
+                    logger.trace("Update state of {} with '{}'",
+                            new Object[] { theChannelUID.toString(), dpValue });
 
-                        if (dp.Value != null) {
-                            logger.trace("Update state of {} with getState '{}'",
-                                    new Object[] { theChannelUID.toString(), selector.getState(dpValue, dmd) });
-                            updateState(theChannelUID, selector.getState(dpValue, dmd));
-                        } else {
-                            updateState(theChannelUID, UnDefType.UNDEF);
-                        }
+                    if (dp.Value != null) {
+                        logger.trace("Update state of {} with getState '{}'",
+                                new Object[] { theChannelUID.toString(), selector.getState(dpValue, dmd) });
+                        updateState(theChannelUID, selector.getState(dpValue, dmd));
                     } else {
-                        if (selector != null && dpValue != null) {
-                            logger.debug("Updating the property '{}' of '{}' to '{}'",
-                                    new Object[] { selector.getChannelID(), getThing().getUID(),
-                                            selector.getState(dpValue, dmd).toString() });
-                            Map<String, String> properties = editProperties();
-                            properties.put(selector.getChannelID(), selector.getState(dpValue, dmd).toString());
-                            updateProperties(properties);
-                        }
+                        updateState(theChannelUID, UnDefType.UNDEF);
+                    }
+                } else {
+                    if (selector != null && dpValue != null) {
+                        logger.debug("Updating the property '{}' of '{}' to '{}'",
+                                new Object[] { selector.getChannelID(), getThing().getUID(),
+                                        selector.getState(dpValue, dmd).toString() });
+                        Map<String, String> properties = editProperties();
+                        properties.put(selector.getChannelID(), selector.getState(dpValue, dmd).toString());
+                        updateProperties(properties);
                     }
                 }
             } catch (IllegalArgumentException e) {

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
@@ -47,7 +47,7 @@ public class MilightBridgeV6Handler extends AbstractMilightBridgeHandler impleme
         BigDecimal pw_byte1 = (BigDecimal) thing.getConfiguration().get(MilightBindingConstants.CONFIG_PASSWORD_BYTE_1);
         BigDecimal pw_byte2 = (BigDecimal) thing.getConfiguration().get(MilightBindingConstants.CONFIG_PASSWORD_BYTE_2);
         if (pw_byte1 != null && pw_byte2 != null && pw_byte1.intValue() >= 0 && pw_byte1.intValue() <= 255
-                && pw_byte2.intValue() >= 0 && pw_byte2.intValue() <= 255 && session != null) {
+                && pw_byte2.intValue() >= 0 && pw_byte2.intValue() <= 255) {
             session.setPasswordBytes((byte) pw_byte1.intValue(), (byte) pw_byte2.intValue());
         }
     }

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/discovery/MinecraftDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/discovery/MinecraftDiscoveryService.java
@@ -148,40 +148,39 @@ public class MinecraftDiscoveryService extends AbstractDiscoveryService {
     /**
      * Submit the discovered Devices to the Smarthome inbox,
      *
-     * @param ip The Device IP
+     * @param bridgeUID
+     * @param name name of the player
      */
     private void submitPlayerDiscoveryResults(ThingUID bridgeUID, String name) {
-
         String id = deviceNameToId(name);
         ThingUID uid = new ThingUID(MinecraftBindingConstants.THING_TYPE_PLAYER, bridgeUID, id);
 
-        if (uid != null) {
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(MinecraftBindingConstants.PARAMETER_PLAYER_NAME, name);
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withBridge(bridgeUID)
-                    .withLabel(name).build();
-            thingDiscovered(result);
-        }
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(MinecraftBindingConstants.PARAMETER_PLAYER_NAME, name);
+        thingDiscovered(DiscoveryResultBuilder.create(uid)
+                .withProperties(properties)
+                .withBridge(bridgeUID)
+                .withLabel(name)
+                .build());
     }
 
     /**
      * Submit the discovered Signs to the Smarthome inbox,
      *
-     * @param serverName name of server
+     * @param bridgeUID
      * @param sign data describing sign
      */
     private void submitSignDiscoveryResults(ThingUID bridgeUID, SignData sign) {
-
         String id = deviceNameToId(sign.getName());
         ThingUID uid = new ThingUID(MinecraftBindingConstants.THING_TYPE_SIGN, bridgeUID, id);
 
-        if (uid != null) {
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(MinecraftBindingConstants.PARAMETER_SIGN_NAME, sign.getName());
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withBridge(bridgeUID)
-                    .withLabel(sign.getName()).build();
-            thingDiscovered(result);
-        }
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(MinecraftBindingConstants.PARAMETER_SIGN_NAME, sign.getName());
+        thingDiscovered(DiscoveryResultBuilder.create(uid)
+                .withProperties(properties)
+                .withBridge(bridgeUID)
+                .withLabel(sign.getName())
+                .build());
     }
 
     /**

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/NetworkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/discovery/NetworkDiscoveryService.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.network.service.DiscoveryCallback;
@@ -93,12 +92,9 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
         // uid must not contains dots
         ThingUID uid = new ThingUID(THING_TYPE_DEVICE, ip.replace('.', '_'));
 
-        if (uid != null) {
-            Map<String, Object> properties = new HashMap<>(1);
-            properties.put(PARAMETER_HOSTNAME, ip);
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel("Network Device (" + ip + ")").build();
-            thingDiscovered(result);
-        }
+        Map<String, Object> properties = new HashMap<>(1);
+        properties.put(PARAMETER_HOSTNAME, ip);
+        thingDiscovered(DiscoveryResultBuilder.create(uid).withProperties(properties)
+                .withLabel("Network Device (" + ip + ")").build());
     }
 }

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/discovery/OpenSprinklerDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/discovery/OpenSprinklerDiscoveryService.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 
 import org.apache.commons.net.util.SubnetUtils;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -88,19 +87,15 @@ public class OpenSprinklerDiscoveryService extends AbstractDiscoveryService {
     public void submitDiscoveryResults(String ip) {
         ThingUID uid = new ThingUID(OPENSPRINKLER_THING, ip.replace('.', '_'));
 
-        if (uid != null) {
-            HashMap<String, Object> properties = new HashMap<String, Object>();
+        HashMap<String, Object> properties = new HashMap<String, Object>();
 
-            properties.put("hostname", ip);
-            properties.put("port", DEFAULT_API_PORT);
-            properties.put("password", DEFAULT_ADMIN_PASSWORD);
-            properties.put("refresh", DEFAULT_REFRESH_RATE);
+        properties.put("hostname", ip);
+        properties.put("port", DEFAULT_API_PORT);
+        properties.put("password", DEFAULT_ADMIN_PASSWORD);
+        properties.put("refresh", DEFAULT_REFRESH_RATE);
 
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel("OpenSprinkler").build();
-
-            thingDiscovered(result);
-        }
+        thingDiscovered(
+                DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel("OpenSprinkler").build());
     }
 
     /**

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
@@ -269,7 +269,7 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
                     command = Commands.STOP;
 
                 } else {
-                    throw new NumberFormatException("Can't convert " + type + " to Command");
+                    throw new RFXComException("Can't convert " + type + " to Command");
                 }
                 break;
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
@@ -176,8 +176,8 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
     public void onValueReceived(String variable, String value, String service) {
 
         String oldValue = stateMap.get(variable);
-        if (value.equals(oldValue)) {
-            logger.trace("Value haven't been changed, ignore update");
+        if ((value == null && oldValue == null) || (value != null && value.equals(oldValue))) {
+            logger.trace("Value '{}' for {} hasn't changed, ignoring update", value, variable);
             return;
         }
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
@@ -188,8 +188,8 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
     public void onValueReceived(String variable, String value, String service) {
 
         String oldValue = stateMap.get(variable);
-        if (value.equals(oldValue)) {
-            logger.trace("Variable '{}' value haven't been changed, ignore update", variable);
+        if ((value == null && oldValue == null) || (value != null && value.equals(oldValue))) {
+            logger.trace("Value '{}' for {} hasn't changed, ignoring update", value, variable);
             return;
         }
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
@@ -149,8 +149,7 @@ public class RemoteControllerService implements SamsungTvService {
     /**
      * Sends a command to Samsung TV device.
      * 
-     * @param key
-     *            Button code to send
+     * @param key Button code to send
      */
     private void sendKeyCode(final KeyCode key) {
 
@@ -158,13 +157,11 @@ public class RemoteControllerService implements SamsungTvService {
 
             RemoteController remoteController = new RemoteController(host, port, "openHAB2", "openHAB2");
 
-            if (remoteController != null) {
-                try {
-                    remoteController.sendKey(key);
+            try {
+                remoteController.sendKey(key);
 
-                } catch (RemoteControllerException e) {
-                    logger.error("Could not send command to device on {}: {}", host + ":" + port, e);
-                }
+            } catch (RemoteControllerException e) {
+                logger.error("Could not send command to device on {}: {}", host + ":" + port, e);
             }
         } else {
             logger.error("TV network address not defined");
@@ -174,8 +171,7 @@ public class RemoteControllerService implements SamsungTvService {
     /**
      * Sends a sequence of command to Samsung TV device.
      * 
-     * @param key
-     *            Button code to send
+     * @param keys List of button codes to send
      */
     private void sendKeyCodes(final List<KeyCode> keys) {
 
@@ -183,13 +179,11 @@ public class RemoteControllerService implements SamsungTvService {
 
             RemoteController remoteController = new RemoteController(host, port, "openHAB2", "openHAB2");
 
-            if (remoteController != null) {
-                try {
-                    remoteController.sendKeys(keys);
+            try {
+                remoteController.sendKeys(keys);
 
-                } catch (RemoteControllerException e) {
-                    logger.error("Could not send command(s) to device on {}: {}", host + ":" + port, e);
-                }
+            } catch (RemoteControllerException e) {
+                logger.error("Could not send command(s) to device on {}: {}", host + ":" + port, e);
             }
         } else {
             logger.error("TV network address not defined");

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
@@ -79,13 +79,13 @@ public class SMAEnergyMeterDiscoveryService extends AbstractDiscoveryService {
         properties.put(Thing.PROPERTY_VENDOR, "SMA");
         properties.put(Thing.PROPERTY_SERIAL_NUMBER, energyMeter.getSerialNumber());
         ThingUID uid = new ThingUID(THING_TYPE_ENERGY_METER, energyMeter.getSerialNumber());
-        if (uid != null) {
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel("SMA Energy Meter").build();
-            thingDiscovered(result);
+        DiscoveryResult result = DiscoveryResultBuilder.create(uid)
+                .withProperties(properties)
+                .withLabel("SMA Energy Meter")
+                .build();
+        thingDiscovered(result);
 
-            logger.debug("Thing discovered '{}'", result);
-        }
+        logger.debug("Thing discovered '{}'", result);
     }
 
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickBridgeDiscovery.java
@@ -95,11 +95,10 @@ public class TellstickBridgeDiscovery extends AbstractDiscoveryService {
             Map<String, Object> properties = new HashMap<>(2);
             ThingUID uid = new ThingUID(TellstickBindingConstants.TELLDUSCOREBRIDGE_THING_TYPE,
                     Integer.toString(controller.getId()));
-            if (uid != null) {
-                DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withLabel(controller.getType().name() + ": " + controller.getName()).build();
-                thingDiscovered(result);
-            }
+            thingDiscovered(DiscoveryResultBuilder.create(uid)
+                    .withProperties(properties)
+                    .withLabel(controller.getType().name() + ": " + controller.getName())
+                    .build());
         }
     }
 

--- a/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/handler/TeslaHandler.java
+++ b/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/handler/TeslaHandler.java
@@ -716,9 +716,11 @@ public class TeslaHandler extends BaseThingHandler {
 
         Response response = tokenTarget.request().post(Entity.entity(payLoad, MediaType.APPLICATION_JSON_TYPE));
 
-        logger.debug("Authenticating : Response : {}:{}", response.getStatus(), response.getStatusInfo());
+        if (response == null) {
+            logger.debug("Authenticating : Response was null");
+        } else{
+            logger.debug("Authenticating : Response : {}:{}", response.getStatus(), response.getStatusInfo());
 
-        if (response != null) {
             if (response.getStatus() == 200 && response.hasEntity()) {
 
                 String responsePayLoad = response.readEntity(String.class);
@@ -748,15 +750,15 @@ public class TeslaHandler extends BaseThingHandler {
 
         Response response = tokenTarget.request().post(Entity.entity(payLoad, MediaType.APPLICATION_JSON_TYPE));
 
-        logger.debug("Authenticating : Response : {}:{}", response.getStatus(), response.getStatusInfo());
-
         if (response != null) {
+            logger.debug("Authenticating : Response : {}:{}", response.getStatus(), response.getStatusInfo());
+
             if (response.getStatus() == 200 && response.hasEntity()) {
 
                 String responsePayLoad = response.readEntity(String.class);
                 TokenResponse tokenResponse = gson.fromJson(responsePayLoad.trim(), TokenResponse.class);
 
-                if (response != null && !StringUtils.isEmpty(tokenResponse.access_token)) {
+                if (StringUtils.isNotEmpty(tokenResponse.access_token)) {
                     Storage<Object> storage = storageService.getStorage(TeslaBindingConstants.BINDING_ID);
                     storage.put(getStorageKey(), gson.toJson(tokenResponse));
                     this.logonToken = tokenResponse;

--- a/addons/binding/org.openhab.binding.toon/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.toon/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Import-Package:
  com.google.gson,
  javax.ws.rs.client,
  javax.ws.rs.core,
+ org.apache.commons.lang,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.library.types,

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/handler/ToonBridgeHandler.java
@@ -8,13 +8,17 @@
  */
 package org.openhab.binding.toon.handler;
 
+import static org.eclipse.smarthome.core.thing.ThingStatus.OFFLINE;
+import static org.eclipse.smarthome.core.thing.ThingStatus.ONLINE;
+import static org.eclipse.smarthome.core.thing.ThingStatusDetail.*;
+
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -92,13 +96,13 @@ public class ToonBridgeHandler extends BaseBridgeHandler {
             try {
                 state = apiClient.collect();
             } catch (Exception e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                updateStatus(OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                 return;
             }
 
             // prevent spamming the log file
-            if (!ThingStatus.ONLINE.equals(getThing().getStatus())) {
-                updateStatus(ThingStatus.ONLINE);
+            if (!ONLINE.equals(getThing().getStatus())) {
+                updateStatus(ONLINE);
             }
 
             for (Thing handler : getThing().getThings()) {
@@ -122,19 +126,18 @@ public class ToonBridgeHandler extends BaseBridgeHandler {
 
     private void updateStatus() {
         try {
-            if (configuration == null || configuration.username == null || configuration.username.length() == 0) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Username not configured");
-                return;
+            if (configuration == null) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, "Configuration is missing or corrupted");
+            } else if (StringUtils.isEmpty(configuration.username)) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, "Username not configured");
+            } else if (StringUtils.isEmpty(configuration.password)) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, "Password not configured");
+            } else {
+                getApiClient().login();
+                updateStatus(ONLINE);
             }
-            if (configuration == null || configuration.password == null || configuration.password.length() == 0) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Password not configured");
-                return;
-            }
-
-            getApiClient().login();
-            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, e.getMessage());
+            updateStatus(OFFLINE, NONE, e.getMessage());
         }
     }
 

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/internal/ToonApiClient.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/internal/ToonApiClient.java
@@ -21,6 +21,7 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.toon.config.ToonBridgeConfiguration;
 import org.openhab.binding.toon.internal.api.Agreement;
 import org.openhab.binding.toon.internal.api.ToonConnectionException;
@@ -73,10 +74,10 @@ public class ToonApiClient {
     public void login() throws ToonConnectionException {
         logger.debug("login start");
 
-        if (configuration == null || configuration.username == null || configuration.username.length() == 0) {
+        if (configuration == null || StringUtils.isEmpty(configuration.username)) {
             throw new ToonConnectionException("Username not provided");
         }
-        if (configuration == null || configuration.password == null || configuration.password.length() == 0) {
+        if (StringUtils.isEmpty(configuration.password)) {
             throw new ToonConnectionException("Password not provided");
         }
 
@@ -112,10 +113,11 @@ public class ToonApiClient {
     public List<Agreement> getAgreements() throws ToonConnectionException {
         logger.debug("getAgreements start");
 
-        if (configuration == null || configuration.username == null || configuration.username.length() == 0) {
+        if (configuration == null) {
+            throw new ToonConnectionException("Configuration is missing or corrupted");
+        } else if (StringUtils.isEmpty(configuration.username)) {
             throw new ToonConnectionException("Username not provided");
-        }
-        if (configuration == null || configuration.password == null || configuration.password.length() == 0) {
+        } else if (StringUtils.isEmpty(configuration.password)) {
             throw new ToonConnectionException("Password not provided");
         }
 

--- a/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/internal/discovery/VitotronicBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/internal/discovery/VitotronicBridgeDiscovery.java
@@ -8,13 +8,6 @@
  */
 package org.openhab.binding.vitotronic.internal.discovery;
 
-/**
- * The {@link VitotronicBridgeDiscovery} class handles the discovery of optolink adapter
- * with broadcasting and put it to inbox, if found.
- *
- *
- * @author Stefan Andres - Initial contribution
- */
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -22,13 +15,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.vitotronic.VitotronicBindingConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The {@link VitotronicBridgeDiscovery} class handles the discovery of optolink adapter
+ * with broadcasting and put it to inbox, if found.
+ *
+ *
+ * @author Stefan Andres - Initial contribution
+ */
 public class VitotronicBridgeDiscovery extends AbstractDiscoveryService {
 
     int adapterPort = 31113;
@@ -112,11 +111,7 @@ public class VitotronicBridgeDiscovery extends AbstractDiscoveryService {
         properties.put(VitotronicBindingConstants.ADAPTER_ID, adapterID);
 
         ThingUID uid = new ThingUID(VitotronicBindingConstants.THING_TYPE_UID_BRIDGE, adapterID);
-        if (uid != null) {
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(adapterID)
-                    .build();
-            thingDiscovered(result);
-        }
+        thingDiscovered(DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(adapterID).build());
     }
 
 }

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/YamahaReceiverCommunication.java
@@ -88,44 +88,42 @@ public class YamahaReceiverCommunication {
     public void updateDeviceInformation(YamahaReceiverState state) throws IOException {
         Document doc = postAndGetXmlResponse(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?><YAMAHA_AV cmd=\"GET\"><System><Config>GetParam</Config></System></YAMAHA_AV>");
-        if (doc != null) {
-            Node basicStatus = getNode(doc.getFirstChild(), "System/Config");
+        Node basicStatus = getNode(doc.getFirstChild(), "System/Config");
 
-            Node node;
-            String value;
+        Node node;
+        String value;
 
-            node = getNode(basicStatus, "Model_Name");
-            value = node != null ? node.getTextContent() : "";
-            state.name = value;
+        node = getNode(basicStatus, "Model_Name");
+        value = node != null ? node.getTextContent() : "";
+        state.name = value;
 
-            node = getNode(basicStatus, "System_ID");
-            value = node != null ? node.getTextContent() : "";
-            state.id = value;
+        node = getNode(basicStatus, "System_ID");
+        value = node != null ? node.getTextContent() : "";
+        state.id = value;
 
-            node = getNode(basicStatus, "Version");
-            value = node != null ? node.getTextContent() : "";
-            state.version = value;
+        node = getNode(basicStatus, "Version");
+        value = node != null ? node.getTextContent() : "";
+        state.version = value;
 
-            state.additional_zones.clear();
+        state.additional_zones.clear();
 
-            node = getNode(basicStatus, "Feature_Existence");
-            if (node != null) {
-                Node subnode;
-                subnode = getNode(node, "Zone_2");
-                value = subnode != null ? subnode.getTextContent() : null;
-                if (value != null && (value.equals("1") || value.equals("Available"))) {
-                    state.additional_zones.add(Zone.Zone_2);
-                }
-                subnode = getNode(node, "Zone_3");
-                value = subnode != null ? subnode.getTextContent() : null;
-                if (value != null && (value.equals("1") || value.equals("Available"))) {
-                    state.additional_zones.add(Zone.Zone_3);
-                }
-                subnode = getNode(node, "Zone_4");
-                value = subnode != null ? subnode.getTextContent() : null;
-                if (value != null && (value.equals("1") || value.equals("Available"))) {
-                    state.additional_zones.add(Zone.Zone_4);
-                }
+        node = getNode(basicStatus, "Feature_Existence");
+        if (node != null) {
+            Node subnode;
+            subnode = getNode(node, "Zone_2");
+            value = subnode != null ? subnode.getTextContent() : null;
+            if (value != null && (value.equals("1") || value.equals("Available"))) {
+                state.additional_zones.add(Zone.Zone_2);
+            }
+            subnode = getNode(node, "Zone_3");
+            value = subnode != null ? subnode.getTextContent() : null;
+            if (value != null && (value.equals("1") || value.equals("Available"))) {
+                state.additional_zones.add(Zone.Zone_3);
+            }
+            subnode = getNode(node, "Zone_4");
+            value = subnode != null ? subnode.getTextContent() : null;
+            if (value != null && (value.equals("1") || value.equals("Available"))) {
+                state.additional_zones.add(Zone.Zone_4);
             }
         }
     }
@@ -247,7 +245,7 @@ public class YamahaReceiverCommunication {
         try {
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(new InputSource(new StringReader(response)));
-            if (doc.getFirstChild().hasChildNodes() == false) {
+            if (!doc.getFirstChild().hasChildNodes()) {
                 throw new IOException("Could not handle response");
             }
             return doc;

--- a/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/handler/ZoneMinderServerBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/handler/ZoneMinderServerBridgeHandler.java
@@ -1051,8 +1051,8 @@ public class ZoneMinderServerBridgeHandler extends BaseBridgeHandler implements 
                 taskPriorityRefreshData = null;
             }
 
-            // Only start if it is not running and Priority Frequency is higher than ordinary
-            if ((taskPriorityRefreshData == null) && (refreshFrequency > 1)) {
+            // Only start if Priority Frequency is higher than ordinary
+            if (refreshFrequency > 1) {
                 taskPriorityRefreshData = startTask(refreshPriorityDataRunnable, 0, 1, TimeUnit.SECONDS);
             }
         }
@@ -1104,17 +1104,13 @@ public class ZoneMinderServerBridgeHandler extends BaseBridgeHandler implements 
      * Method to start a data refresh task.
      */
     protected ScheduledFuture<?> startTask(Runnable command, long delay, long interval, TimeUnit unit) {
-        ScheduledFuture<?> task = null;
         logger.debug("BRIDGE [{}]: Starting ZoneMinder Bridge Monitor Task. Command='{}'", getThingId(),
                 command.toString());
         if (interval == 0) {
-            return task;
+            return null;
         }
 
-        if (task == null || task.isCancelled()) {
-            task = scheduler.scheduleWithFixedDelay(command, delay, interval, unit);
-        }
-        return task;
+        return scheduler.scheduleWithFixedDelay(command, delay, interval, unit);
     }
 
     /**
@@ -1122,8 +1118,8 @@ public class ZoneMinderServerBridgeHandler extends BaseBridgeHandler implements 
      */
     protected void stopTask(ScheduledFuture<?> task) {
         try {
-            logger.debug("{}: Stopping ZoneMinder Bridge Monitor Task. Task='{}'", getLogIdentifier(), task.toString());
             if (task != null && !task.isCancelled()) {
+                logger.debug("{}: Stopping ZoneMinder Bridge Monitor Task. Task='{}'", getLogIdentifier(), task.toString());
                 task.cancel(true);
             }
         } catch (Exception ex) {
@@ -1185,13 +1181,13 @@ public class ZoneMinderServerBridgeHandler extends BaseBridgeHandler implements 
         Map<String, String> originalProperties = editProperties();
         for (String property : properties.keySet()) {
             if ((originalProperties.get(property) == null
-                    || originalProperties.get(property).equals(properties.get(property)) == false)) {
+                    || !originalProperties.get(property).equals(properties.get(property)))) {
                 update = true;
                 break;
             }
         }
 
-        if (update == true) {
+        if (update) {
             logger.info("{}: Properties synchronised", getLogIdentifier(), getThingId());
             updateProperties(properties);
         }

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
@@ -632,8 +632,6 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
     }
 
     protected synchronized void addDeviceAsChannel(Device device) {
-        logger.debug("Add virtual device as channel: {}", device.getMetrics().getTitle());
-
         // Device.probeType
         // |
         // Device.metrics.probeType
@@ -645,6 +643,8 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
         // Default, depends on device type
 
         if (device != null) {
+            logger.debug("Add virtual device as channel: {}", device.getMetrics().getTitle());
+
             HashMap<String, String> properties = new HashMap<String, String>();
             properties.put("deviceId", device.getDeviceId());
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZAutomationDeviceHandler.java
@@ -180,7 +180,7 @@ public class ZWayZAutomationDeviceHandler extends ZWayDeviceHandler {
             Calendar lastUpdateOfDevice = Calendar.getInstance();
             lastUpdateOfDevice.setTimeInMillis(new Long(device.getUpdateTime()) * 1000);
 
-            if (lastUpdate == null || (lastUpdate != null && lastUpdateOfDevice.after(lastUpdate))) {
+            if (lastUpdate == null || lastUpdateOfDevice.after(lastUpdate)) {
                 lastUpdate = lastUpdateOfDevice;
             }
 

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZWaveDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayZWaveDeviceHandler.java
@@ -209,7 +209,7 @@ public class ZWayZWaveDeviceHandler extends ZWayDeviceHandler {
         Calendar lastUpdateOfDevice = Calendar.getInstance();
         lastUpdateOfDevice.setTimeInMillis(new Long(zwaveDevice.getData().getLastReceived().getUpdateTime()) * 1000);
 
-        if (lastUpdate == null || (lastUpdate != null && lastUpdateOfDevice.after(lastUpdate))) {
+        if (lastUpdate == null || lastUpdateOfDevice.after(lastUpdate)) {
             lastUpdate = lastUpdateOfDevice;
         }
 

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -78,9 +78,6 @@ public class HomekitSettings {
     }
 
     private static String getOrDefault(Object value, String defaultValue) {
-        if (value == null) {
-            return defaultValue;
-        }
         return value != null ? (String) value : defaultValue;
     }
 


### PR DESCRIPTION
Conditional statements using a condition which cannot be anything but FALSE have the effect of making blocks of code non-functional. If the condition cannot evaluate to anything but TRUE, the conditional statement is completely redundant, and makes the code less readable.

It is quite likely that the code does not match the programmer's intent.

I checked all occurences a lot were because a null pointer would occur before reaching the statement so the null check became obsolete, some other occurences were about constructor which tend to return non-null values for sure.

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>