### PR TITLE
[amazondashbutton] Add new vendorPrefix to list

### DIFF
--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/discovery/AmazonDashButtonDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/discovery/AmazonDashButtonDiscoveryService.java
@@ -69,7 +69,8 @@ public class AmazonDashButtonDiscoveryService extends AbstractDiscoveryService i
             "0C:47:C9",
             "A0:02:DC",
             "74:75:48",
-            "AC:63:BE"
+            "AC:63:BE",
+            "FC:A6:67"
         );
     // @formatter:on
 


### PR DESCRIPTION
The amazondashbutton binding comes with a list of MAC prefixes accepted.
This PR adds a new one to that list.

Discussed in #2444 

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)
