### PR TITLE
[hdpowerview] Fix configuration to use String for id

### DIFF
--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewHubHandler.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewHubHandler.java
@@ -151,7 +151,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         Shades shades = webTargets.getShades();
         updateStatus(ThingStatus.ONLINE);
         if (shades != null) {
-            Map<Integer, Thing> things = getThingsByShadeId();
+            Map<String, Thing> things = getThingsByShadeId();
             logger.debug("Found {} shades", things.size());
             for (Shade shade : shades.shadeData) {
                 Thing thing = things.get(shade.id);
@@ -206,11 +206,11 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         }
     }
 
-    private Map<Integer, Thing> getThingsByShadeId() {
-        Map<Integer, Thing> ret = new HashMap<>();
+    private Map<String, Thing> getThingsByShadeId() {
+        Map<String, Thing> ret = new HashMap<>();
         for (Thing thing : getThing().getThings()) {
             if (thing.getThingTypeUID().equals(HDPowerViewBindingConstants.THING_TYPE_SHADE)) {
-                Integer id = thing.getConfiguration().as(HDPowerViewShadeConfiguration.class).id;
+                String id = thing.getConfiguration().as(HDPowerViewShadeConfiguration.class).id;
                 ret.put(id, thing);
             }
         }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewShadeHandler.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewShadeHandler.java
@@ -108,7 +108,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         if ((bridge = getBridgeHandler()) == null) {
             return;
         }
-        int shadeId = getShadeId();
+        String shadeId = getShadeId();
         Response response;
         try {
             response = bridge.getWebTargets().moveShade(shadeId, position);
@@ -121,7 +121,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         }
     }
 
-    private int getShadeId() {
+    private String getShadeId() {
         return getConfigAs(HDPowerViewShadeConfiguration.class).id;
     }
 

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -61,7 +61,7 @@ public class HDPowerViewWebTargets {
         }
     }
 
-    public Response moveShade(int shadeId, ShadePosition position) throws IOException {
+    public Response moveShade(String shadeId, ShadePosition position) throws IOException {
         WebTarget target = shadeMove.resolveTemplate("id", shadeId);
         String body = gson.toJson(new ShadeMove(shadeId, position));
         return invoke(target.request().buildPut(Entity.entity(body, MediaType.APPLICATION_JSON_TYPE)), shadeMove);

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
@@ -17,10 +17,10 @@ import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
  */
 class ShadeIdPosition {
 
-    int id;
+    String id;
     ShadePosition positions;
 
-    public ShadeIdPosition(int id, ShadePosition position) {
+    public ShadeIdPosition(String id, ShadePosition position) {
         this.id = id;
         this.positions = position;
     }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
@@ -19,7 +19,7 @@ public class ShadeMove {
 
     ShadeIdPosition shade;
 
-    public ShadeMove(int id, ShadePosition position) {
+    public ShadeMove(String id, ShadePosition position) {
         this.shade = new ShadeIdPosition(id, position);
     }
 }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
@@ -24,7 +24,7 @@ public class Shades {
     public List<String> shadeIds;
 
     public static class Shade {
-        public int id;
+        public String id;
         String name;
         public int roomId;
         public int groupId;

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/config/HDPowerViewShadeConfiguration.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/config/HDPowerViewShadeConfiguration.java
@@ -17,6 +17,6 @@ public class HDPowerViewShadeConfiguration {
 
     public static String ID = "id";
 
-    public int id;
+    public String id;
 
 }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
@@ -80,8 +80,7 @@ public class HDPowerViewShadeDiscoveryService extends AbstractDiscoveryService {
             }
             if (shades != null) {
                 for (Shade shade : shades.shadeData) {
-                    ThingUID thingUID = new ThingUID(HDPowerViewBindingConstants.THING_TYPE_SHADE,
-                            Integer.toString(shade.id));
+                    ThingUID thingUID = new ThingUID(HDPowerViewBindingConstants.THING_TYPE_SHADE, shade.id);
                     DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
                             .withProperty(HDPowerViewShadeConfiguration.ID, shade.id).withLabel(shade.getName())
                             .withBridge(hub.getThing().getUID()).build();


### PR DESCRIPTION
In 2.0, referencing a configuration defined with type 'text' as an int was allowed, so long as the value was initialized as an int originally. In 2.1, this no longer works.

Updating all references to the config to a String. Doing that instead of just changing the thing-type in order to preserve user's configuration. We don't really care about the type anyways - it's just a unique identifier for us.

Fixes #2520

Signed-off-by: Andy Lintner dev@beowulfe.com