### PR TITLE
[PioneerAvr] Zone2 / Zone3 Fix

### DIFF
--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/PioneerAvrBindingConstants.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/PioneerAvrBindingConstants.java
@@ -51,7 +51,7 @@ public class PioneerAvrBindingConstants {
     public static final String DISPLAY_INFORMATION_CHANNEL = "displayInformation#displayInformation";
 
     public static final String GROUP_CHANNEL_PATTERN = "zone%s#%s";
-    public static final Pattern GROUP_CHANNEL_ZONE_PATTERN = Pattern.compile("zone([0-1])#.*");
+    public static final Pattern GROUP_CHANNEL_ZONE_PATTERN = Pattern.compile("zone([0-3])#.*");
 
     // Used for Discovery service
     public static final String MANUFACTURER = "PIONEER";

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
@@ -31,7 +31,7 @@ public class Response implements AvrResponse {
      */
     public enum ResponseType implements AvrResponse.RepsonseType {
         POWER_STATE("[0-2]", "PWR", "APR", "BPR"),
-        VOLUME_LEVEL("[0-9]{3}", "VOL", "ZV", "YV"),
+        VOLUME_LEVEL("[0-9]{2,3}", "VOL", "ZV", "YV"),
         MUTE_STATE("[0-1]", "MUT", "Z2MUT", "Z3MUT"),
         INPUT_SOURCE_CHANNEL("[0-9]{2}", "FN", "Z2F", "Z3F"),
         DISPLAY_INFORMATION("[0-9a-fA-F]{30}", "FL");


### PR DESCRIPTION
[PioneerAVR] Fix for Zone2 / Zone3

this fix addresses two issues:

commands on Zone2 and Zone3 where not working properly due to failing match with GROUP_CHANNEL_ZONE_PATTERN
Volume_Level on Zones where not interpreted correctly due to the AVR sending only 2 digits on zone volume rather than 3 digits on Zone1
Changes where tested on my SC-LX89

this should fix #1206

(as am i new to doing changes to openhab2-addons, Eclipse, Java and even GitHub chances are i got something on the way wrong... please let me know :-)

Signed-off-by: Michel Mohrmann <mailme@thallos.de> (github: mimo74)
