### PR TITLE
[avmfritz] Added new channels `locked`, `mode` and `radiator_mode`

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
@@ -10,6 +10,12 @@ thing-type.avmfritz.FRITZ_DECT_Repeater_100.description = FRITZ!DECT Repeater 10
 thing-type.avmfritz.COMET_DECT.description = Comet DECT Heizkörperregler
 
 # channel types
+channel-type.avmfritz.mode.label = Modus des Gerätes
+channel-type.avmfritz.mode.description = Zeigt den aktuellen Modus des Gerätes an (MANUAL/AUTOMATIC).
+
+channel-type.avmfritz.locked.label = Schalten des Gerätes (extern)
+channel-type.avmfritz.locked.description = Zeigt an, ob die Sperre für Schalten des Gerätes über extern aktiviert ist.
+
 channel-type.avmfritz.temperature.label = Temperatur
 channel-type.avmfritz.temperature.description = Aktuell gemessene Temperatur
 
@@ -34,11 +40,11 @@ channel-type.avmfritz.eco_temp.description = Aktuell eingestellte Absenktemperat
 channel-type.avmfritz.comfort_temp.label = Komforttemperatur
 channel-type.avmfritz.comfort_temp.description = Aktuell eingestellte Komforttemperatur des Heizkörperregler
 
+channel-type.avmfritz.radiator_mode.label = Heizkörperreglermodus
+channel-type.avmfritz.radiator_mode.description = Zeigt den aktuellen Modus des Heizkörperregler an (ON/OFF/COMFORT/ECO/BOOST).
+
 channel-type.avmfritz.next_change.label = Nächste Änderung
 channel-type.avmfritz.next_change.description = Nächste Änderung der Temperatur des Heizkörperregler
 
 channel-type.avmfritz.next_temp.label = Nächste Temperatur
 channel-type.avmfritz.next_temp.description = Nächste Temperatur des Heizkörperregler
-
-channel-type.avmfritz.battery_low.label = Batterie
-channel-type.avmfritz.battery_low.description = Batteriestand niedrig

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de_DE.properties
@@ -3,48 +3,49 @@ binding.avmfritz.name = AVM FRITZ! AHA
 binding.avmfritz.description = AVM FRITZ! AHA Geräte (DECT 100/200/210/300, Comet DECT, Powerline 546E)
 
 # thing types
+thing-type.avmfritz.FRITZ_DECT_Repeater_100.description = FRITZ!DECT Repeater 100
 thing-type.avmfritz.FRITZ_DECT_200.description = FRITZ!DECT 200 schaltbare Steckdose
 thing-type.avmfritz.FRITZ_DECT_210.description = FRITZ!DECT 210 schaltbare Steckdose
 thing-type.avmfritz.FRITZ_DECT_300.description = FRITZ!DECT 300 Heizkörperregler
-thing-type.avmfritz.FRITZ_DECT_Repeater_100.description = FRITZ!DECT Repeater 100
 thing-type.avmfritz.COMET_DECT.description = Comet DECT Heizkörperregler
+thing-type.avmfritz.FRITZ_Powerline_546E.description = FRITZ!Powerline 546E schaltbare Steckdose
 
 # channel types
 channel-type.avmfritz.mode.label = Modus des Gerätes
-channel-type.avmfritz.mode.description = Zeigt den aktuellen Modus des Gerätes an (MANUAL/AUTOMATIC).
+channel-type.avmfritz.mode.description = Zeigt den aktuellen Modus des Gerätes an (MANUAL/AUTOMATIC)
 
 channel-type.avmfritz.locked.label = Schalten des Gerätes (extern)
-channel-type.avmfritz.locked.description = Zeigt an, ob die Sperre für Schalten des Gerätes über extern aktiviert ist.
+channel-type.avmfritz.locked.description = Zeigt an, ob die Sperre für Schalten des Gerätes über extern aktiviert ist
 
 channel-type.avmfritz.temperature.label = Temperatur
-channel-type.avmfritz.temperature.description = Aktuell gemessene Temperatur
+channel-type.avmfritz.temperature.description = Zeigt die aktuelle Temperatur (in °C) an
 
 channel-type.avmfritz.energy.label = Gesamtverbrauch
-channel-type.avmfritz.energy.description = Akkumulierter Gesamtverbrauch (in kWh)
+channel-type.avmfritz.energy.description = Zeigt den akkumulierten Gesamtverbrauch (in kWh) an
 
 channel-type.avmfritz.power.label = Leistung
-channel-type.avmfritz.power.description = Aktuelle Leistung (in W)
+channel-type.avmfritz.power.description = Zeigt die aktuelle Leistung (in W) an
 
 channel-type.avmfritz.outlet.label = Steckdose
 channel-type.avmfritz.outlet.description = Schaltbare Steckdose
 
 channel-type.avmfritz.actual_temp.label = Isttemperatur
-channel-type.avmfritz.actual_temp.description = Aktuell gemessene Isttemperatur des Heizkörperregler
+channel-type.avmfritz.actual_temp.description = Aktuell gemessene Isttemperatur (in °C) des Heizkörperregler
 
 channel-type.avmfritz.set_temp.label = Solltemperatur
-channel-type.avmfritz.set_temp.description = Aktuell eingestellte Solltemperatur des Heizkörperregler
+channel-type.avmfritz.set_temp.description = Aktuell eingestellte Solltemperatur (in °C) des Heizkörperregler
 
 channel-type.avmfritz.eco_temp.label = Absenktemperatur
-channel-type.avmfritz.eco_temp.description = Aktuell eingestellte Absenktemperatur des Heizkörperregler
+channel-type.avmfritz.eco_temp.description = Aktuell eingestellte Absenktemperatur (in °C) des Heizkörperregler
 
 channel-type.avmfritz.comfort_temp.label = Komforttemperatur
-channel-type.avmfritz.comfort_temp.description = Aktuell eingestellte Komforttemperatur des Heizkörperregler
+channel-type.avmfritz.comfort_temp.description = Aktuell eingestellte Komforttemperatur (in °C) des Heizkörperregler
 
-channel-type.avmfritz.radiator_mode.label = Heizkörperreglermodus
-channel-type.avmfritz.radiator_mode.description = Zeigt den aktuellen Modus des Heizkörperregler an (ON/OFF/COMFORT/ECO/BOOST).
+channel-type.avmfritz.radiator_mode.label = Modus des Heizkörperregler
+channel-type.avmfritz.radiator_mode.description = Zeigt den aktuellen Modus des Heizkörperregler an (ON/OFF/COMFORT/ECO/BOOST)
 
 channel-type.avmfritz.next_change.label = Nächste Änderung
 channel-type.avmfritz.next_change.description = Nächste Änderung der Temperatur des Heizkörperregler
 
 channel-type.avmfritz.next_temp.label = Nächste Temperatur
-channel-type.avmfritz.next_temp.description = Nächste Temperatur des Heizkörperregler
+channel-type.avmfritz.next_temp.description = Nächste Temperatur (in °C) des Heizkörperregler

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -331,7 +331,6 @@
 		<item-type>DateTime</item-type>
 		<label>Next Setpoint Change</label>
 		<description>Next change of Set Temperature</description>
-		<category>Temperature</category>
 		<state readOnly="true" />
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -1,90 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="avmfritz"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <!-- Supported FRITZ! devices and features -->
-    <thing-type id="Comet_DECT">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="fritzbox" />
-        </supported-bridge-type-refs>
-        <label>Comet DECT</label>
-        <description>Comet DECT heating thermostat</description>
-        <channels>
-            <channel id="temperature" typeId="temperature" />
-            <channel id="actual_temp" typeId="actual_temp" />
-            <channel id="set_temp" typeId="set_temp" />
-            <channel id="eco_temp" typeId="eco_temp" />
-            <channel id="comfort_temp" typeId="comfort_temp" />
-            <channel id="next_change" typeId="next_change" />
-            <channel id="next_temp" typeId="next_temp" />
-            <channel id="battery_low" typeId="system.low-battery" />
-        </channels>
-        <config-description>
-            <parameter name="ain" type="text" required="true">
-                <label>AIN</label>
-                <description>The AHA id (AIN) that identifies one specific device.</description>
-            </parameter>
-        </config-description>
-    </thing-type>
+	<!-- Supported FRITZ! devices and features -->
+	<thing-type id="Comet_DECT">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+		</supported-bridge-type-refs>
+		<label>Comet DECT</label>
+		<description>Comet DECT heating thermostat</description>
+		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
+			<channel id="temperature" typeId="temperature" />
+			<channel id="actual_temp" typeId="actual_temp" />
+			<channel id="set_temp" typeId="set_temp" />
+			<channel id="eco_temp" typeId="eco_temp" />
+			<channel id="comfort_temp" typeId="comfort_temp" />
+			<channel id="radiator_mode" typeId="radiator_mode" />
+			<channel id="next_change" typeId="next_change" />
+			<channel id="next_temp" typeId="next_temp" />
+			<channel id="battery_low" typeId="system.low-battery" />
+		</channels>
+		<config-description>
+			<parameter name="ain" type="text" required="true">
+				<label>AIN</label>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
+			</parameter>
+		</config-description>
+	</thing-type>
 
-    <thing-type id="FRITZ_DECT_300">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="fritzbox" />
-        </supported-bridge-type-refs>
-        <label>FRITZ!DECT 300</label>
-        <description>FRITZ!DECT 300 heating thermostat</description>
-        <channels>
-            <channel id="temperature" typeId="temperature" />
-            <channel id="actual_temp" typeId="actual_temp" />
-            <channel id="set_temp" typeId="set_temp" />
-            <channel id="eco_temp" typeId="eco_temp" />
-            <channel id="comfort_temp" typeId="comfort_temp" />
-            <channel id="next_change" typeId="next_change" />
-            <channel id="next_temp" typeId="next_temp" />
-            <channel id="battery_low" typeId="system.low-battery" />
-        </channels>
-        <config-description>
-            <parameter name="ain" type="text" required="true">
-                <label>AIN</label>
-                <description>The AHA id (AIN) that identifies one specific device.</description>
-            </parameter>
-        </config-description>
-    </thing-type>
+	<thing-type id="FRITZ_DECT_300">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+		</supported-bridge-type-refs>
+		<label>FRITZ!DECT 300</label>
+		<description>FRITZ!DECT 300 heating thermostat</description>
+		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
+			<channel id="temperature" typeId="temperature" />
+			<channel id="actual_temp" typeId="actual_temp" />
+			<channel id="set_temp" typeId="set_temp" />
+			<channel id="eco_temp" typeId="eco_temp" />
+			<channel id="comfort_temp" typeId="comfort_temp" />
+			<channel id="radiator_mode" typeId="radiator_mode" />
+			<channel id="next_change" typeId="next_change" />
+			<channel id="next_temp" typeId="next_temp" />
+			<channel id="battery_low" typeId="system.low-battery" />
+		</channels>
+		<config-description>
+			<parameter name="ain" type="text" required="true">
+				<label>AIN</label>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
+			</parameter>
+		</config-description>
+	</thing-type>
 
-    <thing-type id="FRITZ_DECT_210">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="fritzbox" />
-        </supported-bridge-type-refs>
-
-        <label>FRITZ!DECT 210</label>
-        <description>FRITZ!DECT210 switchable outlet</description>
-
-        <channels>
-            <channel id="temperature" typeId="temperature" />
-            <channel id="energy" typeId="energy" />
-            <channel id="power" typeId="power" />
-            <channel id="outlet" typeId="outlet" />
-        </channels>
-
-        <config-description>
-            <parameter name="ain" type="text" required="true">
-                <label>AIN</label>
-                <description>The AHA id (AIN) that identifies one specific device.</description>
-            </parameter>
-        </config-description>
-    </thing-type>
-
-    <thing-type id="FRITZ_DECT_200">
+	<thing-type id="FRITZ_DECT_210">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="fritzbox" />
 		</supported-bridge-type-refs>
 
-        <label>FRITZ!DECT 200</label>
-        <description>FRITZ!DECT200 switchable outlet</description>
+		<label>FRITZ!DECT 210</label>
+		<description>FRITZ!DECT210 switchable outlet</description>
 
 		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
 			<channel id="temperature" typeId="temperature" />
 			<channel id="energy" typeId="energy" />
 			<channel id="power" typeId="power" />
@@ -94,20 +81,24 @@
 		<config-description>
 			<parameter name="ain" type="text" required="true">
 				<label>AIN</label>
-				<description>The AHA id (AIN) that identifies one specific device.</description>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
 			</parameter>
 		</config-description>
-    </thing-type>
+	</thing-type>
 
-    <thing-type id="FRITZ_Powerline_546E">
+	<thing-type id="FRITZ_DECT_200">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="fritzbox" />
 		</supported-bridge-type-refs>
 
-        <label>FRITZ!Powerline 546E</label>
-        <description>FRITZ!Powerline 546E with switchable outlet</description>
+		<label>FRITZ!DECT 200</label>
+		<description>FRITZ!DECT200 switchable outlet</description>
 
 		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
+			<channel id="temperature" typeId="temperature" />
 			<channel id="energy" typeId="energy" />
 			<channel id="power" typeId="power" />
 			<channel id="outlet" typeId="outlet" />
@@ -116,16 +107,44 @@
 		<config-description>
 			<parameter name="ain" type="text" required="true">
 				<label>AIN</label>
-				<description>The AHA id (AIN) that identifies one specific device.</description>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
 			</parameter>
 		</config-description>
-    </thing-type>
+	</thing-type>
 
-    <thing-type id="FRITZ_Powerline_546E_Solo">
-        <label>FRITZ!Powerline 546E</label>
-        <description>FRITZ!Powerline 546E with switchable outlet</description>
+	<thing-type id="FRITZ_Powerline_546E">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+		</supported-bridge-type-refs>
+
+		<label>FRITZ!Powerline 546E</label>
+		<description>FRITZ!Powerline 546E with switchable outlet</description>
 
 		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
+			<channel id="energy" typeId="energy" />
+			<channel id="power" typeId="power" />
+			<channel id="outlet" typeId="outlet" />
+		</channels>
+
+		<config-description>
+			<parameter name="ain" type="text" required="true">
+				<label>AIN</label>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<thing-type id="FRITZ_Powerline_546E_Solo">
+		<label>FRITZ!Powerline 546E</label>
+		<description>FRITZ!Powerline 546E with switchable outlet</description>
+
+		<channels>
+			<channel id="mode" typeId="mode" />
+			<channel id="locked" typeId="locked" />
 			<channel id="energy" typeId="energy" />
 			<channel id="power" typeId="power" />
 			<channel id="outlet" typeId="outlet" />
@@ -146,7 +165,8 @@
 			</parameter>
 			<parameter name="protocol" type="text" required="false">
 				<label>Protocol</label>
-				<description>Protocol to connect to the FRITZ!Box (http or https)</description>
+				<description>Protocol to connect to the FRITZ!Box (http or https)
+				</description>
 				<default>http</default>
 				<options>
 					<option value="http">HTTP</option>
@@ -159,49 +179,80 @@
 				<description>Password to access the FRITZ!Box device.
 				</description>
 			</parameter>
-			<parameter name="pollingInterval" type="integer" required="false" min="5" max="60">
+			<parameter name="pollingInterval" type="integer" required="false"
+				min="5" max="60">
 				<label>Polling Interval</label>
 				<description>Interval polling the FRITZ!Box.
 				</description>
 				<default>15</default>
 			</parameter>
-			<parameter name="asyncTimeout" type="integer" required="false" min="1000" max="60000">
+			<parameter name="asyncTimeout" type="integer" required="false"
+				min="1000" max="60000">
 				<label>Async Timeout</label>
 				<description>Timeout for asynchronous connections.
 				</description>
 				<default>10000</default>
 			</parameter>
-			<parameter name="syncTimeout" type="integer" required="false" min="500" max="15000">
+			<parameter name="syncTimeout" type="integer" required="false"
+				min="500" max="15000">
 				<label>Sync Timeout</label>
 				<description>Timeout for synchronous connections.
 				</description>
 				<default>2000</default>
 			</parameter>
 		</config-description>
-    </thing-type>
+	</thing-type>
 
-    <thing-type id="FRITZ_DECT_Repeater_100">
-    	<supported-bridge-type-refs>
-    		<bridge-type-ref id="fritzbox" />
-    	</supported-bridge-type-refs>
-    	<label>FRITZ!DECT Repeater 100</label>
-    	<description>FRITZ!DECT Repeater 100 DECT repeater</description>
-    	<channels>
-    		<channel typeId="temperature" id="temperature"></channel>
-    	</channels>
-    	<config-description>
-    		<parameter name="ain" type="text" required="true">
-    			<label>AIN</label>
-    			<description>The AHA id (AIN) that identifies one specific device.</description></parameter></config-description>
-    </thing-type>
+	<thing-type id="FRITZ_DECT_Repeater_100">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+		</supported-bridge-type-refs>
+		<label>FRITZ!DECT Repeater 100</label>
+		<description>FRITZ!DECT Repeater 100 DECT repeater</description>
 
-    <!-- Channel definitions of FRITZ! devices -->
+		<channels>
+			<channel typeId="temperature" id="temperature"></channel>
+		</channels>
+
+		<config-description>
+			<parameter name="ain" type="text" required="true">
+				<label>AIN</label>
+				<description>The AHA id (AIN) that identifies one specific device.
+				</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<!-- Channel definitions of all FRITZ! devices -->
+	<channel-type id="mode">
+		<item-type>String</item-type>
+		<label>Mode</label>
+		<description>States the mode of the device (MANUAL/AUTOMATIC).
+		</description>
+		<state pattern="%s" readOnly="true">
+			<options>
+				<option value="MANUAL">MANUAL</option>
+				<option value="AUTOMATIC">AUTOMATIC</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="locked" advanced="true">
+		<item-type>Contact</item-type>
+		<label>Device locked (external)</label>
+		<description>Device is locked for switching over external sources.
+		</description>
+		<category>Contact</category>
+		<state pattern="%s" readOnly="true" />
+	</channel-type>
+
+	<!-- Channel definitions of specific FRITZ! devices -->
 	<channel-type id="temperature">
 		<item-type>Number</item-type>
 		<label>Actual Temperature</label>
 		<description>Actual measured temperature</description>
 		<category>Temperature</category>
-		<state pattern="%.1f °C" readOnly="true"/>
+		<state pattern="%.1f °C" readOnly="true" />
 	</channel-type>
 
 	<channel-type id="energy">
@@ -209,7 +260,7 @@
 		<label>Energy Consumption</label>
 		<description>Accumulated energy consumption</description>
 		<category>Energy</category>
-		<state pattern="%.3f kWh" readOnly="true"/>
+		<state pattern="%.3f kWh" readOnly="true" />
 	</channel-type>
 
 	<channel-type id="power">
@@ -217,63 +268,79 @@
 		<label>Power</label>
 		<description>Current power consumption</description>
 		<category>Energy</category>
-		<state pattern="%.2f W" readOnly="true"/>
+		<state pattern="%.2f W" readOnly="true" />
 	</channel-type>
 
-    <channel-type id="outlet">
-        <item-type>Switch</item-type>
-        <label>Outlet</label>
-        <description>Switched outlet</description>
-        <category>PowerOutlet</category>
-		<state readOnly="false"/>
-    </channel-type>
+	<channel-type id="outlet">
+		<item-type>Switch</item-type>
+		<label>Outlet</label>
+		<description>Switched outlet</description>
+		<category>PowerOutlet</category>
+		<state readOnly="false" />
+	</channel-type>
 
-    <channel-type id="actual_temp" advanced="true">
-        <item-type>Number</item-type>
-        <label>Actual Temperature</label>
-        <description>Actual measured temperature</description>
-        <category>Temperature</category>
-        <state pattern="%.1f °C" readOnly="true"/>
-    </channel-type>
+	<channel-type id="actual_temp" advanced="true">
+		<item-type>Number</item-type>
+		<label>Actual Temperature</label>
+		<description>Actual measured temperature</description>
+		<category>Temperature</category>
+		<state pattern="%.1f °C" readOnly="true" />
+	</channel-type>
 
-    <channel-type id="set_temp">
-        <item-type>Number</item-type>
-        <label>Setpoint Temperature</label>
-        <description>Thermostat temperature setpoint</description>
-        <category>Temperature</category>
-        <state min="8" max="28" step="0.5" pattern="%.1f °C" readOnly="false"/>
-    </channel-type>
+	<channel-type id="set_temp">
+		<item-type>Number</item-type>
+		<label>Setpoint Temperature</label>
+		<description>Thermostat temperature setpoint</description>
+		<category>Temperature</category>
+		<state min="8" max="28" step="0.5" pattern="%.1f °C" readOnly="false" />
+	</channel-type>
 
-    <channel-type id="eco_temp">
-        <item-type>Number</item-type>
-        <label>Eco Temperature</label>
-        <description>Eco measured temperature</description>
-        <category>Temperature</category>
-        <state pattern="%.1f °C" readOnly="true"/>
-    </channel-type>
-    
-    <channel-type id="comfort_temp">
-        <item-type>Number</item-type>
-        <label>Comfort Temperature</label>
-        <description>Comfort measured temperature</description>
-        <category>Temperature</category>
-        <state pattern="%.1f °C" readOnly="true"/>
-    </channel-type>
+	<channel-type id="eco_temp">
+		<item-type>Number</item-type>
+		<label>Eco Temperature</label>
+		<description>Eco measured temperature</description>
+		<category>Temperature</category>
+		<state pattern="%.1f °C" readOnly="true" />
+	</channel-type>
 
-    <channel-type id="next_change" advanced="true">
-        <item-type>DateTime</item-type>
-        <label>Next Setpoint Change</label>
-        <description>Next change of Set Temperature</description>
-        <category>Temperature</category>
-        <state readOnly="true"/>
-    </channel-type>
+	<channel-type id="comfort_temp">
+		<item-type>Number</item-type>
+		<label>Comfort Temperature</label>
+		<description>Comfort measured temperature</description>
+		<category>Temperature</category>
+		<state pattern="%.1f °C" readOnly="true" />
+	</channel-type>
 
-    <channel-type id="next_temp" advanced="true">
-        <item-type>Number</item-type>
-        <label>Next Setpoint Temperature</label>
-        <description>Next Set Temperature</description>
-        <category>Temperature</category>
-        <state pattern="%.1f °C" readOnly="true"/>
-    </channel-type>
+	<channel-type id="radiator_mode">
+		<item-type>String</item-type>
+		<label>Radiator mode</label>
+		<description>States the mode of the radiator
+			(ON/OFF/COMFORT/ECO/BOOST).</description>
+		<state pattern="%s">
+			<options>
+				<option value="ON">ON</option>
+				<option value="OFF">OFF</option>
+				<option value="COMFORT">COMFORT</option>
+				<option value="ECO">ECO</option>
+				<option value="BOOST">BOOST</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="next_change" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Next Setpoint Change</label>
+		<description>Next change of Set Temperature</description>
+		<category>Temperature</category>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="next_temp" advanced="true">
+		<item-type>Number</item-type>
+		<label>Next Setpoint Temperature</label>
+		<description>Next Set Temperature</description>
+		<category>Temperature</category>
+		<state pattern="%.1f °C" readOnly="true" />
+	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -64,6 +64,8 @@ If correct credentials are set in the bridge configuration, connected AHA device
 
 | Channel Type ID | Item Type | Description                                                                                            | Available on thing                                                                  |
 |-----------------|-----------|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| mode            | String    | States the mode of the device (MANUAL/AUTOMATIC)                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 300, Comet DECT    |
+| locked          | Contact   | Device is locked for switching over external sources (OPEN/CLOSE)                                      | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 300, Comet DECT    |
 | temperature     | Number    | Actual measured temperature (in °C)                                                                    | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!DECT Repeater 100, FRITZ!DECT 300, Comet DECT |
 | energy          | Number    | Accumulated energy consumption (in kWh)                                                                | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                |
 | power           | Number    | Current power consumption (in W)                                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                |
@@ -72,8 +74,9 @@ If correct credentials are set in the bridge configuration, connected AHA device
 | set_temp        | Number    | Set Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 300, Comet DECT                                                          |
 | eco_temp        | Number    | Eco Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 300, Comet DECT                                                          |
 | comfort_temp    | Number    | Comfort Temperature of heating thermostat (in °C)                                                      | FRITZ!DECT 300, Comet DECT                                                          |
+| radiator_mode   | String    | Mode of heating thermostat (ON/OFF/COMFORT/ECO/BOOST)                                                  | FRITZ!DECT 300, Comet DECT                                                          |
 | next_change     | DateTime  | Next change of the Set Temperature if scheduler is activated in the FRITZ!Box settings - FRITZ!OS 6.80 | FRITZ!DECT 300, Comet DECT                                                          |
-| next_tmep       | Number    | Next Set Temperature if scheduler is activated in the FRITZ!Box settings (in °C) - FRITZ!OS 6.80       | FRITZ!DECT 300, Comet DECT                                                          |
+| next_temp       | Number    | Next Set Temperature if scheduler is activated in the FRITZ!Box settings (in °C) - FRITZ!OS 6.80       | FRITZ!DECT 300, Comet DECT                                                          |
 | battery_low     | Switch    | Battery Level Low (ON/OFF) - FRITZ!OS 6.80                                                             | FRITZ!DECT 300, Comet DECT                                                          |
 
 
@@ -103,6 +106,7 @@ Group gCOMETDECT "Comet DECT heating thermostat" <temperature>
 
 Number COMETDECTActualTemp "Actual measured temperature [%.1f °C]" (gCOMETDECT) { channel="avmfritz:Comet_DECT:1:CD1:actual_temp" }
 Number COMETDECTSetTemp "Thermostat temperature setpoint [%.1f °C]" (gCOMETDECT) { channel="avmfritz:Comet_DECT:1:CD1:set_temp" }
+String COMETDECTRadiatorMode "Radiator mode [%s]" (gCOMETDECT) { channel="avmfritz:Comet_DECT:1:CD1:radiator_mode" }
 Switch COMETDECTBattery "Battery low" (gCOMETDECT) { channel="avmfritz:Comet_DECT:1:CD1:battery_low" }
 ```
 
@@ -123,6 +127,7 @@ sitemap demo label="Main Menu"
 	Frame "Comet DECT heating thermostat" {
 		Text item=COMETDECTActualTemp icon="temperature"
 		Setpoint item=COMETDECTSetTemp minValue=8.0 maxValue=28.0 step=0.5 icon="temperature"
+		Selection item=COMETDECTRadiatorMode mappings=["ON"="ON", "OFF"="OFF", "COMFORT"="COMFORT", "ECO"="ECO", "BOOST"="BOOST"]
 		Switch item=COMETDECTBattery icon="battery"
 	}
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
@@ -32,6 +32,9 @@ public class BindingConstants {
     public static final String BRIDGE_MODEL_NAME = "FRITZ!Box";
     public static final String PL546E_MODEL_NAME = "FRITZ!Powerline";
     public static final String THING_AIN = "ain";
+    public static final String THING_SETTEMP = "set";
+    public static final String THING_ECOTEMP = "eco";
+    public static final String THING_COMFORTTEMP = "comfort";
 
     // List of main device types
     public static final String DEVICE_DECT300 = "FRITZ_DECT_300";
@@ -55,6 +58,8 @@ public class BindingConstants {
     public static final ThingTypeUID COMETDECT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_COMETDECT);
 
     // List of all Channel ids
+    public static final String CHANNEL_MODE = "mode";
+    public static final String CHANNEL_LOCKED = "locked";
     public static final String CHANNEL_TEMP = "temperature";
     public static final String CHANNEL_ENERGY = "energy";
     public static final String CHANNEL_POWER = "power";
@@ -63,11 +68,13 @@ public class BindingConstants {
     public static final String CHANNEL_SETTEMP = "set_temp";
     public static final String CHANNEL_ECOTEMP = "eco_temp";
     public static final String CHANNEL_COMFORTTEMP = "comfort_temp";
+    public static final String CHANNEL_RADIATOR_MODE = "radiator_mode";
     public static final String CHANNEL_NEXTCHANGE = "next_change";
     public static final String CHANNEL_NEXTTEMP = "next_temp";
     public static final String CHANNEL_BATTERY = "battery_low";
 
     // List of all Input tags
+    public static final String INPUT_PRESENT = "present";
     public static final String INPUT_ACTUALTEMP = "tist";
     public static final String INPUT_SETTEMP = "tsoll";
     public static final String INPUT_ECOTEMP = "absenk";
@@ -75,6 +82,16 @@ public class BindingConstants {
     public static final String INPUT_NEXTCHANGE = "endperiod";
     public static final String INPUT_NEXTTEMP = "tchange";
     public static final String INPUT_BATTERY = "batterylow";
+
+    // List of all Mode types
+    public static final String MODE_AUTO = "AUTOMATIC";
+    public static final String MODE_MANUAL = "MANUAL";
+    public static final String MODE_ON = "ON";
+    public static final String MODE_OFF = "OFF";
+    public static final String MODE_COMFORT = "COMFORT";
+    public static final String MODE_ECO = "ECO";
+    public static final String MODE_BOOST = "BOOST";
+    public static final String MODE_UNKNOWN = "UNKNOWN";
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(DECT100_THING_TYPE,
             DECT200_THING_TYPE, DECT210_THING_TYPE, DECT300_THING_TYPE, PL546E_THING_TYPE, BRIDGE_THING_TYPE,

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/config/AvmFritzConfiguration.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/config/AvmFritzConfiguration.java
@@ -95,9 +95,9 @@ public class AvmFritzConfiguration {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append("IP", this.getIpAddress()).append("port", this.getPort())
-                .append("proto", this.getProtocol()).append("user", this.getUser())
-                .append("password", this.getPassword()).append("pollingInterval", this.getPollingInterval())
-                .append("asyncTimeout", this.getAsyncTimeout()).append("syncTimeout", this.getSyncTimeout()).toString();
+        return new ToStringBuilder(this).append("IP", getIpAddress()).append("port", getPort())
+                .append("proto", getProtocol()).append("user", getUser())
+                .append("password", getPassword()).append("pollingInterval", getPollingInterval())
+                .append("asyncTimeout", getAsyncTimeout()).append("syncTimeout", getSyncTimeout()).toString();
     }
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -41,7 +41,6 @@ import org.openhab.binding.avmfritz.config.AvmFritzConfiguration;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
-import org.openhab.binding.avmfritz.internal.ahamodel.TemperatureModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzahaWebInterface;
 import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaUpdateXmlCallback;
 import org.slf4j.Logger;
@@ -175,8 +174,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
                 Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(),
-                        new DecimalType(TemperatureModel.toCelsius(device.getTemperature().getCelsius())));
+                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
                 Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -173,101 +173,56 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
         if (device.getPresent() == 1) {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
-                Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
+                updateState(CHANNEL_TEMP, new DecimalType(device.getTemperature().getCelsius()));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
-                Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);
-                updateState(channelEnergy.getUID(), new DecimalType(device.getPowermeter().getEnergy()));
-                Channel channelPower = thing.getChannel(CHANNEL_POWER);
-                updateState(channelPower.getUID(), new DecimalType(device.getPowermeter().getPower()));
+                updateState(CHANNEL_ENERGY, new DecimalType(device.getPowermeter().getEnergy()));
+                updateState(CHANNEL_POWER, new DecimalType(device.getPowermeter().getPower()));
             }
             if (device.isSwitchableOutlet() && device.getSwitch() != null) {
-                Channel channelMode = thing.getChannel(CHANNEL_MODE);
-                if (channelMode != null) {
-                    updateState(channelMode.getUID(), new StringType(device.getSwitch().getMode()));
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_MODE,
-                            thing.getUID());
-                }
-                Channel channelLocked = thing.getChannel(CHANNEL_LOCKED);
-                if (channelLocked != null) {
-                    updateState(channelLocked.getUID(), device.getSwitch().getLock().equals(BigDecimal.ONE)
-                            ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_LOCKED,
-                            thing.getUID());
-                }
-                Channel channelSwitch = thing.getChannel(CHANNEL_SWITCH);
+                updateState(CHANNEL_MODE, new StringType(device.getSwitch().getMode()));
+                updateState(CHANNEL_LOCKED, device.getSwitch().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED
+                        : OpenClosedType.OPEN);
                 if (device.getSwitch().getState() == null) {
-                    updateState(channelSwitch.getUID(), UnDefType.UNDEF);
-                } else if (device.getSwitch().getState().equals(SwitchModel.ON)) {
-                    updateState(channelSwitch.getUID(), OnOffType.ON);
-                } else if (device.getSwitch().getState().equals(SwitchModel.OFF)) {
-                    updateState(channelSwitch.getUID(), OnOffType.OFF);
+                    updateState(CHANNEL_SWITCH, UnDefType.UNDEF);
                 } else {
-                    logger.warn("Received unknown value {} for channel {}", device.getSwitch().getState(),
-                            channelSwitch.getUID());
+                    updateState(CHANNEL_SWITCH,
+                            device.getSwitch().getState().equals(SwitchModel.ON) ? OnOffType.ON : OnOffType.OFF);
                 }
             }
             if (device.isHeatingThermostat() && device.getHkr() != null) {
-                Channel channelMode = thing.getChannel(CHANNEL_MODE);
-                if (channelMode != null) {
-                    updateState(channelMode.getUID(), new StringType(device.getHkr().getMode()));
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_MODE,
-                            thing.getUID());
-                }
-                Channel channelLocked = thing.getChannel(CHANNEL_LOCKED);
-                if (channelLocked != null) {
-                    updateState(channelLocked.getUID(), device.getHkr().getLock().equals(BigDecimal.ONE)
-                            ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_LOCKED,
-                            thing.getUID());
-                }
-                Channel channelActualTemp = thing.getChannel(CHANNEL_ACTUALTEMP);
-                updateState(channelActualTemp.getUID(),
-                        new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
+                updateState(CHANNEL_MODE, new StringType(device.getHkr().getMode()));
+                updateState(CHANNEL_LOCKED,
+                        device.getHkr().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
+                updateState(CHANNEL_ACTUALTEMP, new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
                 BigDecimal settemp = HeatingModel.toCelsius(device.getHkr().getTsoll());
                 if (HeatingModel.inCelsiusRange(settemp)) {
                     thing.getConfiguration().put(THING_SETTEMP, settemp);
                 }
-                Channel channelSetTemp = thing.getChannel(CHANNEL_SETTEMP);
-                updateState(channelSetTemp.getUID(), new DecimalType(settemp));
+                updateState(CHANNEL_SETTEMP, new DecimalType(settemp));
                 BigDecimal ecotemp = HeatingModel.toCelsius(device.getHkr().getAbsenk());
                 thing.getConfiguration().put(THING_ECOTEMP, ecotemp);
-                Channel channelEcoTemp = thing.getChannel(CHANNEL_ECOTEMP);
-                updateState(channelEcoTemp.getUID(), new DecimalType(ecotemp));
+                updateState(CHANNEL_ECOTEMP, new DecimalType(ecotemp));
                 BigDecimal comforttemp = HeatingModel.toCelsius(device.getHkr().getKomfort());
                 thing.getConfiguration().put(THING_COMFORTTEMP, comforttemp);
-                Channel channelComfortTemp = thing.getChannel(CHANNEL_COMFORTTEMP);
-                updateState(channelComfortTemp.getUID(), new DecimalType(comforttemp));
-                Channel channelRadiatorMode = thing.getChannel(CHANNEL_RADIATOR_MODE);
-                updateState(channelRadiatorMode.getUID(), new StringType(device.getHkr().getRadiatorMode()));
+                updateState(CHANNEL_COMFORTTEMP, new DecimalType(comforttemp));
+                updateState(CHANNEL_RADIATOR_MODE, new StringType(device.getHkr().getRadiatorMode()));
                 if (device.getHkr().getNextchange() != null) {
-                    Channel channelNextChange = thing.getChannel(CHANNEL_NEXTCHANGE);
                     if (device.getHkr().getNextchange().getEndperiod() == 0) {
-                        updateState(channelNextChange.getUID(), UnDefType.UNDEF);
+                        updateState(CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
                     } else {
                         Calendar calendar = Calendar.getInstance();
                         calendar.setTime(new Date(device.getHkr().getNextchange().getEndperiod() * 1000L));
-                        updateState(channelNextChange.getUID(), new DateTimeType(calendar));
+                        updateState(CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
                     }
-                    Channel channelNextTemp = thing.getChannel(CHANNEL_NEXTTEMP);
-                    updateState(channelNextTemp.getUID(),
+                    updateState(CHANNEL_NEXTTEMP,
                             new DecimalType(HeatingModel.toCelsius(device.getHkr().getNextchange().getTchange())));
                 }
-                Channel channelBattery = thing.getChannel(CHANNEL_BATTERY);
                 if (device.getHkr().getBatterylow() == null) {
-                    updateState(channelBattery.getUID(), UnDefType.UNDEF);
-                } else if (device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON)) {
-                    updateState(channelBattery.getUID(), OnOffType.ON);
-                } else if (device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_OFF)) {
-                    updateState(channelBattery.getUID(), OnOffType.OFF);
+                    updateState(CHANNEL_BATTERY, UnDefType.UNDEF);
                 } else {
-                    logger.warn("Received unknown value {} for channel {}", device.getHkr().getBatterylow(),
-                            channelBattery.getUID());
+                    updateState(CHANNEL_BATTERY, device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON)
+                            ? OnOffType.ON : OnOffType.OFF);
                 }
             }
         } else {

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -41,6 +41,7 @@ import org.openhab.binding.avmfritz.config.AvmFritzConfiguration;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
+import org.openhab.binding.avmfritz.internal.ahamodel.TemperatureModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzahaWebInterface;
 import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaUpdateXmlCallback;
 import org.slf4j.Logger;
@@ -174,7 +175,8 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
                 Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
+                updateState(channelTemp.getUID(),
+                        new DecimalType(TemperatureModel.toCelsius(device.getTemperature().getCelsius())));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
                 Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -39,6 +39,7 @@ import org.openhab.binding.avmfritz.config.AvmFritzConfiguration;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
+import org.openhab.binding.avmfritz.internal.ahamodel.TemperatureModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzahaWebInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -270,7 +271,8 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
                 Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
+                updateState(channelTemp.getUID(),
+                        new DecimalType(TemperatureModel.toCelsius(device.getTemperature().getCelsius())));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
                 Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.avmfritz.BindingConstants;
 import org.openhab.binding.avmfritz.config.AvmFritzConfiguration;
@@ -216,25 +217,16 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setStatusInfo(ThingStatus status, ThingStatusDetail statusDetail, String description) {
         super.updateStatus(status, statusDetail, description);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public FritzahaWebInterface getWebInterface() {
         return this.connection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void addDeviceList(DeviceModel device) {
         try {
@@ -263,57 +255,59 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
         if (device.getPresent() == 1) {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
-                updateState(CHANNEL_TEMP, new DecimalType(device.getTemperature().getCelsius()));
+                updateThingChannelState(thing, CHANNEL_TEMP, new DecimalType(device.getTemperature().getCelsius()));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
-                updateState(CHANNEL_ENERGY, new DecimalType(device.getPowermeter().getEnergy()));
-                updateState(CHANNEL_POWER, new DecimalType(device.getPowermeter().getPower()));
+                updateThingChannelState(thing, CHANNEL_ENERGY, new DecimalType(device.getPowermeter().getEnergy()));
+                updateThingChannelState(thing, CHANNEL_POWER, new DecimalType(device.getPowermeter().getPower()));
             }
             if (device.isSwitchableOutlet() && device.getSwitch() != null) {
-                updateState(CHANNEL_MODE, new StringType(device.getSwitch().getMode()));
-                updateState(CHANNEL_LOCKED, device.getSwitch().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED
-                        : OpenClosedType.OPEN);
-                Channel channelSwitch = thing.getChannel(CHANNEL_SWITCH);
+                updateThingChannelState(thing, CHANNEL_MODE, new StringType(device.getSwitch().getMode()));
+                updateThingChannelState(thing, CHANNEL_LOCKED, device.getSwitch().getLock().equals(BigDecimal.ONE)
+                        ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
                 if (device.getSwitch().getState() == null) {
-                    updateState(CHANNEL_SWITCH, UnDefType.UNDEF);
+                    updateThingChannelState(thing, CHANNEL_SWITCH, UnDefType.UNDEF);
                 } else {
-                    updateState(CHANNEL_SWITCH,
+                    updateThingChannelState(thing, CHANNEL_SWITCH,
                             device.getSwitch().getState().equals(SwitchModel.ON) ? OnOffType.ON : OnOffType.OFF);
                 }
             }
             if (device.isHeatingThermostat() && device.getHkr() != null) {
-                updateState(CHANNEL_MODE, new StringType(device.getHkr().getMode()));
-                updateState(CHANNEL_LOCKED,
+                updateThingChannelState(thing, CHANNEL_MODE, new StringType(device.getHkr().getMode()));
+                updateThingChannelState(thing, CHANNEL_LOCKED,
                         device.getHkr().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
-                updateState(CHANNEL_ACTUALTEMP, new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
-                BigDecimal settemp = HeatingModel.toCelsius(device.getHkr().getTsoll());
+                updateThingChannelState(thing, CHANNEL_ACTUALTEMP,
+                        new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
+                final BigDecimal settemp = HeatingModel.toCelsius(device.getHkr().getTsoll());
                 if (HeatingModel.inCelsiusRange(settemp)) {
                     thing.getConfiguration().put(THING_SETTEMP, settemp);
                 }
-                updateState(CHANNEL_SETTEMP, new DecimalType(settemp));
-                BigDecimal ecotemp = HeatingModel.toCelsius(device.getHkr().getAbsenk());
+                updateThingChannelState(thing, CHANNEL_SETTEMP, new DecimalType(settemp));
+                final BigDecimal ecotemp = HeatingModel.toCelsius(device.getHkr().getAbsenk());
                 thing.getConfiguration().put(THING_ECOTEMP, ecotemp);
-                updateState(CHANNEL_ECOTEMP, new DecimalType(ecotemp));
-                BigDecimal comforttemp = HeatingModel.toCelsius(device.getHkr().getKomfort());
+                updateThingChannelState(thing, CHANNEL_ECOTEMP, new DecimalType(ecotemp));
+                final BigDecimal comforttemp = HeatingModel.toCelsius(device.getHkr().getKomfort());
                 thing.getConfiguration().put(THING_COMFORTTEMP, comforttemp);
-                updateState(CHANNEL_COMFORTTEMP, new DecimalType(comforttemp));
-                updateState(CHANNEL_RADIATOR_MODE, new StringType(device.getHkr().getRadiatorMode()));
+                updateThingChannelState(thing, CHANNEL_COMFORTTEMP, new DecimalType(comforttemp));
+                updateThingChannelState(thing, CHANNEL_RADIATOR_MODE,
+                        new StringType(device.getHkr().getRadiatorMode()));
                 if (device.getHkr().getNextchange() != null) {
                     if (device.getHkr().getNextchange().getEndperiod() == 0) {
-                        updateState(CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
+                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
                     } else {
-                        Calendar calendar = Calendar.getInstance();
+                        final Calendar calendar = Calendar.getInstance();
                         calendar.setTime(new Date(device.getHkr().getNextchange().getEndperiod() * 1000L));
-                        updateState(CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
+                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
                     }
-                    updateState(CHANNEL_NEXTTEMP,
+                    updateThingChannelState(thing, CHANNEL_NEXTTEMP,
                             new DecimalType(HeatingModel.toCelsius(device.getHkr().getNextchange().getTchange())));
                 }
                 if (device.getHkr().getBatterylow() == null) {
-                    updateState(CHANNEL_BATTERY, UnDefType.UNDEF);
+                    updateThingChannelState(thing, CHANNEL_BATTERY, UnDefType.UNDEF);
                 } else {
-                    updateState(CHANNEL_BATTERY, device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON)
-                            ? OnOffType.ON : OnOffType.OFF);
+                    updateThingChannelState(thing, CHANNEL_BATTERY,
+                            device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON) ? OnOffType.ON
+                                    : OnOffType.OFF);
                 }
             }
             // save AIN to config for PL546E standalone
@@ -322,6 +316,22 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             }
         } else {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Device not present"));
+        }
+    }
+
+    /**
+     * Updates thing channels.
+     *
+     * @param thing Thing to be updated.
+     * @param channelId ID of the channel to be updated.
+     * @param state State to be set.
+     */
+    private void updateThingChannelState(Thing thing, String channelId, State state) {
+        final Channel channel = thing.getChannel(channelId);
+        if (channel != null) {
+            updateState(channel.getUID(), state);
+        } else {
+            logger.warn("Channel {} in thing {} does not exist, please recreate the thing", channelId, thing.getUID());
         }
     }
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -39,7 +39,6 @@ import org.openhab.binding.avmfritz.config.AvmFritzConfiguration;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
-import org.openhab.binding.avmfritz.internal.ahamodel.TemperatureModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzahaWebInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,7 +184,6 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                 break;
             case CHANNEL_RADIATOR_MODE:
                 if (command instanceof StringType) {
-                    String mode = command.toString();
                     if (command.equals(MODE_ON)) {
                         BigDecimal settemp = (BigDecimal) getThing().getConfiguration().get(THING_SETTEMP);
                         fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(settemp));
@@ -271,8 +269,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
                 Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(),
-                        new DecimalType(TemperatureModel.toCelsius(device.getTemperature().getCelsius())));
+                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
                 Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -187,27 +187,22 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                     if (command.equals(MODE_ON)) {
                         BigDecimal settemp = (BigDecimal) getThing().getConfiguration().get(THING_SETTEMP);
                         fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(settemp));
-                        Channel channelSetTemp = getThing().getChannel(CHANNEL_SETTEMP);
-                        updateState(channelSetTemp.getUID(), new DecimalType(settemp));
+                        updateState(CHANNEL_SETTEMP, new DecimalType(settemp));
                     } else if (command.equals(MODE_OFF)) {
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_OFF);
-                        Channel channelSetTemp = getThing().getChannel(CHANNEL_SETTEMP);
-                        updateState(channelSetTemp.getUID(),
+                        updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_OFF)));
                     } else if (command.equals(MODE_COMFORT)) {
                         BigDecimal comfort_temp = (BigDecimal) getThing().getConfiguration().get(THING_COMFORTTEMP);
                         fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(comfort_temp));
-                        Channel channelSetTemp = getThing().getChannel(CHANNEL_SETTEMP);
-                        updateState(channelSetTemp.getUID(), new DecimalType(comfort_temp));
+                        updateState(CHANNEL_SETTEMP, new DecimalType(comfort_temp));
                     } else if (command.equals(MODE_ECO)) {
                         BigDecimal eco_temp = (BigDecimal) getThing().getConfiguration().get(THING_ECOTEMP);
                         fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(eco_temp));
-                        Channel channelSetTemp = getThing().getChannel(CHANNEL_SETTEMP);
-                        updateState(channelSetTemp.getUID(), new DecimalType(eco_temp));
+                        updateState(CHANNEL_SETTEMP, new DecimalType(eco_temp));
                     } else if (command.equals(MODE_BOOST)) {
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_MAX);
-                        Channel channelSetTemp = getThing().getChannel(CHANNEL_SETTEMP);
-                        updateState(channelSetTemp.getUID(),
+                        updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_MAX)));
                     } else {
                         logger.warn("Received unknown command {} for channel {}", command.toString(),
@@ -268,101 +263,57 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
         if (device.getPresent() == 1) {
             thing.setStatusInfo(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
             if (device.isTempSensor() && device.getTemperature() != null) {
-                Channel channelTemp = thing.getChannel(CHANNEL_TEMP);
-                updateState(channelTemp.getUID(), new DecimalType(device.getTemperature().getCelsius()));
+                updateState(CHANNEL_TEMP, new DecimalType(device.getTemperature().getCelsius()));
             }
             if (device.isPowermeter() && device.getPowermeter() != null) {
-                Channel channelEnergy = thing.getChannel(CHANNEL_ENERGY);
-                updateState(channelEnergy.getUID(), new DecimalType(device.getPowermeter().getEnergy()));
-                Channel channelPower = thing.getChannel(CHANNEL_POWER);
-                updateState(channelPower.getUID(), new DecimalType(device.getPowermeter().getPower()));
+                updateState(CHANNEL_ENERGY, new DecimalType(device.getPowermeter().getEnergy()));
+                updateState(CHANNEL_POWER, new DecimalType(device.getPowermeter().getPower()));
             }
             if (device.isSwitchableOutlet() && device.getSwitch() != null) {
-                Channel channelMode = thing.getChannel(CHANNEL_MODE);
-                if (channelMode != null) {
-                    updateState(channelMode.getUID(), new StringType(device.getSwitch().getMode()));
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_MODE,
-                            thing.getUID());
-                }
-                Channel channelLocked = thing.getChannel(CHANNEL_LOCKED);
-                if (channelLocked != null) {
-                    updateState(channelLocked.getUID(), device.getSwitch().getLock().equals(BigDecimal.ONE)
-                            ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_LOCKED,
-                            thing.getUID());
-                }
+                updateState(CHANNEL_MODE, new StringType(device.getSwitch().getMode()));
+                updateState(CHANNEL_LOCKED, device.getSwitch().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED
+                        : OpenClosedType.OPEN);
                 Channel channelSwitch = thing.getChannel(CHANNEL_SWITCH);
                 if (device.getSwitch().getState() == null) {
-                    updateState(channelSwitch.getUID(), UnDefType.UNDEF);
-                } else if (device.getSwitch().getState().equals(SwitchModel.ON)) {
-                    updateState(channelSwitch.getUID(), OnOffType.ON);
-                } else if (device.getSwitch().getState().equals(SwitchModel.OFF)) {
-                    updateState(channelSwitch.getUID(), OnOffType.OFF);
+                    updateState(CHANNEL_SWITCH, UnDefType.UNDEF);
                 } else {
-                    logger.warn("Received unknown value {} for channel {}", device.getSwitch().getState(),
-                            channelSwitch.getUID());
+                    updateState(CHANNEL_SWITCH,
+                            device.getSwitch().getState().equals(SwitchModel.ON) ? OnOffType.ON : OnOffType.OFF);
                 }
             }
             if (device.isHeatingThermostat() && device.getHkr() != null) {
-                Channel channelMode = thing.getChannel(CHANNEL_MODE);
-                if (channelMode != null) {
-                    updateState(channelMode.getUID(), new StringType(device.getHkr().getMode()));
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_MODE,
-                            thing.getUID());
-                }
-                Channel channelLocked = thing.getChannel(CHANNEL_LOCKED);
-                if (channelLocked != null) {
-                    updateState(channelLocked.getUID(), device.getHkr().getLock().equals(BigDecimal.ONE)
-                            ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
-                } else {
-                    logger.warn("Channel {} in thing {} does not exist, please recreate the thing", CHANNEL_LOCKED,
-                            thing.getUID());
-                }
-                Channel channelActualTemp = thing.getChannel(CHANNEL_ACTUALTEMP);
-                updateState(channelActualTemp.getUID(),
-                        new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
+                updateState(CHANNEL_MODE, new StringType(device.getHkr().getMode()));
+                updateState(CHANNEL_LOCKED,
+                        device.getHkr().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
+                updateState(CHANNEL_ACTUALTEMP, new DecimalType(HeatingModel.toCelsius(device.getHkr().getTist())));
                 BigDecimal settemp = HeatingModel.toCelsius(device.getHkr().getTsoll());
                 if (HeatingModel.inCelsiusRange(settemp)) {
                     thing.getConfiguration().put(THING_SETTEMP, settemp);
                 }
-                Channel channelSetTemp = thing.getChannel(CHANNEL_SETTEMP);
-                updateState(channelSetTemp.getUID(), new DecimalType(settemp));
+                updateState(CHANNEL_SETTEMP, new DecimalType(settemp));
                 BigDecimal ecotemp = HeatingModel.toCelsius(device.getHkr().getAbsenk());
                 thing.getConfiguration().put(THING_ECOTEMP, ecotemp);
-                Channel channelEcoTemp = thing.getChannel(CHANNEL_ECOTEMP);
-                updateState(channelEcoTemp.getUID(), new DecimalType(ecotemp));
+                updateState(CHANNEL_ECOTEMP, new DecimalType(ecotemp));
                 BigDecimal comforttemp = HeatingModel.toCelsius(device.getHkr().getKomfort());
                 thing.getConfiguration().put(THING_COMFORTTEMP, comforttemp);
-                Channel channelComfortTemp = thing.getChannel(CHANNEL_COMFORTTEMP);
-                updateState(channelComfortTemp.getUID(), new DecimalType(comforttemp));
-                Channel channelRadiatorMode = thing.getChannel(CHANNEL_RADIATOR_MODE);
-                updateState(channelRadiatorMode.getUID(), new StringType(device.getHkr().getRadiatorMode()));
+                updateState(CHANNEL_COMFORTTEMP, new DecimalType(comforttemp));
+                updateState(CHANNEL_RADIATOR_MODE, new StringType(device.getHkr().getRadiatorMode()));
                 if (device.getHkr().getNextchange() != null) {
-                    Channel channelNextChange = thing.getChannel(CHANNEL_NEXTCHANGE);
                     if (device.getHkr().getNextchange().getEndperiod() == 0) {
-                        updateState(channelNextChange.getUID(), UnDefType.UNDEF);
+                        updateState(CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
                     } else {
                         Calendar calendar = Calendar.getInstance();
                         calendar.setTime(new Date(device.getHkr().getNextchange().getEndperiod() * 1000L));
-                        updateState(channelNextChange.getUID(), new DateTimeType(calendar));
+                        updateState(CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
                     }
-                    Channel channelNextTemp = thing.getChannel(CHANNEL_NEXTTEMP);
-                    updateState(channelNextTemp.getUID(),
+                    updateState(CHANNEL_NEXTTEMP,
                             new DecimalType(HeatingModel.toCelsius(device.getHkr().getNextchange().getTchange())));
                 }
-                Channel channelBattery = thing.getChannel(CHANNEL_BATTERY);
                 if (device.getHkr().getBatterylow() == null) {
-                    updateState(channelBattery.getUID(), UnDefType.UNDEF);
-                } else if (device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON)) {
-                    updateState(channelBattery.getUID(), OnOffType.ON);
-                } else if (device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_OFF)) {
-                    updateState(channelBattery.getUID(), OnOffType.OFF);
+                    updateState(CHANNEL_BATTERY, UnDefType.UNDEF);
                 } else {
-                    logger.warn("Received unknown value {} for channel {}", device.getHkr().getBatterylow(),
-                            channelBattery.getUID());
+                    updateState(CHANNEL_BATTERY, device.getHkr().getBatterylow().equals(HeatingModel.BATTERY_ON)
+                            ? OnOffType.ON : OnOffType.OFF);
                 }
             }
             // save AIN to config for PL546E standalone

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/HandlerFactory.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/HandlerFactory.java
@@ -101,3 +101,4 @@ public class HandlerFactory extends BaseThingHandlerFactory {
                 .registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
     }
 }
+

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
@@ -38,15 +38,15 @@ public class HeatingModel {
     public static final BigDecimal BATTERY_OFF = BigDecimal.ZERO;
     public static final BigDecimal BATTERY_ON = BigDecimal.ONE;
 
-    protected BigDecimal tist;
-    protected BigDecimal tsoll;
-    protected BigDecimal absenk;
-    protected BigDecimal komfort;
-    protected BigDecimal lock;
-    protected BigDecimal devicelock;
-    protected String errorcode;
-    protected BigDecimal batterylow;
-    protected Nextchange nextchange;
+    private BigDecimal tist;
+    private BigDecimal tsoll;
+    private BigDecimal absenk;
+    private BigDecimal komfort;
+    private BigDecimal lock;
+    private BigDecimal devicelock;
+    private String errorcode;
+    private BigDecimal batterylow;
+    private Nextchange nextchange;
 
     public BigDecimal getTist() {
         return tist;
@@ -154,15 +154,15 @@ public class HeatingModel {
     }
 
     public static boolean inCelsiusRange(BigDecimal celsiusValue) {
-        return (celsiusValue.compareTo(TEMP_CELSIUS_MIN) >= 0) && (celsiusValue.compareTo(TEMP_CELSIUS_MAX) <= 0);
+        return (TEMP_CELSIUS_MIN.compareTo(celsiusValue) <= 0) && (TEMP_CELSIUS_MAX.compareTo(celsiusValue) >= 0);
     }
 
     public static BigDecimal fromCelsius(BigDecimal celsiusValue) {
         if (celsiusValue == null) {
             return BigDecimal.ZERO;
-        } else if (HeatingModel.TEMP_CELSIUS_MIN.compareTo(celsiusValue) == -1) {
+        } else if (TEMP_CELSIUS_MIN.compareTo(celsiusValue) == 1) {
             return TEMP_FRITZ_MIN;
-        } else if (HeatingModel.TEMP_CELSIUS_MAX.compareTo(celsiusValue) == 1) {
+        } else if (TEMP_CELSIUS_MAX.compareTo(celsiusValue) == -1) {
             return TEMP_FRITZ_MAX;
         }
         return celsiusValue.divide(TEMP_FACTOR);
@@ -182,8 +182,8 @@ public class HeatingModel {
     @XmlType(name = "", propOrder = { "endperiod", "tchange" })
     public static class Nextchange {
 
-        protected int endperiod;
-        protected BigDecimal tchange;
+        private int endperiod;
+        private BigDecimal tchange;
 
         public int getEndperiod() {
             return endperiod;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.avmfritz.internal.ahamodel;
 
+import static org.openhab.binding.avmfritz.BindingConstants.*;
+
 import java.math.BigDecimal;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -27,10 +29,12 @@ import org.apache.commons.lang.builder.ToStringBuilder;
         "nextchange" })
 public class HeatingModel {
     public static final BigDecimal TEMP_FACTOR = new BigDecimal("0.5");
-    public static final BigDecimal TEMP_MIN = new BigDecimal("8.0");
-    public static final BigDecimal TEMP_MAX = new BigDecimal("28.0");
-    public static final BigDecimal TEMP_OFF = new BigDecimal("253.0");
-    public static final BigDecimal TEMP_ON = new BigDecimal("254.0");
+    public static final BigDecimal TEMP_CELSIUS_MIN = new BigDecimal("8.0");
+    public static final BigDecimal TEMP_CELSIUS_MAX = new BigDecimal("28.0");
+    public static final BigDecimal TEMP_FRITZ_MIN = new BigDecimal("16.0");
+    public static final BigDecimal TEMP_FRITZ_MAX = new BigDecimal("56.0");
+    public static final BigDecimal TEMP_FRITZ_OFF = new BigDecimal("253.0");
+    public static final BigDecimal TEMP_FRITZ_ON = new BigDecimal("254.0");
     public static final BigDecimal BATTERY_OFF = BigDecimal.ZERO;
     public static final BigDecimal BATTERY_ON = BigDecimal.ONE;
 
@@ -45,7 +49,7 @@ public class HeatingModel {
     protected Nextchange nextchange;
 
     public BigDecimal getTist() {
-        return tist != null ? tist.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+        return tist;
     }
 
     public void setTist(BigDecimal tist) {
@@ -53,15 +57,7 @@ public class HeatingModel {
     }
 
     public BigDecimal getTsoll() {
-        if (tsoll == null) {
-            return BigDecimal.ZERO;
-        } else if (tsoll.compareTo(TEMP_ON) == 0) {
-            return TEMP_MAX.add(new BigDecimal("2.0"));
-        } else if (tsoll.compareTo(TEMP_OFF) == 0) {
-            return TEMP_MIN.subtract(new BigDecimal("2.0"));
-        } else {
-            return tsoll.multiply(TEMP_FACTOR);
-        }
+        return tsoll;
     }
 
     public void setTsoll(BigDecimal tsoll) {
@@ -69,7 +65,7 @@ public class HeatingModel {
     }
 
     public BigDecimal getKomfort() {
-        return komfort != null ? komfort.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+        return komfort;
     }
 
     public void setKomfort(BigDecimal komfort) {
@@ -77,11 +73,37 @@ public class HeatingModel {
     }
 
     public BigDecimal getAbsenk() {
-        return absenk != null ? absenk.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+        return absenk;
     }
 
     public void setAbsenk(BigDecimal absenk) {
         this.absenk = absenk;
+    }
+
+    public String getMode() {
+        if (getNextchange() != null && getNextchange().getEndperiod() != 0) {
+            return MODE_AUTO;
+        } else {
+            return MODE_MANUAL;
+        }
+    }
+
+    public String getRadiatorMode() {
+        if (tsoll == null) {
+            return MODE_UNKNOWN;
+        } else if (TEMP_FRITZ_ON.compareTo(tsoll) == 0) {
+            return MODE_ON;
+        } else if (TEMP_FRITZ_OFF.compareTo(tsoll) == 0) {
+            return MODE_OFF;
+        } else if (tsoll.compareTo(komfort) == 0) {
+            return MODE_COMFORT;
+        } else if (tsoll.compareTo(absenk) == 0) {
+            return MODE_ECO;
+        } else if (TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
+            return MODE_BOOST;
+        } else {
+            return MODE_UNKNOWN;
+        }
     }
 
     public BigDecimal getLock() {
@@ -131,6 +153,32 @@ public class HeatingModel {
                 .append("nextchange", getNextchange()).toString();
     }
 
+    public static boolean inCelsiusRange(BigDecimal celsiusValue) {
+        return (celsiusValue.compareTo(TEMP_CELSIUS_MIN) >= 0) && (celsiusValue.compareTo(TEMP_CELSIUS_MAX) <= 0);
+    }
+
+    public static BigDecimal fromCelsius(BigDecimal celsiusValue) {
+        if (celsiusValue == null) {
+            return BigDecimal.ZERO;
+        } else if (HeatingModel.TEMP_CELSIUS_MIN.compareTo(celsiusValue) == -1) {
+            return TEMP_FRITZ_MIN;
+        } else if (HeatingModel.TEMP_CELSIUS_MAX.compareTo(celsiusValue) == 1) {
+            return TEMP_FRITZ_MAX;
+        }
+        return celsiusValue.divide(TEMP_FACTOR);
+    }
+
+    public static BigDecimal toCelsius(BigDecimal fritzValue) {
+        if (fritzValue == null) {
+            return BigDecimal.ZERO;
+        } else if (TEMP_FRITZ_ON.compareTo(fritzValue) == 0) {
+            return TEMP_CELSIUS_MAX.add(new BigDecimal("2.0"));
+        } else if (TEMP_FRITZ_OFF.compareTo(fritzValue) == 0) {
+            return TEMP_CELSIUS_MIN.subtract(new BigDecimal("2.0"));
+        }
+        return TEMP_FACTOR.multiply(fritzValue);
+    }
+
     @XmlType(name = "", propOrder = { "endperiod", "tchange" })
     public static class Nextchange {
 
@@ -146,7 +194,7 @@ public class HeatingModel {
         }
 
         public BigDecimal getTchange() {
-            return tchange != null ? tchange.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+            return tchange;
         }
 
         public void setTchange(BigDecimal tchange) {

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/SwitchModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/SwitchModel.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.avmfritz.internal.ahamodel;
 
+import static org.openhab.binding.avmfritz.BindingConstants.*;
+
 import java.math.BigDecimal;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -18,7 +20,8 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 /**
  * See {@link DevicelistModel}.
  *
- * @author Robert Bausdorf
+ * @author Robert Bausdorf - Initial contribution
+ * @author Christoph Weitkamp - Added new channels `locked`, `mode` and `radiator_mode`
  *
  */
 @XmlRootElement(name = "switch")
@@ -40,7 +43,11 @@ public class SwitchModel {
     }
 
     public String getMode() {
-        return mode;
+        if (mode.equals("auto")) {
+            return MODE_AUTO;
+        } else {
+            return MODE_MANUAL;
+        }
     }
 
     public void setMode(String mode) {
@@ -57,7 +64,7 @@ public class SwitchModel {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append("state", this.getState()).append("mode", this.getMode())
-                .append("lock", this.getLock()).toString();
+        return new ToStringBuilder(this).append("state", getState()).append("mode", getMode()).append("lock", getLock())
+                .toString();
     }
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/SwitchModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/SwitchModel.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 public class SwitchModel {
     public static final BigDecimal ON = BigDecimal.ONE;
     public static final BigDecimal OFF = BigDecimal.ZERO;
+    public static final String MODE_FRITZ_AUTO = "auto";
+    public static final String MODE_FRITZ_MANUAL = "manuell";
 
     private BigDecimal state;
     private String mode;
@@ -43,7 +45,7 @@ public class SwitchModel {
     }
 
     public String getMode() {
-        if (mode.equals("auto")) {
+        if (MODE_FRITZ_AUTO.equals(mode)) {
             return MODE_AUTO;
         } else {
             return MODE_MANUAL;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/TemperatureModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/TemperatureModel.java
@@ -18,7 +18,8 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 /**
  * See {@link DevicelistModel}.
  *
- * @author Robert Bausdorf
+ * @author Robert Bausdorf - Initial contribution
+ * @author Christoph Weitkamp - Added new channels `locked`, `mode` and `radiator_mode`
  *
  */
 @XmlRootElement(name = "temperature")
@@ -30,7 +31,7 @@ public class TemperatureModel {
     private BigDecimal offset;
 
     public BigDecimal getCelsius() {
-        return celsius != null ? celsius.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+        return celsius;
     }
 
     public void setCelsius(BigDecimal celsius) {
@@ -38,16 +39,22 @@ public class TemperatureModel {
     }
 
     public BigDecimal getOffset() {
-        return offset != null ? offset.multiply(TEMP_FACTOR) : BigDecimal.ZERO;
+        return offset;
     }
 
     public void setOffset(BigDecimal offset) {
         this.offset = offset;
     }
 
+    public static BigDecimal toCelsius(BigDecimal fritzValue) {
+        if (fritzValue == null) {
+            return BigDecimal.ZERO;
+        }
+        return TEMP_FACTOR.multiply(fritzValue);
+    }
+
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append("celsius", this.getCelsius()).append("offset", this.getOffset())
-                .toString();
+        return new ToStringBuilder(this).append("celsius", getCelsius()).append("offset", getOffset()).toString();
     }
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/TemperatureModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/TemperatureModel.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * See {@link DevicelistModel}.
  *
  * @author Robert Bausdorf - Initial contribution
- * @author Christoph Weitkamp - Added new channels `locked`, `mode` and `radiator_mode`
+ * @author Christoph Weitkamp - Refactoring of temperature conversion from celsius to FRITZ!Box values
  *
  */
 @XmlRootElement(name = "temperature")
@@ -31,7 +31,7 @@ public class TemperatureModel {
     private BigDecimal offset;
 
     public BigDecimal getCelsius() {
-        return celsius;
+        return celsius != null ? TEMP_FACTOR.multiply(celsius) : BigDecimal.ZERO;
     }
 
     public void setCelsius(BigDecimal celsius) {
@@ -39,18 +39,11 @@ public class TemperatureModel {
     }
 
     public BigDecimal getOffset() {
-        return offset;
+        return offset != null ? TEMP_FACTOR.multiply(offset) : BigDecimal.ZERO;
     }
 
     public void setOffset(BigDecimal offset) {
         this.offset = offset;
-    }
-
-    public static BigDecimal toCelsius(BigDecimal fritzValue) {
-        if (fritzValue == null) {
-            return BigDecimal.ZERO;
-        }
-        return TEMP_FACTOR.multiply(fritzValue);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzahaWebInterface.java
@@ -69,7 +69,7 @@ public class FritzahaWebInterface {
      */
     protected IFritzHandler fbHandler;
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(FritzahaWebInterface.class);
     // Uses RegEx to handle bad FRITZ!Box XML
     /**
      * RegEx Pattern to grab the session ID from a login XML response
@@ -198,7 +198,7 @@ public class FritzahaWebInterface {
      * @return Response to the challenge
      */
     protected String createResponse(String challenge) {
-        String handshake = challenge.concat("-").concat(this.config.getPassword());
+        String handshake = challenge.concat("-").concat(config.getPassword());
         MessageDigest md5;
         try {
             md5 = MessageDigest.getInstance("MD5");
@@ -247,8 +247,8 @@ public class FritzahaWebInterface {
      * @return URL
      */
     public String getURL(String path) {
-        return this.config.getProtocol() + "://" + this.config.getIpAddress()
-                + (this.config.getPort() != null ? ":" + this.config.getPort() : "") + "/" + path;
+        return config.getProtocol() + "://" + config.getIpAddress()
+                + (config.getPort() != null ? ":" + config.getPort() : "") + "/" + path;
     }
 
     /**
@@ -284,7 +284,7 @@ public class FritzahaWebInterface {
             authenticate();
         }
         FritzahaContentExchange getExchange = new FritzahaContentExchange(callback);
-        asyncclient.newRequest(getURL(path, this.addSID(args))).method(HttpMethod.GET).onResponseSuccess(getExchange)
+        asyncclient.newRequest(getURL(path, addSID(args))).method(HttpMethod.GET).onResponseSuccess(getExchange)
                 .onResponseFailure(getExchange) // .onComplete(getExchange)
                 .send(getExchange);
         logger.debug("GETting URL {}", getURL(path, addSID(args)));
@@ -292,7 +292,7 @@ public class FritzahaWebInterface {
     }
 
     public FritzahaContentExchange asyncGet(FritzAhaCallback callback) {
-        return this.asyncGet(callback.getPath(), callback.getArgs(), callback);
+        return asyncGet(callback.getPath(), callback.getArgs(), callback);
     }
 
     /**
@@ -307,8 +307,8 @@ public class FritzahaWebInterface {
             authenticate();
         }
         FritzahaContentExchange postExchange = new FritzahaContentExchange(callback);
-        asyncclient.newRequest(getURL(path)).timeout(this.config.getAsyncTimeout(), TimeUnit.SECONDS)
-                .method(HttpMethod.POST).onResponseSuccess(postExchange).onResponseFailure(postExchange) // .onComplete(postExchange)
+        asyncclient.newRequest(getURL(path)).timeout(config.getAsyncTimeout(), TimeUnit.SECONDS).method(HttpMethod.POST)
+                .onResponseSuccess(postExchange).onResponseFailure(postExchange) // .onComplete(postExchange)
                 .content(new StringContentProvider(addSID(args), "UTF-8")).send(postExchange);
         return postExchange;
     }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetHeatingTemperatureCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetHeatingTemperatureCallback.java
@@ -42,9 +42,6 @@ public class FritzAhaSetHeatingTemperatureCallback extends FritzAhaReauthCallbac
         itemName = ain;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void execute(int status, String response) {
         super.execute(status, response);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetHeatingTemperatureCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaSetHeatingTemperatureCallback.java
@@ -22,7 +22,9 @@ import org.slf4j.LoggerFactory;
  * 
  */
 public class FritzAhaSetHeatingTemperatureCallback extends FritzAhaReauthCallback {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Logger logger = LoggerFactory.getLogger(FritzAhaSetHeatingTemperatureCallback.class);
+
     /**
      * Item to update
      */
@@ -40,6 +42,10 @@ public class FritzAhaSetHeatingTemperatureCallback extends FritzAhaReauthCallbac
         itemName = ain;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void execute(int status, String response) {
         super.execute(status, response);
         if (isValidRequest()) {


### PR DESCRIPTION
* Added new channels `locked`, `mode` and `radiator_mode`
* Refactoring of updating channels in `BoxHandler` and `DeviceHandler`
* Refactoring of temperature conversion from celsius to FRITZ!Box values and vice versa
* Removed translation for `battery_low` channel

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>