### PR TITLE
[WiFiLED] Fix HIGH CPU during fading during transitions

### DIFF
--- a/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.wifiled/ESH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 
 	<name>WiFi LED Binding</name>
 	<description>Binding for WiFi LED devices. These are known as Magic Home RGBW LED, UFO LED, LED NET controller etc.</description>
-	<author>Osman Basha, Stefan Endrullis</author>
+	<author>Osman Basha, Stefan Endrullis,Ries van Twisk</author>
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/AbstractWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/AbstractWiFiLEDDriver.java
@@ -27,6 +27,7 @@ import static org.openhab.binding.wifiled.handler.ClassicWiFiLEDDriver.bytesToHe
  *
  * @author Osman Basha - Initial contribution
  * @author Stefan Endrullis
+ * @author Ries van Twisk
  */
 public abstract class AbstractWiFiLEDDriver {
 
@@ -55,6 +56,11 @@ public abstract class AbstractWiFiLEDDriver {
         this.port = port;
         this.protocol = protocol;
     }
+
+    /**
+     * Allow to cleanup the driver
+     */
+    public abstract void shutdown();
 
     public abstract void setColor(HSBType color) throws IOException;
 

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/ClassicWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/ClassicWiFiLEDDriver.java
@@ -21,11 +21,17 @@ import org.eclipse.smarthome.core.library.types.StringType;
  *
  * @author Osman Basha - Initial contribution
  * @author Stefan Endrullis
+ * @author Ries van Twisk
  */
 public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
 
     public ClassicWiFiLEDDriver(String host, int port, Protocol protocol) {
         super(host, port, protocol);
+    }
+
+    @Override
+    public void shutdown() {
+
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/FadingWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/FadingWiFiLEDDriver.java
@@ -12,44 +12,55 @@ import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.net.NoRouteToHostException;
 import java.net.Socket;
-import java.net.SocketException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * The {@link FadingWiFiLEDDriver} class is responsible for the communication with the WiFi LED controller.
  * It utilizes color fading when changing colors or turning the light on of off.
  *
  * @author Stefan Endrullis
+ * @author Ries van Twisk
  */
 public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
 
     public static final int DEFAULT_FADE_DURATION_IN_MS = 1000;
     public static final int DEFAULT_FADE_STEPS = 100;
+    public static final int KEEP_COMMUNICATION_OPEN_FOR_MS = 1000;
+
+    private static final InternalLedState blackState = new InternalLedState();
 
     private boolean power = false;
-    private InternalLedState blackState = new InternalLedState();
-    private InternalLedState currentState = new InternalLedState();
-    private InternalLedState currentTargetState = new InternalLedState();
+    private InternalLedState currentState = new InternalLedState(); // USe to not update the controller with the same value
+    private InternalLedState currentFaderState = new InternalLedState();
     private InternalLedState targetState = new InternalLedState();
-    private InternalLedState realTargetState = new InternalLedState();
     private LEDStateDTO dtoState = LEDStateDTO.valueOf(0, 0, 0, 0, 0, 0, 0, 0);
-    private ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService waiterExecutor = Executors.newSingleThreadScheduledExecutor();;
+    private final ScheduledExecutorService faderExecutor = Executors.newSingleThreadScheduledExecutor();;
+    private LEDFaderRunner ledfaderThread = null;
+    private final Semaphore ledUpdateSyncSemaphore = new Semaphore(1, false);
     private final int fadeDurationInMs;
-    private final int fadeSteps;
-    private boolean keepFading = false;
+    private final int totalFadingSteps;
 
     public FadingWiFiLEDDriver(String host, int port, AbstractWiFiLEDDriver.Protocol protocol, int fadeDurationInMs,
-            int fadeSteps) {
+                               int totalFadingSteps) {
         super(host, port, protocol);
-        this.fadeDurationInMs = fadeDurationInMs;
-        this.fadeSteps = fadeSteps;
+        this.fadeDurationInMs = fadeDurationInMs < 10 ? 10 : fadeDurationInMs;
+        this.totalFadingSteps = totalFadingSteps < 1 ? 1 : totalFadingSteps;
     }
 
     @Override
@@ -59,9 +70,28 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
             dtoState = LEDStateDTO.valueOf(s.state, s.program, s.programSpeed, s.red, s.green, s.blue, s.white,
                     s.white2);
             power = (s.state & 0x01) != 0;
-            currentTargetState = InternalLedState.fromRGBW(s.red, s.green, s.blue, s.white, s.white2);
-        } catch (IOException ignored) {
+            currentState = InternalLedState.fromRGBW(s.red, s.green, s.blue, s.white, s.white2);
+            currentFaderState = currentState;
+        } catch (IOException e) {
+            logger.warn("IOException", e);
         }
+    }
+
+    @Override
+    public void shutdown() {
+        waiterExecutor.shutdown();
+        faderExecutor.shutdown();
+        try {
+            if (!waiterExecutor.awaitTermination((fadeDurationInMs / totalFadingSteps) * 2, TimeUnit.MILLISECONDS)) {
+                waiterExecutor.shutdownNow();
+            }
+            if (!faderExecutor.awaitTermination((fadeDurationInMs / totalFadingSteps) * 2, TimeUnit.MILLISECONDS)) {
+                faderExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            // Ignored
+        }
+
     }
 
     @Override
@@ -79,13 +109,13 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
     @Override
     public void incBrightness(int step) throws IOException {
         dtoState = dtoState.withIncrementedBrightness(step);
-        changeState(targetState.withBrightness(currentTargetState.getBrightness() + ((double) step / 100)));
+        changeState(targetState.withBrightness(targetState.getBrightness() + ((double) step / 100)));
     }
 
     @Override
     public void decBrightness(int step) throws IOException {
         dtoState = dtoState.withIncrementedBrightness(-step);
-        changeState(targetState.withBrightness(currentTargetState.getBrightness() - ((double) step / 100)));
+        changeState(targetState.withBrightness(targetState.getBrightness() - ((double) step / 100)));
     }
 
     @Override
@@ -97,7 +127,7 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
     @Override
     public void incWhite(int step) throws IOException {
         dtoState = dtoState.withIncrementedWhite(step);
-        changeState(targetState.withWhite(currentTargetState.getWhite() + ((double) step / 100)));
+        changeState(targetState.withWhite(targetState.getWhite() + ((double) step / 100)));
     }
 
     @Override
@@ -109,7 +139,7 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
     @Override
     public void incWhite2(int step) throws IOException {
         dtoState = dtoState.withIncrementedWhite2(step);
-        changeState(targetState.withWhite2(currentTargetState.getWhite2() + ((double) step / 100)));
+        changeState(targetState.withWhite2(targetState.getWhite2() + ((double) step / 100)));
     }
 
     @Override
@@ -143,49 +173,151 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
         }
     }
 
-    private void fadeToState(final InternalLedState newState) throws IOException {
-        if (!newState.equals(realTargetState)) {
-            keepFading = false;
-            realTargetState = newState;
+    /**
+     * Runnable that takes care of fading of the LED's
+     */
+    final static class LEDFaderRunner implements Runnable {
+        private Logger logger = LoggerFactory.getLogger(LEDFaderRunner.class);
 
-            executorService.schedule(() -> {
-                if (currentTargetState.equals(newState)) {
-                    return;
+        private String host;
+        private int port;
+        private InternalLedState fromState;
+        private InternalLedState toState;
+        private final int totalFadingSteps;
+        private final long keepCommOpenForMS;
+        private final Function<DataOutputStream, Boolean> powerOnFunc;
+        private final BiFunction<DataOutputStream, InternalLedState, Boolean> ledSender;
+
+        private long lastCommunicationTime = 0;
+
+        private int currentFadingStep = 1;
+
+        private final Lock lock = new ReentrantLock();
+
+        private InternalLedState currentFadeState;
+        private Socket socket;
+        private DataOutputStream outputStream;
+
+        public LEDFaderRunner(String host, int port,
+                              InternalLedState fromState, InternalLedState toState,
+                              int totalFadingSteps, int keepCommOpenForMS,
+                              Function<DataOutputStream, Boolean> powerOnFunc,
+                              BiFunction<DataOutputStream, InternalLedState, Boolean> ledSender) {
+            this.host = host;
+            this.port = port;
+            this.fromState = fromState;
+            this.toState = toState;
+            this.totalFadingSteps = totalFadingSteps;
+            this.keepCommOpenForMS = keepCommOpenForMS;
+            this.powerOnFunc = powerOnFunc;
+            this.ledSender = ledSender;
+        }
+
+        /**
+         * Call before starting a thre`ad, it will initialise a socket and power on the LEDs
+         *
+         * @throws IOException
+         */
+        public void init() throws IOException {
+            socket = new Socket(host, port);
+            socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT);
+            outputStream = new DataOutputStream(socket.getOutputStream());
+            logger.debug("Connected to '{}'", socket);
+            powerOnFunc.apply(outputStream);
+            currentFadeState = fromState;
+        }
+
+        public void setToState(InternalLedState toState) {
+            lock.lock();
+            this.fromState = currentFadeState;
+            this.toState = toState;
+            this.currentFadingStep = 1;
+            lock.unlock();
+        }
+
+        public void run() {
+            lock.lock();
+            if (currentFadingStep <= totalFadingSteps) {
+                currentFadeState = fromState.fade(toState, (double) currentFadingStep / totalFadingSteps);
+                lock.unlock();
+
+                logger.debug("currentFadeState: {}", currentFadeState);
+                if (!ledSender.apply(outputStream, currentFadeState)) {
+                    logger.warn("Failed sending at step {}", currentFadingStep);
+                    throw new RuntimeException("Failed sending at step " + currentFadingStep);
                 }
+                lastCommunicationTime = System.currentTimeMillis();
+            } else {
+                lock.unlock();
+                if (lastCommunicationTime < (System.currentTimeMillis() - keepCommOpenForMS)) {
+                    throw new RuntimeException("Reached end step");
+                }
+            }
+            currentFadingStep++;
+        }
 
-                keepFading = true;
+        public void shutdown() {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    // Ignored
+                }
+            }
+        }
+    }
 
-                try (Socket socket = new Socket(host, port)) {
-                    logger.debug("Connected to '{}'", socket);
+    synchronized private void fadeToState(final InternalLedState newTargetState) throws IOException {
 
-                    socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT);
+        if (ledUpdateSyncSemaphore.tryAcquire(1)) {
 
-                    try (DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
-                        // ensure controller is on
-                        sendRaw(getBytesForPower(true), outputStream);
-
-                        InternalLedState fadeState = currentTargetState;
-
-                        for (int i = 1; i <= fadeSteps && keepFading; i++) {
-                            long lastTime = System.nanoTime();
-                            fadeState = currentTargetState.fade(newState, (double) i / fadeSteps);
-                            logger.debug("fadeState: {}", fadeState);
-
-                            sendLEDData(fadeState, outputStream);
-
-                            busySleep(fadeDurationInMs / fadeSteps, lastTime);
+            // Create and Execute a new LED Fader
+            ledfaderThread = new LEDFaderRunner(
+                    host,
+                    port,
+                    currentFaderState,
+                    newTargetState,
+                    totalFadingSteps,
+                    KEEP_COMMUNICATION_OPEN_FOR_MS,
+                    (outputStream) -> {
+                        try {
+                            sendRaw(getBytesForPower(true), outputStream);
+                            return true;
+                        } catch (IOException e) {
+                            logger.warn("IOException", e);
+                            return false;
                         }
+                    },
+                    (outputStream, fs) -> {
+                        try {
+                            sendLEDData(fs, outputStream);
+                            currentFaderState = fs;
+                            logger.trace("Current: {} {} {} {}", fs.getR(), fs.getG(), fs.getB(), fs.getWhite());
+                            return true;
+                        } catch (IOException e) {
+                            logger.warn("IOException", e);
+                            return false;
+                        }
+                    });
+            ledfaderThread.init();
+            final int period = fadeDurationInMs / totalFadingSteps;
+            final Future<?> future = faderExecutor.scheduleAtFixedRate(ledfaderThread, 0, period < 1 ? 1 : period, TimeUnit.MILLISECONDS);
 
-                        currentTargetState = fadeState;
-                    }
-                } catch (NoRouteToHostException e) {
-                    logger.warn("No route to host {}:{}", host, port, e);
-                } catch (SocketException e) {
-                    logger.warn("SocketException", e);
+            // Wait untill LED Thread has finished, when so shutdown fader
+            waiterExecutor.schedule(() -> {
+                try {
+                    future.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    // Ignored
                 } catch (Exception e) {
-                    logger.warn("An error occurred", e);
+                    logger.warn("Exception", e);
                 }
-            }, 0, TimeUnit.SECONDS);
+                ledfaderThread.shutdown();
+                ledfaderThread = null;
+                ledUpdateSyncSemaphore.release(1);
+            }, 0, TimeUnit.MILLISECONDS);
+        } else {
+            ledfaderThread.setToState(newTargetState);
         }
     }
 
@@ -207,13 +339,6 @@ public class FadingWiFiLEDDriver extends AbstractWiFiLEDDriver {
         }
 
         currentState = ledState;
-    }
-
-    private static void busySleep(final long nanos, final long startTime) {
-        // noinspection StatementWithEmptyBody
-        while (System.nanoTime() - startTime < nanos * 1000000) {
-            ;
-        }
     }
 
 }

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDHandler.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/handler/WiFiLEDHandler.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
  * sent to one of the channels.
  *
  * @author Osman Basha - Initial contribution
+ * @author Ries van Twisk
  */
 public class WiFiLEDHandler extends BaseThingHandler {
 
@@ -92,6 +93,7 @@ public class WiFiLEDHandler extends BaseThingHandler {
             pollingJob.cancel(true);
             pollingJob = null;
         }
+        driver.shutdown();
         driver = null;
     }
 

--- a/addons/binding/org.openhab.binding.wifiled/src/test/java/org/openhab/binding/wifiled/handler/WiFiLEDHandlerTestApp.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/test/java/org/openhab/binding/wifiled/handler/WiFiLEDHandlerTestApp.java
@@ -33,8 +33,8 @@ public class WiFiLEDHandlerTestApp {
 		System.out.println("start");
 
 		driver = fadingDriver ?
-			new FadingWiFiLEDDriver(ip, port, protocol, 0, 1) :
-			new ClassicWiFiLEDDriver(ip, port, protocol);
+				new FadingWiFiLEDDriver(ip, port, protocol, 0, 1) :
+				new ClassicWiFiLEDDriver(ip, port, protocol);
 
 		System.out.println("driver created");
 


### PR DESCRIPTION
The original code used a while loop that tests for System.nanoTime()
This caused high CPU spikes during fading between transitions for the duration of fading time.

```
    while (System.nanoTime() - startTime < nanos * 1000000) {
        ;
    }
```
In additional a few possible tread safety items are solved during updates of the targetSate to keep track of the current state just in case something went wrong.
Lastly a displosed method was added to ensure the driver can correctly be disposed by calling executorService.awaitTermination(...)

The fix is to use an additional Runnable using an schedule scheduleAtFixedRate that ensure the fading happens within an fading thread.

Signed-off-by: R. van Twisk <github@rvt.dds.nl> (github: rvt)