### PR TITLE
Fixed the problems found by import-exported-packages check.

### DIFF
--- a/addons/binding/org.openhab.binding.allplay/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.allplay/META-INF/MANIFEST.MF
@@ -25,7 +25,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.allplay,
+ org.openhab.binding.allplay.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.allplay,
  org.openhab.binding.allplay.handler

--- a/addons/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
@@ -26,7 +26,9 @@ Import-Package: com.google.common.collect,
  org.quartz.impl,
  org.quartz.impl.matchers,
  org.quartz.utils,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.astro,
+ org.openhab.binding.astro.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.astro,
  org.openhab.binding.astro.handler

--- a/addons/binding/org.openhab.binding.autelis/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.autelis/META-INF/MANIFEST.MF
@@ -24,7 +24,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.io.transport.upnp,
  org.jupnp.model.meta,
  org.jupnp.model.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.autelis,
+ org.openhab.binding.autelis.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.autelis,
  org.openhab.binding.autelis.handler

--- a/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
@@ -29,7 +29,9 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.avmfritz,
+ org.openhab.binding.avmfritz.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.avmfritz,
  org.openhab.binding.avmfritz.handler

--- a/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.dscalarm,
+ org.openhab.binding.dscalarm.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.dscalarm,
  org.openhab.binding.dscalarm.handler

--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -31,7 +31,9 @@ Import-Package: com.google.common.base,
  org.eclipse.smarthome.io.net.http,
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.freebox,
+ org.openhab.binding.freebox.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.freebox,
  org.openhab.binding.freebox.handler

--- a/addons/binding/org.openhab.binding.gardena/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.gardena/META-INF/MANIFEST.MF
@@ -29,7 +29,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.gardena,
+ org.openhab.binding.gardena.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.gardena,
  org.openhab.binding.gardena.handler

--- a/addons/binding/org.openhab.binding.globalcache/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.globalcache/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.openhab.binding.globalcache,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.globalcache.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.globalcache,
  org.openhab.binding.globalcache.handler

--- a/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
@@ -37,8 +37,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.harmonyhub,
+ org.openhab.binding.harmonyhub.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.harmonyhub,
  org.openhab.binding.harmonyhub.handler
-

--- a/addons/binding/org.openhab.binding.hdanywhere/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.hdanywhere/META-INF/MANIFEST.MF
@@ -17,7 +17,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.net.http,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.hdanywhere,
+ org.openhab.binding.hdanywhere.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.hdanywhere,
  org.openhab.binding.hdanywhere.handler

--- a/addons/binding/org.openhab.binding.ipp/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.ipp/META-INF/MANIFEST.MF
@@ -33,7 +33,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.ipp,
+ org.openhab.binding.ipp.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.ipp,
  org.openhab.binding.ipp.handler

--- a/addons/binding/org.openhab.binding.keba/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.keba/META-INF/MANIFEST.MF
@@ -14,7 +14,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.keba,
+ org.openhab.binding.keba.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.keba,
  org.openhab.binding.keba.handler

--- a/addons/binding/org.openhab.binding.lutron/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.lutron/META-INF/MANIFEST.MF
@@ -23,7 +23,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.lutron,
+ org.openhab.binding.lutron.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.lutron,
  org.openhab.binding.lutron.handler

--- a/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Import-Package: com.google.common.base;version="10.0.1",
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.max
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.max
-
-

--- a/addons/binding/org.openhab.binding.meteostick/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.meteostick/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.meteostick,
+ org.openhab.binding.meteostick.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.meteostick,
  org.openhab.binding.meteostick.handler

--- a/addons/binding/org.openhab.binding.miele/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.miele/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Import-Package:
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.openhab.binding.miele.handler,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.miele
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.miele,
  org.openhab.binding.miele.handler

--- a/addons/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
@@ -18,7 +18,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.milight,
+ org.openhab.binding.milight.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.milight,
  org.openhab.binding.milight.handler

--- a/addons/binding/org.openhab.binding.minecraft/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.minecraft/META-INF/MANIFEST.MF
@@ -25,7 +25,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.minecraft,
+ org.openhab.binding.minecraft.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.minecraft,
  org.openhab.binding.minecraft.handler

--- a/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
@@ -26,7 +26,9 @@ Import-Package:
  org.osgi.framework,
  org.slf4j,
  javax.net,
- javax.net.ssl
+ javax.net.ssl,
+ org.openhab.binding.netatmo,
+ org.openhab.binding.netatmo.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.netatmo,
  org.openhab.binding.netatmo.handler

--- a/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
@@ -16,7 +16,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.model.script.actions,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.network,
+ org.openhab.binding.network.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.network,
  org.openhab.binding.network.handler

--- a/addons/binding/org.openhab.binding.oceanic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.oceanic/META-INF/MANIFEST.MF
@@ -16,7 +16,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.oceanic,
+ org.openhab.binding.oceanic.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.oceanic,
  org.openhab.binding.oceanic.handler

--- a/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
@@ -24,7 +24,9 @@ Import-Package: com.google.common.base,
  org.jupnp.model.types,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.onkyo,
+ org.openhab.binding.onkyo.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.onkyo,
  org.openhab.binding.onkyo.handler

--- a/addons/binding/org.openhab.binding.opensprinkler/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.opensprinkler/META-INF/MANIFEST.MF
@@ -18,7 +18,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.opensprinkler,
+ org.openhab.binding.opensprinkler.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.opensprinkler,
  org.openhab.binding.opensprinkler.handler

--- a/addons/binding/org.openhab.binding.orvibo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.orvibo/META-INF/MANIFEST.MF
@@ -20,7 +20,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.orvibo,
+ org.openhab.binding.orvibo.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.orvibo,
  org.openhab.binding.orvibo.handler

--- a/addons/binding/org.openhab.binding.pioneeravr/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.pioneeravr/META-INF/MANIFEST.MF
@@ -21,7 +21,12 @@ Import-Package: com.google.common.base,
  org.jupnp.model.types,
  org.osgi.service.cm,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.pioneeravr,
+ org.openhab.binding.pioneeravr.protocol,
+ org.openhab.binding.pioneeravr.protocol.event,
+ org.openhab.binding.pioneeravr.protocol.states,
+ org.openhab.binding.pioneeravr.protocol.utils
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.pioneeravr,
  org.openhab.binding.pioneeravr.protocol,

--- a/addons/binding/org.openhab.binding.pulseaudio/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.pulseaudio/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.pulseaudio,
+ org.openhab.binding.pulseaudio.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.pulseaudio,
  org.openhab.binding.pulseaudio.handler

--- a/addons/binding/org.openhab.binding.rme/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.rme/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.rme,
+ org.openhab.binding.rme.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.rme,
  org.openhab.binding.rme.handler

--- a/addons/binding/org.openhab.binding.samsungtv/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.samsungtv/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.jupnp.registry,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.samsungtv,
+ org.openhab.binding.samsungtv.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.samsungtv,
  org.openhab.binding.samsungtv.handler

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.silvercrestwifisocket,
+ org.openhab.binding.silvercrestwifisocket.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.silvercrestwifisocket,
  org.openhab.binding.silvercrestwifisocket.handler

--- a/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
@@ -13,7 +13,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.smaenergymeter,
+ org.openhab.binding.smaenergymeter.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.smaenergymeter,
  org.openhab.binding.smaenergymeter.handler

--- a/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
@@ -29,7 +29,9 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.squeezebox,
+ org.openhab.binding.squeezebox.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.squeezebox,
  org.openhab.binding.squeezebox.handler

--- a/addons/binding/org.openhab.binding.tellstick/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.tellstick/META-INF/MANIFEST.MF
@@ -27,7 +27,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.tellstick,
+ org.openhab.binding.tellstick.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.tellstick,
  org.openhab.binding.tellstick.handler

--- a/addons/binding/org.openhab.binding.tesla/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.tesla/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.io.console.extensions,
  org.glassfish.jersey.client,
  org.glassfish.jersey.media.sse,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.tesla,
+ org.openhab.binding.tesla.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.tesla,
  org.openhab.binding.tesla.handler

--- a/addons/binding/org.openhab.binding.toon/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.toon/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.toon,
+ org.openhab.binding.toon.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.toon,
  org.openhab.binding.toon.handler

--- a/addons/binding/org.openhab.binding.vitotronic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.vitotronic/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.vitotronic,
+ org.openhab.binding.vitotronic.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.vitotronic,
  org.openhab.binding.vitotronic.handler

--- a/addons/binding/org.openhab.binding.wifiled/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.wifiled/META-INF/MANIFEST.MF
@@ -13,7 +13,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.wifiled,
+ org.openhab.binding.wifiled.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.wifiled,
  org.openhab.binding.wifiled.handler

--- a/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
@@ -24,7 +24,9 @@ Import-Package: com.google.common.collect,
  org.w3c.dom,
  org.osgi.framework,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.yamahareceiver,
+ org.openhab.binding.yamahareceiver.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.yamahareceiver,
  org.openhab.binding.yamahareceiver.handler

--- a/addons/binding/org.openhab.binding.zway/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.zway/META-INF/MANIFEST.MF
@@ -34,7 +34,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.zway,
+ org.openhab.binding.zway.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.zway,
  org.openhab.binding.zway.handler

--- a/addons/io/org.openhab.io.openhabcloud/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.openhabcloud/META-INF/MANIFEST.MF
@@ -40,7 +40,8 @@ Import-Package: javax.net,
  org.osgi.framework,
  org.osgi.service.cm,
  org.osgi.service.event,
- org.slf4j
+ org.slf4j,
+ org.openhab.io.openhabcloud
 Export-Package: org.openhab.io.openhabcloud
 Bundle-ClassPath: .,
  lib/json-20140107.jar,
@@ -51,4 +52,3 @@ Bundle-ClassPath: .,
  lib/socket.io-client-0.8.2.jar
 Bundle-Vendor: openHAB.org
 Bundle-ActivationPolicy: lazy
-

--- a/addons/ui/org.openhab.ui.cometvisu/META-INF/MANIFEST.MF
+++ b/addons/ui/org.openhab.ui.cometvisu/META-INF/MANIFEST.MF
@@ -44,7 +44,8 @@ Import-Package:
  org.osgi.service.cm;version="[1.5,2)",
  org.osgi.service.http;version="[1.2,2)",
  org.slf4j;version="[1.7,2)",
- org.xml.sax
+ org.xml.sax,
+ org.openhab.ui.cometvisu.php
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .,
  lib/rrd4j-2.2.jar,


### PR DESCRIPTION
See: https://github.com/openhab/static-code-analysis/pull/57
The necessary imports are added in all Manifest.MF files which the check gave warnings for.

The only concern that I have is about org.openhab.binding.max.test bundle. 
https://github.com/openhab/openhab2-addons/blob/master/addons/binding/org.openhab.binding.max.test/META-INF/MANIFEST.MF#L26

I am not sure why a test bundle would export any package. So I am not importing that exported package for now. If anyone has more information or a better suggestion, please let me know.

Regards,
Mihaela

Signed-off-by: Mihaela Memova <mihaela.memova@musala.com>