### PR TITLE
Documentation fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ One way to automate this, is customise your get ``commit.template`` by adding
 a ``prepare-commit-msg`` hook to your openHAB checkout:
 
 ```
-curl -L -o .git/hooks/prepare-commit-msg https://raw.github.com/openhab/openhab2/master/contrib/prepare-commit-msg.hook && chmod +x .git/hooks/prepare-commit-msg
+curl -L -o .git/hooks/prepare-commit-msg https://raw.githubusercontent.com/openhab/openhab-core/master/contrib/prepare-commit-msg.hook && chmod +x .git/hooks/prepare-commit-msg
 ```
 
 * Note: the above script expects to find your GitHub user name in ``git config --get github.user``


### PR DESCRIPTION
The URL for the `prepare-commit-msg.hook` file points to a non-existing location. Updated with the correct location.