### PR TITLE
rfxcom.test: Add missing CP entry in .classpath

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom.test/.classpath
+++ b/addons/binding/org.openhab.binding.rfxcom.test/.classpath
@@ -7,5 +7,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core.thing"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core.thing.xml.test"/>
+	<classpathentry exported="true" kind="con" path="GROOVY_DSL_SUPPORT"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
This line is added after fresh install with eclipse installer. Maybe one of those changes wich only appear after Eclipse IDE close+open projects.