### PR TITLE
[yamaha] netradio navigation fix

### DIFF
--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaZoneThingHandler.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaZoneThingHandler.java
@@ -199,6 +199,22 @@ public class YamahaZoneThingHandler extends BaseThingHandler implements ZoneCont
     void updateZoneInformation() {
         updateAsyncMakeOfflineIfFail(zoneAvailableInputs);
         updateAsyncMakeOfflineIfFail(zoneControl);
+
+        if (inputWithPlayControl != null) {
+            updateAsyncMakeOfflineIfFail(inputWithPlayControl);
+        }
+
+        if (inputWithNavigationControl != null) {
+            updateAsyncMakeOfflineIfFail(inputWithNavigationControl);
+        }
+
+        if (inputWithPresetControl != null) {
+            updateAsyncMakeOfflineIfFail(inputWithPresetControl);
+        }
+
+        if (inputWithDabBandControl != null) {
+            updateAsyncMakeOfflineIfFail(inputWithDabBandControl);
+        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithNavigationControl.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithNavigationControl.java
@@ -10,8 +10,8 @@ package org.openhab.binding.yamahareceiver.internal.protocol;
 
 import java.io.IOException;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The navigation control protocol interface
@@ -24,8 +24,8 @@ public interface InputWithNavigationControl extends IStateUpdatable {
     /**
      * List all inputs that are compatible with this kind of control
      */
-    Set<String> SUPPORTED_INPUTS = Sets.newHashSet("NET_RADIO", "USB", "DOCK", "iPOD_USB", "PC", "Napster",
-            "Pandora", "SIRIUS", "Rhapsody", "iPod", "HD_RADIO");
+    Set<String> SUPPORTED_INPUTS = Stream.of("NET_RADIO", "NET RADIO", "USB", "DOCK", "iPOD_USB", "PC", "Napster",
+            "Pandora", "SIRIUS", "Rhapsody", "iPod", "HD_RADIO").collect(Collectors.toSet());
 
     /**
      * Navigate back

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithPlayControl.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithPlayControl.java
@@ -10,8 +10,9 @@ package org.openhab.binding.yamahareceiver.internal.protocol;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants;
 
 /**
@@ -25,13 +26,11 @@ public interface InputWithPlayControl extends IStateUpdatable {
     /**
      * List all inputs that are compatible with this kind of control
      */
-    Set<String> SUPPORTED_INPUTS = Sets.newHashSet(
-            YamahaReceiverBindingConstants.INPUT_TUNER,
-            "NET_RADIO", "USB", "DOCK", "iPOD_USB", "PC",
-            "Napster", "Pandora", "SIRIUS", "Rhapsody",
-            YamahaReceiverBindingConstants.INPUT_BLUETOOTH,
-            "iPod", "HD_RADIO",
-            YamahaReceiverBindingConstants.INPUT_SPOTIFY);
+    Set<String> SUPPORTED_INPUTS = Stream
+            .of(YamahaReceiverBindingConstants.INPUT_TUNER, "NET_RADIO", "NET RADIO", "USB", "DOCK", "iPOD_USB", "PC",
+                    "Napster", "Pandora", "SIRIUS", "Rhapsody", YamahaReceiverBindingConstants.INPUT_BLUETOOTH, "iPod",
+                    "HD_RADIO", YamahaReceiverBindingConstants.INPUT_SPOTIFY)
+            .collect(Collectors.toSet());
 
     /**
      * Start the playback of the content which is usually selected by the means of the Navigation control class or

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithPresetControl.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/InputWithPresetControl.java
@@ -10,8 +10,9 @@ package org.openhab.binding.yamahareceiver.internal.protocol;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants;
 
 /**
@@ -24,9 +25,9 @@ public interface InputWithPresetControl extends IStateUpdatable {
     /**
      * List all inputs that are compatible with this kind of control
      */
-    Set<String> SUPPORTED_INPUTS = Sets.newHashSet(YamahaReceiverBindingConstants.INPUT_TUNER,
-            "NET_RADIO", "USB", "DOCK", "iPOD_USB", "PC",
-            "Napster", "Pandora", "SIRIUS", "Rhapsody", YamahaReceiverBindingConstants.INPUT_BLUETOOTH, "iPod", "HD_RADIO");
+    Set<String> SUPPORTED_INPUTS = Stream.of(YamahaReceiverBindingConstants.INPUT_TUNER, "NET_RADIO", "NET RADIO",
+            "USB", "DOCK", "iPOD_USB", "PC", "Napster", "Pandora", "SIRIUS", "Rhapsody",
+            YamahaReceiverBindingConstants.INPUT_BLUETOOTH, "iPod", "HD_RADIO").collect(Collectors.toSet());
 
     /**
      * Select a preset channel.


### PR DESCRIPTION
There are Yamaha AVRs like the RX-V777 that are using input name  `NET RADIO` (space separated) and not `NET_RADIO` (underscore separated). Consequently navigation and playback control are not working.
This PR adds the space-separated spelling as alternative to the list of supported inputs.

Additionally, special zone status like playback, DAB, navigation status were only refreshed when the input has changed. It is now done periodically, if the input supports it.