### PR TITLE
[homematic] Quick fix for TCL backup script solves #2662

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/resources/homematic/tclrega-scripts.xml
+++ b/addons/binding/org.openhab.binding.homematic/src/main/resources/homematic/tclrega-scripts.xml
@@ -124,10 +124,12 @@ Write('<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>\n');
 Write("<list>\n");
 foreach (datapointName, datapointNames) {
     object dp = dom.GetObject(channel #  datapointName);
-    Write("  <entry");
-    Write(" name='"); WriteXML(dp.Name().StrValueByIndex(".",2));
-    Write("' value='"); WriteXML(dp.Value());
-    Write("' />\n");
+	if(dp) {
+        Write("  <entry");
+        Write(" name='"); WriteXML(dp.Name().StrValueByIndex(".",2));
+        Write("' value='"); WriteXML(dp.Value());
+        Write("' />\n");
+	}
 }
 Write("</list>");
         ]]>


### PR DESCRIPTION
Quick fix for Homematic TCL script

Sometimes Homematic binding is failing to parse the TCL script XML output, this patch fixes it. For more details see #2662 
