### PR TITLE
[senseBox] set configurationPid instead of name on generated DS descriptor

### DIFF
--- a/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link SenseBoxHandlerFactory} is responsible for creating things and thing
@@ -27,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Hakan Tandogan - Initial contribution
  */
-@Component(service = BaseThingHandlerFactory.class, immediate = true, name="binding.sensebox")
+@Component(service = BaseThingHandlerFactory.class, immediate = true, configurationPid = "binding.sensebox")
 public class SenseBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BOX);


### PR DESCRIPTION
Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

as mentioned by @kaikreuzer  on https://github.com/eclipse/smarthome/pull/4113#issuecomment-324352709