### PR TITLE
Allow 'localhost' to be overridden by jetty.host system property.

### DIFF
--- a/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
+++ b/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
@@ -190,7 +190,8 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
             cloudClient.shutdown();
         }
 
-        String localBaseUrl = "http://localhost:" + localPort;
+        String localHost = System.getProperty("jetty.host", "localhost");
+        String localBaseUrl = "http://" + localHost + ":" + localPort;
         cloudClient = new CloudClient(InstanceUUID.get(), getSecret(), cloudBaseUrl, localBaseUrl, remoteAccessEnabled,
                 exposedItems);
         cloudClient.setOpenHABVersion(OpenHAB.getVersion());


### PR DESCRIPTION
This PR allows the cloud connector's use of `localhost` to be overridden with the `jetty.host` system property in the cases where the local OH instance is unreachable via `localhost`.

I'm running OH2 bound to an IP aliases `eth0:1` (not the actual interface `eth0`) and therefore the cloud connector kept giving me "Connection Refused" errors. 

Looking through the code, I discovered the cloud connector was using `localhost` (it was hardcoded - maybe for security?) and my OH2 instance was not reachable at `localhost` so I could not use the cloud service.

Being that this was a simple fix, I figured I'd do a quick PR to hopefully fix this issue for anyone in the future.