### PR TITLE
Remove wrong groupIds from nest and network binding tests

### DIFF
--- a/addons/binding/org.openhab.binding.nest.test/pom.xml
+++ b/addons/binding/org.openhab.binding.nest.test/pom.xml
@@ -9,7 +9,6 @@
     <version>2.2.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.openhab.binding.nest.test</artifactId>
   <version>2.2.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/addons/binding/org.openhab.binding.network.test/pom.xml
+++ b/addons/binding/org.openhab.binding.network.test/pom.xml
@@ -9,8 +9,6 @@
     <version>2.2.0-SNAPSHOT</version>
   </parent>
 
-
-  <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.openhab.binding.network.test</artifactId>
   <version>2.2.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>


### PR DESCRIPTION
Signed-off-by: Patrick Fink <mail@pfink.de>