### PR TITLE
[homematic] Quick fix for Integer values parser

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
@@ -40,7 +40,7 @@ public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
             return (Integer) object;
         }
         try {
-            return Double.valueOf(ObjectUtils.toString(object)).intValue();
+            return Long.valueOf(Double.valueOf(ObjectUtils.toString(object)).longValue()).intValue();
         } catch (NumberFormatException ex) {
             return null;
         }
@@ -181,7 +181,7 @@ public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
         } else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("off")) {
             return (Boolean.FALSE);
         } else if (value.matches("(-|\\+)?[0-9]+")) {
-            return (Integer.valueOf(value));
+            return Integer.valueOf((Long.valueOf(value).intValue()));
         } else if (value.matches("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?")) {
             return (Double.valueOf(value));
         } else {

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
@@ -40,7 +40,7 @@ public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
             return (Integer) object;
         }
         try {
-            return Long.valueOf(Double.valueOf(ObjectUtils.toString(object)).longValue()).intValue();
+            return Double.valueOf(ObjectUtils.toString(object)).intValue();
         } catch (NumberFormatException ex) {
             return null;
         }
@@ -181,7 +181,7 @@ public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
         } else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("off")) {
             return (Boolean.FALSE);
         } else if (value.matches("(-|\\+)?[0-9]+")) {
-            return Integer.valueOf((Long.valueOf(value).intValue()));
+            return Long.valueOf(value).intValue();
         } else if (value.matches("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?")) {
             return (Double.valueOf(value));
         } else {


### PR DESCRIPTION
Homematic quick&diry fix for Integer values parser.

Since Homematic is using integer values that are bigger then Java **Integer**, the binding fails to parse it correctly. This is a quick&dirty fix, a code update to user **Long** instead of **Integer** is still needed.
