### PR TITLE
Removed the unsupported MACROMAN encoding

### DIFF
--- a/addons/ui/pom.xml
+++ b/addons/ui/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="MACROMAN"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="MACROMAN"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>


### PR DESCRIPTION
Currently the static analysis fail because of the following error:

```
[ERROR] Failed to execute goal org.openhab.tools:static-code-analysis:0.0.6:checkstyle (default) on project org.openhab.ui.cometvisu: Unable to execute mojo: An error has occurred in Checkstyle report generation. Failed during checkstyle configuration: Exception was thrown while processing /home/travis/build/openhab/openhab2-addons/addons/ui/org.openhab.ui.cometvisu/pom.xml: Unable to read from file: /home/travis/build/openhab/openhab2-addons/addons/ui/pom.xml: Invalid encoding name "MACROMAN". -> [Help 1]
```

This PR resolves this.
