### PR TITLE
[Milight] The session handler can cope with bridges in different subnets now

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV6Handler.java
@@ -81,7 +81,7 @@ public class MilightBridgeV6Handler extends AbstractMilightBridgeHandler impleme
         com.start();
 
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Waiting for session");
-        session = new MilightV6SessionManager(com, bridgeid, scheduler, this);
+        session = new MilightV6SessionManager(com, bridgeid, scheduler, this, addr);
     }
 
     @Override
@@ -89,8 +89,12 @@ public class MilightBridgeV6Handler extends AbstractMilightBridgeHandler impleme
         return new Runnable() {
             @Override
             public void run() {
-                // logger.debug("Session keep alive");
-                session.keep_alive(refrehIntervalSec * 1000);
+                try {
+                    session.keep_alive(refrehIntervalSec * 1000);
+                } catch (InterruptedException e) {
+                    // Someone wants to end this thread
+                    return;
+                }
                 updateProperty(MilightBindingConstants.PROPERTY_SESSIONID, session.getSession());
                 updateProperty(MilightBindingConstants.PROPERTY_SESSIONCONFIRMED,
                         String.valueOf(session.getLastSessionValidConfirmation()));


### PR DESCRIPTION
The session manager will first try to use a unicast packet if an IP is known
and only falls back to broadcast packets in further attempts.

The Interrupted exception is now handled in a more reasonable way.

Fixes #2321