### PR TITLE
[avmfritz] Removed deviceList Map from BoxHandler

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -13,8 +13,6 @@ import static org.openhab.binding.avmfritz.BindingConstants.*;
 import java.math.BigDecimal;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -50,7 +48,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Handler for a FRITZ!Box device. Handles polling of values from AHA devices.
  *
- * @author Robert Bausdorf
+ * @author Robert Bausdorf - Initial contribution
  * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet
  *         DECT
  *
@@ -60,8 +58,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
     private final Logger logger = LoggerFactory.getLogger(BoxHandler.class);
 
     /**
-     * the refresh interval which is used to poll values from the fritzaha.
-     * server (optional, defaults to 15 s)
+     * Refresh interval which is used to poll values from the FRITZ!Box web interface (optional, defaults to 15 s)
      */
     private long refreshInterval = 15;
     /**
@@ -69,13 +66,9 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
      */
     private FritzahaWebInterface connection;
     /**
-     * Holder for last data received from the box.
-     */
-    private Map<String, DeviceModel> deviceList;
-    /**
      * Job which will do the FRITZ!Box polling
      */
-    private DeviceListPolling pollingRunnable;
+    private final DeviceListPolling pollingRunnable;
     /**
      * Schedule for polling
      */
@@ -88,7 +81,6 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
      */
     public BoxHandler(Bridge bridge) {
         super(bridge);
-        this.deviceList = new TreeMap<String, DeviceModel>();
         this.pollingRunnable = new DeviceListPolling(this);
     }
 
@@ -140,7 +132,6 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
     public void addDeviceList(DeviceModel device) {
         try {
             logger.debug("set device model: {}", device);
-            deviceList.put(device.getIdentifier(), device);
             ThingUID thingUID = getThingUID(device);
             Thing thing = getThingByUID(thingUID);
             if (thing != null) {

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -32,7 +32,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.avmfritz.BindingConstants;
@@ -45,8 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link DeviceHandler} is responsible for handling commands, which are
- * sent to one of the channels.
+ * Handler for a FRITZ! device. Handles commands , which are sent to one of the channels.
  *
  * @author Robert Bausdorf - Initial contribution
  * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet
@@ -58,34 +56,38 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
     private final Logger logger = LoggerFactory.getLogger(DeviceHandler.class);
 
     /**
-     * Ip of PL546E in standalone mode
+     * IP of FRITZ!Powerline 546E in standalone mode
      */
     private String soloIp;
     /**
-     * the refresh interval which is used to poll values from the FRITZ!Box web
-     * interface server (optional, defaults to 15 s)
+     * Refresh interval which is used to poll values from the FRITZ!Box web interface (optional, defaults to 15 s)
      */
-    protected long refreshInterval = 15;
+    private long refreshInterval = 15;
     /**
      * Interface object for querying the FRITZ!Box web interface
      */
-    protected FritzahaWebInterface connection;
+    private FritzahaWebInterface connection;
     /**
-     * Job which will do the FRITZ!Box polling
+     * Job which will do the FRITZ! device polling
      */
-    private DeviceListPolling pollingRunnable;
+    private final DeviceListPolling pollingRunnable;
     /**
      * Schedule for polling
      */
     private ScheduledFuture<?> pollingJob;
 
+    /**
+     * Constructor
+     *
+     * @param thing Thing object representing a FRITZ! device
+     */
     public DeviceHandler(Thing thing) {
         super(thing);
         this.pollingRunnable = new DeviceListPolling(this);
     }
 
     /**
-     * Initializes the bridge.
+     * Initializes the thing.
      */
     @Override
     public void initialize() {


### PR DESCRIPTION
* Removed `deviceList` Map from `BoxHandler` to prevent memory leaks, it is never used

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>