### PR TITLE
[senseBox] Use the proper service class in the DS component configuration

### DIFF
--- a/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
@@ -18,7 +18,9 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link SenseBoxHandlerFactory} is responsible for creating things and thing
@@ -26,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Hakan Tandogan - Initial contribution
  */
-@Component(service = BaseThingHandlerFactory.class, immediate = true, configurationPid = "binding.sensebox")
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sensebox", configurationPolicy = ConfigurationPolicy.OPTIONAL)
 public class SenseBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BOX);


### PR DESCRIPTION
Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

As requested by @kaikreuzer on https://github.com/openhab/openhab2-addons/pull/2590#pullrequestreview-58288243 and following the example on https://github.com/eclipse/smarthome/pull/4113