### PR TITLE
[homematic] Prevent ClassCastException in case of unexpectect message types

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetDescriptionParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetDescriptionParser.java
@@ -15,6 +15,8 @@ import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmInterface;
 import org.openhab.binding.homematic.internal.model.HmParamsetType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Parses a parameter description message and extracts datapoint metadata.
@@ -22,6 +24,7 @@ import org.openhab.binding.homematic.internal.model.HmParamsetType;
  * @author Gerhard Riegler - Initial contribution
  */
 public class GetParamsetDescriptionParser extends CommonRpcParser<Object[], Void> {
+    private final Logger logger = LoggerFactory.getLogger(GetParamsetDescriptionParser.class);
     private HmParamsetType paramsetType;
     private HmChannel channel;
     private boolean isHmIpDevice;
@@ -38,6 +41,10 @@ public class GetParamsetDescriptionParser extends CommonRpcParser<Object[], Void
     @Override
     @SuppressWarnings("unchecked")
     public Void parse(Object[] message) throws IOException {
+        if (!(message[0] instanceof Map)) {
+            logger.debug("Unexpected datatype '{}',  ignoring message", message[0].getClass());
+            return null;
+        }
         Map<String, Map<String, Object>> dpNames = (Map<String, Map<String, Object>>) message[0];
 
         for (String datapointName : dpNames.keySet()) {


### PR DESCRIPTION
This PR fixes issue #2373 by preventing an exception in the case of unexpected response message content.

Should be tested by the issue creator before merging, because this correction may not be sufficient.

Signed-off-by: Martin Herbst <mail@mherbst.de>
