### PR TITLE
[Milight] Add description for offline bridge

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/handler/MilightBridgeV3Handler.java
@@ -171,6 +171,7 @@ public class MilightBridgeV3Handler extends AbstractMilightBridgeHandler impleme
 
     @Override
     public void noBridgeDetected() {
-        updateStatus(ThingStatus.OFFLINE);
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
+                "Bridge did not respond or the bridge's MAC address does not match with your configuration!");
     }
 }


### PR DESCRIPTION
This very little information why a bridge is offline could be very useful for new adopters of the binding. It would have saved me an hour of troubleshooting ;-)

Signed-off-by: Patrick Fink <mail@pfink.de>