### PR TITLE
[Tankerkoenig] New channel "holiday" which reads switch item states. Also solves #2513

### DIFF
--- a/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/i18n/tankerkoenig_de.properties
+++ b/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/i18n/tankerkoenig_de.properties
@@ -19,8 +19,11 @@ thing-type.config.tankerkoenig.station.locationid.description=Tankstellen-ID. Di
 channel-type.tankerkoenig.diesel.label = Diesel
 channel-type.tankerkoenig.e5.label = E5
 channel-type.tankerkoenig.e10.label = E10
+channel-type.tankerkkoenig.station_open.label = Öffnungs-Status
+channel-type.tankerkkoenig.holiday.label = Feiertag
 
 channel-type.tankerkoenig.diesel.description = Diesel-Preis
 channel-type.tankerkoenig.e5.description= E5-Preis
 channel-type.tankerkoenig.e10.description = E10-Preis
-
+channel-type.tankerkoenig.station_open.description = Gemeldeter Öffnungs-Status
+channel-type.tankerkoenig.holiday.description = ON wenn Heute ein Feiertag ist

--- a/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/station.xml
+++ b/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/station.xml
@@ -8,11 +8,12 @@
                 <bridge-type-ref id="webservice" />
             </supported-bridge-type-refs>
             <label>Gas-Station</label>
-            <description>Provides the prices of gas types E5-, E10- and Diesel of that station.</description>
+            <description>Provides the prices of gas types E5-, E10- and Diesel of that station and if that station reports as opened.</description>
             <channels>
                 <channel id="diesel" typeId="diesel"/>
                 <channel id="e10" typeId="e10"/>
                 <channel id="e5" typeId="e5"/>
+                <channel id="station_open" typeId="station_open" />
             </channels>
             <config-description>
                 <parameter name="locationid" type="text" required="true">
@@ -38,5 +39,11 @@
             <label>E5</label>
             <description>price for E5</description>
             <state pattern="%.3f €" readOnly="true"></state>
+        </channel-type>
+            <channel-type id="station_open">
+            <item-type>Contact</item-type>
+            <label>Opening state</label>
+            <description>The reported opening-state of that Station</description>
+            <state pattern="%s" readOnly="true"></state>
         </channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
+++ b/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
@@ -4,14 +4,14 @@
 	<bridge-type id="webservice">
 		<label>Tankerkönig Webservice</label>
 		<description>The Tankerkönig Webservice can handle 1 to 10 gas stations.</description>
-        <channels>
-            <channel id="holiday" typeId="holiday"/>
-        </channels>
+		<channels>
+			<channel id="holiday" typeId="holiday" />
+		</channels>
 		<config-description>
 			<parameter name="apikey" type="text" required="true">
 				<label>API-Key</label>
 				<description>API-Key. Necessary registration under https://creativecommons.tankerkoenig.de</description>
-				<default></default>
+				<default />
 			</parameter>
 			<parameter name="refresh" type="integer" required="true" min="10">
 				<label>Refresh Time</label>
@@ -25,9 +25,9 @@
 			</parameter>
 		</config-description>
 	</bridge-type>
-    <channel-type id="holiday">
-        <item-type>Switch</item-type>
-        <label>Holiday</label>
-        <description>ON if today is a holiday</description>
-    </channel-type>
+	<channel-type id="holiday">
+		<item-type>Switch</item-type>
+		<label>Holiday</label>
+		<description>ON if today is a holiday</description>
+	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
+++ b/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
@@ -4,6 +4,9 @@
 	<bridge-type id="webservice">
 		<label>Tankerkönig Webservice</label>
 		<description>The Tankerkönig Webservice can handle 1 to 10 gas stations.</description>
+        <channels>
+            <channel id="holiday" typeId="holiday"/>
+        </channels>
 		<config-description>
 			<parameter name="apikey" type="text" required="true">
 				<label>API-Key</label>
@@ -22,4 +25,9 @@
 			</parameter>
 		</config-description>
 	</bridge-type>
+    <channel-type id="holiday">
+        <item-type>Switch</item-type>
+        <label>Holiday</label>
+        <description>ON if today is a holiday</description>
+    </channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
+++ b/addons/binding/org.openhab.binding.tankerkoenig/ESH-INF/thing/webservice.xml
@@ -11,7 +11,7 @@
 			<parameter name="apikey" type="text" required="true">
 				<label>API-Key</label>
 				<description>API-Key. Necessary registration under https://creativecommons.tankerkoenig.de</description>
-				<default />
+				<default></default>
 			</parameter>
 			<parameter name="refresh" type="integer" required="true" min="10">
 				<label>Refresh Time</label>

--- a/addons/binding/org.openhab.binding.tankerkoenig/README.md
+++ b/addons/binding/org.openhab.binding.tankerkoenig/README.md
@@ -5,7 +5,7 @@ Special thanks to the creators of Tankerkönig for providing an easy way to get 
 
 Tankerkönig is providing this service for free, however they request to prevent overloading of their server by reducing the number of web-requests. This binding handles those requests (minimum Refresh Interval is 10 minutes, a webserver does handle maximum of 10 stations.
 The data will be updated for each Station individually after the initialization and after each Refresh Interval for all (open) stations (Note: changing the Webservice will cause the Refresh Interval to restart).
-Additionally one may select the mode Opening-Times in which only those Stations get polled which are actually open.
+Additionally one may select the mode Opening-Times in which only those Stations get polled which are actually open.  For a correct usage of opening times the binding needs the information if the actual day is a holiday.
 
 
 ## Preparation
@@ -46,10 +46,11 @@ Each Station needs to be configured with a LocationID and the Webservice to whic
 
 ## Channels
 
-The binding introduces the following channels:
+The binding introduces the channel holiday for the Webservice and the channels e10, e5 and diesel for the Stations:
 
 | Channel ID                                      | Channel Description                                          | Supported item type | Advanced |
 |-------------------------------------------------|--------------------------------------------------------------|---------------------|----------|
+| holiday                                         | ON if today is a holiday                                     | Switch              | False    |
 | e10                                             | price of e10                                                 | Number              | False    |
 | e5                                              | price of e5                                                  | Number              | False    |
 | diesel                                          | price of diesel                                              | Number              | False    |
@@ -72,10 +73,10 @@ Bridge tankerkoenig:webservice:WebserviceName "MyWebserviceName" [ apikey="xxxxx
 tankerkoenig.items:
 
 ```
-Number E10_1 "E10 [%.3f €]" { channel="tankerkoenig:station:StationName1:e10" }
+Number E10_1 "E10 [%.3f €]" { channel="tankerkoenig:station:WebserviceName:StationName1:e10" }
 Number E5_1 "E5 [%.3f €]"  { channel="tankerkoenig:station:WebserviceName:StationName1:e5" }
 Number Diesel_1 "Diesel [%.3f €]" { channel="tankerkoenig:station:WebserviceName:StationName1:diesel"}
-Number E10_2 "E10 [%.3f €]" { channel="tankerkoenig:station:StationName2:e10"}
+Number E10_2 "E10 [%.3f €]" { channel="tankerkoenig:WebserviceName:station:StationName2:e10"}
 Number E5_2 "E5 [%.3f €]" { channel="tankerkoenig:station:WebserviceName:StationName2:e5"}
 Number Diesel_2 "Diesel [%.3f €]" { channel="tankerkoenig:station:WebserviceName:StationName2:diesel"}
 ```
@@ -116,10 +117,15 @@ Users should check the log for any reports to solve the reason for this status. 
 next to the OFFLINE not return the status "OK", which could for an example be caused by a banned API-key. In such a case the polling of price-data is stopped. 
 If no valid response is received the polling will continue. On the next receipt of a valid message Webservice and Station(s) will go ONLINE again. 
 
+-How to set the switch item for the channel holiday?
+
+The correct usage of opening times needs the information if the actual day is a holiday. The binding expects a switch item linked to the Webservice channel holiday.
+This switch can be set either manually (only suggested for testing!), by a rule [openHAB1-addons rules] or by the usage of the CALDAV binding with a calendar.
+
 ## Tankerkönig API
 
 *  https://creativecommons.tankerkoenig.de/  (sorry, only available in german)
 
    [MTS-K]: <https://www.bundeskartellamt.de/DE/Wirtschaftsbereiche/Mineral%C3%B6l/MTS-Kraftstoffe/Verbraucher/verbraucher_node.html>
-
+   [openhab1-addons rules]: <https://github.com/openhab/openhab1-addons/wiki/Samples-Rules#how-to-calculate-public-holidays>
 

--- a/addons/binding/org.openhab.binding.tankerkoenig/README.md
+++ b/addons/binding/org.openhab.binding.tankerkoenig/README.md
@@ -3,10 +3,12 @@
 The binding uses the Tankerkönig API (https://www.tankerkoenig.de) for collecting gas price data of german gas stations. 
 Special thanks to the creators of Tankerkönig for providing an easy way to get data from  the [MTS-K]  (Markttransparenzstelle für Kraftstoffe).
 
-Tankerkönig is providing this service for free, however they request to prevent overloading of their server by reducing the number of web-requests. This binding handles those requests (minimum Refresh Interval is 10 minutes, a webserver does handle maximum of 10 stations.
+Tankerkönig is providing this service for free, however they request to prevent overloading of their server by reducing the number of web-requests. This binding handles those requests (minimum Refresh Interval is 10 minutes, a webserver does handle a maximum of 10 stations).
 The data will be updated for each Station individually after the initialization and after each Refresh Interval for all (open) stations (Note: changing the Webservice will cause the Refresh Interval to restart).
 Additionally one may select the mode Opening-Times in which only those Stations get polled which are actually open.  For a correct usage of opening times the binding needs the information if the actual day is a holiday.
 
+Note: 
+While using the mode Opening-Times the channel "station_open" will NOT show "close" because during such times no update is being requested from that Station! 
 
 ## Preparation
 
@@ -54,7 +56,7 @@ The binding introduces the channel holiday for the Webservice and the channels e
 | e10                                             | price of e10                                                 | Number              | False    |
 | e5                                              | price of e5                                                  | Number              | False    |
 | diesel                                          | price of diesel                                              | Number              | False    |
-
+| station_open                                    | reported opening-state of the station                        | Contact             | False    |
 
 ## Full example
 
@@ -90,7 +92,7 @@ The further price-updates for all Stations are scheduled by the Webservice using
 
 -The Station(s) and Webservice stay OFFLINE
 
-Set the logging level for the binding to DEBUG (Karaf-Console command: "log:set DEBUG org.openhabbinding.tankerkoenig". Create a new Station (in order to start the "initialize" routine). Check the openhab.log for entries like:
+Set the logging level for the binding to DEBUG (Karaf-Console command: "log:set DEBUG org.openhab.binding.tankerkoenig". Create a new Station (in order to start the "initialize" routine). Check the openhab.log for entries like:
 
 ```
  2017-06-25 16:02:12.679 [DEBUG] [ig.internal.data.TankerkoenigService] - getTankerkoenigDetailResult IOException: 

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
@@ -36,7 +36,9 @@ public class TankerkoenigBindingConstants {
     public static final String CHANNEL_DIESEL = "diesel";
     public static final String CHANNEL_E10 = "e10";
     public static final String CHANNEL_E5 = "e5";
+    public static final String CHANNEL_STATION_OPEN = "station_open";
     public static final String CHANNEL_HOLIDAY = "holiday";
+
     // config
     public static final String CONFIG_LOCATION_ID = "locationid";
     public static final String CONFIG_API_KEY = "apikey";

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
@@ -36,7 +36,7 @@ public class TankerkoenigBindingConstants {
     public static final String CHANNEL_DIESEL = "diesel";
     public static final String CHANNEL_E10 = "e10";
     public static final String CHANNEL_E5 = "e5";
-
+    public static final String CHANNEL_HOLIDAY = "holiday";
     // config
     public static final String CONFIG_LOCATION_ID = "locationid";
     public static final String CONFIG_API_KEY = "apikey";

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/StationHandler.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/StationHandler.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -124,11 +125,10 @@ public class StationHandler extends BaseThingHandler {
      */
     public void updateData(LittleStation station) {
         logger.debug("Update Tankerkoenig data '{}'", getThing().getUID());
-
         DecimalType diesel = new DecimalType(station.getDiesel());
         DecimalType e10 = new DecimalType(station.getE10());
         DecimalType e5 = new DecimalType(station.getE5());
-
+        updateState(CHANNEL_STATION_OPEN, (station.isOpen() ? OpenClosedType.OPEN : OpenClosedType.CLOSED));
         updateState(CHANNEL_DIESEL, diesel);
         updateState(CHANNEL_E10, e10);
         updateState(CHANNEL_E5, e5);

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.tankerkoenig.handler;
 
+import static org.openhab.binding.tankerkoenig.TankerkoenigBindingConstants.CHANNEL_HOLIDAY;
+
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.DayOfWeek;
@@ -51,6 +53,7 @@ public class WebserviceHandler extends BaseBridgeHandler {
     private int refreshInterval;
     private boolean modeOpeningTime;
     private String userAgent;
+    private boolean isHoliday;
     private final TankerkoenigService service = new TankerkoenigService();
 
     private Map<String, LittleStation> stationMap;
@@ -66,7 +69,19 @@ public class WebserviceHandler extends BaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // no code needed.
+        try {
+            if (channelUID.getId().contentEquals(CHANNEL_HOLIDAY)) {
+                logger.debug("HandleCommand recieved: {}", channelUID.getId());
+                if (command.toString() == "OFF") {
+                    isHoliday = false;
+                } else {
+                    isHoliday = true;
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Error in HandleCommand: {}", e);
+            isHoliday = false;
+        }
     }
 
     @Override
@@ -237,6 +252,10 @@ public class WebserviceHandler extends BaseBridgeHandler {
                         DayOfWeek weekday = today.getDayOfWeek();
                         logger.debug("Checking day: {}", day);
                         logger.debug("Todays weekday: {}", weekday);
+                        if (isHoliday) {
+                            weekday = DayOfWeek.SUNDAY;
+                            logger.debug("Today is a holiday using : {}", weekday);
+                        }
                         // if Daily, further checking not needed!
                         if (day.contains("täglich")) {
                             logger.debug("Found a setting for daily opening times.");

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.tankerkoenig.handler;
 
-import static org.openhab.binding.tankerkoenig.TankerkoenigBindingConstants.CHANNEL_HOLIDAY;
-
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.DayOfWeek;
@@ -21,6 +19,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -69,18 +68,9 @@ public class WebserviceHandler extends BaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        try {
-            if (channelUID.getId().contentEquals(CHANNEL_HOLIDAY)) {
-                logger.debug("HandleCommand recieved: {}", channelUID.getId());
-                if (command.toString() == "OFF") {
-                    isHoliday = false;
-                } else {
-                    isHoliday = true;
-                }
-            }
-        } catch (Exception e) {
-            logger.debug("Error in HandleCommand: {}", e);
-            isHoliday = false;
+        if (channelUID.getId().equals(TankerkoenigBindingConstants.CHANNEL_HOLIDAY)) {
+            logger.debug("HandleCommand recieved: {}", channelUID.getId());
+            isHoliday = (command == OnOffType.ON);
         }
     }
 

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
@@ -161,11 +161,7 @@ public class WebserviceHandler extends BaseBridgeHandler {
                 setTankerkoenigListResult(result);
                 stationMap.clear();
                 for (LittleStation station : result.getPrices().getStations()) {
-                    if (station.getStatus().equals("open")) {
-                        station.setOpen(true);
-                    } else {
-                        station.setOpen(false);
-                    }
+                    station.setOpen("open".equals(station.getStatus()));
                     stationMap.put(station.getID(), station);
                 }
                 logger.debug("UpdateStationData: tankstellenList.size {}", stationMap.size());

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/handler/WebserviceHandler.java
@@ -161,6 +161,11 @@ public class WebserviceHandler extends BaseBridgeHandler {
                 setTankerkoenigListResult(result);
                 stationMap.clear();
                 for (LittleStation station : result.getPrices().getStations()) {
+                    if (station.getStatus().equals("open")) {
+                        station.setOpen(true);
+                    } else {
+                        station.setOpen(false);
+                    }
                     stationMap.put(station.getID(), station);
                 }
                 logger.debug("UpdateStationData: tankstellenList.size {}", stationMap.size());

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
@@ -25,7 +25,7 @@ public class LittleStation {
     private double diesel;
     private String status;
     private String id;
-    private boolean isOpen;
+    private boolean open;
 
     public double getE5() {
         return e5;
@@ -68,11 +68,11 @@ public class LittleStation {
     }
 
     public boolean isOpen() {
-        return isOpen;
+        return open;
     }
 
     public void setOpen(boolean isOpen) {
-        this.isOpen = isOpen;
+        this.open = isOpen;
     }
 
 }

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
@@ -25,7 +25,7 @@ public class LittleStation {
     private double diesel;
     private String status;
     private String id;
-    private boolean open;
+    private Boolean open;
 
     public double getE5() {
         return e5;
@@ -67,11 +67,11 @@ public class LittleStation {
         this.id = id;
     }
 
-    public boolean isOpen() {
+    public Boolean isOpen() {
         return open;
     }
 
-    public void setOpen(boolean isOpen) {
+    public void setOpen(Boolean isOpen) {
         this.open = isOpen;
     }
 

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/LittleStation.java
@@ -25,6 +25,7 @@ public class LittleStation {
     private double diesel;
     private String status;
     private String id;
+    private boolean isOpen;
 
     public double getE5() {
         return e5;
@@ -65,4 +66,13 @@ public class LittleStation {
     public void setID(String id) {
         this.id = id;
     }
+
+    public boolean isOpen() {
+        return isOpen;
+    }
+
+    public void setOpen(boolean isOpen) {
+        this.isOpen = isOpen;
+    }
+
 }

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
@@ -30,7 +30,7 @@ public class Station {
     private String street;
     private String place;
     private String postCode;
-    private boolean open;
+    private Boolean open;
 
     public String getId() {
         return id;
@@ -104,11 +104,11 @@ public class Station {
         this.postCode = postCode;
     }
 
-    public boolean isOpen() {
+    public Boolean isOpen() {
         return open;
     }
 
-    public void setOpen(boolean isOpen) {
+    public void setOpen(Boolean isOpen) {
         this.open = isOpen;
     }
 }

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
@@ -30,7 +30,7 @@ public class Station {
     private String street;
     private String place;
     private String postCode;
-    private boolean isOpen;
+    private boolean open;
 
     public String getId() {
         return id;
@@ -105,10 +105,10 @@ public class Station {
     }
 
     public boolean isOpen() {
-        return isOpen;
+        return open;
     }
 
     public void setOpen(boolean isOpen) {
-        this.isOpen = isOpen;
+        this.open = isOpen;
     }
 }

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/config/Station.java
@@ -111,5 +111,4 @@ public class Station {
     public void setOpen(boolean isOpen) {
         this.isOpen = isOpen;
     }
-
 }

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/serializer/CustomTankerkoenigDetailResultDeserializer.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/serializer/CustomTankerkoenigDetailResultDeserializer.java
@@ -43,6 +43,7 @@ public class CustomTankerkoenigDetailResultDeserializer implements JsonDeseriali
             final Double e10 = jsonStation.get("e10").getAsDouble();
             final Double e5 = jsonStation.get("e5").getAsDouble();
             final Double diesel = jsonStation.get("diesel").getAsDouble();
+            final Boolean isOpen = jsonStation.get("isOpen").getAsBoolean();
             final String stationID = jsonStation.get("id").getAsString();
             final LittleStation littleStation = new LittleStation();
             OpeningTime[] openingTime = context.deserialize(jsonStation.get("openingTimes"), OpeningTime[].class);
@@ -50,6 +51,7 @@ public class CustomTankerkoenigDetailResultDeserializer implements JsonDeseriali
             littleStation.setE10(e10);
             littleStation.setE5(e5);
             littleStation.setDiesel(diesel);
+            littleStation.setOpen(isOpen);
             littleStation.setID(stationID);
             final OpeningTimes openingTimes = new OpeningTimes(stationID, isWholeDay, openingTime);
             result.setLittleStation(littleStation);


### PR DESCRIPTION
The new channel "holiday" is reading the state of a switch item. This information is read as actual day is/is not a holiday, which in turn is used by the mode Opening Times. The ReadMe is changed accordingly.
Typo in ReadMe removed.
All changes tested.


Signed-off-by: Jürgen Baginski <opus42@gmx.de>
