### PR TITLE
[network binding] Fix examples in README.md

### DIFF
--- a/addons/binding/org.openhab.binding.network/README.md
+++ b/addons/binding/org.openhab.binding.network/README.md
@@ -32,7 +32,7 @@ Auto discovery can be used to scan the local network for **pingdevice** things b
 ```
 network:pingdevice:one_device [ hostname="192.168.0.64" ]
 
-network:device:second_device [ hostname="192.168.0.65", retry=1, timeout=5000, refresh_interval=60000 ]
+network:pingdevice:second_device [ hostname="192.168.0.65", retry=1, timeout=5000, refresh_interval=60000 ]
 
 network:servicedevice:important_server [ hostname="192.168.0.62", port=1234 ]
 ```
@@ -133,7 +133,7 @@ demo.items:
 
 ```xtend
 Switch MyDevice { channel="network:device:devicename:online" }
-Number MyDeviceResponseTime { channel="network:device:devicename:time" }
+Number MyDeviceResponseTime { channel="network:device:devicename:latency" }
 ```
 
 demo.sitemap:

--- a/addons/binding/org.openhab.binding.network/README.md
+++ b/addons/binding/org.openhab.binding.network/README.md
@@ -132,8 +132,8 @@ network:pingdevice:devicename [ hostname="192.168.0.42" ]
 demo.items:
 
 ```xtend
-Switch MyDevice { channel="network:device:devicename:online" }
-Number MyDeviceResponseTime { channel="network:device:devicename:latency" }
+Switch MyDevice { channel="network:pingdevice:devicename:online" }
+Number MyDeviceResponseTime { channel="network:pingdevice:devicename:latency" }
 ```
 
 demo.sitemap:


### PR DESCRIPTION
Replaced old devicetype and channel in examples, don't know, whether that are all mistakes, but at least those two are corrected now.