### PR TITLE
[rfxcom] Added ASA option to "RFXCOM Rfy Actuator" thing

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/rfy.xml
@@ -40,6 +40,7 @@
 				<options>
 					<option value="RFY">RFY</option>
 					<option value="RFY_EXT">RFY Ext</option>
+					<option value="ASA">ASA</option>
 				</options>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
Added ASA as an option to the "RFXCOM Rfy Actuator" thing. This subcode is already available in the RFXComRfyMessage.java, but was not an option in the "thing" configuration.
