### PR TITLE
Gardena: Fixed item type typo

### DIFF
--- a/addons/binding/org.openhab.binding.gardena/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.gardena/ESH-INF/thing/thing-types.xml
@@ -298,7 +298,7 @@
 	</channel-type>
 
 	<channel-type id="firmwareUploadProgress" advanced="true">
-		<item-type>Numper</item-type>
+		<item-type>Number</item-type>
 		<label>Upload progress</label>
 		<description>Firmware upload in progress</description>
 		<state readOnly="true" />


### PR DESCRIPTION
Signed-off-by: Gerhard Riegler <gerhard.riegler@gmail.com>
