### PR TITLE
[onkyo] remove quotation marks from port in onkyo example

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -59,7 +59,7 @@ In the thing file, this looks e.g. like
 Model specific
 
 ```
-onkyo:TX-NR818:myOnkyo [ipAddress="192.168.1.100", port="60128"]
+onkyo:TX-NR818:myOnkyo [ipAddress="192.168.1.100", port=60128]
 ```
 
 or
@@ -67,19 +67,19 @@ or
 Generic model
 
 ```
-onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port="60128"]
+onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port=60128]
 ```
 
 Optionally you can specify the refresh interval by refreshInterval parameter.
 
 ```
-onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port="60128", refreshInterval=30]
+onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port=60128, refreshInterval=30]
 ```
 
 Maximum volume level can also be configured by volumeLimit parameter. This prevent setting receiver volume level too high, which could damage your speakers or receiver.
 
 ```
-onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port="60128", volumeLimit=50]
+onkyo:onkyoAVR:myOnkyo [ipAddress="192.168.1.100", port=60128, volumeLimit=50]
 ```
 
 Binding then automatically scale the volume level in both directions (100% = 50 = 100%).


### PR DESCRIPTION
port expects integer rather than string, so no quotation marks allowed

see: https://github.com/openhab/openhab2-addons/issues/2412

Signed-off-by: Christoph Wempe cw-git@wempe.net (github: CWempe)