### PR TITLE
[Test skeleton] Add create_openhab_binding_test_skeleton.sh/cmd to the binding directory

### DIFF
--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -1,0 +1,23 @@
+@echo off
+
+SETLOCAL
+SET ARGC=0
+
+FOR %%x IN (%*) DO SET /A ARGC+=1
+
+IF %ARGC% NEQ 2 (
+	echo Usage: %0 BindingIdInCamelCase BindingIdInLowerCase
+	exit /B 1
+)
+
+If NOT exist "org.openhab.binding.%2" (
+	echo The binding with the id must exist: org.openhab.binding.%2
+	exit /B 1
+)
+
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2.test -Dversion=2.1.0-SNAPSHOT -DbindingId=%2.test -DbindingIdCamelCase=%1.test -DvendorName=openHAB -Dnamespace=org.openhab
+
+COPY ..\..\src\etc\about.html org.openhab.binding.%2.test%\
+
+ENDLOCAL
+

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+camelcaseId=$1
+[ $# -eq 0 ] && { echo "Usage: $0 <BindingIdInCamelCase>"; exit 1; }
+
+id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
+
+[ -d org.openhab.binding.$id ] || { echo "The binding with the id must exist: org.openhab.binding.$id"; exit 1; }
+
+mvn -s ../archetype-settings.xml archetype:generate -N \
+  -DarchetypeGroupId=org.eclipse.smarthome.archetype \
+  -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test \
+  -DarchetypeVersion=0.9.0-SNAPSHOT \
+  -DgroupId=org.openhab.binding \
+  -DartifactId=org.openhab.binding.$id.test \
+  -Dpackage=org.openhab.binding.$id.test \
+  -Dversion=2.1.0-SNAPSHOT \
+  -DbindingId=$id.test \
+  -DbindingIdCamelCase=$camelcaseId.test \
+  -DvendorName=openHAB \
+  -Dnamespace=org.openhab
+
+directory=`echo "org.openhab.binding."$id".test"/`
+
+cp ../../src/etc/about.html "$directory"


### PR DESCRIPTION
I'd like to create a test for the yamaha binding, and in contrast to creating a new binding, there is no script to create a skeleton test directory.

This pull request adds the missing scripts for linux and windows and uses the "Eclipse Smarthome Binding Archetype Testsuite" artifact (org.eclipse.smarthome.archetype.binding.test). If this is not appropriate for OH2, somebody should create a fitting artifact. It is definitely harder then necessary to create a test suite for a binding at the moment.

Cheers, David