### PR TITLE
[WIP] [audio] Added support for new AudioSink API

### DIFF
--- a/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayAudioSink.java
+++ b/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayAudioSink.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.audio.AudioSink;
 import org.eclipse.smarthome.core.audio.AudioStream;
 import org.eclipse.smarthome.core.audio.URLAudioStream;
 import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException;
+import org.eclipse.smarthome.core.audio.UnsupportedAudioStreamException;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.openhab.binding.allplay.handler.AllPlayHandler;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ public class AllPlayAudioSink implements AudioSink {
     private final Logger logger = LoggerFactory.getLogger(AllPlayAudioSink.class);
 
     private static final HashSet<AudioFormat> SUPPORTED_FORMATS = new HashSet<>();
+    private static final HashSet<Class<? extends AudioStream>> SUPPORTED_STREAMS = new HashSet<>();
     private final AllPlayHandler handler;
     private final AudioHTTPServer audioHTTPServer;
     private final String callbackUrl;
@@ -43,6 +45,8 @@ public class AllPlayAudioSink implements AudioSink {
     static {
         SUPPORTED_FORMATS.add(AudioFormat.MP3);
         SUPPORTED_FORMATS.add(AudioFormat.WAV);
+
+        SUPPORTED_STREAMS.add(AudioStream.class);
     }
 
     /**
@@ -67,11 +71,12 @@ public class AllPlayAudioSink implements AudioSink {
     }
 
     @Override
-    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+    public void process(AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         try {
             String url = convertAudioStreamToUrl(audioStream);
             handler.playUrl(url);
-        } catch (SpeakerException | AllPlayAudioStreamException e) {
+        } catch (SpeakerException | AllPlayCallbackException e) {
             logger.warn("Unable to play audio stream on speaker {}", getId(), e);
         }
     }
@@ -79,6 +84,11 @@ public class AllPlayAudioSink implements AudioSink {
     @Override
     public Set<AudioFormat> getSupportedFormats() {
         return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
     }
 
     @Override
@@ -104,9 +114,9 @@ public class AllPlayAudioSink implements AudioSink {
      *
      * @param audioStream The incoming {@link AudioStream}
      * @return The URL to use for streaming
-     * @throws AllPlayAudioStreamException Exception if the URL cannot be created
+     * @throws AllPlayCallbackException Exception if the URL cannot be created
      */
-    private String convertAudioStreamToUrl(AudioStream audioStream) throws AllPlayAudioStreamException {
+    private String convertAudioStreamToUrl(AudioStream audioStream) throws AllPlayCallbackException {
         if (audioStream instanceof URLAudioStream) {
             // it is an external URL, the speaker can access it itself and play it
             return ((URLAudioStream) audioStream).getURL();
@@ -115,19 +125,19 @@ public class AllPlayAudioSink implements AudioSink {
         }
     }
 
-    private String createUrlForLocalHttpServer(AudioStream audioStream) throws AllPlayAudioStreamException {
+    private String createUrlForLocalHttpServer(AudioStream audioStream) throws AllPlayCallbackException {
         if (callbackUrl != null) {
             String relativeUrl = audioHTTPServer.serve(audioStream);
             return callbackUrl + relativeUrl;
         } else {
-            throw new AllPlayAudioStreamException("Unable to play audio stream as callback URL is not set");
+            throw new AllPlayCallbackException("Unable to play audio stream as callback URL is not set");
         }
     }
 
     @SuppressWarnings("serial")
-    private class AllPlayAudioStreamException extends Exception {
+    private class AllPlayCallbackException extends Exception {
 
-        public AllPlayAudioStreamException(String message) {
+        public AllPlayCallbackException(String message) {
             super(message);
         }
     }

--- a/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/FreeboxAirPlayAudioSink.java
+++ b/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/FreeboxAirPlayAudioSink.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.audio.AudioStream;
 import org.eclipse.smarthome.core.audio.FixedLengthAudioStream;
 import org.eclipse.smarthome.core.audio.URLAudioStream;
 import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException;
+import org.eclipse.smarthome.core.audio.UnsupportedAudioStreamException;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
@@ -49,10 +50,15 @@ public class FreeboxAirPlayAudioSink implements AudioSink {
     private static final AudioFormat MP3_256 = new AudioFormat(CONTAINER_NONE, CODEC_MP3, null, null, 256000, null);
     private static final AudioFormat MP3_320 = new AudioFormat(CONTAINER_NONE, CODEC_MP3, null, null, 320000, null);
 
-    private Set<AudioFormat> supportedFormats;
+    private static final Set<AudioFormat> SUPPORTED_FORMATS = new HashSet<>();
+    private static final HashSet<Class<? extends AudioStream>> SUPPORTED_STREAMS = new HashSet<>();
     private AudioHTTPServer audioHTTPServer;
     private FreeboxThingHandler handler;
     private String callbackUrl;
+
+    static {
+        SUPPORTED_STREAMS.add(AudioStream.class);
+    }
 
     public FreeboxAirPlayAudioSink(FreeboxThingHandler handler, AudioHTTPServer audioHTTPServer, String callbackUrl) {
         this.handler = handler;
@@ -60,22 +66,21 @@ public class FreeboxAirPlayAudioSink implements AudioSink {
         this.callbackUrl = callbackUrl;
         Boolean acceptLowBitrate = (Boolean) handler.getThing().getConfiguration()
                 .get(FreeboxAirPlayDeviceConfiguration.ACCEPT_ALL_MP3);
-        this.supportedFormats = new HashSet<>();
-        this.supportedFormats.add(WAV);
+        this.SUPPORTED_FORMATS.add(WAV);
         if (acceptLowBitrate) {
-            this.supportedFormats.add(MP3);
+            this.SUPPORTED_FORMATS.add(MP3);
         } else {
             // Only accept MP3 bitrates >= 96 kbps
-            this.supportedFormats.add(MP3_96);
-            this.supportedFormats.add(MP3_112);
-            this.supportedFormats.add(MP3_128);
-            this.supportedFormats.add(MP3_160);
-            this.supportedFormats.add(MP3_192);
-            this.supportedFormats.add(MP3_224);
-            this.supportedFormats.add(MP3_256);
-            this.supportedFormats.add(MP3_320);
+            this.SUPPORTED_FORMATS.add(MP3_96);
+            this.SUPPORTED_FORMATS.add(MP3_112);
+            this.SUPPORTED_FORMATS.add(MP3_128);
+            this.SUPPORTED_FORMATS.add(MP3_160);
+            this.SUPPORTED_FORMATS.add(MP3_192);
+            this.SUPPORTED_FORMATS.add(MP3_224);
+            this.SUPPORTED_FORMATS.add(MP3_256);
+            this.SUPPORTED_FORMATS.add(MP3_320);
         }
-        this.supportedFormats.add(OGG);
+        this.SUPPORTED_FORMATS.add(OGG);
     }
 
     @Override
@@ -89,7 +94,8 @@ public class FreeboxAirPlayAudioSink implements AudioSink {
     }
 
     @Override
-    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+    public void process(AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         if (!ThingHandlerHelper.isHandlerInitialized(handler)
                 || ((handler.getThing().getStatus() == ThingStatus.OFFLINE)
                         && ((handler.getThing().getStatusInfo().getStatusDetail() == ThingStatusDetail.BRIDGE_OFFLINE)
@@ -131,7 +137,12 @@ public class FreeboxAirPlayAudioSink implements AudioSink {
 
     @Override
     public Set<AudioFormat> getSupportedFormats() {
-        return supportedFormats;
+        return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/UpnpAudioSinkHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/handler/UpnpAudioSinkHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.audio.AudioStream;
 import org.eclipse.smarthome.core.audio.FixedLengthAudioStream;
 import org.eclipse.smarthome.core.audio.URLAudioStream;
 import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException;
+import org.eclipse.smarthome.core.audio.UnsupportedAudioStreamException;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
@@ -41,11 +42,14 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class UpnpAudioSinkHandler extends BaseThingHandler implements AudioSink, UpnpIOParticipant {
 
-    private static HashSet<AudioFormat> supportedFormats = new HashSet<>();
+    private static final HashSet<AudioFormat> SUPPORTED_FORMATS = new HashSet<>();
+    private static final HashSet<Class<? extends AudioStream>> SUPPORTED_STREAMS = new HashSet<>();
 
     static {
-        supportedFormats.add(AudioFormat.WAV);
-        supportedFormats.add(AudioFormat.MP3);
+        SUPPORTED_FORMATS.add(AudioFormat.WAV);
+        SUPPORTED_FORMATS.add(AudioFormat.MP3);
+
+        SUPPORTED_STREAMS.add(AudioStream.class);
     }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -91,7 +95,12 @@ public abstract class UpnpAudioSinkHandler extends BaseThingHandler implements A
 
     @Override
     public Set<AudioFormat> getSupportedFormats() {
-        return supportedFormats;
+        return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
     }
 
     private void stop() {
@@ -160,7 +169,8 @@ public abstract class UpnpAudioSinkHandler extends BaseThingHandler implements A
     }
 
     @Override
-    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+    public void process(AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         String url = null;
         if (audioStream instanceof URLAudioStream) {
             // it is an external URL, the speaker can access it itself and play it.

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxAudioSink.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxAudioSink.java
@@ -16,9 +16,11 @@ import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioHTTPServer;
 import org.eclipse.smarthome.core.audio.AudioSink;
 import org.eclipse.smarthome.core.audio.AudioStream;
+import org.eclipse.smarthome.core.audio.FileAudioStream;
 import org.eclipse.smarthome.core.audio.FixedLengthAudioStream;
 import org.eclipse.smarthome.core.audio.URLAudioStream;
 import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException;
+import org.eclipse.smarthome.core.audio.UnsupportedAudioStreamException;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.openhab.binding.squeezebox.handler.SqueezeBoxPlayerHandler;
@@ -34,14 +36,18 @@ public class SqueezeBoxAudioSink implements AudioSink {
 
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxAudioSink.class);
 
-    private static HashSet<AudioFormat> supportedFormats = new HashSet<>();
+    private static final HashSet<AudioFormat> SUPPORTED_FORMATS = new HashSet<>();
+    private static final HashSet<Class<? extends AudioStream>> SUPPORTED_STREAMS = new HashSet<>();
 
     // Needed because Squeezebox does multiple requests for the stream
     private final int STREAM_TIMEOUT = 15;
 
     static {
-        supportedFormats.add(AudioFormat.WAV);
-        supportedFormats.add(AudioFormat.MP3);
+        SUPPORTED_FORMATS.add(AudioFormat.WAV);
+        SUPPORTED_FORMATS.add(AudioFormat.MP3);
+
+        SUPPORTED_STREAMS.add(FixedLengthAudioStream.class);
+        SUPPORTED_STREAMS.add(URLAudioStream.class);
     }
 
     private AudioHTTPServer audioHTTPServer;
@@ -63,21 +69,26 @@ public class SqueezeBoxAudioSink implements AudioSink {
     }
 
     @Override
-    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+    public void process(AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         AudioFormat format = audioStream.getFormat();
         if (!AudioFormat.WAV.isCompatible(format) && !AudioFormat.MP3.isCompatible(format)) {
             throw new UnsupportedAudioFormatException("Currently only MP3 and WAV formats are supported: ", format);
         }
 
         String url;
-        if (audioStream instanceof FixedLengthAudioStream) {
+        if (audioStream instanceof URLAudioStream) {
+            url = ((URLAudioStream) audioStream).getURL();
+        } else if (audioStream instanceof FixedLengthAudioStream) {
             // Since Squeezebox will make multiple requests for the stream, set a timeout on the stream
             url = audioHTTPServer.serve((FixedLengthAudioStream) audioStream, STREAM_TIMEOUT).toString();
 
             if (AudioFormat.WAV.isCompatible(format)) {
-                url += ".wav";
+                // TODO add FileAudioStream.EXTENSION_SEPARATOR
+                url += FileAudioStream.WAV_EXTENSION;
             } else if (AudioFormat.MP3.isCompatible(format)) {
-                url += ".mp3";
+                // TODO add FileAudioStream.EXTENSION_SEPARATOR
+                url += FileAudioStream.MP3_EXTENSION;
             }
 
             // Form the URL for streaming the notification from the OH2 web server
@@ -87,11 +98,9 @@ public class SqueezeBoxAudioSink implements AudioSink {
                 return;
             }
             url = host + url;
-        } else if (audioStream instanceof URLAudioStream) {
-            url = ((URLAudioStream) audioStream).getURL();
         } else {
-            logger.warn("Audio stream must be a FixedLengthAudioStream or URLAudioStream");
-            return;
+            throw new UnsupportedAudioStreamException(
+                    "SqueezeBox can only handle URLAudioStream or FixedLengthAudioStreams.", null);
         }
 
         logger.debug("Processing audioStream {} of format {}", url, format);
@@ -100,7 +109,12 @@ public class SqueezeBoxAudioSink implements AudioSink {
 
     @Override
     public Set<AudioFormat> getSupportedFormats() {
-        return supportedFormats;
+        return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
     }
 
     @Override


### PR DESCRIPTION
Follow-Up PR for [https://github.com/eclipse/smarthome/pull/3764](https://github.com/eclipse/smarthome/pull/3764)

* Added missing `getSupportedStreams()` methods
* Added `UnsupportedAudioStreamException` to method `process()`
* Minor changes for an unified implementation

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>