### PR TITLE
[systeminfo] Stop displaying average load as percentage

### DIFF
--- a/addons/binding/org.openhab.binding.systeminfo/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.systeminfo/ESH-INF/thing/channels.xml
@@ -288,8 +288,8 @@
 	<channel-type id="loadAverage" advanced="true">
 		<item-type>Number</item-type>
 		<label>Load average</label>
-		<description>Load in percent for the last 1,5 or 15 minutes</description>
-		<state readOnly="true" pattern="%.1f %%" />
+		<description>Load as a number of processes for the last 1,5 or 15 minutes</description>
+		<state readOnly="true" pattern="%.1f" />
 		<config-description-ref uri="systeminfo:channels:mediumpriority" />
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/model/SysteminfoInterface.java
+++ b/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/model/SysteminfoInterface.java
@@ -69,21 +69,21 @@ public interface SysteminfoInterface {
     /**
      * Returns the system load average for the last minute.
      *
-     * @return the load as percentage value /0-100/ or null, if no information is available
+     * @return the load as a number of processes or null, if no information is available
      */
     public DecimalType getCpuLoad1();
 
     /**
      * Returns the system load average for the last 5 minutes.
      *
-     * @return the load as percentage value /0-100/ or null, if no information is available
+     * @return the load as number of processes or null, if no information is available
      */
     public DecimalType getCpuLoad5();
 
     /**
      * Returns the system load average for the last 15 minutes.
      *
-     * @return the load as percentage value /0-100/ or null, if no information is available
+     * @return the load as number of processes or null, if no information is available
      */
     public DecimalType getCpuLoad15();
 


### PR DESCRIPTION
System **average** load is a unitless number that describes average number of processes running within that a time frame. The binding uses [this method](http://oshi.github.io/oshi/apidocs/oshi/hardware/CentralProcessor.html#getSystemLoadAverage-int-) to fetch this number.

It should not be appended by a percentage symbol during display.

(Let me know if anything else needs to be changed, but I believe this to be correct)

Closes #2451 

Signed-off-by: Ben Clark <ben@benjyc.uk>