### PR TITLE
Fix binding test skeleton scripts

### DIFF
--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -15,7 +15,7 @@ If NOT exist "org.openhab.binding.%2" (
 	exit /B 1
 )
 
-call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2.test -Dversion=2.2.0-SNAPSHOT -DbindingId=%2.test -DbindingIdCamelCase=%1.test -DvendorName=openHAB -Dnamespace=org.openhab
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2 -Dversion=2.2.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
 
 COPY ..\..\src\etc\about.html org.openhab.binding.%2.test%\
 

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -13,10 +13,10 @@ mvn -s ../archetype-settings.xml archetype:generate -N \
   -DarchetypeVersion=0.9.0-SNAPSHOT \
   -DgroupId=org.openhab.binding \
   -DartifactId=org.openhab.binding.$id.test \
-  -Dpackage=org.openhab.binding.$id.test \
+  -Dpackage=org.openhab.binding.$id \
   -Dversion=2.2.0-SNAPSHOT \
-  -DbindingId=$id.test \
-  -DbindingIdCamelCase=$camelcaseId.test \
+  -DbindingId=$id \
+  -DbindingIdCamelCase=$camelcaseId \
   -DvendorName=openHAB \
   -Dnamespace=org.openhab
 


### PR DESCRIPTION
Fix the binding test skeleton scripts:

- bindingId is not suffixed `.test`
- default package name is not suffixed `.test`
- bindingId camelCase is not suffixed `.test`

In conjunction with https://github.com/eclipse/smarthome/pull/3948 this should create working test fragments for openHAB bindings.

Addresses discussion about test setup here: #2515.

Signed-off-by: Henning Treu <henning.treu@telekom.de>