### PR TITLE
[SamsungTV] support manual configured tv

### DIFF
--- a/addons/binding/org.openhab.binding.samsungtv/README.md
+++ b/addons/binding/org.openhab.binding.samsungtv/README.md
@@ -8,10 +8,11 @@ Samsung TV C (2010), D (2011), E (2012) and F (2013) models should be supported.
 
 Tested TV models:
 
-| Model     | State | Notes |
-|-----------|-------|--------------------------------------------------------------------|
-| UE46E5505 | OK | Initial contribution is done by this model |
-| UE40F6500 | OK | All channels except `colorTemperature`, `programTitle` and `channelName` are working |
+| Model     | State   | Notes                                                                                |
+|-----------|---------|--------------------------------------------------------------------------------------|
+| UE46E5505 | OK      | Initial contribution is done by this model                                           |
+| UE46D5700 | PARTIAL | Supports at my home only commands via the fake remote, no discovery                  |
+| UE40F6500 | OK      | All channels except `colorTemperature`, `programTitle` and `channelName` are working |
 
 
 ## Discovery
@@ -36,24 +37,23 @@ Thing samsungtv:tv:livingroom [ hostName="192.168.1.10", port=55000, refreshInte
 
 TV's support the following channels:
 
-| Channel Type ID | Item Type    | Description  |
-|-----------------|------------------------|--------------|
-| volume | Dimmer | Volume level of the TV. |
-| mute | Switch | Mute state of the TV. |
-| brightness | Dimmer | Brightness of the TV picture. |
-| contrast | Dimmer | Contrast of the TV picture. |
-| sharpness | Dimmer | Sharpness of the TV picture. |
-| colorTemperature | Number | Color temperature of the TV picture. Minimum value is 0 and maximum 4. |
-| sourceName | String | Name of the current source. |
-| sourceId | Number | Id of the current source. |
-| channel | Number | Selected TV channel number. |
-| programTitle | String | Program title of the current channel. |
-| channelName | String | Name of the current TV channel. |
-| url | String | Start TV web browser and go the given web page. |
-| stopBrowser | Switch | Stop TV's web browser and go back to TV mode. |
-| power | Switch | TV power. Some of the Samsung TV models doesn't allow to set Power ON remotely. |
-| keyCode | String | The key code channel emulates the infrared remote controller and allows to send virtual button presses. |
-
+| Channel Type ID  | Item Type | Description                                                                                             |
+|------------------|-----------|---------------------------------------------------------------------------------------------------------|
+| volume           | Dimmer    | Volume level of the TV.                                                                                 |
+| mute             | Switch    | Mute state of the TV.                                                                                   |
+| brightness       | Dimmer    | Brightness of the TV picture.                                                                           |
+| contrast         | Dimmer    | Contrast of the TV picture.                                                                             |
+| sharpness        | Dimmer    | Sharpness of the TV picture.                                                                            |
+| colorTemperature | Number    | Color temperature of the TV picture. Minimum value is 0 and maximum 4.                                  |
+| sourceName       | String    | Name of the current source.                                                                             |
+| sourceId         | Number    | Id of the current source.                                                                               |
+| channel          | Number    | Selected TV channel number.                                                                             |
+| programTitle     | String    | Program title of the current channel.                                                                   |
+| channelName      | String    | Name of the current TV channel.                                                                         |
+| url              | String    | Start TV web browser and go the given web page.                                                         |
+| stopBrowser      | Switch    | Stop TV's web browser and go back to TV mode.                                                           |
+| power            | Switch    | TV power. Some of the Samsung TV models doesn't allow to set Power ON remotely.                         |
+| keyCode          | String    | The key code channel emulates the infrared remote controller and allows to send virtual button presses. |
 
 E.g.
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/handler/SamsungTvHandler.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/handler/SamsungTvHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
 import org.jupnp.UpnpService;
+import org.jupnp.model.meta.Device;
 import org.jupnp.model.meta.LocalDevice;
 import org.jupnp.model.meta.RemoteDevice;
 import org.jupnp.registry.Registry;
@@ -151,13 +152,7 @@ public class SamsungTvHandler extends BaseThingHandler implements DiscoveryListe
      * Media Renderer UPnP device. This polling job tries to find another UPnP
      * devices related to same Samsung TV and create handler for those.
      */
-    private Runnable scanUPnPDevicesRunnable = new Runnable() {
-
-        @Override
-        public void run() {
-            checkAndCreateServices();
-        }
-    };
+    private Runnable scanUPnPDevicesRunnable = this::checkAndCreateServices;
 
     @Override
     public void initialize() {
@@ -283,7 +278,7 @@ public class SamsungTvHandler extends BaseThingHandler implements DiscoveryListe
     @Override
     public synchronized void valueReceived(String variable, State value) {
         logger.debug("Received value '{}':'{}' for thing '{}'",
-                new Object[] { variable, value, this.getThing().getUID() });
+                variable, value, this.getThing().getUID());
 
         updateState(new ChannelUID(getThing().getUID(), variable), value);
 
@@ -295,10 +290,9 @@ public class SamsungTvHandler extends BaseThingHandler implements DiscoveryListe
 
     private void checkAndCreateServices() {
         logger.debug("Check and create missing UPnP services");
-        Iterator<?> itr = upnpService.getRegistry().getDevices().iterator();
 
-        while (itr.hasNext()) {
-            RemoteDevice device = (RemoteDevice) itr.next();
+        for (Device o : upnpService.getRegistry().getDevices()) {
+            RemoteDevice device = (RemoteDevice) o;
             createService(device);
         }
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/config/SamsungTvConfiguration.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/config/SamsungTvConfiguration.java
@@ -8,8 +8,10 @@
  */
 package org.openhab.binding.samsungtv.internal.config;
 
+import org.openhab.binding.samsungtv.handler.SamsungTvHandler;
+
 /**
- * Configuration class for {@link SamsungTvBinding} device.
+ * Configuration class for {@link SamsungTvHandler}.
  *
  * @author Pauli Anttila - Initial contribution
  */

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/discovery/SamsungTvDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/discovery/SamsungTvDiscoveryParticipant.java
@@ -32,8 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Pauli Anttila - Initial contribution
  */
 public class SamsungTvDiscoveryParticipant implements UpnpDiscoveryParticipant {
-
-    private Logger logger = LoggerFactory.getLogger(SamsungTvDiscoveryParticipant.class);
+    private final Logger logger = LoggerFactory.getLogger(SamsungTvDiscoveryParticipant.class);
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
@@ -44,16 +43,12 @@ public class SamsungTvDiscoveryParticipant implements UpnpDiscoveryParticipant {
     public DiscoveryResult createResult(RemoteDevice device) {
         ThingUID uid = getThingUID(device);
         if (uid != null) {
-            Map<String, Object> properties = new HashMap<>(3);
-            String label = "Samsung TV";
-            try {
-                label = device.getDetails().getFriendlyName();
-            } catch (Exception e) {
-                // ignore and use the default label
-            }
+            Map<String, Object> properties = new HashMap<>();
             properties.put(HOST_NAME, device.getIdentity().getDescriptorURL().getHost());
 
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid)
+                    .withProperties(properties)
+                    .withLabel(getLabel(device))
                     .build();
 
             logger.debug("Created a DiscoveryResult for device '{}' with UDN '{}'",
@@ -65,13 +60,23 @@ public class SamsungTvDiscoveryParticipant implements UpnpDiscoveryParticipant {
         }
     }
 
+    private String getLabel(RemoteDevice device) {
+        String label = "Samsung TV";
+        try {
+            label = device.getDetails().getFriendlyName();
+        } catch (Exception e) {
+            // ignore and use the default label
+        }
+        return label;
+    }
+
     @Override
     public ThingUID getThingUID(RemoteDevice device) {
         if (device != null) {
 
             String manufacturer = device.getDetails().getManufacturerDetails().getManufacturer();
             String modelName = device.getDetails().getModelDetails().getModelName();
-            String friedlyName = device.getDetails().getFriendlyName();
+            String friendlyName = device.getDetails().getFriendlyName();
 
             if (manufacturer != null && modelName != null) {
 
@@ -85,8 +90,7 @@ public class SamsungTvDiscoveryParticipant implements UpnpDiscoveryParticipant {
                     // device and ignore rest of the UPnP devices.
 
                     if (device.getType().getType().equals("MediaRenderer")) {
-
-                        logger.debug("Discovered a Samsung TV '{}' model '{}' thing with UDN '{}'", friedlyName,
+                        logger.debug("Discovered a Samsung TV '{}' model '{}' thing with UDN '{}'", friendlyName,
                                 modelName, udn);
 
                         return new ThingUID(SAMSUNG_TV_THING_TYPE, udn);

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/KeyCode.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/KeyCode.java
@@ -265,17 +265,17 @@ public enum KeyCode {
     KEY_ZOOM_MOVE,
     KEY_ZOOM_OUT;
 
-    private String value;
+    private final String value;
 
-    private KeyCode() {
+    KeyCode() {
         value = null;
     }
 
-    private KeyCode(String value) {
+    KeyCode(String value) {
         this.value = value;
     }
 
-    private KeyCode(KeyCode otherKey) {
+    KeyCode(KeyCode otherKey) {
         this(otherKey.getValue());
     }
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteController.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteController.java
@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
  */
 public class RemoteController {
 
-    private Logger logger = LoggerFactory.getLogger(RemoteController.class);
+    private static final int CONNECTION_TIMEOUT = 500;
+
+    private final Logger logger = LoggerFactory.getLogger(RemoteController.class);
 
     // Access granted response
     private final char[] ACCESS_GRANTED_RESP = new char[] { 0x64, 0x00, 0x01, 0x00 };
@@ -53,8 +55,6 @@ public class RemoteController {
     private final char[] ACCESS_TIMEOUT_RESP = new char[] { 0x65, 0x00 };
 
     private final String APP_STRING = "iphone.iapp.samsung";
-
-    private final int TIMEOUT = 5000;
 
     private String host;
     private int port;
@@ -90,7 +90,7 @@ public class RemoteController {
 
         socket = new Socket();
         try {
-            socket.connect(new InetSocketAddress(host, port), TIMEOUT);
+            socket.connect(new InetSocketAddress(host, port), CONNECTION_TIMEOUT);
         } catch (Exception e) {
             throw new RemoteControllerException("Connection failed", e);
         }
@@ -271,11 +271,7 @@ public class RemoteController {
     }
 
     private boolean isConnected() {
-        if (socket == null || socket.isClosed() || !socket.isConnected()) {
-            return false;
-        } else {
-            return true;
-        }
+        return socket != null && !socket.isClosed() && socket.isConnected();
     }
 
     private String createRegistrationPayload(String ip) throws IOException {

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteControllerException.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteControllerException.java
@@ -17,10 +17,6 @@ public class RemoteControllerException extends Exception {
 
     private static final long serialVersionUID = -5292218577704635666L;
 
-    public RemoteControllerException() {
-        super();
-    }
-
     public RemoteControllerException(String message) {
         super(message);
     }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/DataConverters.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/DataConverters.java
@@ -34,9 +34,7 @@ public class DataConverters {
      * @return
      */
     public static int convertCommandToIntValue(Command command, int min, int max, int currentValue) {
-        if (command instanceof IncreaseDecreaseType || command instanceof DecimalType
-                || command instanceof PercentType) {
-
+        if (command instanceof IncreaseDecreaseType || command instanceof DecimalType) {
             int value;
             if (command instanceof IncreaseDecreaseType && command == IncreaseDecreaseType.INCREASE) {
                 value = Math.min(max, currentValue + 1);

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
@@ -10,7 +10,6 @@ package org.openhab.binding.samsungtv.internal.service;
 
 import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,8 +28,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
-import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.openhab.binding.samsungtv.internal.service.api.EventListener;
+import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -114,8 +113,8 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
     }
 
     @Override
-    public boolean isManual() {
-        return false;
+    public boolean isUpnp() {
+        return true;
     }
 
     private Runnable pollingRunnable = new Runnable() {

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -23,12 +24,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
 import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
-import org.openhab.binding.samsungtv.internal.service.api.ValueReceiver;
+import org.openhab.binding.samsungtv.internal.service.api.EventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -58,7 +60,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
 
     private Map<String, String> stateMap = Collections.synchronizedMap(new HashMap<String, String>());
 
-    private List<ValueReceiver> listeners = new ArrayList<ValueReceiver>();
+    private List<EventListener> listeners = new CopyOnWriteArrayList<>();
 
     public MainTVServerService(UpnpIOService upnpIOService, String udn, int pollingInterval) {
         logger.debug("Create a Samsung TV MainTVServer service");
@@ -76,22 +78,17 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
     }
 
     @Override
-    public String getServiceName() {
-        return SERVICE_NAME;
-    }
-
-    @Override
     public List<String> getSupportedChannelNames() {
         return supportedCommands;
     }
 
     @Override
-    public void addEventListener(ValueReceiver listener) {
+    public void addEventListener(EventListener listener) {
         listeners.add(listener);
     }
 
     @Override
-    public void removeEventListener(ValueReceiver listener) {
+    public void removeEventListener(EventListener listener) {
         listeners.remove(listener);
     }
 
@@ -116,6 +113,11 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
         stateMap.clear();
     }
 
+    @Override
+    public boolean isManual() {
+        return false;
+    }
+
     private Runnable pollingRunnable = new Runnable() {
 
         @Override
@@ -130,7 +132,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
 
                     updateResourceState("MainTVAgent2", "GetCurrentBrowserURL", null);
                 } catch (Exception e) {
-                    logger.debug("Exception during poll : {}", e);
+                    reportError("Error occurred during poll", e);
                 }
             }
         }
@@ -183,7 +185,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
 
         stateMap.put(variable, value);
 
-        for (ValueReceiver listener : listeners) {
+        for (EventListener listener : listeners) {
 
             switch (variable) {
                 case "ProgramTitle":
@@ -249,7 +251,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
                     SamsungTvUtils.buildHashMap("Source", source, "ID", id, "UiID", "0"));
 
             if (result.get("Result").equals("OK")) {
-                logger.debug("Command succesfully executed");
+                logger.debug("Command successfully executed");
             } else {
                 logger.error("Command execution failed, result='{}'", result.get("Result"));
             }
@@ -264,7 +266,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
                 SamsungTvUtils.buildHashMap("BrowserURL", command.toString()));
 
         if (result.get("Result").equals("OK")) {
-            logger.debug("Command succesfully executed");
+            logger.debug("Command successfully executed");
         } else {
             logger.error("Command execution failed, result='{}'", result.get("Result"));
         }
@@ -275,7 +277,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
         Map<String, String> result = updateResourceState("MainTVAgent2", "StopBrowser", null);
 
         if (result.get("Result").equals("OK")) {
-            logger.debug("Command succesfully executed");
+            logger.debug("Command successfully executed");
         } else {
             logger.error("Command execution failed, result='{}'", result.get("Result"));
         }
@@ -340,5 +342,11 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
     @Override
     public void onStatusChanged(boolean status) {
         logger.debug("onStatusChanged: status={}", status);
+    }
+
+    private void reportError(String message, Throwable e) {
+        for (EventListener listener : listeners) {
+            listener.reportError(ThingStatusDetail.COMMUNICATION_ERROR, message, e);
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -24,13 +25,15 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
+import org.openhab.binding.samsungtv.internal.protocol.RemoteControllerException;
 import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
-import org.openhab.binding.samsungtv.internal.service.api.ValueReceiver;
+import org.openhab.binding.samsungtv.internal.service.api.EventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +61,7 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
 
     private Map<String, String> stateMap = Collections.synchronizedMap(new HashMap<String, String>());
 
-    private List<ValueReceiver> listeners = new ArrayList<ValueReceiver>();
+    private List<EventListener> listeners = new CopyOnWriteArrayList<>();
 
     public MediaRendererService(UpnpIOService upnpIOService, String udn, int pollingInterval) {
         logger.debug("Create a Samsung TV MediaRenderer service");
@@ -76,22 +79,17 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
     }
 
     @Override
-    public String getServiceName() {
-        return SERVICE_NAME;
-    }
-
-    @Override
     public List<String> getSupportedChannelNames() {
         return supportedCommands;
     }
 
     @Override
-    public void addEventListener(ValueReceiver listener) {
+    public void addEventListener(EventListener listener) {
         listeners.add(listener);
     }
 
     @Override
-    public void removeEventListener(ValueReceiver listener) {
+    public void removeEventListener(EventListener listener) {
         listeners.remove(listener);
     }
 
@@ -116,6 +114,11 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
         stateMap.clear();
     }
 
+    @Override
+    public boolean isManual() {
+        return false;
+    }
+
     private Runnable pollingRunnable = new Runnable() {
 
         @Override
@@ -137,7 +140,7 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
                             SamsungTvUtils.buildHashMap("InstanceID", "0"));
 
                 } catch (Exception e) {
-                    logger.debug("Exception during poll : {}", e);
+                    reportError("Error occurred during poll", e);
                 }
             }
         }
@@ -195,7 +198,7 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
 
         stateMap.put(variable, value);
 
-        for (ValueReceiver listener : listeners) {
+        for (EventListener listener : listeners) {
             switch (variable) {
                 case "CurrentVolume":
                     listener.valueReceived(VOLUME, (value != null) ? new PercentType(value) : UnDefType.UNDEF);
@@ -341,5 +344,11 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
     @Override
     public void onStatusChanged(boolean status) {
         logger.debug("onStatusChanged");
+    }
+
+    private void reportError(String message, Throwable e) {
+        for (EventListener listener : listeners) {
+            listener.reportError(ThingStatusDetail.COMMUNICATION_ERROR, message, e);
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MediaRendererService.java
@@ -10,7 +10,6 @@ package org.openhab.binding.samsungtv.internal.service;
 
 import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,9 +30,8 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
-import org.openhab.binding.samsungtv.internal.protocol.RemoteControllerException;
-import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.openhab.binding.samsungtv.internal.service.api.EventListener;
+import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,8 +113,8 @@ public class MediaRendererService implements UpnpIOParticipant, SamsungTvService
     }
 
     @Override
-    public boolean isManual() {
-        return false;
+    public boolean isUpnp() {
+        return true;
     }
 
     private Runnable pollingRunnable = new Runnable() {

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
@@ -8,63 +8,81 @@
  */
 package org.openhab.binding.samsungtv.internal.service;
 
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.CHANNEL;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.KEY_CODE;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.MUTE;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.POWER;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.VOLUME;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.samsungtv.internal.protocol.KeyCode;
 import org.openhab.binding.samsungtv.internal.protocol.RemoteController;
 import org.openhab.binding.samsungtv.internal.protocol.RemoteControllerException;
 import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
-import org.openhab.binding.samsungtv.internal.service.api.ValueReceiver;
+import org.openhab.binding.samsungtv.internal.service.api.EventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The {@link RemoteControllerService} is responsible for handling remote
  * controller commands.
  *
  * @author Pauli Anttila - Initial contribution
+ * @author Martin van Wingerden - Some changes for manually configured devices
  */
 public class RemoteControllerService implements SamsungTvService {
 
-    public static final String SERVICE_NAME = "RemoteControlReceiver";
-    private final List<String> supportedCommands = Arrays.asList(KEY_CODE, POWER, CHANNEL);
-
     private Logger logger = LoggerFactory.getLogger(RemoteControllerService.class);
+
+    static final String SERVICE_NAME = "RemoteControlReceiver";
+
+    private final List<String> supportedCommandsDiscovered = Arrays.asList(KEY_CODE, POWER, CHANNEL);
+    private final List<String> supportedCommandsManual = Arrays.asList(KEY_CODE, VOLUME, MUTE, POWER, CHANNEL);
 
     private String host;
     private int port;
+    private boolean manual;
 
-    public RemoteControllerService(String host, int port) {
+    private List<EventListener> listeners = new CopyOnWriteArrayList<>();
+
+    private RemoteControllerService(String host, int port, boolean manual) {
         logger.debug("Create a Samsung TV RemoteController service");
+        this.manual = manual;
         this.host = host;
         this.port = port;
     }
 
-    @Override
-    public String getServiceName() {
-        return SERVICE_NAME;
+    static RemoteControllerService createDiscoveredService(String host, int port) {
+        return new RemoteControllerService(host, port, false);
+    }
+
+    public static RemoteControllerService createManualService(String host, int port) {
+        return new RemoteControllerService(host, port, true);
     }
 
     @Override
     public List<String> getSupportedChannelNames() {
-        return supportedCommands;
+        return manual ? supportedCommandsManual : supportedCommandsDiscovered;
     }
 
     @Override
-    public void addEventListener(ValueReceiver listener) {
-        // This service does not send any value updates
+    public void addEventListener(EventListener listener) {
+        listeners.add(listener);
     }
 
     @Override
-    public void removeEventListener(ValueReceiver listener) {
+    public void removeEventListener(EventListener listener) {
+        listeners.remove(listener);
     }
 
     @Override
@@ -81,6 +99,11 @@ public class RemoteControllerService implements SamsungTvService {
     }
 
     @Override
+    public boolean isManual() {
+        return manual;
+    }
+
+    @Override
     public void handleCommand(String channel, Command command) {
         logger.debug("Received channel: {}, command: {}", channel, command);
 
@@ -92,11 +115,10 @@ public class RemoteControllerService implements SamsungTvService {
 
                     try {
                         key = KeyCode.valueOf(command.toString().toUpperCase());
-                    } catch (Exception e) {
-
+                    } catch (IllegalArgumentException e) {
                         try {
                             key = KeyCode.valueOf("KEY_" + command.toString().toUpperCase());
-                        } catch (Exception e2) {
+                        } catch (IllegalArgumentException e2) {
                             // do nothing, error message is logged later
                         }
                     }
@@ -115,6 +137,20 @@ public class RemoteControllerService implements SamsungTvService {
                         sendKeyCode(KeyCode.KEY_POWERON);
                     } else {
                         sendKeyCode(KeyCode.KEY_POWEROFF);
+                    }
+                }
+                break;
+
+            case MUTE:
+                sendKeyCode(KeyCode.KEY_MUTE);
+                break;
+
+            case VOLUME:
+                if (command instanceof UpDownType) {
+                    if (command.equals(UpDownType.UP)) {
+                        sendKeyCode(KeyCode.KEY_VOLUP);
+                    } else {
+                        sendKeyCode(KeyCode.KEY_VOLDOWN);
                     }
                 }
                 break;
@@ -148,46 +184,63 @@ public class RemoteControllerService implements SamsungTvService {
 
     /**
      * Sends a command to Samsung TV device.
-     * 
+     *
      * @param key Button code to send
      */
     private void sendKeyCode(final KeyCode key) {
-
         if (host != null) {
-
-            RemoteController remoteController = new RemoteController(host, port, "openHAB2", "openHAB2");
-
             try {
-                remoteController.sendKey(key);
-
+                getRemoteController().sendKey(key);
             } catch (RemoteControllerException e) {
-                logger.error("Could not send command to device on {}: {}", host + ":" + port, e);
+                reportError(String.format("Could not send command to device on %s:%d", host, port), e);
             }
         } else {
-            logger.error("TV network address not defined");
+            reportError(ThingStatusDetail.CONFIGURATION_ERROR, "TV network address not defined");
         }
     }
 
     /**
      * Sends a sequence of command to Samsung TV device.
-     * 
+     *
      * @param keys List of button codes to send
      */
     private void sendKeyCodes(final List<KeyCode> keys) {
-
         if (host != null) {
-
-            RemoteController remoteController = new RemoteController(host, port, "openHAB2", "openHAB2");
-
             try {
-                remoteController.sendKeys(keys);
-
+                getRemoteController().sendKeys(keys);
             } catch (RemoteControllerException e) {
-                logger.error("Could not send command(s) to device on {}: {}", host + ":" + port, e);
+                reportError(String.format("Could not send command to device on %s:%d", host, port), e);
             }
         } else {
-            logger.error("TV network address not defined");
+            reportError(ThingStatusDetail.CONFIGURATION_ERROR, "TV network address not defined");
         }
     }
 
+    private void reportError(ThingStatusDetail statusDetail, String message) {
+        reportError(statusDetail, message, null);
+    }
+
+    private void reportError(String message, RemoteControllerException e) {
+        reportError(ThingStatusDetail.COMMUNICATION_ERROR, message, e);
+    }
+
+    private void reportError(ThingStatusDetail statusDetail, String message, RemoteControllerException e) {
+        for (EventListener listener : listeners) {
+            listener.reportError(statusDetail, message, e);
+        }
+    }
+
+    public boolean checkConnection() {
+        try {
+            getRemoteController().openConnection();
+            return true;
+        } catch (RemoteControllerException e) {
+            logger.trace("Failed opening connection, check failed", e);
+            return false;
+        }
+    }
+
+    private RemoteController getRemoteController() {
+        return new RemoteController(host, port, "openHAB", "openHAB");
+    }
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
@@ -8,11 +8,12 @@
  */
 package org.openhab.binding.samsungtv.internal.service;
 
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.CHANNEL;
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.KEY_CODE;
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.MUTE;
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.POWER;
-import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.VOLUME;
+import static org.openhab.binding.samsungtv.SamsungTvBindingConstants.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -23,15 +24,10 @@ import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.samsungtv.internal.protocol.KeyCode;
 import org.openhab.binding.samsungtv.internal.protocol.RemoteController;
 import org.openhab.binding.samsungtv.internal.protocol.RemoteControllerException;
-import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.openhab.binding.samsungtv.internal.service.api.EventListener;
+import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The {@link RemoteControllerService} is responsible for handling remote
@@ -46,33 +42,33 @@ public class RemoteControllerService implements SamsungTvService {
 
     static final String SERVICE_NAME = "RemoteControlReceiver";
 
-    private final List<String> supportedCommandsDiscovered = Arrays.asList(KEY_CODE, POWER, CHANNEL);
-    private final List<String> supportedCommandsManual = Arrays.asList(KEY_CODE, VOLUME, MUTE, POWER, CHANNEL);
+    private final List<String> supportedCommandsUpnp = Arrays.asList(KEY_CODE, POWER, CHANNEL);
+    private final List<String> supportedCommandsNonUpnp = Arrays.asList(KEY_CODE, VOLUME, MUTE, POWER, CHANNEL);
 
     private String host;
     private int port;
-    private boolean manual;
+    private boolean upnp;
 
     private List<EventListener> listeners = new CopyOnWriteArrayList<>();
 
-    private RemoteControllerService(String host, int port, boolean manual) {
+    private RemoteControllerService(String host, int port, boolean upnp) {
         logger.debug("Create a Samsung TV RemoteController service");
-        this.manual = manual;
+        this.upnp = upnp;
         this.host = host;
         this.port = port;
     }
 
-    static RemoteControllerService createDiscoveredService(String host, int port) {
-        return new RemoteControllerService(host, port, false);
+    static RemoteControllerService createUpnpService(String host, int port) {
+        return new RemoteControllerService(host, port, true);
     }
 
-    public static RemoteControllerService createManualService(String host, int port) {
-        return new RemoteControllerService(host, port, true);
+    public static RemoteControllerService createNonUpnpService(String host, int port) {
+        return new RemoteControllerService(host, port, false);
     }
 
     @Override
     public List<String> getSupportedChannelNames() {
-        return manual ? supportedCommandsManual : supportedCommandsDiscovered;
+        return upnp ? supportedCommandsUpnp : supportedCommandsNonUpnp;
     }
 
     @Override
@@ -99,8 +95,8 @@ public class RemoteControllerService implements SamsungTvService {
     }
 
     @Override
-    public boolean isManual() {
-        return manual;
+    public boolean isUpnp() {
+        return upnp;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/ServiceFactory.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/ServiceFactory.java
@@ -24,8 +24,8 @@ import org.openhab.binding.samsungtv.internal.service.api.SamsungTvService;
 public class ServiceFactory {
 
     @SuppressWarnings("serial")
-    private static final Map<String, Class<?>> serviceMap = Collections
-            .unmodifiableMap(new HashMap<String, Class<?>>() {
+    private static final Map<String, Class<? extends SamsungTvService>> serviceMap = Collections
+            .unmodifiableMap(new HashMap<String, Class<? extends SamsungTvService>>() {
                 {
                     put(MainTVServerService.SERVICE_NAME, MainTVServerService.class);
                     put(MediaRendererService.SERVICE_NAME, MediaRendererService.class);
@@ -57,7 +57,7 @@ public class ServiceFactory {
                 service = new MediaRendererService(upnpIOService, udn, pollingInterval);
                 break;
             case RemoteControllerService.SERVICE_NAME:
-                service = new RemoteControllerService(host, port);
+                service = RemoteControllerService.createDiscoveredService(host, port);
                 break;
         }
 
@@ -79,7 +79,7 @@ public class ServiceFactory {
      * @param serviceName Name of the service
      * @return Class of the service
      */
-    public static Class<?> getClassByServiceName(String serviceName) {
+    public static Class<? extends SamsungTvService> getClassByServiceName(String serviceName) {
         return serviceMap.get(serviceName);
     }
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/ServiceFactory.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/ServiceFactory.java
@@ -57,7 +57,7 @@ public class ServiceFactory {
                 service = new MediaRendererService(upnpIOService, udn, pollingInterval);
                 break;
             case RemoteControllerService.SERVICE_NAME:
-                service = RemoteControllerService.createDiscoveredService(host, port);
+                service = RemoteControllerService.createUpnpService(host, port);
                 break;
         }
 

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/EventListener.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/EventListener.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.samsungtv.internal.service.api;
 
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.State;
 
 /**
@@ -15,12 +16,21 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Pauli Anttila - Initial contribution
  */
-public interface ValueReceiver {
+public interface EventListener {
     /**
      * Invoked when value is received from the TV.
      * 
      * @param variable Name of the variable.
      * @param value Value of the variable value.
      */
-    public void valueReceived(String variable, State value);
+    void valueReceived(String variable, State value);
+
+    /**
+     * Report an error to this event listener
+     *
+     * @param statusDetail hint about the actual underlying problem
+     * @param message of the error
+     * @param e exception that might have occurred
+     */
+    void reportError(ThingStatusDetail statusDetail, String message, Throwable e);
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/SamsungTvService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/SamsungTvService.java
@@ -8,9 +8,9 @@
  */
 package org.openhab.binding.samsungtv.internal.service.api;
 
-import java.util.List;
-
 import org.eclipse.smarthome.core.types.Command;
+
+import java.util.List;
 
 /**
  * Interface for Samsung TV services.
@@ -20,59 +20,58 @@ import org.eclipse.smarthome.core.types.Command;
 public interface SamsungTvService {
 
     /**
-     * Procedure to get service name.
-     * 
-     * @return Service name
-     */
-    public String getServiceName();
-
-    /**
      * Procedure to get list of supported channel names.
-     * 
+     *
      * @return List of supported
      */
-    public List<String> getSupportedChannelNames();
+    List<String> getSupportedChannelNames();
 
     /**
      * Procedure for sending command.
-     * 
-     * @param listener
-     *            Event listener instance to handle events.
+     *
+     * @param channel the channel to which the command applies
+     * @param command the command to be handled
      */
-    public void handleCommand(String channel, Command command);
+    void handleCommand(String channel, Command command);
 
     /**
      * Procedure for register event listener.
-     * 
+     *
      * @param listener
      *            Event listener instance to handle events.
      */
-    public void addEventListener(ValueReceiver listener);
+    void addEventListener(EventListener listener);
 
     /**
      * Procedure for remove event listener.
-     * 
+     *
      * @param listener
      *            Event listener instance to remove.
      */
-    public void removeEventListener(ValueReceiver listener);
+    void removeEventListener(EventListener listener);
 
     /**
      * Procedure for starting service.
-     * 
+     *
      */
-    public void start();
+    void start();
 
     /**
      * Procedure for stopping service.
-     * 
+     *
      */
-    public void stop();
+    void stop();
 
     /**
      * Procedure for clearing internal caches.
-     * 
+     *
      */
-    public void clearCache();
+    void clearCache();
 
+    /**
+     * Is this a manual configured service
+     *
+     * @return whether this service was a manual override
+     */
+    boolean isManual();
 }

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/SamsungTvService.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/api/SamsungTvService.java
@@ -8,9 +8,9 @@
  */
 package org.openhab.binding.samsungtv.internal.service.api;
 
-import org.eclipse.smarthome.core.types.Command;
-
 import java.util.List;
+
+import org.eclipse.smarthome.core.types.Command;
 
 /**
  * Interface for Samsung TV services.
@@ -69,9 +69,9 @@ public interface SamsungTvService {
     void clearCache();
 
     /**
-     * Is this a manual configured service
+     * Is this an UPnP configured service
      *
-     * @return whether this service was a manual override
+     * @return whether this service is an UPnP configured / discovered service
      */
-    boolean isManual();
+    boolean isUpnp();
 }


### PR DESCRIPTION
If no tv's are discovered via upnp the binding falls back to an override modus with a network based remote, similar to openHAB1 binding. As soon a tv is detected later it overrides the override mode.

Also some improvements are made to mark the thing offline in case of errors.

See also #2354