### PR TITLE
[Netatmo] Added NPE safeguard

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAMainHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAMainHandler.java
@@ -11,7 +11,6 @@ package org.openhab.binding.netatmo.handler.station;
 import static org.openhab.binding.netatmo.NetatmoBindingConstants.*;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.config.NetatmoDeviceConfiguration;
@@ -19,6 +18,7 @@ import org.openhab.binding.netatmo.handler.NetatmoDeviceHandler;
 import org.openhab.binding.netatmo.internal.ChannelTypeUtils;
 import org.openhab.binding.netatmo.internal.NADeviceAdapter;
 import org.openhab.binding.netatmo.internal.NAStationAdapter;
+import org.openhab.binding.netatmo.internal.WeatherUtils;
 
 import io.swagger.client.model.NADashboardData;
 import io.swagger.client.model.NAStationDataBody;
@@ -62,13 +62,13 @@ public class NAMainHandler extends NetatmoDeviceHandler<NetatmoDeviceConfigurati
             case CHANNEL_MAX_TEMP:
                 return ChannelTypeUtils.toDecimalType(dashboardData.getMaxTemp());
             case CHANNEL_TEMP_TREND:
-                return new StringType(dashboardData.getTempTrend());
+                return ChannelTypeUtils.toStringType(dashboardData.getTempTrend());
             case CHANNEL_NOISE:
                 return ChannelTypeUtils.toDecimalType(dashboardData.getNoise());
             case CHANNEL_PRESSURE:
                 return ChannelTypeUtils.toDecimalType(dashboardData.getPressure());
             case CHANNEL_PRESS_TREND:
-                return new StringType(dashboardData.getPressureTrend());
+                return ChannelTypeUtils.toStringType(dashboardData.getPressureTrend());
             case CHANNEL_ABSOLUTE_PRESSURE:
                 return ChannelTypeUtils.toDecimalType(dashboardData.getAbsolutePressure());
             case CHANNEL_TIMEUTC:

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule1Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule1Handler.java
@@ -10,12 +10,12 @@ package org.openhab.binding.netatmo.handler.station;
 
 import static org.openhab.binding.netatmo.NetatmoBindingConstants.*;
 
-import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.config.NetatmoModuleConfiguration;
 import org.openhab.binding.netatmo.handler.NetatmoModuleHandler;
 import org.openhab.binding.netatmo.internal.ChannelTypeUtils;
+import org.openhab.binding.netatmo.internal.WeatherUtils;
 
 import io.swagger.client.model.NADashboardData;
 
@@ -38,7 +38,7 @@ public class NAModule1Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
             NADashboardData dashboardData = module.getDashboardData();
             switch (channelId) {
                 case CHANNEL_TEMP_TREND:
-                    return new StringType(dashboardData.getTempTrend());
+                    return ChannelTypeUtils.toStringType(dashboardData.getTempTrend());
                 case CHANNEL_TEMPERATURE:
                     return ChannelTypeUtils.toDecimalType(dashboardData.getTemperature());
                 case CHANNEL_DATE_MIN_TEMP:

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule4Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/station/NAModule4Handler.java
@@ -10,12 +10,12 @@ package org.openhab.binding.netatmo.handler.station;
 
 import static org.openhab.binding.netatmo.NetatmoBindingConstants.*;
 
-import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.config.NetatmoModuleConfiguration;
 import org.openhab.binding.netatmo.handler.NetatmoModuleHandler;
 import org.openhab.binding.netatmo.internal.ChannelTypeUtils;
+import org.openhab.binding.netatmo.internal.WeatherUtils;
 
 import io.swagger.client.model.NADashboardData;
 
@@ -38,7 +38,7 @@ public class NAModule4Handler extends NetatmoModuleHandler<NetatmoModuleConfigur
             NADashboardData dashboardData = module.getDashboardData();
             switch (channelId) {
                 case CHANNEL_TEMP_TREND:
-                    return new StringType(dashboardData.getTempTrend());
+                    return ChannelTypeUtils.toStringType(dashboardData.getTempTrend());
                 case CHANNEL_CO2:
                     return ChannelTypeUtils.toDecimalType(dashboardData.getCO2());
                 case CHANNEL_TEMPERATURE:

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NAPlugHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NAPlugHandler.java
@@ -10,7 +10,6 @@ package org.openhab.binding.netatmo.handler.thermostat;
 
 import static org.openhab.binding.netatmo.NetatmoBindingConstants.*;
 
-import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
@@ -53,7 +52,7 @@ public class NAPlugHandler extends NetatmoDeviceHandler<NetatmoDeviceConfigurati
             case CHANNEL_LAST_PLUG_SEEN:
                 return ChannelTypeUtils.toDateTimeType(plugAdapter.getLastPlugSeen());
             case CHANNEL_LAST_BILAN:
-                return new DateTimeType(plugAdapter.getLastBilan());
+                return ChannelTypeUtils.toDateTimeType(plugAdapter.getLastBilan());
             default:
                 return super.getNAThingProperty(channelId);
         }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NATherm1Handler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/thermostat/NATherm1Handler.java
@@ -69,7 +69,7 @@ public class NATherm1Handler extends NetatmoModuleHandler<NATherm1Configuration>
             if (thermostat != null) {
                 switch (channelId) {
                     case CHANNEL_THERM_ORIENTATION:
-                        return new DecimalType(thermostat.getThermOrientation());
+                        return ChannelTypeUtils.toDecimalType(thermostat.getThermOrientation());
                     case CHANNEL_THERM_RELAY:
                         return thermostat.getThermRelayCmd() == 100 ? OnOffType.ON : OnOffType.OFF;
                     case CHANNEL_TEMPERATURE:
@@ -93,7 +93,8 @@ public class NATherm1Handler extends NetatmoModuleHandler<NATherm1Configuration>
                     }
                     case CHANNEL_SETPOINT_MODE: {
                         return thermostat.getSetpoint() != null
-                                ? new StringType(thermostat.getSetpoint().getSetpointMode()) : UnDefType.NULL;
+                                ? ChannelTypeUtils.toStringType(thermostat.getSetpoint().getSetpointMode())
+                                : UnDefType.NULL;
                     }
 
                 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
@@ -37,6 +37,14 @@ public class ChannelTypeUtils {
         return (calendar == null) ? UnDefType.NULL : new DateTimeType(calendar);
     }
 
+    public static State toDecimalType(Float value) {
+        return (value == null) ? UnDefType.NULL : toDecimalType(new BigDecimal(value));
+    }
+
+    public static State toDecimalType(Double value) {
+        return (value == null) ? UnDefType.NULL : toDecimalType(new BigDecimal(value));
+    }
+
     public static State toDecimalType(float value) {
         return toDecimalType(new BigDecimal(value));
     }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
@@ -13,6 +13,9 @@ import java.util.Calendar;
 
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * This class holds various channel values conversion methods
@@ -20,19 +23,33 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
  * @author Gaël L'hopital
  */
 public class ChannelTypeUtils {
-    public static DateTimeType toDateTimeType(Integer netatmoTS) {
+    public static State toStringType(String value) {
+        return (value == null) ? UnDefType.NULL : new StringType(value);
+    }
+
+    public static State toDateTimeType(Integer netatmoTS) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(netatmoTS * 1000L);
-        return new DateTimeType(calendar);
+        return toDateTimeType(calendar);
     }
 
-    public static DecimalType toDecimalType(float value) {
-        BigDecimal decimal = new BigDecimal(value).setScale(2, BigDecimal.ROUND_HALF_UP);
-        return new DecimalType(decimal);
+    public static State toDateTimeType(Calendar calendar) {
+        return (calendar == null) ? UnDefType.NULL : new DateTimeType(calendar);
     }
 
-    public static DecimalType toDecimalType(double value) {
-        BigDecimal decimal = new BigDecimal(value).setScale(2, BigDecimal.ROUND_HALF_UP);
-        return new DecimalType(decimal);
+    public static State toDecimalType(float value) {
+        return toDecimalType(new BigDecimal(value));
+    }
+
+    public static State toDecimalType(double value) {
+        return toDecimalType(new BigDecimal(value));
+    }
+
+    public static State toDecimalType(BigDecimal decimal) {
+        if (decimal == null) {
+            return UnDefType.NULL;
+        } else {
+            return new DecimalType(decimal.setScale(2, BigDecimal.ROUND_HALF_UP));
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/WeatherUtils.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/WeatherUtils.java
@@ -6,14 +6,14 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.netatmo.handler.station;
+package org.openhab.binding.netatmo.internal;
 
 /**
  * This class holds various unit/measurement conversion methods
  *
  * @author Gaël L'hopital
  */
-class WeatherUtils {
+public class WeatherUtils {
 
     /**
      * Compute the HeatIndex temperature given temperature and hygrometry
@@ -23,7 +23,7 @@ class WeatherUtils {
      * @param hygro relative level (%)
      * @return heatIndex
      */
-    static double getHeatIndex(double temperature, double humidity) {
+    public static double getHeatIndex(double temperature, double humidity) {
         double t = (9 / 5) * temperature + 32; // switch to °F
         double hi = 16.923 + (1.85212 * Math.pow(10, -1) * t) + (5.37941 * humidity)
                 - (1.00254 * Math.pow(10, -1) * t * humidity) + (9.41695 * Math.pow(10, -3) * Math.pow(t, 2))
@@ -41,7 +41,7 @@ class WeatherUtils {
         return hi;
     }
 
-    static double getDewPointDep(double temperature, double dewpoint) {
+    public static double getDewPointDep(double temperature, double dewpoint) {
         return temperature - dewpoint;
     }
 
@@ -54,7 +54,7 @@ class WeatherUtils {
      * @param hygro relative level (%)
      * @return dewpoint temperature
      */
-    static double getDewPoint(double temperature, double humidity) {
+    public static double getDewPoint(double temperature, double humidity) {
         double a = 17.271, b = 237.2;
         double gamma = ((a * temperature) / (b + temperature)) + Math.log(humidity / 100.0);
         return b * gamma / (a - gamma);
@@ -68,7 +68,7 @@ class WeatherUtils {
      * @param hygro relative level (%)
      * @return Humidex index value
      */
-    static double getHumidex(double temperature, double hygro) {
+    public static double getHumidex(double temperature, double hygro) {
         double result = 6.112 * Math.pow(10, 7.5 * temperature / (237.7 + temperature)) * hygro / 100;
         result = temperature + 0.555555556 * (result - 10);
         return result;


### PR DESCRIPTION
* Added `null` checks for NPE safeguard (the dashboardData.getXXX() methods seem to return `null` values from time to time, which leads to NPE errors deeper in the framework see eclipse/smarthome#4104)
* Moved class WeatherUtils into different package

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>