### PR TITLE
Homematic: Fixed toNumber conversion

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
@@ -67,7 +67,11 @@ public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
         if (object == null || object instanceof Number) {
             return (Number) object;
         }
-        return NumberUtils.createNumber(ObjectUtils.toString(object));
+        try {
+            return NumberUtils.createNumber(ObjectUtils.toString(object));
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Gerhard Riegler <gerhard.riegler@gmail.com>

fixes https://community.openhab.org/t/homematic-ip-radiator-thermostat-hmip-etrv-does-not-work-with-homematic-binding/34450