### PR TITLE
[network] use passed componentContext in deactivate(...) (2735)

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -38,14 +38,15 @@ public class NetworkHandlerFactory extends BaseThingHandlerFactory {
 
     // The activate component call is used to access the bindings configuration
     @Activate
-    protected void activate(ComponentContext componentContext, Map<String, Object> config) {
+    protected void activate(@NonNull ComponentContext componentContext, Map<String, Object> config) {
         super.activate(componentContext);
         modified(config);
     };
 
     @Deactivate
-    protected void deactivate() {
-        super.deactivate(null);
+    @Override
+    protected void deactivate(ComponentContext componentContext) {
+        super.deactivate(componentContext);
     }
 
     @Modified


### PR DESCRIPTION
Signed-off-by: Patrick Gottschaemmer <mail@gottschaemmer.net>

Fixes #2735 by using the passed ComponentContext, likewise in
[openhab2-addons/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java](https://github.com/openhab/openhab2-addons/blob/52f768a3f8f80ac30d98dfb286bac134116baf99/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java#L119)

Left "@Deactivate" annotation if someone wants to generate an osgi xml.