### PR TITLE
Change the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
+sudo: required
+dist: trusty
+
 language: java
 jdk: oraclejdk8
-before_install:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-  - unzip -qq apache-maven-3.3.9-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.3.9
-  - export PATH=$M2_HOME/bin:$PATH
+before_install: echo "MAVEN_OPTS='-Xms1g -Xmx2g -XX:PermSize=512m -XX:MaxPermSize=1g'" > ~/.mavenrc
+
+install:
+  - echo 'mvn clean install -B -V 1> .build.stdout 2> .build.stderr' > .build.sh
+  - chmod 0755 .build.sh
+script:
+  - travis_wait 60 ./.build.sh
+after_success:
+  - tail -n  200 .build.stdout
+after_failure:
+  - tail -n  300 .build.stderr
+  - tail -n 2000 .build.stdout


### PR DESCRIPTION
I believe we no longer depend on mvn 3.3.9 and this should both improve error handling and should actually perform the tests.

Source is the eclipse smart home config :-)