### PR TITLE
[nest] add missing null-checks

### DIFF
--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
@@ -185,7 +185,7 @@ public class NestBridgeHandler extends BaseBridgeHandler {
 
     }
 
-    private Thing getDevice(String deviceId, List<Thing> things) {
+    private Thing getExistingDevice(String deviceId, List<Thing> things) {
         for (Thing thing : things) {
             String thingDeviceId = thing.getUID().getId();
             if (thingDeviceId.equals(deviceId)) {
@@ -199,45 +199,53 @@ public class NestBridgeHandler extends BaseBridgeHandler {
         Bridge bridge = getThing();
         List<Thing> things = bridge.getThings();
 
-        for (Thermostat thermostat : devices.getThermostats().values()) {
-            Thing thingThermostat = getDevice(thermostat.getDeviceId(), things);
-            if (thingThermostat != null) {
-                NestThermostatHandler handler = (NestThermostatHandler) thingThermostat.getHandler();
-                if (handler != null) {
-                    handler.updateThermostat(thermostat);
-                }
-            } else {
-                for (NestDeviceAddedListener listener : listeners) {
-                    logger.debug("Found new thermostat {}", thermostat.getDeviceId());
-                    listener.onThermostatAdded(thermostat);
-                }
-            }
-        }
-        for (Camera camera : devices.getCameras().values()) {
-            Thing thingCamera = getDevice(camera.getDeviceId(), things);
-            if (thingCamera != null) {
-                NestCameraHandler handler = (NestCameraHandler) thingCamera.getHandler();
-                if (handler != null) {
-                    handler.updateCamera(camera);
-                }
-            } else {
-                for (NestDeviceAddedListener listener : listeners) {
-                    logger.debug("Found new camera. {}", camera.getDeviceId());
-                    listener.onCameraAdded(camera);
+        if (devices.getThermostats() != null) {
+            for (Thermostat thermostat : devices.getThermostats().values()) {
+                Thing thingThermostat = getExistingDevice(thermostat.getDeviceId(), things);
+                if (thingThermostat != null) {
+                    NestThermostatHandler handler = (NestThermostatHandler) thingThermostat.getHandler();
+                    if (handler != null) {
+                        handler.updateThermostat(thermostat);
+                    }
+                } else {
+                    for (NestDeviceAddedListener listener : listeners) {
+                        logger.debug("Found new thermostat {}", thermostat.getDeviceId());
+                        listener.onThermostatAdded(thermostat);
+                    }
                 }
             }
         }
-        for (SmokeDetector smokeDetector : devices.getSmokeDetectors().values()) {
-            Thing thingSmokeDetector = getDevice(smokeDetector.getDeviceId(), things);
-            if (thingSmokeDetector != null) {
-                NestSmokeDetectorHandler handler = (NestSmokeDetectorHandler) thingSmokeDetector.getHandler();
-                if (handler != null) {
-                    handler.updateSmokeDetector(smokeDetector);
+
+        if (devices.getCameras() != null) {
+            for (Camera camera : devices.getCameras().values()) {
+                Thing thingCamera = getExistingDevice(camera.getDeviceId(), things);
+                if (thingCamera != null) {
+                    NestCameraHandler handler = (NestCameraHandler) thingCamera.getHandler();
+                    if (handler != null) {
+                        handler.updateCamera(camera);
+                    }
+                } else {
+                    for (NestDeviceAddedListener listener : listeners) {
+                        logger.debug("Found new camera. {}", camera.getDeviceId());
+                        listener.onCameraAdded(camera);
+                    }
                 }
-            } else {
-                for (NestDeviceAddedListener listener : listeners) {
-                    logger.debug("Found new smoke detector. {}", smokeDetector.getDeviceId());
-                    listener.onSmokeDetectorAdded(smokeDetector);
+            }
+        }
+
+        if (devices.getSmokeDetectors() != null) {
+            for (SmokeDetector smokeDetector : devices.getSmokeDetectors().values()) {
+                Thing thingSmokeDetector = getExistingDevice(smokeDetector.getDeviceId(), things);
+                if (thingSmokeDetector != null) {
+                    NestSmokeDetectorHandler handler = (NestSmokeDetectorHandler) thingSmokeDetector.getHandler();
+                    if (handler != null) {
+                        handler.updateSmokeDetector(smokeDetector);
+                    }
+                } else {
+                    for (NestDeviceAddedListener listener : listeners) {
+                        logger.debug("Found new smoke detector. {}", smokeDetector.getDeviceId());
+                        listener.onSmokeDetectorAdded(smokeDetector);
+                    }
                 }
             }
         }
@@ -248,7 +256,7 @@ public class NestBridgeHandler extends BaseBridgeHandler {
         List<Thing> things = bridge.getThings();
 
         for (Structure struct : structures) {
-            Thing thingStructure = getDevice(struct.getStructureId(), things);
+            Thing thingStructure = getExistingDevice(struct.getStructureId(), things);
             if (thingStructure != null) {
                 NestStructureHandler handler = (NestStructureHandler) thingStructure.getHandler();
                 if (handler != null) {


### PR DESCRIPTION
Added null check because nest unfortunately returns null instead of an empty map if you do not own a certain type of device.

Fixes the following NPE if you are missing certain devices, see also https://github.com/openhab/openhab2-addons/pull/2658#issuecomment-328283484:


```
2017-09-09 17:16:10.710 [ERROR] [nternal.DiscoveryServiceRegistryImpl] - Cannot trigger scan for thing types '[nest:structure, nest:camera, nest:thermostat, nest:smoke_detector]' on 'NestDiscoveryService'!
java.lang.NullPointerException: null
	at org.openhab.binding.nest.handler.NestBridgeHandler.compareThings(NestBridgeHandler.java:202) [214:org.openhab.binding.nest:2.2.0.201709071552]
	at org.openhab.binding.nest.handler.NestBridgeHandler.refreshData(NestBridgeHandler.java:178) [214:org.openhab.binding.nest:2.2.0.201709071552]
	at org.openhab.binding.nest.handler.NestBridgeHandler.startDiscoveryScan(NestBridgeHandler.java:339) [214:org.openhab.binding.nest:2.2.0.201709071552]
	at org.openhab.binding.nest.discovery.NestDiscoveryService.startScan(NestDiscoveryService.java:61) [214:org.openhab.binding.nest:2.2.0.201709071552]
	at org.eclipse.smarthome.config.discovery.AbstractDiscoveryService.startScan(AbstractDiscoveryService.java:200) [98:org.eclipse.smarthome.config.discovery:0.9.0.201709071501]
	at org.eclipse.smarthome.config.discovery.internal.DiscoveryServiceRegistryImpl.startScan(DiscoveryServiceRegistryImpl.java:399) [98:org.eclipse.smarthome.config.discovery:0.9.0.201709071501]
	at org.eclipse.smarthome.config.discovery.internal.DiscoveryServiceRegistryImpl.startScans(DiscoveryServiceRegistryImpl.java:384) [98:org.eclipse.smarthome.config.discovery:0.9.0.201709071501]
	at org.eclipse.smarthome.config.discovery.internal.DiscoveryServiceRegistryImpl.startScan(DiscoveryServiceRegistryImpl.java:228) [98:org.eclipse.smarthome.config.discovery:0.9.0.201709071501]
	at org.eclipse.smarthome.io.rest.core.discovery.DiscoveryResource.scan(DiscoveryResource.java:86) [118:org.eclipse.smarthome.io.rest.core:0.9.0.201709071501]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
```
