### PR TITLE
[DSCAlarm] Various Fixes and Enhancements

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/channels.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+
+	<!-- bridge -->
+	<channel-type id="reset">
+		<item-type>Switch</item-type>
+		<label>Reset</label>
+		<description>Reset Switch</description>
+	</channel-type>
+
+	<channel-type id="command">
+		<item-type>String</item-type>
+		<label>Send Command</label>
+		<description>Sends a DSC Alarm Command</description>
+	</channel-type>
+
+	<!-- keypad -->
+	<channel-type id="led">
+		<item-type>Number</item-type>
+		<label>Keypad LED</label>
+		<description>Keypad LED (0=Off, 1=On, 2=Flashing)</description>
+		<state pattern="%d" readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">On</option>
+				<option value="2">Flashing</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<!-- panel -->
+	<channel-type id="panel_command">
+		<item-type>Number</item-type>
+		<label>Panel Command</label>
+		<description>Send Command</description>
+		<state pattern="%d">
+			<options>
+				<option value="-1">None</option>
+				<option value="0">Poll</option>
+				<option value="1">Status Report</option>
+				<option value="2">Labels Request (Serial Only)</option>
+				<option value="8">Dump Zone Timers (TCP Only)</option>
+				<option value="10">Set Time/Date</option>
+				<option value="200">Send User Code</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="time">
+		<item-type>DateTime</item-type>
+		<label>Time</label>
+		<description>Time</description>
+	</channel-type>
+
+	<channel-type id="state">
+		<item-type>Switch</item-type>
+		<label>State</label>
+		<description>State (On/Off)</description>
+	</channel-type>
+
+	<!-- partition -->
+	<channel-type id="arm_mode">
+		<item-type>Number</item-type>
+		<label>Arm Mode</label>
+		<description>Arm Mode</description>
+		<state pattern="%d">
+			<options>
+				<option value="0">Disarm</option>
+				<option value="1">Away</option>
+				<option value="2">Stay</option>
+				<option value="3">Zero</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<!-- zone -->
+	<channel-type id="zone_status">
+		<item-type>Contact</item-type>
+		<label>Zone Status</label>
+		<description>Zone Status (Open/Closed)</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="bypass_mode">
+		<item-type>Switch</item-type>
+		<label>Bypass Mode</label>
+		<description>Bypass Mode (OFF=Armed, ON=Bypassed)</description>
+	</channel-type>
+
+	<!-- common -->
+	<channel-type id="message">
+		<item-type>String</item-type>
+		<label>Message</label>
+		<description>Message Received</description>
+		<state pattern="%s" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="status">
+		<item-type>Switch</item-type>
+		<label>Status</label>
+		<description>Status</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/envisalinkbridge.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/envisalinkbridge.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="envisalink">
 		<label>EyezOn Envisalink</label>
@@ -13,6 +11,10 @@
 			<channel id="bridge_reset" typeId="reset">
 				<label>Reset Envisalink</label>
 				<description>Resets the Envisalink</description>
+			</channel>
+			<channel id="send_command" typeId="command">
+				<label>Send Command</label>
+				<description>Sends a DSC Alarm Command</description>
 			</channel>
 		</channels>
 
@@ -39,26 +41,18 @@
 				<default>user</default>
 			</parameter>
 
-			<parameter name="connectionTimeout" type="integer"
-				required="false">
+			<parameter name="connectionTimeout" type="integer" required="false">
 				<label>Connection Timeout</label>
 				<description>TCP Socket Connection Timeout (milliseconds).</description>
 				<default>5000</default>
 			</parameter>
 
-			<parameter name="pollPeriod" type="integer" required="false"
-				min="1" max="15">
+			<parameter name="pollPeriod" type="integer" required="false" min="1" max="15">
 				<label>Poll Period</label>
 				<description>The Poll Period (minutes).</description>
 				<default>1</default>
 			</parameter>
 		</config-description>
 	</bridge-type>
-
-	<channel-type id="reset">
-		<item-type>Switch</item-type>
-		<label>Reset</label>
-		<description>Reset Switch</description>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/it100bridge.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/it100bridge.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="it100">
 		<label>DSC IT-100</label>
@@ -13,6 +11,10 @@
 				<label>Reset IT100</label>
 				<description>Resets the IT100</description>
 			</channel>
+			<channel id="send_command" typeId="command">
+				<label>Send Command</label>
+				<description>Sends a DSC Alarm Command</description>
+			</channel>
 		</channels>
 
 		<config-description>
@@ -20,7 +22,8 @@
 				<context>network_address</context>
 				<label>IT-100 Bridge Serial Port</label>
 				<description>The serial port name for the DSC IT-100. Valid values
-					are e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.</description>
+					are e.g. COM1 for Windows and /dev/ttyS0 or
+					/dev/ttyUSB0 for Linux.</description>
 			</parameter>
 
 			<parameter name="baud" type="integer" required="false">
@@ -30,19 +33,12 @@
 				<default>9600</default>
 			</parameter>
 
-			<parameter name="pollPeriod" type="integer" required="false"
-				min="1" max="15">
+			<parameter name="pollPeriod" type="integer" required="false" min="1" max="15">
 				<label>Poll Period</label>
 				<description>The Poll Period.</description>
 				<default>1</default>
 			</parameter>
 		</config-description>
 	</bridge-type>
-
-	<channel-type id="reset">
-		<item-type>Switch</item-type>
-		<label>Reset</label>
-		<description>Reset Switch</description>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/keypad.xml
@@ -4,7 +4,6 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="keypad">
-
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
@@ -60,27 +59,6 @@
 				<description>Keypad LCD Cursor Position Changes</description>
 			</channel>
 		</channels>
-
 	</thing-type>
-
-	<channel-type id="led">
-		<item-type>Number</item-type>
-		<label>Keypad LED</label>
-		<description>Keypad LED (0=Off, 1=On, 2=Flashing)</description>
-		<state pattern="%d" readOnly="true">
-			<options>
-				<option value="0">Off</option>
-				<option value="1">On</option>
-				<option value="2">Flashing</option>
-			</options>
-		</state>
-	</channel-type>
-
-	<channel-type id="message">
-		<item-type>String</item-type>
-		<label>Message</label>
-		<description>Message Received</description>
-		<state pattern="%s" readOnly="true"></state>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/panel.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/panel.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="panel">
-
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
-            <bridge-type-ref id="tcpserver" />
+			<bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Panel</label>
@@ -22,7 +20,7 @@
 			</channel>
 			<channel id="panel_command" typeId="panel_command">
 				<label>Panel Command</label>
-				<description>Send Command</description>
+				<description>Send Selected Command</description>
 			</channel>
 			<channel id="panel_system_error" typeId="message">
 				<label>Panel System Error</label>
@@ -99,65 +97,18 @@
 		</channels>
 
 		<config-description>
-
 			<parameter name="userCode" type="text" required="false">
 				<label>User Code</label>
 				<description>The User Code.</description>
 				<default>1234</default>
 			</parameter>
 
-			<parameter name="suppressAcknowledgementMsgs" type="boolean"
-				required="false">
+			<parameter name="suppressAcknowledgementMsgs" type="boolean" required="false">
 				<label>Suppress Acknowledgement Messages</label>
 				<description>Suppress Acknowledgement Messages When Received.</description>
 				<default>false</default>
 			</parameter>
-
 		</config-description>
-
 	</thing-type>
-
-	<channel-type id="message">
-		<item-type>String</item-type>
-		<label>Message</label>
-		<description>Message Received</description>
-		<state pattern="%s" readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="panel_command">
-		<item-type>Number</item-type>
-		<label>Panel Command</label>
-		<description>Send Command</description>
-		<state pattern="%d">
-			<options>
-				<option value="-1">None</option>
-				<option value="0">Poll</option>
-				<option value="1">Status Report</option>
-				<option value="2">Labels Request (Serial Only)</option>
-				<option value="8">Dump Zone Timers (TCP Only)</option>
-				<option value="10">Set Time/Date</option>
-				<option value="200">Send User Code</option>
-			</options>
-		</state>
-	</channel-type>
-
-	<channel-type id="status">
-		<item-type>Switch</item-type>
-		<label>Status</label>
-		<description>Status</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="time">
-		<item-type>DateTime</item-type>
-		<label>Time</label>
-		<description>Time</description>
-	</channel-type>
-
-	<channel-type id="state">
-		<item-type>Switch</item-type>
-		<label>State</label>
-		<description>State (On/Off)</description>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/partition.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/partition.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="partition">
-
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
-            <bridge-type-ref id="tcpserver" />
+			<bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Partition</label>
@@ -47,44 +45,12 @@
 		</channels>
 
 		<config-description>
-
-			<parameter name="partitionNumber" type="integer" required="true"
-				min="1" max="8">
+			<parameter name="partitionNumber" type="integer" required="true" min="1" max="8">
 				<label>Partition Number</label>
 				<description>The Partition Number (1-8).</description>
 				<default>1</default>
 			</parameter>
-
 		</config-description>
-
 	</thing-type>
-
-	<channel-type id="message">
-		<item-type>String</item-type>
-		<label>Message</label>
-		<description>Message Received</description>
-		<state pattern="%s" readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="arm_mode">
-		<item-type>Number</item-type>
-		<label>Arm Mode</label>
-		<description>Arm Mode</description>
-		<state pattern="%d">
-			<options>
-				<option value="0">Disarm</option>
-				<option value="1">Away</option>
-				<option value="2">Stay</option>
-				<option value="3">Zero</option>
-			</options>
-		</state>
-	</channel-type>
-
-	<channel-type id="status">
-		<item-type>Switch</item-type>
-		<label>Status</label>
-		<description>Status</description>
-		<state readOnly="true"></state>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/tcpserverbridge.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/tcpserverbridge.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
 	<bridge-type id="tcpserver">
 		<label>TCP Server</label>
 		<description>This bridge represents a TCP Server
-			Ethernet interface.</description>
+			Ethernet interface.
+		</description>
 
 		<channels>
 			<channel id="bridge_reset" typeId="reset">
 				<label>Reset TCP Server</label>
 				<description>Resets the TCP Server</description>
+			</channel>
+			<channel id="send_command" typeId="command">
+				<label>Send Command</label>
+				<description>Sends a DSC Alarm Command</description>
 			</channel>
 		</channels>
 
@@ -39,13 +42,18 @@
 				<description>The Poll Period (minutes).</description>
 				<default>1</default>
 			</parameter>
+
+			<parameter name="protocol" type="integer" required="false" min="1" max="2">
+				<label>Protocol</label>
+				<description>The protocol used to interact with the DSC Alarm. Valid options are 'IT100 API' and 'Envisalink TPI'.
+					The default is 'IT100 API'.</description>
+				<options>
+					<option value="1">IT100 API</option>
+					<option value="2">Envisalink TPI</option>
+				</options>
+				<default>1</default>
+			</parameter>
 		</config-description>
 	</bridge-type>
-
-	<channel-type id="reset">
-		<item-type>Switch</item-type>
-		<label>Reset</label>
-		<description>Reset Switch</description>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/zone.xml
+++ b/addons/binding/org.openhab.binding.dscalarm/ESH-INF/thing/zone.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dscalarm"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="dscalarm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="zone">
-
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="envisalink" />
 			<bridge-type-ref id="it100" />
-            <bridge-type-ref id="tcpserver" />
+			<bridge-type-ref id="tcpserver" />
 		</supported-bridge-type-refs>
 
 		<label>DSC Alarm Zone</label>
@@ -47,49 +45,17 @@
 		</channels>
 
 		<config-description>
-
-			<parameter name="partitionNumber" type="integer" min="1"
-				max="8">
+			<parameter name="partitionNumber" type="integer" min="1" max="8">
 				<label>Partition Number</label>
 				<description>The Partition Number (1-8).</description>
 				<default>1</default>
 			</parameter>
 
-			<parameter name="zoneNumber" type="integer" required="true"
-				min="1" max="64">
+			<parameter name="zoneNumber" type="integer" required="true" min="1" max="64">
 				<label>Zone Number</label>
 				<description>The Zone Number (1-64).</description>
 			</parameter>
-
 		</config-description>
-
 	</thing-type>
-
-	<channel-type id="zone_status">
-		<item-type>Contact</item-type>
-		<label>Zone Status</label>
-		<description>Zone Status (Open/Closed)</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="message">
-		<item-type>String</item-type>
-		<label>Message</label>
-		<description>Message Received</description>
-		<state pattern="%s" readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="bypass_mode">
-		<item-type>Switch</item-type>
-		<label>Bypass Mode</label>
-		<description>Bypass Mode (OFF=Armed, ON=Bypassed)</description>
-	</channel-type>
-
-	<channel-type id="status">
-		<item-type>Switch</item-type>
-		<label>Status</label>
-		<description>Status</description>
-		<state readOnly="true"></state>
-	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j
+ org.slf4j,
+ org.openhab.binding.dscalarm,
+ org.openhab.binding.dscalarm.handler
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.dscalarm,
  org.openhab.binding.dscalarm.handler

--- a/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
@@ -19,9 +19,8 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
- org.slf4j,
- org.openhab.binding.dscalarm,
- org.openhab.binding.dscalarm.handler
+ org.slf4j
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.dscalarm,
  org.openhab.binding.dscalarm.handler
+Bundle-ActivationPolicy: lazy

--- a/addons/binding/org.openhab.binding.dscalarm/README.md
+++ b/addons/binding/org.openhab.binding.dscalarm/README.md
@@ -1,10 +1,8 @@
 # DSC Alarm Binding
 
-This is an openHAB binding for a DSC PowerSeries Alarm System utilizing the EyezOn Envisalink 3/2DS interface or the DSC IT-100 RS-232 interface.
-
 The DSC PowerSeries Alarm System is a popular do-it-yourself home security system, which can be monitored and controlled remotely through a standard web-browser or mobile device.
 
-The openHAB DSC Alarm binding provides connectivity to the DSC Alarm panel via a TCP socket connection to the EyesOn Envisalink 3/2DS interface or a RS-232 serial connection to the DSC IT-100 interface.
+This is the binding for the DSC PowerSeries Alarm System, utilizing either the EyezOn Envisalink 4/3/2DS interface or the DSC IT-100 RS-232 interface. It provides connectivity to the DSC Alarm panel via a TCP socket connection to the EyesOn Envisalink 4/3/2DS interface or a RS-232 serial connection to the DSC IT-100 interface.  Additionally, their is provision to connect to the DSC IT-100 interface through a TCP serial server.
 
 ## Supported Things
 
@@ -27,7 +25,11 @@ There are essentially no overall binding configuration settings that need to be 
 
 ## Discovery
 
-The DSC Alarm binding incorporates several discovery modes in order to find DSC Alarm systems.  First, there is the Envisalink bridge discovery mode which performs a network query for any Envisalink adapters and adds them to the discovery inbox.  Second, there is The IT-100 bridge discovery mode which will search serial ports for any IT-100 adapters and add them to the discovery inbox.  The bridge discovery modes are started manually through PaperUI.  Third, after a bridge is discovered and available to openHAB, the binding will attempt to discover DSC Alarm devices and add them to the discovery inbox.  The TCP Server bridge does not implement bridge discovery but will utilize device discovery once it is online.
+The DSC Alarm binding incorporates several discovery modes in order to find DSC Alarm systems.  First, there is the Envisalink bridge discovery mode which performs a network query for any Envisalink adapters and adds them to the discovery inbox.  Second, there is The IT-100 bridge discovery mode which will search serial ports for any IT-100 adapters and add them to the discovery inbox.  The bridge discovery modes are started manually through PaperUI.  Third, after a bridge is discovered and available to openHAB, the binding will attempt to discover DSC Alarm things and add them to the discovery inbox.  The TCP Server bridge does not implement bridge discovery but will utilize thing discovery once it is online.
+
+Note: The Envisalink Bridge discovery does a TCP scan across your local network to find the interface.  This may create issues on the network so it is suggested that caution be used when trying this discovery.  The recommended method would be to manually add and configure the bridge through the 'dscalarm.thing' file or the PaperUI.  And then allow the binding to discover the DSC Alarm things.
+
+
 
 ## Thing Configuration
 
@@ -37,7 +39,7 @@ DSC Alarm things can be configured either through the online configuration utili
 	<tr><td><b>Thing</b></td><td><b>Configuration Parameters</b></td></tr>	
 	<tr><td>envisalink</td><td><table><tr><td><b>ipAddress</b> - IP address for the Envisalink adapter - Required.</td></tr><tr><td><b>port</b> - TCP port for the Envisalink adapter - Not Required - default = 4025.</td></tr><tr><td><b>password</b> - Password to login to the Envisalink bridge - Not Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the Envisalink bridge - Not Required - default=1.</td></tr></table></td></tr>
 	<tr><td>it100</td><td><table><tr><td><b>serialPort</b> - Serial port for the IT-100s bridge - Required.</td></tr><tr><td><b>baud</b> - Baud rate of the IT-100 bridge - Not Required - default = 9600.</td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the IT-100 bridge - Not Required - default=1.</td></tr></table></td></tr>
-    <tr><td>tcpserver</td><td><table><tr><td><b>ipAddress</b> - IP address for the TCP Server - Required.</td></tr><tr><td><b>port</b> - TCP port for the TCP Server - Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the TCP Server bridge - Not Required - default=1.</td></tr></table></td></tr>
+    <tr><td>tcpserver</td><td><table><tr><td><b>ipAddress</b> - IP address for the TCP Server - Required.</td></tr><tr><td><b>port</b> - TCP port for the TCP Server - Required.</td></tr><tr><td><b>connectionTimeout</b> - TCP socket connection timeout in milliseconds - Not Required - default=5000.<br/></td></tr><tr><td><b>pollPeriod</b> - Period of time in minutes between the poll command being sent to the TCP Server bridge - Not Required - default=1.</td></tr><tr><td><b>protocol</b> - The protocol used to interact with the DSC Alarm. Valid values are 1 for IT100 API or 2 for Envisalink TPI. The default is 1. - Not Required.</td></tr></table></td></tr>
     <tr><td>panel</td><td><table><tr><td><b>userCode</b> - User code for the DSC alarm panel - Not Required.</td></tr><tr><td><b>suppressAcknowledgementMsgs</b> - Suppress the display of acknowledgement messages when received - Not Required - default = false.</td></tr></table></td></tr>
 	<tr><td>partition</td><td><b>partitionNumber</b> - Partition number (1-8) - Required.</td></tr>
 	<tr><td>zone</td><td><table><tr><td><b>partitionNumber</b> - Partition number (1-8) - Not Required - default=1.</td></tr><tr><td><b>zoneNumber</b> - Zone number (1-64) - Required.</td></tr></table></td></tr>
@@ -74,6 +76,7 @@ DSC Alarm things support a variety of channels as seen below in the following ta
 <table>
     <tr><td><b>Channel</b></td><td><b>Item Type</b></td><td><b>Description</b></td></tr>
     <tr><td>bridge_reset</td><td>Switch</td><td>Reset the bridge connection.</td></tr>
+    <tr><td>send_command</td><td>Switch</td><td>Send a DSC Alarm command.</td></tr>
     <tr><td>panel_message</td><td>String</td><td>Event messages received from the DSC Alarm system.</td></tr>
     <tr><td>panel_system_error</td><td>String</td><td>DSC Alarm system error.</td></tr>
     <tr><td>panel_trouble_message</td><td>String</td><td>Displays any trouble messages the panel might send.</td></tr>
@@ -84,7 +87,7 @@ DSC Alarm things support a variety of channels as seen below in the following ta
     <tr><td>panel_ftc_trouble</td><td>Switch</td><td>Failure to communicate with monitoring station.</td></tr>
     <tr><td>panel_zone_fault</td><td>Switch</td><td>There is a fault condition on a zone/sensor.</td></tr>
     <tr><td>panel_zone_tamper</td><td>Switch</td><td>There is a tamper condition on a zone/sensor.</td></tr>
-    <tr><td>panel_time_low_battery</td><td>Switch</td><td>There is a low battery condition on a zone/sensor.</td></tr>
+    <tr><td>panel_zone_low_battery</td><td>Switch</td><td>There is a low battery condition on a zone/sensor.</td></tr>
     <tr><td>panel_time_loss</td><td>Switch</td><td>Loss of time on the panel.</td></tr>
     <tr><td>panel_time</td><td>DateTime</td><td>DSC Alarm system time and date.</td></tr>
     <tr><td>panel_time_stamp</td><td>Switch</td><td>Turn DSC Alarm message time stamping ON/OFF.</td></tr>
@@ -183,6 +186,7 @@ Group:Contact:OR(OPEN, CLOSED) DSCAlarmSmoke <smokeDetector>
 /* DSC Alarm Items */
 
 Switch BRIDGE_CONNECTION {channel="dscalarm:envisalink:MyBridgeName:bridge_reset"}
+String SEND_DSC_ALARM_COMMAND "Send a DSC Alarm Command" {channel="dscalarm:envisalink:MyBridgeName:send_command"}
 
 /* DSC Alarm Panel Items */
 String PANEL_MESSAGE "Panel Message: [%s]" (DSCAlarmPanel) {channel="dscalarm:panel:MyBridgeName:panel:panel_message"}
@@ -379,20 +383,20 @@ Here is an example sitemap:
 
 ```
     Frame label="Alarm System" {
-        Text label="DSC Alarm System" icon="DSC" {
+        Text label="DSC Alarm System" {
             Frame label="Panel" {
                 Switch item=BRIDGE_CONNECTION label="Panel Connection" mappings=[ON="Connected", OFF="Disconnected"]
-                Text item=PANEL_MESSAGE icon="returnpipe"
-                Selection item=PANEL_COMMAND icon="flowpipe" mappings=[0="Poll", 1="Status Report", 2="Labels Request (Serial Only)", 8="Dump Zone Timers (TCP Only)", 10="Set Time/Date", 200="Send User Code"]
+                Text item=PANEL_MESSAGE
+                Selection item=PANEL_COMMAND mappings=[0="Poll", 1="Status Report", 2="Labels Request (Serial Only)", 8="Dump Zone Timers (TCP Only)", 10="Set Time/Date", 200="Send User Code"]
                 Text item=PANEL_TIME {
                     Switch item=PANEL_TIME_STAMP label="Panel Time Stamp"
                     Switch item=PANEL_TIME_BROADCAST label="Panel Time Broadcast"
                 }
                 
-                Text item=PANEL_SYSTEM_ERROR icon="systemError"
+                Text item=PANEL_SYSTEM_ERROR
                                 
                 Text item=PANEL_TROUBLE_LED label="Panel Trouble Condition" {
-                    Text item=PANEL_TROUBLE_MESSAGE icon="shieldRed"
+                    Text item=PANEL_TROUBLE_MESSAGE
                     Text item=PANEL_SERVICE_REQUIRED label="Service Required"
                     Text item=PANEL_AC_TROUBLE label="AC Trouble"
                     Text item=PANEL_TELEPHONE_TROUBLE label="Telephone Line Trouble"
@@ -405,14 +409,14 @@ Here is an example sitemap:
             }
 
             Frame label="Partitions" {
-                Text item=PARTITION1_STATUS icon="shieldGreen" {
-                    Switch item=PARTITION1_ARM_MODE label="Partition 1 Arm Options" icon="shieldGreen" mappings=[0="Disarm", 1="Away", 2="Stay", 3="No Entry Delay", 4="With User Code"]
-                    Text item=PARTITION1_OPENING_CLOSING_MODE icon="shieldGreen"
+                Text item=PARTITION1_STATUS {
+                    Switch item=PARTITION1_ARM_MODE label="Partition 1 Arm Options" mappings=[0="Disarm", 1="Away", 2="Stay", 3="No Entry Delay", 4="With User Code"]
+                    Text item=PARTITION1_OPENING_CLOSING_MODE
                 }
             }
 
             Frame label="Keypad" {
-                Text label="Keypad LED Status" icon="DSCKeypad" {
+                Text label="Keypad LED Status" {
                     Text item=KEYPAD_READY_LED label="Ready LED Status"
                     Text item=KEYPAD_ARMED_LED label="Armed LED Status"
                     Text item=KEYPAD_MEMORY_LED label="Memory LED Status"
@@ -426,150 +430,150 @@ Here is an example sitemap:
             }
 
             Frame label="Zones" {
-                Text label="All Zones" icon="ZoneAlarm" {
+                Text label="All Zones" {
                     Text item=ZONE1_STATUS {
-                        Switch item=ZONE1_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE1_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE1_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE1_TAMPER icon="statusWarning"
-                            Switch item=ZONE1_FAULT icon="statusWarning"
+                            Switch item=ZONE1_IN_ALARM
+                            Switch item=ZONE1_TAMPER
+                            Switch item=ZONE1_FAULT
                         }
                     }
 
                     Text item=ZONE9_STATUS {
-                        Switch item=ZONE9_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE9_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE9_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE9_TAMPER icon="statusWarning"
-                            Switch item=ZONE9_FAULT icon="statusWarning"
+                            Switch item=ZONE9_IN_ALARM
+                            Switch item=ZONE9_TAMPER
+                            Switch item=ZONE9_FAULT
                         }
                     }
                     Text item=ZONE10_STATUS {
-                        Switch item=ZONE10_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE10_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE10_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE10_TAMPER icon="statusWarning"
-                            Switch item=ZONE10_FAULT icon="statusWarning"
+                            Switch item=ZONE10_IN_ALARM
+                            Switch item=ZONE10_TAMPER
+                            Switch item=ZONE10_FAULT
                         }
                     }
                     Text item=ZONE11_STATUS {
-                        Switch item=ZONE11_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE11_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE11_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE11_TAMPER icon="statusWarning"
-                            Switch item=ZONE11_FAULT icon="statusWarning"
+                            Switch item=ZONE11_IN_ALARM
+                            Switch item=ZONE11_TAMPER
+                            Switch item=ZONE11_FAULT
                         }
                     }
                     Text item=ZONE12_STATUS {
-                        Switch item=ZONE12_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE12_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE12_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE12_TAMPER icon="statusWarning"
-                            Switch item=ZONE12_FAULT icon="statusWarning"
+                            Switch item=ZONE12_IN_ALARM
+                            Switch item=ZONE12_TAMPER
+                            Switch item=ZONE12_FAULT
                         }
                     }
                     Text item=ZONE13_STATUS {
-                        Switch item=ZONE13_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE13_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE13_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE13_TAMPER icon="statusWarning"
-                            Switch item=ZONE13_FAULT icon="statusWarning"
+                            Switch item=ZONE13_IN_ALARM
+                            Switch item=ZONE13_TAMPER
+                            Switch item=ZONE13_FAULT
                         }
                     }
                     Text item=ZONE14_STATUS {
-                        Switch item=ZONE14_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE14_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE14_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE14_TAMPER icon="statusWarning"
-                            Switch item=ZONE14_FAULT icon="statusWarning"
+                            Switch item=ZONE14_IN_ALARM
+                            Switch item=ZONE14_TAMPER
+                            Switch item=ZONE14_FAULT
                         }
                     }
                     Text item=ZONE15_STATUS {
-                        Switch item=ZONE15_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE15_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE15_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE15_TAMPER icon="statusWarning"
-                            Switch item=ZONE15_FAULT icon="statusWarning"
+                            Switch item=ZONE15_IN_ALARM
+                            Switch item=ZONE15_TAMPER
+                            Switch item=ZONE15_FAULT
                         }
                     }
                     Text item=ZONE21_STATUS {
-                        Switch item=ZONE21_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE21_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE21_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE21_TAMPER icon="statusWarning"
-                            Switch item=ZONE21_FAULT icon="statusWarning"
+                            Switch item=ZONE21_IN_ALARM
+                            Switch item=ZONE21_TAMPER
+                            Switch item=ZONE21_FAULT
                         }
                     }
                     Text item=ZONE22_STATUS {
-                        Switch item=ZONE22_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE22_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE22_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE22_TAMPER icon="statusWarning"
-                            Switch item=ZONE22_FAULT icon="statusWarning"
+                            Switch item=ZONE22_IN_ALARM
+                            Switch item=ZONE22_TAMPER
+                            Switch item=ZONE22_FAULT
                         }
                     }
                     Text item=ZONE23_STATUS {
-                        Switch item=ZONE23_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE23_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE23_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE23_TAMPER icon="statusWarning"
-                            Switch item=ZONE23_FAULT icon="statusWarning"
+                            Switch item=ZONE23_IN_ALARM
+                            Switch item=ZONE23_TAMPER
+                            Switch item=ZONE23_FAULT
                         }
                     }
                     Text item=ZONE24_STATUS {
-                        Switch item=ZONE24_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE24_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE24_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE24_TAMPER icon="statusWarning"
-                            Switch item=ZONE24_FAULT icon="statusWarning"
+                            Switch item=ZONE24_IN_ALARM
+                            Switch item=ZONE24_TAMPER
+                            Switch item=ZONE24_FAULT
                         }
                     }
                     Text item=ZONE25_STATUS {
-                        Switch item=ZONE25_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE25_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE25_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE25_TAMPER icon="statusWarning"
-                            Switch item=ZONE25_FAULT icon="statusWarning"
+                            Switch item=ZONE25_IN_ALARM
+                            Switch item=ZONE25_TAMPER
+                            Switch item=ZONE25_FAULT
                         }
                     }
                     Text item=ZONE51_STATUS {
-                        Switch item=ZONE51_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE51_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE51_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE51_TAMPER icon="statusWarning"
-                            Switch item=ZONE51_FAULT icon="statusWarning"
+                            Switch item=ZONE51_IN_ALARM
+                            Switch item=ZONE51_TAMPER
+                            Switch item=ZONE51_FAULT
                         }
                     }
                     Text item=ZONE52_STATUS {
-                        Switch item=ZONE52_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE52_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE52_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE52_TAMPER icon="statusWarning"
-                            Switch item=ZONE52_FAULT icon="statusWarning"
+                            Switch item=ZONE52_IN_ALARM
+                            Switch item=ZONE52_TAMPER
+                            Switch item=ZONE52_FAULT
                         }
                     }
                     Text item=ZONE53_STATUS {
-                        Switch item=ZONE53_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE53_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE53_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE53_TAMPER icon="statusWarning"
-                            Switch item=ZONE53_FAULT icon="statusWarning"
+                            Switch item=ZONE53_IN_ALARM
+                            Switch item=ZONE53_TAMPER
+                            Switch item=ZONE53_FAULT
                         }
                     }
                     Text item=ZONE54_STATUS {
-                        Switch item=ZONE54_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE54_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE54_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE54_TAMPER icon="statusWarning"
-                            Switch item=ZONE54_FAULT icon="statusWarning"
+                            Switch item=ZONE54_IN_ALARM
+                            Switch item=ZONE54_TAMPER
+                            Switch item=ZONE54_FAULT
                         }
                     }
                     Text item=ZONE55_STATUS {
-                        Switch item=ZONE55_BYPASS_MODE icon="ZoneAlarm" mappings=[OFF="Armed", ON="Bypassed"]
+                        Switch item=ZONE55_BYPASS_MODE mappings=[OFF="Armed", ON="Bypassed"]
                         Frame label="Other Status:" {
-                            Switch item=ZONE55_IN_ALARM icon="statusWarning"
-                            Switch item=ZONE55_TAMPER icon="statusWarning"
-                            Switch item=ZONE55_FAULT icon="statusWarning"
+                            Switch item=ZONE55_IN_ALARM
+                            Switch item=ZONE55_TAMPER
+                            Switch item=ZONE55_FAULT
                         }
                     }
                 }
@@ -583,18 +587,23 @@ Here is an example sitemap:
     }
 ```
 
-## Change Log
+Sample Rules for Sending a DSC Alarm Command
 
-### openHAB 2.0.0 Beta 1
+```
+rule "SendKeystrokeStringCommand"
+when   
+    Item SwitchItemName received command ON
+then   
+    sendCommand(SEND_DSC_ALARM_COMMAND, "071,1*101#")
+end
 
-* Initial commit of the DSC Alarm Binding. ([#324](https://github.com/openhab/openhab2-addons/pull/324))
+rule "SendPollingCommand"
 
-### openHAB 2.0.0 Beta 3
+when   
+    Item SwitchItemName received command ON
+then   
+    sendCommand(SEND_DSC_ALARM_COMMAND, "000")
+end
+```
 
-* Added support for the DSC Alarm binding to communicate with an IT-100 through a TCP/IP serial server.  Also, fixed a bug where the IT-100 serial interface requires a 6 digit usercode but was only receiving 4 digits.  The channel named `PANEL_COMMAND` was changed from type String to type Number.  Fixed bug where the IT-100 bridge would not connect.  ([#846](https://github.com/openhab/openhab2-addons/pull/846))
-
-### openHAB 2.0.0 Beta 4
-
-* Fixed bug where the binding would prematurely set the channel `PARTITION_ARM_MODE` when issuing a partition arm command.
-* Fixed issue where the binding stopped handling incoming messages from the DSC Alarm system.
-* Disabled background discovery of DSC Alarm bridges as this may create network issues.  Manual discovery is still available.
+Notice the command variations in the examples. If a command has data, there needs to be a comma between the command and the data as seen above in the first example. If there is no data then it would only require the command itself as in the second example. 

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
@@ -48,6 +48,7 @@ public class DSCAlarmBindingConstants {
 
     // List of all Channel IDs
     public static final String BRIDGE_RESET = "bridge_reset";
+    public static final String SEND_COMMAND = "send_command";
 
     public static final String PANEL_MESSAGE = "panel_message";
     public static final String PANEL_COMMAND = "panel_command";

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/TCPServerBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/config/TCPServerBridgeConfiguration.java
@@ -22,6 +22,7 @@ public class TCPServerBridgeConfiguration {
     public static final String PASSWORD = "password";
     public static final String CONNECTION_TIMEOUT = "connectionTimeout";
     public static final String POLL_PERIOD = "pollPeriod";
+    public static final String PROTOCOL = "protocol";
 
     /**
      * The IP address of the TCP Server
@@ -42,4 +43,10 @@ public class TCPServerBridgeConfiguration {
      * The Panel Poll Period. Can be set in range 1-15 minutes. Default is 1 minute;
      */
     public Integer pollPeriod;
+
+    /**
+     * The Protocol Type - 1 for IT-100 API or 2 for Envisalink TPI.
+     */
+    public Integer protocol;
+
 }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseBridgeHandler.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.dscalarm.handler;
 
-import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.BRIDGE_RESET;
+import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
@@ -19,12 +19,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.dscalarm.config.DSCAlarmPartitionConfiguration;
 import org.openhab.binding.dscalarm.config.DSCAlarmZoneConfiguration;
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
@@ -363,13 +365,13 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
                         handler.bridgeStatusChanged(getThing().getStatusInfo());
                     }
 
-                    if (handler.getDSCAlarmThingType().equals(DSCAlarmThingType.PANEL)) {
-                        if (panelThingHandler == null) {
-                            panelThingHandler = handler;
-                        }
-                    }
-
                     allThingsInitialized = false;
+                }
+
+                if (handler.getDSCAlarmThingType().equals(DSCAlarmThingType.PANEL)) {
+                    if (panelThingHandler == null) {
+                        panelThingHandler = handler;
+                    }
                 }
 
             } else {
@@ -467,6 +469,10 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
             DSCAlarmCode dscAlarmCode = DSCAlarmCode
                     .getDSCAlarmCodeValue(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
 
+            if (panelThingHandler != null) {
+                panelThingHandler.setPanelMessage(dscAlarmMessage);
+            }
+
             if (dscAlarmCode == DSCAlarmCode.LoginResponse) {
                 String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
                 if (dscAlarmMessageData.equals("3")) {
@@ -516,11 +522,6 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
                         if (thingHandler.isThingHandlerInitialized()) {
                             thingHandler.dscAlarmEventReceived(event, thing);
 
-                            if (panelThingHandler != null) {
-                                if (!thingHandler.equals(panelThingHandler)) {
-                                    panelThingHandler.dscAlarmEventReceived(event, thing);
-                                }
-                            }
                         } else {
                             logger.debug("handleIncomingMessage(): Thing '{}' Not Refreshed!", thing.getUID());
                         }
@@ -540,7 +541,13 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.warn("No bridge commands defined.");
+
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
+
+        if (command instanceof RefreshType) {
+            return;
+        }
+
         if (isConnected()) {
             switch (channelUID.getId()) {
                 case BRIDGE_RESET:
@@ -548,9 +555,64 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
                         disconnect();
                     }
                     break;
+                case SEND_COMMAND:
+                    if (!command.toString().isEmpty()) {
+                        String[] tokens = command.toString().split(",");
+
+                        String cmd = tokens[0];
+                        String data = "";
+                        if (tokens.length > 1) {
+                            data = tokens[1];
+                        }
+
+                        sendDSCAlarmCommand(cmd, data);
+
+                        updateState(channelUID, new StringType(""));
+                    }
+                    break;
                 default:
                     break;
             }
+        }
+    }
+
+    /**
+     * Method to send a sequence of key presses one at a time using the '070' command.
+     *
+     * @param keySequence
+     */
+    private boolean sendKeySequence(String keySequence) {
+        logger.debug("sendKeySequence(): Sending key sequence '{}'.", keySequence);
+
+        boolean sent = false;
+
+        for (char key : keySequence.toCharArray()) {
+            sent = sendCommand(DSCAlarmCode.KeyStroke, String.valueOf(key));
+
+            if (!sent) {
+                return sent;
+            }
+        }
+
+        return sent;
+    }
+
+    /**
+     * Sends a DSC Alarm command
+     *
+     * @param command
+     * @param data
+     */
+    public boolean sendDSCAlarmCommand(String command, String data) {
+        logger.debug("sendDSCAlarmCommand(): Attempting to send DSC Alarm Command: command - {} - data: {}", command,
+                data);
+
+        DSCAlarmCode dscAlarmCode = DSCAlarmCode.getDSCAlarmCodeValue(command);
+
+        if (dscAlarmProtocol.equals(DSCAlarmProtocol.IT100_API) && dscAlarmCode.equals(DSCAlarmCode.KeySequence)) {
+            return sendKeySequence(data);
+        } else {
+            return sendCommand(dscAlarmCode, data);
         }
     }
 
@@ -675,19 +737,12 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
                 validCommand = true;
                 break;
             case TriggerPanicAlarm: /* 060 */
-                if (dscAlarmData[0] == null || !dscAlarmData[0].matches("[1-8]")) {
-                    logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
-                            dscAlarmData[0]);
-                    break;
-                }
-
-                if (dscAlarmData[1] == null || !dscAlarmData[1].matches("[1-3]")) {
+                if (dscAlarmData[0] == null || !dscAlarmData[0].matches("[1-3]")) {
                     logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}",
                             dscAlarmData[1]);
                     break;
                 }
-                data = dscAlarmData[0] + dscAlarmData[1];
+                data = dscAlarmData[0];
                 validCommand = true;
                 break;
             case KeyStroke: /* 070 */

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseThingHandler.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.dscalarm.handler;
 
+import static org.openhab.binding.dscalarm.DSCAlarmBindingConstants.PANEL_MESSAGE;
+
 import java.util.EventObject;
 import java.util.List;
 
@@ -23,6 +25,9 @@ import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.dscalarm.config.DSCAlarmPanelConfiguration;
 import org.openhab.binding.dscalarm.config.DSCAlarmPartitionConfiguration;
 import org.openhab.binding.dscalarm.config.DSCAlarmZoneConfiguration;
+import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
+import org.openhab.binding.dscalarm.internal.DSCAlarmMessage;
+import org.openhab.binding.dscalarm.internal.DSCAlarmMessage.DSCAlarmMessageInfoType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -363,4 +368,25 @@ public abstract class DSCAlarmBaseThingHandler extends BaseThingHandler {
     public void setThingHandlerInitialized(boolean refreshed) {
         this.thingHandlerInitialized = refreshed;
     }
+
+    /**
+     * Method to set the panel message.
+     *
+     * @param dscAlarmMessage
+     */
+    public void setPanelMessage(DSCAlarmMessage dscAlarmMessage) {
+        ChannelUID channelUID = new ChannelUID(getThing().getUID(), PANEL_MESSAGE);
+        String message = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DESCRIPTION);
+        DSCAlarmCode dscAlarmCode = DSCAlarmCode
+                .getDSCAlarmCodeValue(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
+
+        if ((dscAlarmCode == DSCAlarmCode.CommandAcknowledge || dscAlarmCode == DSCAlarmCode.TimeDateBroadcast)
+                && getSuppressAcknowledgementMsgs()) {
+            return;
+        } else {
+            updateChannel(channelUID, 0, message);
+            logger.debug("setPanelMessage(): Panel Message Set to - {}", message);
+        }
+    }
+
 }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/EnvisalinkBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/EnvisalinkBridgeHandler.java
@@ -101,8 +101,8 @@ public class EnvisalinkBridgeHandler extends DSCAlarmBaseBridgeHandler {
             logger.debug("openConnection(): Connecting to Envisalink ");
 
             tcpSocket = new Socket();
-            SocketAddress TPIsocketAddress = new InetSocketAddress(ipAddress, tcpPort);
-            tcpSocket.connect(TPIsocketAddress, connectionTimeout);
+            SocketAddress tpiSocketAddress = new InetSocketAddress(ipAddress, tcpPort);
+            tcpSocket.connect(tpiSocketAddress, connectionTimeout);
             tcpOutput = new OutputStreamWriter(tcpSocket.getOutputStream(), "US-ASCII");
             tcpInput = new BufferedReader(new InputStreamReader(tcpSocket.getInputStream()));
 

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/KeypadThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/KeypadThingHandler.java
@@ -16,12 +16,10 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
 import org.openhab.binding.dscalarm.internal.DSCAlarmMessage;
 import org.openhab.binding.dscalarm.internal.DSCAlarmMessage.DSCAlarmMessageInfoType;
-//import org.openhab.binding.dscalarm.internal.DSCAlarmProperties.LEDStateType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +48,6 @@ public class KeypadThingHandler extends DSCAlarmBaseThingHandler {
     @Override
     public void updateChannel(ChannelUID channelUID, int state, String description) {
         logger.debug("updateChannel(): Keypad Channel UID: {}", channelUID);
-
-        // int state;
 
         if (channelUID != null) {
             switch (channelUID.getId()) {
@@ -91,14 +87,6 @@ public class KeypadThingHandler extends DSCAlarmBaseThingHandler {
                     break;
             }
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void handleCommand(ChannelUID channelUID, Command command) {
-        // No Commands to Handle
     }
 
     /**

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
@@ -84,8 +84,7 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
                     try {
                         date = sdfReceived.parse(description);
                     } catch (ParseException e) {
-                        logger.error(
-                                "updateChannel(): Parse Exception occurred while trying to parse date string: {}. ",
+                        logger.warn("updateChannel(): Parse Exception occurred while trying to parse date string: {}. ",
                                 e.getMessage());
                     }
 

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
 import org.openhab.binding.dscalarm.internal.DSCAlarmMessage;
@@ -48,6 +49,13 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
         super(thing);
         setDSCAlarmThingType(DSCAlarmThingType.PANEL);
     }
+
+    private static final int PANEL_COMMAND_POLL = 0;
+    private static final int PANEL_COMMAND_STATUS_REPORT = 1;
+    private static final int PANEL_COMMAND_LABELS_REQUEST = 2;
+    private static final int PANEL_COMMAND_DUMP_ZONE_TIMERS = 8;
+    private static final int PANEL_COMMAND_SET_TIME_DATE = 10;
+    private static final int PANEL_COMMAND_CODE_SEND = 200;
 
     /**
      * {@inheritDoc}
@@ -76,7 +84,8 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
                     try {
                         date = sdfReceived.parse(description);
                     } catch (ParseException e) {
-                        logger.error("updateChannel(): Parse Exception occurred while trying to parse date string: {}. ",
+                        logger.error(
+                                "updateChannel(): Parse Exception occurred while trying to parse date string: {}. ",
                                 e.getMessage());
                     }
 
@@ -180,44 +189,22 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (dscAlarmBridgeHandler == null) {
-            logger.warn("DSC Alarm bridge handler not available. Cannot handle command without bridge.");
+
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
+
+        if (command instanceof RefreshType) {
             return;
         }
 
-        int cmd;
+        if (dscAlarmBridgeHandler != null && dscAlarmBridgeHandler.isConnected()) {
 
-        boolean connected = dscAlarmBridgeHandler.isConnected();
+            int cmd;
 
-        if (connected) {
             switch (channelUID.getId()) {
                 case PANEL_COMMAND:
                     cmd = Integer.parseInt(command.toString());
-                    switch (cmd) {
-                        case 0:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.Poll);
-                            break;
-                        case 1:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.StatusReport);
-                            break;
-                        case 2:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.LabelsRequest);
-                            break;
-                        case 8:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.DumpZoneTimers);
-                            break;
-                        case 10:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.SetTimeDate);
-                            break;
-                        case 200:
-                            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.CodeSend, getUserCode());
-                            break;
-                        default:
-                            break;
-                    }
-
+                    handlePanelCommand(cmd);
                     updateState(channelUID, new StringType(String.valueOf(-1)));
-
                     break;
                 case PANEL_TIME_STAMP:
                     if (command instanceof OnOffType) {
@@ -240,13 +227,33 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
     }
 
     /**
-     * Method to set Channel PANEL_MESSAGE.
+     * Method to handle PANEL_COMMAND
      *
-     * @param message
+     * @param cmd
      */
-    private void setPanelMessage(String message) {
-        ChannelUID channelUID = new ChannelUID(getThing().getUID(), PANEL_MESSAGE);
-        updateChannel(channelUID, 0, message);
+    private void handlePanelCommand(int cmd) {
+        switch (cmd) {
+            case PANEL_COMMAND_POLL:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.Poll);
+                break;
+            case PANEL_COMMAND_STATUS_REPORT:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.StatusReport);
+                break;
+            case PANEL_COMMAND_LABELS_REQUEST:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.LabelsRequest);
+                break;
+            case PANEL_COMMAND_DUMP_ZONE_TIMERS:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.DumpZoneTimers);
+                break;
+            case PANEL_COMMAND_SET_TIME_DATE:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.SetTimeDate);
+                break;
+            case PANEL_COMMAND_CODE_SEND:
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.CodeSend, getUserCode());
+                break;
+            default:
+                break;
+        }
     }
 
     /**
@@ -416,7 +423,6 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
             DSCAlarmMessage dscAlarmMessage = dscAlarmEvent.getDSCAlarmMessage();
             String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
             setTimeStampState(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.TIME_STAMP));
-            boolean suppressPanelMsg = false;
 
             if (getThing() == thing) {
                 ChannelUID channelUID = null;
@@ -428,9 +434,6 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
 
                 switch (dscAlarmCode) {
                     case CommandAcknowledge: /* 500 */
-                        if (getSuppressAcknowledgementMsgs()) {
-                            suppressPanelMsg = true;
-                        }
                         break;
                     case SystemError: /* 502 */
                         int errorCode = Integer.parseInt(dscAlarmMessageData);
@@ -457,11 +460,6 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
 
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_TIME_BROADCAST);
                         updateChannel(channelUID, 1, "");
-
-                        if (getSuppressAcknowledgementMsgs()) {
-                            suppressPanelMsg = true;
-                        }
-
                         break;
                     case FireKeyAlarm: /* 621 */
                         state = 1;
@@ -558,10 +556,6 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
                     default:
                         break;
                 }
-            }
-
-            if (!suppressPanelMsg) {
-                setPanelMessage(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DESCRIPTION));
             }
         }
     }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PartitionThingHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
 import org.openhab.binding.dscalarm.internal.DSCAlarmMessage;
@@ -97,12 +98,15 @@ public class PartitionThingHandler extends DSCAlarmBaseThingHandler {
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (dscAlarmBridgeHandler == null) {
-            logger.warn("DSC Alarm bridge handler not available. Cannot handle command without bridge.");
+
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
+
+        if (command instanceof RefreshType) {
             return;
         }
 
-        if (dscAlarmBridgeHandler.isConnected()) {
+        if (dscAlarmBridgeHandler != null && dscAlarmBridgeHandler.isConnected()) {
+
             switch (channelUID.getId()) {
                 case PARTITION_ARM_MODE:
                     int partitionNumber = getPartitionNumber();

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/TCPServerBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/TCPServerBridgeHandler.java
@@ -47,6 +47,7 @@ public class TCPServerBridgeHandler extends DSCAlarmBaseBridgeHandler {
     private String ipAddress;
     private int tcpPort;
     private int connectionTimeout;
+    private int protocol;
     private Socket tcpSocket = null;
     private OutputStreamWriter tcpOutput = null;
     private BufferedReader tcpInput = null;
@@ -63,11 +64,18 @@ public class TCPServerBridgeHandler extends DSCAlarmBaseBridgeHandler {
             tcpPort = configuration.port.intValue();
             connectionTimeout = configuration.connectionTimeout.intValue();
             pollPeriod = configuration.pollPeriod.intValue();
+            protocol = configuration.protocol.intValue();
 
             if (this.pollPeriod > 15) {
                 this.pollPeriod = 15;
             } else if (this.pollPeriod < 1) {
                 this.pollPeriod = 1;
+            }
+
+            if (this.protocol == 2) {
+                setProtocol(DSCAlarmProtocol.ENVISALINK_TPI);
+            } else {
+                setProtocol(DSCAlarmProtocol.IT100_API);
             }
 
             logger.debug("TCP Server Bridge Handler Initialized");
@@ -100,8 +108,8 @@ public class TCPServerBridgeHandler extends DSCAlarmBaseBridgeHandler {
             logger.debug("openConnection(): Connecting to Envisalink ");
 
             tcpSocket = new Socket();
-            SocketAddress TPIsocketAddress = new InetSocketAddress(ipAddress, tcpPort);
-            tcpSocket.connect(TPIsocketAddress, connectionTimeout);
+            SocketAddress tpiSocketAddress = new InetSocketAddress(ipAddress, tcpPort);
+            tcpSocket.connect(tpiSocketAddress, connectionTimeout);
             tcpOutput = new OutputStreamWriter(tcpSocket.getOutputStream(), "US-ASCII");
             tcpInput = new BufferedReader(new InputStreamReader(tcpSocket.getInputStream()));
 

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/ZoneThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/ZoneThingHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
 import org.openhab.binding.dscalarm.internal.DSCAlarmMessage;
@@ -100,26 +101,24 @@ public class ZoneThingHandler extends DSCAlarmBaseThingHandler {
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (dscAlarmBridgeHandler == null) {
-            logger.warn("DSC Alarm bridge handler not available. Cannot handle command without bridge.");
+
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
+
+        if (command instanceof RefreshType) {
             return;
         }
 
-        if (dscAlarmBridgeHandler.isConnected()) {
-            switch (channelUID.getId()) {
-                case ZONE_BYPASS_MODE:
-                    if (command == OnOffType.OFF) {
-                        String data = String.valueOf(getPartitionNumber()) + "*1"
-                                + String.format("%02d", getZoneNumber()) + "#";
-                        dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
-                    } else if (command == OnOffType.ON) {
-                        String data = String.valueOf(getPartitionNumber()) + "*1"
-                                + String.format("%02d", getZoneNumber()) + "#";
-                        dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
-                    }
-                    break;
-                default:
-                    break;
+        if (dscAlarmBridgeHandler != null && dscAlarmBridgeHandler.isConnected()
+                && channelUID.getId() == ZONE_BYPASS_MODE) {
+
+            if (command == OnOffType.OFF) {
+                String data = String.valueOf(getPartitionNumber()) + "*1" + String.format("%02d", getZoneNumber())
+                        + "#";
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
+            } else if (command == OnOffType.ON) {
+                String data = String.valueOf(getPartitionNumber()) + "*1" + String.format("%02d", getZoneNumber())
+                        + "#";
+                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
             }
         }
     }

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmMessage.java
@@ -22,7 +22,7 @@ public class DSCAlarmMessage {
 
     private final Logger logger = LoggerFactory.getLogger(DSCAlarmMessage.class);
 
-    private static final EnumMap<DSCAlarmCode, MessageParameters> dscAlarmMessageParameters = new EnumMap<>(
+    private static final EnumMap<DSCAlarmCode, MessageParameters> DSCALARM_MESSAGE_PARAMETERS = new EnumMap<>(
             DSCAlarmCode.class);
 
     public enum DSCAlarmMessageType {
@@ -103,7 +103,7 @@ public class DSCAlarmMessage {
                 name = dscAlarmCode.getName();
                 description = dscAlarmCode.getDescription();
 
-                MessageParameters messageParms = dscAlarmMessageParameters.get(dscAlarmCode);
+                MessageParameters messageParms = DSCALARM_MESSAGE_PARAMETERS.get(dscAlarmCode);
 
                 if (messageParms != null) {
                     boolean hasPartition = messageParms.hasPartition();
@@ -405,201 +405,201 @@ public class DSCAlarmMessage {
     }
 
     static {
-        dscAlarmMessageParameters.put(DSCAlarmCode.CommandAcknowledge,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.CommandAcknowledge,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.CommandError,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.CommandError,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SystemError,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SystemError,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.LoginResponse,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.LoginResponse,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.KeypadLEDState,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.KeypadLEDState,
                 new MessageParameters(DSCAlarmMessageType.KEYPAD_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.KeypadLEDFlashState,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.KeypadLEDFlashState,
                 new MessageParameters(DSCAlarmMessageType.KEYPAD_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TimeDateBroadcast,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TimeDateBroadcast,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.RingDetected,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.RingDetected,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.IndoorTemperatureBroadcast,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.IndoorTemperatureBroadcast,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.OutdoorTemperatureBroadcast,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.OutdoorTemperatureBroadcast,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ThermostatSetPoints,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ThermostatSetPoints,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.BroadcastLabels,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.BroadcastLabels,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.BaudRateSet,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.BaudRateSet,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
 
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneAlarm,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, true, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneAlarmRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneAlarmRestore,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, true, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneTamper,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneTamper,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, true, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneTamperRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneTamperRestore,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, true, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneFault,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneFault,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneFaultRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneFaultRestore,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneOpen,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneOpen,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ZoneRestored,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ZoneRestored,
                 new MessageParameters(DSCAlarmMessageType.ZONE_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.EnvisalinkZoneTimerDump,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.EnvisalinkZoneTimerDump,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.DuressAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.DuressAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FireKeyAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FireKeyAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FireKeyRestored,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FireKeyRestored,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.AuxiliaryKeyAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.AuxiliaryKeyAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.AuxiliaryKeyRestored,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.AuxiliaryKeyRestored,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanicKeyAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanicKeyAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanicKeyRestored,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanicKeyRestored,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.AuxiliaryInputAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.AuxiliaryInputAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.AuxiliaryInputAlarmRestored,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.AuxiliaryInputAlarmRestored,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionReady,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionReady,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionNotReady,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionNotReady,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionArmed,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionArmed,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionReadyForceArming,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionReadyForceArming,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionInAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionInAlarm,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionDisarmed,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionDisarmed,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ExitDelayInProgress,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ExitDelayInProgress,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.EntryDelayInProgress,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.EntryDelayInProgress,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.KeypadLockout,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.KeypadLockout,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionFailedToArm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionFailedToArm,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PGMOutputInProgress,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PGMOutputInProgress,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ChimeEnabled,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ChimeEnabled,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ChimeDisabled,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ChimeDisabled,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.InvalidAccessCode,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.InvalidAccessCode,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FunctionNotAvailable,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FunctionNotAvailable,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FailureToArm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FailureToArm,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartitionBusy,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartitionBusy,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SystemArmingInProgress,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SystemArmingInProgress,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SystemInInstallerMode,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SystemInInstallerMode,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
 
-        dscAlarmMessageParameters.put(DSCAlarmCode.UserClosing,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.UserClosing,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SpecialClosing,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SpecialClosing,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PartialClosing,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PartialClosing,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.UserOpening,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.UserOpening,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SpecialOpening,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SpecialOpening,
                 new MessageParameters(DSCAlarmMessageType.PARTITION_EVENT, true, false));
 
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanelBatteryTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanelBatteryTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanelBatteryTroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanelBatteryTroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanelACTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanelACTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.PanelACRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.PanelACRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SystemBellTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SystemBellTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SystemBellTroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SystemBellTroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TLMLine1Trouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TLMLine1Trouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TLMLine1TroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TLMLine1TroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TLMLine2Trouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TLMLine2Trouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TLMLine2TroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TLMLine2TroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FTCTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FTCTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.BufferNearFull,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.BufferNearFull,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.GeneralDeviceLowBattery,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.GeneralDeviceLowBattery,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.GeneralDeviceLowBatteryRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.GeneralDeviceLowBatteryRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.WirelessKeyLowBatteryTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.WirelessKeyLowBatteryTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.WirelessKeyLowBatteryTroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.WirelessKeyLowBatteryTroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.HandheldKeypadLowBatteryTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.HandheldKeypadLowBatteryTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.HandheldKeypadLowBatteryTroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.HandheldKeypadLowBatteryTroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, true));
-        dscAlarmMessageParameters.put(DSCAlarmCode.GeneralSystemTamper,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.GeneralSystemTamper,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.GeneralSystemTamperRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.GeneralSystemTamperRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.HomeAutomationTrouble,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.HomeAutomationTrouble,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.HomeAutomationTroubleRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.HomeAutomationTroubleRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TroubleLEDOn,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TroubleLEDOn,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.TroubleLEDOff,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.TroubleLEDOff,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, true, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FireTroubleAlarm,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FireTroubleAlarm,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.FireTroubleAlarmRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.FireTroubleAlarmRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.VerboseTroubleStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.VerboseTroubleStatus,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.KeybusFault,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.KeybusFault,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.KeybusFaultRestore,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.KeybusFaultRestore,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
 
-        dscAlarmMessageParameters.put(DSCAlarmCode.CodeRequired,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.CodeRequired,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.LCDUpdate,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.LCDUpdate,
                 new MessageParameters(DSCAlarmMessageType.KEYPAD_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.LCDCursor,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.LCDCursor,
                 new MessageParameters(DSCAlarmMessageType.KEYPAD_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.LEDStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.LEDStatus,
                 new MessageParameters(DSCAlarmMessageType.KEYPAD_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.BeepStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.BeepStatus,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.ToneStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.ToneStatus,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.BuzzerStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.BuzzerStatus,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.DoorChimeStatus,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.DoorChimeStatus,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.SoftwareVersion,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.SoftwareVersion,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.CommandOutputPressed,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.CommandOutputPressed,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.MasterCodeRequired,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.MasterCodeRequired,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
-        dscAlarmMessageParameters.put(DSCAlarmCode.InstallersCodeRequired,
+        DSCALARM_MESSAGE_PARAMETERS.put(DSCAlarmCode.InstallersCodeRequired,
                 new MessageParameters(DSCAlarmMessageType.PANEL_EVENT, false, false));
     }
 }


### PR DESCRIPTION
This is a re-submission of PR [#2057](https://github.com/openhab/openhab2-addons/pull/2057).
 
Fixes:
* Fixed 'DSC Alarm bridge handler not available. Cannot handle command
without bridge.' error upon binding startup
* The binding was not sending all received messages to the channel
panel_message. This is fixed.
* Fixed DSC Alarm command 060 not working.
* Fixed some errors found by the Static Code Analysis Tool

Enhancements:
* Added send_command channel to allow for sending DSC commands.
* Ability to select the protocol type when using the TCPServer bridge.
* Modified and cleaned up README.md.

Signed-off-by: Russell Stephens rsstephens@gmail.com (github:
RSStephens)