### PR TITLE
[Milight] Prevent listing non Milight bridge devices in the discovery.

### DIFF
--- a/addons/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package: com.google.common.collect,
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.milight,
  org.openhab.binding.milight.handler
+Bundle-ActivationPolicy: lazy

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV3Handler.java
@@ -107,7 +107,7 @@ public class MilightBridgeV3Handler extends AbstractMilightBridgeHandler impleme
     @Override
     public void dispose() {
         if (discover != null) {
-            discover.dispose();
+            discover.release();
         }
         super.dispose();
     }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/discovery/MilightBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/discovery/MilightBridgeDiscovery.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class MilightBridgeDiscovery extends AbstractDiscoveryService implements DiscoverResult {
     private ScheduledFuture<?> backgroundFuture;
-    private final InetAddress broadcast;
     private Logger logger = LoggerFactory.getLogger(MilightBridgeDiscovery.class);
     private MilightDiscover receiveThread;
 
@@ -61,8 +60,6 @@ public class MilightBridgeDiscovery extends AbstractDiscoveryService implements 
 
     public MilightBridgeDiscovery() throws IllegalArgumentException, UnknownHostException {
         super(MilightBindingConstants.BRIDGE_THING_TYPES_UIDS, 2, true);
-        byte[] addr = { (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
-        broadcast = InetAddress.getByAddress(addr);
         startDiscoveryService();
     }
 
@@ -85,7 +82,7 @@ public class MilightBridgeDiscovery extends AbstractDiscoveryService implements 
             backgroundFuture = null;
         }
         if (receiveThread != null) {
-            receiveThread.dispose();
+            receiveThread.release();
         }
         receiveThread = null;
     }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightDiscover.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightDiscover.java
@@ -16,13 +16,15 @@ import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.openhab.binding.milight.MilightBindingConstants;
+import org.openhab.binding.milight.internal.protocol.MilightV6SessionManager.SessionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +32,11 @@ import org.slf4j.LoggerFactory;
  * Milight bridges v3/v4/v5 and v6 can be discovered by sending specially formated UDP packets.
  * This class sends UDP packets on port PORT_DISCOVER up to three times in a row
  * and listens for the response and will call discoverResult.bridgeDetected() eventually.
+ *
+ * The response of the bridges is unfortunately very generic and is the unmodified response of
+ * any HF-LPB100 wifi chipset. Therefore other devices as the Orvibo Smart Plugs are recognised
+ * as Milight Bridges as well. For v5/v6 there are some additional checks to make sure we are
+ * talking to a Milight.
  *
  * @author David Graeff <david.graeff@web.de>
  */
@@ -63,6 +70,7 @@ public class MilightDiscover extends Thread {
     private final int resendTimeoutInMillis;
     private final int resendAttempts;
     private InetAddress destIP;
+    private ScheduledExecutorService scheduler;
 
     public MilightDiscover(DiscoverResult discoverResult, int resendTimeoutInMillis, int resendAttempts)
             throws SocketException {
@@ -76,62 +84,64 @@ public class MilightDiscover extends Thread {
         this.discoverResult = discoverResult;
     }
 
-    public void dispose() {
+    /**
+     * Closes the socket and waits for the thread to shutdown.
+     * You cannot reuse this object after calling release.
+     */
+    public void release() {
+        if (datagramSocket == null) {
+            return;
+        }
+        stopResend();
         willbeclosed = true;
         datagramSocket.close();
-        try {
-            join(500);
-        } catch (InterruptedException e) {
-        }
-        interrupt();
-        if (datagramSocket != null) {
-            datagramSocket.close();
-            datagramSocket = null;
+        if (Thread.currentThread() != this) {
+            try {
+                join(500);
+            } catch (InterruptedException e) {
+            }
+            interrupt();
         }
     }
 
     /**
-     * Used by the scheduler to resend discover messages. Stops after 3 attempts.
+     * Used by the scheduler to resend discover messages. Stops after a configured amount of attempts.
      */
     private class SendDiscoverRunnable implements Runnable {
         @Override
         public void run() {
+            // Stop after a certain amount of attempts
             if (++resendCounter > resendAttempts) {
-                if (resendTimer != null) {
-                    resendTimer.cancel(false);
-                    resendTimer = null;
+                stopResend();
+                // If we tried to discover a specific bridge, we apparently failed. Report this to the observer.
+                if (destIP != null) {
+                    discoverResult.noBridgeDetected();
                 }
-                discoverResult.noBridgeDetected();
                 return;
             }
 
             if (destIP != null) {
                 sendDiscover(destIP);
-            } else {
-                Enumeration<NetworkInterface> e;
-                try {
-                    e = NetworkInterface.getNetworkInterfaces();
-                } catch (SocketException e1) {
-                    logger.error("Could not enumerate network interfaces for sending the discover packet!");
-                    stopResend();
-                    return;
-                }
-                while (e.hasMoreElements()) {
-                    NetworkInterface networkInterface = e.nextElement();
-                    Iterator<InterfaceAddress> it = networkInterface.getInterfaceAddresses().iterator();
-                    while (it.hasNext()) {
-                        InterfaceAddress address = it.next();
-                        if (address == null) {
-                            continue;
-                        }
-                        InetAddress broadcast = address.getBroadcast();
-                        if (broadcast != null && !address.getAddress().isLoopbackAddress()) {
-                            sendDiscover(broadcast);
-                        }
+                return;
+            }
+
+            Enumeration<NetworkInterface> e;
+            try {
+                e = NetworkInterface.getNetworkInterfaces();
+            } catch (SocketException e1) {
+                logger.error("Could not enumerate network interfaces for sending the discover packet!");
+                stopResend();
+                return;
+            }
+            while (e.hasMoreElements()) {
+                NetworkInterface networkInterface = e.nextElement();
+                for (InterfaceAddress address : networkInterface.getInterfaceAddresses()) {
+                    InetAddress broadcast = address.getBroadcast();
+                    if (broadcast != null && !address.getAddress().isLoopbackAddress()) {
+                        sendDiscover(broadcast);
                     }
                 }
             }
-
         }
 
         private void sendDiscover(InetAddress destIP) {
@@ -156,6 +166,12 @@ public class MilightDiscover extends Thread {
         }
     }
 
+    /**
+     * This will not stop the discovery thread (like dispose()), so discovery
+     * packet responses can still be received, but will stop
+     * re-sending discovery packets. Call sendDiscover() to restart sending
+     * discovery packets.
+     */
     public void stopResend() {
         if (resendTimer != null) {
             resendTimer.cancel(false);
@@ -176,6 +192,7 @@ public class MilightDiscover extends Thread {
         }
 
         resendCounter = 0;
+        this.scheduler = scheduler;
         resendTimer = scheduler.scheduleWithFixedDelay(new SendDiscoverRunnable(), 0, resendTimeoutInMillis,
                 TimeUnit.MILLISECONDS);
     }
@@ -183,37 +200,94 @@ public class MilightDiscover extends Thread {
     @Override
     public void run() {
         try {
-            // logger.debug("Discovery receive thread ready");
-
-            // Now loop forever, waiting to receive packets and printing them.
             while (!willbeclosed) {
                 packet.setLength(buffer.length);
                 datagramSocket.receive(packet);
-                // example: 10.1.1.27,ACCF23F57AD4,HF-LPB100
+                // We expect packets with a format like this: 10.1.1.27,ACCF23F57AD4,HF-LPB100
                 String[] msg = new String(buffer, 0, packet.getLength()).split(",");
-                if (msg.length >= 2 && msg[1].length() == 12) {
-                    // Stop resend timer if we got a packet.
-                    if (resendTimer != null) {
-                        resendTimer.cancel(true);
-                        resendTimer = null;
-                    }
-                    // Determine version: Version 6 sends a third argument != ""
-                    int version = msg.length >= 3 && msg[2].trim().length() > 0 ? 6 : 3;
-                    // Notify all observers
-                    discoverResult.bridgeDetected(((InetSocketAddress) packet.getSocketAddress()).getAddress(), msg[1],
-                            version);
-                } else {
-                    logger.error("Unexpected data received {}", msg[0]);
+
+                if (msg.length != 2 && msg.length != 3) {
+                    // That data packet does not belong to a Milight bridge. Just ignore it.
+                    continue;
                 }
+
+                int version = 3; // Assume version 3
+                // First argument is the IP
+                try {
+                    InetAddress.getByName(msg[0]);
+                } catch (UnknownHostException ignored) {
+                    // That data packet does not belong to a Milight bridge, we expect an IP address as first argument.
+                    // Just ignore it.
+                    continue;
+                }
+
+                // Second argument is the MAC address
+                if (msg[1].length() != 12) {
+                    // That data packet does not belong to a Milight bridge, we expect a MAC address as second argument.
+                    // Just ignore it.
+                    continue;
+                }
+
+                InetAddress addressOfBridge = ((InetSocketAddress) packet.getSocketAddress()).getAddress();
+                if (msg.length == 3) {
+                    version = 6; // It is probably version 6
+                    if (!(msg[2].length() == 0 || "HF-LPB100".equals(msg[2]))) {
+                        logger.trace("Unexpected data. We expected a HF-LPB100 or empty identifier {}", msg[2]);
+                        continue;
+                    }
+                    if (!checkForV6Bridge(addressOfBridge, msg[1])) {
+                        logger.trace("The device at IP {} does not seem to be a V6 Milight bridge", msg[0]);
+                        continue;
+                    }
+                }
+
+                stopResend();
+                discoverResult.bridgeDetected(addressOfBridge, msg[1], version);
             }
         } catch (IOException e) {
             if (willbeclosed) {
                 return;
             }
-            logger.error("{}", e.getLocalizedMessage());
+            logger.warn("{}", e.getLocalizedMessage());
+        } catch (InterruptedException ignore) {
+            // Ignore this exception, the thread is finished now anyway
         }
     }
 
+    /**
+     * We use the {@see MilightV6SessionManager} to establish a full session to the bridge. If we reach
+     * the SESSION_VALID state within 1.3s, we can safely assume it is a V6 Milight bridge.
+     *
+     * @param addressOfBridge IP Address of the bridge
+     * @return
+     * @throws InterruptedException If waiting for the session is interrupted we throw this exception
+     */
+    private boolean checkForV6Bridge(InetAddress addressOfBridge, String bridgeID) throws InterruptedException {
+        QueuedSend queuedSend;
+        try {
+            queuedSend = new QueuedSend();
+            Semaphore s = new Semaphore(0);
+            MilightV6SessionManager session = new MilightV6SessionManager(queuedSend, bridgeID, scheduler,
+                    (SessionState state) -> {
+                        if (state == SessionState.SESSION_VALID) {
+                            s.release();
+                        }
+                    });
+            boolean success = s.tryAcquire(1, 1300, TimeUnit.MILLISECONDS);
+            session.dispose();
+            queuedSend.dispose();
+            return success;
+        } catch (SocketException e) {
+            logger.debug("Could not create a udp socket", e);
+        }
+        return false;
+    }
+
+    /**
+     * Perform a discovery on a fixed IP address
+     *
+     * @param addr The IP address
+     */
     public void setFixedAddr(InetAddress addr) {
         destIP = addr;
     }


### PR DESCRIPTION
The milight V6 bridges respond with a very generic response typical for the used wifi chip.
Therefore the discovery listed Orvibo Smart Plugs as Milight V6 bridges.
To prevent this, we establish a full Milight V6 bridge session as part of the discovery process.

Fixes #2090