### PR TITLE
[homematic] Do not start RPC server too often.

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -824,6 +824,10 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
             if (timeSinceLastEvent >= config.getAliveInterval()) {
                 logger.info("No event since {} seconds from gateway '{}', restarting RPC server", timeSinceLastEvent,
                         id);
+
+                // set lastEventTime so that the alive interval starts again
+                lastEventTime = System.currentTimeMillis();
+
                 try {
                     stopServers();
                     startServers();


### PR DESCRIPTION
Sets the last event time to the time when the RPC server has been restarted. Otherwise the RPC server is restarted on every subsequent invocation until an event has been received.

Fixes #2565.