### PR TITLE
[milight] Fix brightness and colour temperature for V3 white bulbs

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3White.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3White.java
@@ -51,6 +51,7 @@ public class MilightV3White extends MilightV3 {
             sendQueue.queueRepeatable(uidc(CAT_POWER_SET), new byte[] { command_on[zone], 0x00, 0x55 });
         } else {
             sendQueue.queueRepeatable(uidc(CAT_POWER_SET), new byte[] { command_off[zone], 0x00, 0x55 });
+            state.brightness = 0;
         }
     }
 
@@ -104,17 +105,17 @@ public class MilightV3White extends MilightV3 {
         state.colorTemperature = Math.min(100, Math.max(state.colorTemperature + color_temp_relative, 0));
         final byte c_on[] = { command_on[zone], 0x00, 0x55 };
         final byte c_temp[] = { (byte) (color_temp_relative > 0 ? 0x3E : 0x3F), 0x00, 0x55 };
-        sendQueue.queue(QueueItem.createRepeatable(uidc(CAT_COLOR_SET), c_on).addNonRepeatable(c_temp));
+        sendQueue.queue(QueueItem.createRepeatable(c_on).addNonRepeatable(c_temp));
     }
 
     // This just emulates an absolute brightness command with the relative commands.
     @Override
     public void setBrightness(int value, MilightThingState state) {
         if (value <= 0) {
-            sendQueue.queueRepeatable(uidc(CAT_POWER_SET), new byte[] { command_off[zone], 0x00, 0x55 });
+            setPower(false, state);
             return;
         } else if (value >= 100) {
-            sendQueue.queueRepeatable(uidc(CAT_BRIGHTNESS_SET), new byte[] { command_full[zone], 0x00, 0x55 });
+            setFull(zone, state);
             return;
         }
 


### PR DESCRIPTION
Fixes issues with the setting of brightness and colour temperature for V3 white bulbs:

1. When setting the brightness to 0% or 100% the internal state was not updated which would result in subsequent brightness settings applying the wrong number of increments.
2. Queued colour temperature increments were being removed from the queue resulting in a smaller than expected change in colour temperature.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>
