### PR TITLE
[systeminfo]Update README.md

### DIFF
--- a/addons/binding/org.openhab.binding.systeminfo/README.md
+++ b/addons/binding/org.openhab.binding.systeminfo/README.md
@@ -102,9 +102,9 @@ The binding introduces the following channels:
 | Channel ID | Channel Description | Supported item type | Default priority | Advanced |
 | ------------- | ------------- |------------|----------|----------|
 | load  | Recent load in percents  | Number | High | False |
-| load1 | Load in percents for the last 1 minute | Number | Medium | True |
-| load5 | Load in percents for the last 5 minutes | Number | Medium | True |
-| load15 | Load in percents for the last 15 minutes | Number | Medium | True |
+| load1 | Load for the last 1 minute | Number | Medium | True |
+| load5 | Load for the last 5 minutes | Number | Medium | True |
+| load15 | Load for the last 15 minutes | Number | Medium | True |
 | threads | Number of threads currently running | Number | Medium | True |
 | uptime | System uptime (time after start) in minutes | Number | Medium | True |
 | name | Name of the device  | String | Low | False |


### PR DESCRIPTION
The load **averages** don't have the unit "%".

See also: https://github.com/openhab/openhab2-addons/issues/2451#event-1161482665
And: https://github.com/openhab/openhab2-addons/pull/2455

Thanks!