### PR TITLE
[max] Improvements in documentation and channel definitions

### DIFF
--- a/addons/binding/org.openhab.binding.max/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.max/ESH-INF/thing/thing-types.xml
@@ -13,7 +13,7 @@
 
 		<channels>
 			<channel id="valve" typeId="valve" />
-			<channel id="battery_low" typeId="battery" />
+			<channel id="battery_low" typeId="system.low-battery" />
 			<channel id="mode" typeId="mode" />
 			<channel id="actual_temp" typeId="actual_temp" />
 			<channel id="set_temp" typeId="set_temp" />
@@ -140,7 +140,7 @@
 
 		<channels>
 			<channel id="valve" typeId="valve" />
-			<channel id="battery_low" typeId="battery" />
+			<channel id="battery_low" typeId="system.low-battery" />
 			<channel id="mode" typeId="mode" />
 			<channel id="actual_temp" typeId="actual_temp" />
 			<channel id="set_temp" typeId="set_temp" />
@@ -267,7 +267,7 @@
 
 		<channels>
 			<channel id="valve" typeId="valve" />
-			<channel id="battery_low" typeId="battery" />
+			<channel id="battery_low" typeId="system.low-battery" />
 			<channel id="mode" typeId="mode" />
 			<channel id="actual_temp" typeId="actual_temp" />
 			<channel id="set_temp" typeId="set_temp" />
@@ -336,7 +336,7 @@
 		<description>This is a MAX! EcoSwitch</description>
 
 		<channels>
-			<channel id="battery_low" typeId="battery" />
+			<channel id="battery_low" typeId="system.low-battery" />
 		</channels>
 
 		<config-description>
@@ -392,7 +392,7 @@
 
 		<channels>
 			<channel id="contact_state" typeId="contact_state" />
-			<channel id="battery_low" typeId="battery" />
+			<channel id="battery_low" typeId="system.low-battery" />
 		</channels>
 
 		<config-description>
@@ -455,14 +455,6 @@
 		<description>Thermostat Valve Position</description>
 		<state pattern="%d %%" readOnly="true">
 		</state>
-	</channel-type>
-
-	<channel-type id="battery">
-		<item-type>Switch</item-type>
-		<label>Battery Level Low</label>
-		<description>Battery charge Level</description>
-		<category>Battery</category>
-		<state readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="mode">

--- a/addons/binding/org.openhab.binding.max/README.md
+++ b/addons/binding/org.openhab.binding.max/README.md
@@ -7,14 +7,14 @@ This binding allows you to integrate, view and control the MAX! Thermostats in t
 
 This binding support 6 different things types
 
-| Thing | Type    | Description  |
-|----------------|---------|-----------------------------------|
-| bridge | Bridge | This is the MAX! Cube LAN gateway  |
-| thermostat | Thing | This is for the MAX! Heating Thermostat. This is also used for the powerplug switch "Zwischenstecker-Schaltaktor".  |
-| thermostatplus | Thing | This is for the MAX! Heating Thermostat+. This is the type that can hold the program by itself |
-| wallthermostat | Thing | MAX! Wall Thermostat. |
-| ecoswitch  | Thing | MAX! Ecoswitch. |
-| shuttercontact | Thing  | MAX! Shuttercontact / Window Contact. |
+| Thing          | Type   | Description                                                                                                        |
+|----------------|--------|--------------------------------------------------------------------------------------------------------------------|
+| bridge         | Bridge | This is the MAX! Cube LAN gateway.                                                                                 |
+| thermostat     | Thing  | This is for the MAX! Heating Thermostat. This is also used for the powerplug switch "Zwischenstecker-Schaltaktor". |
+| thermostatplus | Thing  | This is for the MAX! Heating Thermostat+. This is the type that can hold the program by itself.                    |
+| wallthermostat | Thing  | MAX! Wall Thermostat.                                                                                              |
+| ecoswitch      | Thing  | MAX! Ecoswitch.                                                                                                    |
+| shuttercontact | Thing  | MAX! Shuttercontact / Window Contact.                                                                              |
 
 Generally one does not have to worry about the thing types as they are automatically defined.
 If for any reason you need to manually define the Things and you are not exactly sure what type of thermostat you have, you can choose `thermostat` for both the thermostat and thermostat+, this will not affect their working.
@@ -22,7 +22,7 @@ If for any reason you need to manually define the Things and you are not exactly
 ## Discovery
 
 The discovery process for the MAX! binding works in 2 steps.
-When the binding is started or when manually triggered, the network is queried for the existence of a MAX! Cube lan gateway. When the Cube is found, it will become available in the discovery inbox. Periodically the network is queried again for a Cube.
+When the binding is started or when manually triggered, the network is queried for the existence of a MAX! Cube LAN gateway. When the Cube is found, it will become available in the discovery inbox. Periodically the network is queried again for a Cube.
 
 Once the Cube is available in openHAB, all the devices connected to it are discovered and added to the discovery inbox. No scan is needed to trigger this.
 
@@ -33,9 +33,9 @@ All the configuration settings are now per MAX! Cube, hence in case you have mul
 
 ## Thing Configuration
 
-All the things are identified by their Serial number, hence this is mandatory. 
-The Cube (`bridge` thing) also requires the IP address to be defined. 
-All other configuration is optional. 
+All the things are identified by their serial number, hence this is mandatory.
+The Cube (`bridge` thing) also requires the IP address to be defined.
+All other configuration is optional.
 
 Note that several configuration options are automatically populated. Later versions of the binding may allow you to update this information. These properties can be found in the `Device Settings` section of parameters.
 
@@ -44,23 +44,22 @@ Note that several configuration options are automatically populated. Later versi
 
 Depending on the thing it supports different Channels
 
-
-| Channel Type ID | Item Type    | Description  | Available on thing |
-|-------------|--------|-----------------------------|------------------------------------|
-| mode | String | This channel indicates the mode of a thermostat (AUTOMATIC/MANUAL/BOOST/VACATION). | thermostat, thermostatplus, wallthermostat |
-| battery_low | Switch | This channel indicates if the device battery is low. (ON/OFF) | thermostat, thermostatplus, wallthermostat, ecoswitch, shuttercontact |
-| set_temp | Number | This channel indicates the sets temperature (in °C) of a thermostat. | thermostat, thermostatplus, wallthermostat |
-| actual_temp | Number | This channel indicates the measured temperature (in °C) of a thermostat (see below for more details). | thermostat, thermostatplus, wallthermostat |
-| valve | Number | This channel indicates the valve opening in %. Note this is an advaned setting, normally not visible. | thermostat, thermostatplus, wallthermostat |
-| locked | Contact | This channel indocates if the thermostat is locked for adjustments (OPEN/CLOSED). Note this is an advanced setting, normally not visible. | thermostat, thermostatplus, wallthermostat |
-| contact_state | Contact | This channel indicates the contact state for a shutterswitch (OPEN/CLOSED). | shuttercontact |
-| free_mem | Number | This channel indicates the free available memory on the cube to hold send commands. Note this is an advanced setting, normally not visible. | bridge |
-| duty_cycle | Number | This channel indicates the duty cycle (due to regulatory compliance reasons the cube is allowed only to send for a limited time. Duty cycle indicates how much of the available time is consumed) Note this is an advanced setting, normally not visible. | bridge |
+| Channel Type ID | Item Type | Description                                                                                                                                                                                                                                               | Available on thing                                                    |
+|-----------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| mode            | String    | This channel indicates the mode of a thermostat (AUTOMATIC/MANUAL/BOOST/VACATION).                                                                                                                                                                        | thermostat, thermostatplus, wallthermostat                            |
+| battery_low     | Switch    | This channel indicates if the device battery is low (ON/OFF).                                                                                                                                                                                             | thermostat, thermostatplus, wallthermostat, ecoswitch, shuttercontact |
+| set_temp        | Number    | This channel indicates the sets temperature (in °C) of a thermostat.                                                                                                                                                                                      | thermostat, thermostatplus, wallthermostat                            |
+| actual_temp     | Number    | This channel indicates the measured temperature (in °C) of a thermostat (see below for more details).                                                                                                                                                     | thermostat, thermostatplus, wallthermostat                            |
+| valve           | Number    | This channel indicates the valve opening in %. Note this is an advanced setting, normally not visible.                                                                                                                                                    | thermostat, thermostatplus, wallthermostat                            |
+| locked          | Contact   | This channel indicates if the thermostat is locked for adjustments (OPEN/CLOSED). Note this is an advanced setting, normally not visible.                                                                                                                 | thermostat, thermostatplus, wallthermostat                            |
+| contact_state   | Contact   | This channel indicates the contact state for a shutterswitch (OPEN/CLOSED).                                                                                                                                                                               | shuttercontact                                                        |
+| free_mem        | Number    | This channel indicates the free available memory on the cube to hold send commands. Note this is an advanced setting, normally not visible.                                                                                                               | bridge                                                                |
+| duty_cycle      | Number    | This channel indicates the duty cycle (due to regulatory compliance reasons the cube is allowed only to send for a limited time. Duty cycle indicates how much of the available time is consumed) Note this is an advanced setting, normally not visible. | bridge                                                                |
 
 
 ## Full Example
 
-In most cases no Things need to be defined manually. In case your Cube can't be discovered you need a `max:bridge` definition incl the right IP address of the Cube. Only in exceptional cases you would need to define the thermostats etc.
+In most cases no Things need to be defined manually. In case your Cube can't be discovered you need a `max:bridge` definition incl. the right IP address of the Cube. Only in exceptional cases you would need to define the thermostats etc.
 
 max.things:
 
@@ -77,8 +76,8 @@ Group gMAX 			"MAX Heating" 	<temperature>	[ "home-group" ]
 
 Switch maxBattery "Battery Low" (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:battery_low"}
 String maxMode    "Thermostat Mode Setting" (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:mode"}
-Number maxActual  "Actual measured room temperature  [%.1f �C]" (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:actual_temp"}
-Number maxSetTemp "Thermostat temperature setpoint [%.1f �C]"  (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:set_temp"}
+Number maxActual  "Actual measured room temperature  [%.1f °C]" (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:actual_temp"}
+Number maxSetTemp "Thermostat temperature setpoint [%.1f °C]" (gMAX) {channel="max:thermostat:KEQ0565026:KEQ0648949:set_temp"}
 
 
 ```
@@ -101,24 +100,27 @@ sitemap demo label="Main Menu"
 ## Actual Temperature Update
 
 Please be aware that the actual temperature measure for thermostats is only updated after the valve moved position or the thermostats mode has changed. Hence the temperature you see may be hours old. In that case you can update the temperature by changing the mode, wait approx. 2 minutes and change the mode back. 
-There is an experimental mode that does this automatically. This can be enabled by showing the "advanced settings"(e.g. in Habmin UI. Than the "Actual Temperature Refresh Rate" can be set. Minimum refresh rate once/10 minutes, recommended 60min to avoid excessive battery drain.
+There is an experimental mode that does this automatically. This can be enabled by showing the "advanced settings" (e.g. in HABmin UI. Than the "Actual Temperature Refresh Rate" can be set. Minimum refresh rate once/10 minutes, recommended 60min to avoid excessive battery drain.
 
 
 ## New Device Inclusion
+
 When clicking the discovery button for MAX! devices manually in the UI, you  will start New Device Inclusion mode for 60s. During this time holding the _boost_ button on your device will link it to the Cube.
 
 ## Device configuration
+
 In the _Configuration Parameters_ section of the device things you can update some of the device configuration parameters. Currently the following parameters can be updated:
 
-* _name_ Name of the thermostat stored in the Cube (also used by the eq3 software).
+* _name_ Name of the thermostat stored in the Cube (also used by the eQ-3 software).
 
 _Cube device configurable parameters_ 
 
 * _ntpServer1_ The hostname for NTP Server 1 used by the Cube to get the time
 * _ntpServer2_ The hostname for NTP Server 2 used by the Cube to get the time
 
-## Action Buttons (visible in Habmin)
-In the Habmin thing configuration screen several action buttons are available to trigger special actions on the Cube
+## Action Buttons (visible in HABmin)
+
+In the HABmin thing configuration screen several action buttons are available to trigger special actions on the Cube
 
 * _Reset Cube Configuration_. This resets the MAX! Cube room and device information. Devices will need to be included again! To use this button you need to enable 'Advanced settings'
 
@@ -128,4 +130,4 @@ On the MAX! devices you can trigger the following action
 
 * _Delete Device from Cube_. Deletes the device from the MAX! Cube. Device will need to be included again! To use this button you need to enable 'Advanced settings'
 
-Note: In PaperUI there are no action buttons. You can trigger these actions changing from 'No Action' in the dropdown to the action value. 
+Note: In Paper UI there are no action buttons. You can trigger these actions changing from 'No Action' in the dropdown to the action value. 


### PR DESCRIPTION
- Updated README.md (correct spelling and format of markdown tabels)
- Changed definition of 'battery_low' channel to sytemwide channel type 'system.low-battery'

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>