### PR TITLE
[jeelink] Flush stream after sending init command, resend on reconnect.

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
@@ -150,6 +150,8 @@ public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, 
             connection.closeConnection();
         }
 
+        connectionInitialized.set(false);
+
         SensorDefinition.disposeConverters(this);
         super.dispose();
     }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
@@ -90,6 +90,7 @@ public abstract class AbstractJeeLinkConnection implements JeeLinkConnection {
                 for (String cmd : initCommands) {
                     w.write(cmd);
                 }
+                w.flush();
             }
         } catch (IOException ex) {
             logger.debug("Error writing to output stream!", ex);


### PR DESCRIPTION
Signed-off-by: Volker Bier <volker.bier@web.de>

Fixes #2587 . This makes sure the stream is flushed after writing the init commands and also resends the init commands when the connection is re-established.
