### PR TITLE
[hueemulation] Device name transformation added

### DIFF
--- a/addons/io/org.openhab.io.hueemulation/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.hueemulation/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.openhab.io.hueemulation;singleton:=true
 Bundle-Vendor: openHAB
 Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Activator: org.openhab.io.hueemulation.internal.HueActivator
 Bundle-ClassPath: .
 Import-Package: com.google.gson,
  javax.servlet,
@@ -20,6 +21,7 @@ Import-Package: com.google.gson,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.transform,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.rest,
  org.osgi.framework,

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueActivator.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueActivator.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.io.hueemulation.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension of the default OSGi bundle activator
+ *
+ * @author Thomas.Eichstaedt-Engelen
+ * @since 0.6.0
+ */
+public final class HueActivator implements BundleActivator {
+
+    private static Logger logger = LoggerFactory.getLogger(HueActivator.class);
+
+    private static BundleContext context;
+
+    /**
+     * Called whenever the OSGi framework starts our bundle
+     */
+    @Override
+    public void start(BundleContext bc) throws Exception {
+        context = bc;
+        logger.debug("HueEmulation binding has been started.");
+    }
+
+    /**
+     * Called whenever the OSGi framework stops our bundle
+     */
+    @Override
+    public void stop(BundleContext bc) throws Exception {
+        context = null;
+        logger.debug("HueEmulation binding has been stopped.");
+    }
+
+    /**
+     * Returns the bundle context of this bundle
+     * 
+     * @return the bundle context
+     */
+    public static BundleContext getContext() {
+        return context;
+    }
+}

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationServlet.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationServlet.java
@@ -151,7 +151,7 @@ public class HueEmulationServlet extends HttpServlet {
         Object translateObj = config.get(CONFIG_TRANSLATION_FILE);
         if (translateObj != null ) {
         	translationFile = (String) translateObj;
-        	logger.debug("Enable device tranlaation from {}",translationFile);
+        	logger.debug("Enable device transformation from {}",translationFile);
             transformationService = TransformationHelper
                     .getTransformationService(HueActivator.getContext(), "MAP");
         }
@@ -531,7 +531,7 @@ public class HueEmulationServlet extends HttpServlet {
 					if (transformedResponse == null || transformedResponse == "") {
 						transformedResponse = item.getLabel();
 					}
-					logger.debug("Label translated {} into {}",item.getLabel(),transformedResponse);
+					logger.debug("Label {} transformed into {}",item.getLabel(),transformedResponse);
 				} catch (TransformationException e) {
 					logger.debug("Exception in transformation for {}",item.getLabel());
 					transformedResponse = item.getLabel();
@@ -576,7 +576,7 @@ public class HueEmulationServlet extends HttpServlet {
 				if (transformedResponse == null || transformedResponse == "") {
 					transformedResponse = item.getLabel();
 				}
-				logger.debug("Label translated {} into {}",item.getLabel(),transformedResponse);
+				logger.debug("Label {} transformed into {}",item.getLabel(),transformedResponse);
 			} catch (TransformationException e) {
 				logger.debug("Exception in transformation for {}",item.getLabel());
 				transformedResponse = item.getLabel();


### PR DESCRIPTION
I've added MAP translation for devices exposed by HueEmulation. The original HueEmulation uses item Label. I've added possibility to exposure item with different names. It's useful for Amazon Alexa integration as Alexa can understand only English or German language. My labels are in local language, but I would like to integrate them with Alexa. I made file with translation Polish<->English.
new configuration has been added:

`translationFile=<map file name>`

in conf/services/hueemulation.cfg
when <map file name> is a MAP transformation file [described here ](https://github.com/openhab/openhab1-addons/wiki/Transformations)

file contains pairs:
Label=Name exposed by HueEmulation

when Label does not exist in transformation file Label is used.
