### PR TITLE
[homekit] Remove duplicate 'openhab-misc-homekit' feature

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -426,12 +426,6 @@
         <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.homekit/${project.version}</bundle>
     </feature>
 
-    <feature name="openhab-misc-homekit" description="HomeKit Integration" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <feature>openhab-transport-mdns</feature>
-        <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.homekit/${project.version}</bundle>
-    </feature>
-
     <feature name="openhab-misc-imperihome" description="ImperiHome Integration" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>esh-model-item</feature>


### PR DESCRIPTION
Currently, `openhab-misc-homekit` is seen twice on the features list. This duplicate feature was added a year ago in https://github.com/openhab/openhab2-addons/pull/1219, and I assume it's not supposed to be here.

![image](https://user-images.githubusercontent.com/8983584/30865384-55fea092-a2ce-11e7-88f9-16ff7b893d38.png)

Related topic: https://community.openhab.org/t/duplicate-features-listed-in-console/34508/3

Signed-off-by: Ben Clark <ben@benjyc.uk>