### PR TITLE
[Binding][wakeonlan] Wake on LAN binding for OH2

### DIFF
--- a/addons/binding/org.openhab.binding.wakeonlan/.classpath
+++ b/addons/binding/org.openhab.binding.wakeonlan/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/addons/binding/org.openhab.binding.wakeonlan/.project
+++ b/addons/binding/org.openhab.binding.wakeonlan/.project
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.wakeonlan</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addons/binding/org.openhab.binding.wakeonlan/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.wakeonlan/ESH-INF/binding/binding.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+ -->
+<binding:binding id="wakeonlan"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>Wake on LAN Binding OH2</name>
+    <description>Remotely wakeup devices over LAN</description>
+    <author>Ganesh Ingle</author>
+
+</binding:binding>

--- a/addons/binding/org.openhab.binding.wakeonlan/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.wakeonlan/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+ -->
+<thing:thing-descriptions bindingId="wakeonlan" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- WOL Device -->
+	<thing-type id="wol-device">
+		<label>Wol Device</label>
+		<description><![CDATA[
+		An IPv4 enabled device that suports waking up by a magic packet on LAN.
+		If your target device runs windows and you usually put it to sleep, 
+		you need to enable wake on lan from target network adapter properties page.
+		If your target device is a PC, you need to enable WOL in BIOS settings.
+		Raspberry Pis do not support WOL when powered off, instead keep them running on dynamic freq scaling to save power.
+		In addition to class wide logging, it is also done seprately per Thing, 
+		to enable logs of specific thing, use karaf console command: <b>log:set debug "Thing Label"</b> 
+		]]>
+        </description>
+
+		<channels>
+			<channel id="wakeup" typeId="wakeup-channel" />
+			<channel id="status" typeId="status-channel" />
+		</channels>
+
+		<config-description>
+		    <parameter name="targetMAC" type="text" required="true" pattern="([0-9a-fA-F]{2}[: -]?){5}[0-9a-fA-F]{2}">
+                <label>Target MAC Address</label>
+                <description><![CDATA[Target device's ethernet MAC address. 
+                Do NOT use wifi adapter's MAC.<br/>
+                MAC address may be in one of the following hex formats:<br/> 
+                <b>b8:27:eb:d0:e6:12</b><br/>
+                <b>b8-27-eb-d0-e6-12</b><br/>
+                <b>b8 27 eb d0 e6 12</b><br/>
+                <b>b827ebd0e612</b><br/><br/>
+                Upper or lower case doesn't matter.
+                ]]>
+                </description>
+            </parameter>
+			<parameter name="targetIP" type="text" required="false" pattern="([0-9]{1,3}[.]){3}[0-9]{1,3}">
+			    <!-- <context>network-address</context>-->
+				<label>Target IPv4 Subnet Broadcast Address</label>
+				<description><![CDATA[Target IPv4 BROADCAST IP to send wol UDP packet to. 
+				It could be limited broadcast address, 
+				subnet directed broadcast address, subnet base address or host's unicast IP address.
+				If you do not specify an address, then address 255.255.255.255 (limited broadcast) is used. 
+				It works when openhab and target device is on same physical network (subnet).<br/>
+				If they are on different subnets, you need directed subnet broadcast address.
+				An IP router is a device that connects two subnets. 
+				You need to make sure your routers allow forwarding directed broadcast packets. <br/>
+			    <b>How to calculate subnet directed broadcast address?</b><br/>
+                If your target host usually gets IP addresses in the range 192.168.1.X and subnet mask is 255.255.255.0 
+                then you need to specify 192.168.1.255 here.
+                Formula is: <br/>
+                <b>TargetHostIP BITWISE_OR (BITWISE_NOT(TargetSubnetMask))</b><br/>
+                On linux, the command /sbin/ifconfig reports subnet directed broadcast address.
+                For detailed information look here :<br/> 
+                https://www.countryipblocks.net/identifying-the-network-and-broadcast-address-of-a-subnet<br/>
+                Sometimes, using target subnet's base address also works. 
+                It is obtained by bitwise AND of target machine's unicast IP address and subnet mask.
+                In above examples, target subnet's base addresses would be 192.168.1.0 and 10.1.0.0.
+                If nothing works, try giving target host's IP address itself.
+                ]]>
+                </description>
+                <default>255.255.255.255</default>
+			</parameter>
+			<parameter name="targetUDPPort" type="integer" required="false" min="1" max="65535">
+			    <context></context>
+                <label>Target UDP Port</label>
+                <description><![CDATA[WOL target UDP port. 
+                Typically it is 9 (discard) or 7 (echo). Default 9.
+                ]]>
+                </description>
+                <default>9</default>
+            </parameter>
+            <parameter name="sendOnAllInterfaces" type="boolean" required="false">
+                <label>Send On All N/W Interfaces</label>
+                <description><![CDATA[Should the binding send WOL UDP packet on all physical n/w interfaces of opehab2 server?
+                If disabled, the OS routing table decides which interface to use for a given destination IP address.  
+                ]]>
+                </description>
+                <default>false</default>
+            </parameter>
+            <parameter name="sendOnInterface" type="text" required="false">
+                <label>Send On Specific N/W Interface</label>
+                <description><![CDATA[Should the binding send WOL UDP packet on specific physical n/w interface of opehab2 server?
+                If left empty, the OS routing table decides which interface to use for a given destination IP address.
+                Specify interface's name e.g eth0, eth1, wlan0.
+                Note that if your openhab2 server is only connected to network via wireless lan, the wifi router may or may not
+                forward the WOL broadcast packet to target machine connected via wired ethernet port. 
+                If it does not forward, you have to connect openhab2 server as well to wired ethernet port.
+                ]]>
+                </description>
+            </parameter>
+            <parameter name="setSO_BROADCAST" type="boolean" required="false">
+                <label>Set SO_BROADCAST option on socket</label>
+                <description><![CDATA[Set SO_BROADCAST OS level socket option.
+                    SO_BROADCAST allows OS to catch unwanted broadcast messages arising from buggy aplication software.
+                    When application writer explicitely sets SO_BROADCAST, the intention becomes clear to OS and 
+                    it allows sending packet to subnet base address or subnet broadcast address.
+                    Some operating systems may require that the Java virtual machine be started with 
+                    implementation specific privileges to enable this option or send broadcast datagrams.
+                    If you get java.io.IOException: Permission denied, first try enabling this option, 
+                    if that doesn't work try disabling this option and change <b>Target Address</b> to target host's unicast IP.
+                ]]>
+                </description>
+                <default>true</default>
+            </parameter>            
+		</config-description>
+	</thing-type>
+
+	<channel-type id="wakeup-channel">
+		<item-type>Switch</item-type>
+		<label>Wakeup</label>
+		<description>Send WOL magic packet</description>
+		<category>PowerOutlet</category>
+		<state readOnly="false"/>
+	</channel-type>
+	<channel-type id="status-channel">
+        <item-type>String</item-type>
+        <label>Status</label>
+        <description>Status Info</description>
+        <state readOnly="true" pattern="%s"/>
+    </channel-type>
+
+</thing:thing-descriptions>
+

--- a/addons/binding/org.openhab.binding.wakeonlan/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.wakeonlan/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wake On LAN Binding OH2
 Bundle-SymbolicName: org.openhab.binding.wakeonlan;singleton:=true
 Bundle-Vendor: openHAB
-Bundle-Version: 2.2.0.001
+Bundle-Version: 2.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: org.apache.commons.codec.binary,

--- a/addons/binding/org.openhab.binding.wakeonlan/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.wakeonlan/META-INF/MANIFEST.MF
@@ -1,0 +1,24 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Wake On LAN Binding OH2
+Bundle-SymbolicName: org.openhab.binding.wakeonlan;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.2.0.001
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: org.apache.commons.codec.binary,
+ org.apache.commons.io,
+ org.apache.commons.lang,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.types,
+ org.openhab.binding.wakeonlan,
+ org.openhab.binding.wakeonlan.handler,
+ org.slf4j
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.wakeonlan,
+ org.openhab.binding.wakeonlan.handler

--- a/addons/binding/org.openhab.binding.wakeonlan/OSGI-INF/WakeOnLanHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.wakeonlan/OSGI-INF/WakeOnLanHandlerFactory.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.wakeonlan">
+
+   <implementation class="org.openhab.binding.wakeonlan.internal.WakeOnLanHandlerFactory"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.wakeonlan/README.md
+++ b/addons/binding/org.openhab.binding.wakeonlan/README.md
@@ -1,0 +1,174 @@
+# Wake On Lan Binding for Openhab2
+
+Remotely wakeup devices over LAN.
+
+## LICENSE 
+
+Original work of this binding was done at Asvilabs and posted in below repository:
+<https://github.com/ganeshingale/openhab2/tree/master/org.openhab.binding.wakeonlan>
+
+Original work was published under **Apache License, Version 2.0** 
+You may obtain a copy of the License at  
+  
+  <http://www.apache.org/licenses/LICENSE-2.0>  
+  
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.  
+
+The work is re-published here under EPLv1.0 license. 
+Any modifications posted henceforth on this repository are subject to EPLv1.0 terms.
+Modifications posted on original repository github.com/ganeshingale/openhab2 remain 
+under Apache License v2.0
+
+## Supported Things
+
+### Thing Type 'wol-device'
+ 
+An IPv4 enabled device that suports waking up by a magic packet on LAN.
+If your target device runs windows and you usually put it to sleep, 
+you need to enable wake on lan from target network adapter properties page.
+If your target device is a PC, you need to enable WOL in BIOS settings.
+Raspberry Pis do not support WOL when powered off, instead keep them running on dynamic freq scaling to save power.
+In addition to class wide logging, it is also done seprately per Thing, 
+to enable logs of specific thing, use karaf console command: <b>log:set debug "Thing Label"</b>
+
+## Discovery
+
+Auto discovery not supported, because there could be hundreds of devices on LAN. 
+
+## Binding Configuration
+ 
+The binding has no configuration options, all configuration is done at Thing level.
+ 
+## Thing Configuration
+
+The thing has a few configuration parameters:
+
+| Parameter           | Description                                                                         |
+|---------------------|-------------------------------------------------------------------------------------|
+| targetMAC           | MAC Address of ethernet card of target device you want to wakeup. REQUIRED          |
+| targetIP            | Broadcast address to send WOL magic packet to. Default 255.255.255.255              |
+| targetUDPPort       | UDP Port. Default 9 (discard port). You may try 7 (echo port)                       |
+| sendOnAllInterfaces | Send magic packet on all outgoing interfaces. Default 0.0.0.0, kernel selected NIC  |
+| sendOnInterface     | Send magic packet on specified outgoing interface. Default 0.0.0.0, kernel selected |
+| setSO_BROADCAST     | Set SO_BROADCAST socket option. Default true                                        |
+
+### Decription
+
+### Target MAC Address (*targetMAC*)
+
+Target device's ethernet MAC address. Do NOT use wifi adapter's MAC.   
+MAC address may be in one of the following hex formats:  
+**b8:27:eb:d0:e6:12**  
+**b8-27-eb-d0-e6-12**  
+**b8 27 eb d0 e6 12**  
+**b827ebd0e612**  
+Upper or lower case doesn't matter.
+
+### Target IPv4 Subnet Broadcast Address (*targetIP*)
+
+Target IPv4 BROADCAST IP to send wol UDP packet to. It could be limited broadcast address, subnet directed broadcast address, subnet base address or host's unicast IP address. If you do not specify an address, then address 255.255.255.255 (limited broadcast) is used. It works when openhab and target device is on same physical network (subnet).  
+  
+If they are on different subnets, you need directed subnet broadcast address. An IP router is a device that connects two subnets. You need to make sure your routers allow forwarding directed broadcast packets.  
+
+**How to calculate subnet directed broadcast address?**  
+
+If your target host usually gets IP addresses in the range 192.168.1.X and subnet mask is 255.255.255.0 then you need to specify 192.168.1.255 here.
+  
+**Formula**  
+
+*TargetHostIP* **BITWISE_OR** (**BITWISE_NOT**(*TargetSubnetMask*))
+
+On linux, the command */sbin/ifconfig* reports *subnet directed broadcast address*.
+
+For detailed information look here : 
+<https://www.countryipblocks.net/identifying-the-network-and-broadcast-address-of-a-subnet>
+
+Sometimes, using target subnet's base address also works. It is obtained by bitwise AND of target machine's unicast IP address and subnet mask. In above example, target subnet's base addresses would be 192.168.1.0.
+
+If nothing works, try giving target host's IP address itself.
+
+### Target UDP Port (*targetUDPPort*)
+
+WOL target UDP port. Typically it is 9 (discard) or 7 (echo). Default 9.
+
+### Send On All N/W Interfaces (*sendOnAllInterfaces*)
+
+Should the binding send WOL UDP packet on all physical n/w interfaces of opehab2 server?   
+If disabled, the OS routing table decides which interface to use for a given destination IP address.
+
+### Send On Specific N/W Interface (*sendOnInterface*)
+
+Should the binding send WOL UDP packet on specific physical n/w interface of opehab2 server?  
+If left empty, the OS routing table decides which interface to use for a given destination IP address. Specify interface's name e.g eth0, eth1, wlan0. Note that if your openhab2 server is only connected to network via wireless lan, the wifi router may or may not forward the WOL broadcast packet to target machine connected via wired ethernet port. If it does not forward, you have to connect openhab2 server as well to wired ethernet port.
+
+### Set SO_BROADCAST option on socket (*setSO_BROADCAST*)
+
+Set SO_BROADCAST OS level socket option. SO_BROADCAST allows OS to catch unwanted broadcast messages arising from buggy aplication software. When application writer explicitely sets SO_BROADCAST, the intention becomes clear to OS and              it allows sending packet to subnet base address or subnet broadcast address. Some operating systems may require that the Java virtual machine be started with implementation specific privileges to enable this option or send broadcast datagrams.                     If you get java.io.IOException: Permission denied, first try enabling this option, if that doesn't work try disabling this option and change <b>Target Address</b> to target host's unicast IP.
+
+## Channels
+
+Available channels:
+
+| Channel | Type   | Description                                             |
+|---------|--------|-------------------------------------------------------- |
+| wakeup  | Switch | Send WOL Magic Packet. OnOffType.ON, "ON", "1" accepted |
+| status  | String | Status/Error. Also OnOffType.ON, "ON", "1" accepted     |
+
+## Full Example
+
+### wakeonlan.things  
+
+```
+wakeonlan:wol-device:wolkodi1 "Kodi1" @ "LivingRoom1" [ targetMAC="08:60:6E:F4:87:4A" ]
+wakeonlan:wol-device:wolkodi2 "Kodi2" @ "LivingRoom2" [ targetMAC="76:90:44:DC:79:FF", targetIP="10.0.1.255" ]
+wakeonlan:wol-device:pc1 "PC1" @ "StudyRoom1" [ targetMAC="08:60:6E:F4:87:4A", sendOnAllInterfaces=true ]
+wakeonlan:wol-device:pc1 "PC2" @ "StudyRoom2" [ targetMAC="08:60:6E:CC:CC:5C", targetIP="192.168.2.15", targetUDPPort=7, sendOnInterface="eth2", setSO_BROADCAST=false ]
+```
+
+### wakeonlan.items
+
+```
+Switch   Kodi1Wakeup     "Wakeup Kodi1" { channel="wakeonlan:wol-device:wolkodi1:wakeup" }
+String   Kod1WolStatus   "Status Kodi1" { channel="wakeonlan:wol-device:wolkodi1:status" }
+
+Switch   Kodi2Wakeup     "Wakeup Kodi2" { channel="wakeonlan:wol-device:wolkodi2:wakeup" }
+String   Kod2WolStatus   "Status Kodi2" { channel="wakeonlan:wol-device:wolkodi2:status" }
+
+Switch   PC1Wakeup     "Wakeup PC1" { channel="wakeonlan:wol-device:pc1:wakeup" }
+String   PC1WolStatus   "Status PC1" { channel="wakeonlan:wol-device:pc1:status" }
+
+Switch   PC2Wakeup     "Wakeup PC2" { channel="wakeonlan:wol-device:pc2:wakeup" }
+String   PC2WolStatus   "Status PC2" { channel="wakeonlan:wol-device:pc2:status" }
+```
+
+### wakeonlan.sitemap
+
+```
+sitemap wakeonlan label="Wake On LAN" {
+    Frame {
+        Switch item=Kod1Wakeup
+        Text item=Kod1WolStatus
+    }
+
+    Frame {
+        Switch item=Kod2Wakeup
+        Text item=Kod2WolStatus
+    }
+    
+    Frame {
+        Switch item=PC1Wakeup
+        Text item=PC1WolStatus
+    }
+    
+    Frame {
+        Switch item=PC2Wakeup
+        Text item=PC2WolStatus
+    }
+}
+```
+

--- a/addons/binding/org.openhab.binding.wakeonlan/about.html
+++ b/addons/binding/org.openhab.binding.wakeonlan/about.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>Sept 30, 2017</p>	
+<h3>License</h3>
+
+<p>
+Original work of this binding was done at Asvilabs and posted in below repository:<br/>
+<br/>
+https://github.com/ganeshingale/openhab2/tree/master/org.openhab.binding.wakeonlan<br/>
+<br/>
+Original work was published under <b>Apache License, Version 2.0</b><br/> 
+You may obtain a copy of the License at  <br/>
+<br/>
+  http://www.apache.org/licenses/LICENSE-2.0<br/>  
+<br/>
+
+The work is re-published here as of "Sept 30, 2017" under Eclipse Public License v1.0, 
+this is allowed under the terms of original license. 
+Any modifications posted henceforth on this repository are subject to EPLv1.0 terms.
+Modifications posted on original repository github.com/ganeshingale/openhab2 remain 
+under Apache License v2.0.
+
+</p>
+<p>The openHAB community makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the openHAB community, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.openhab.org/">openhab.org</a>.</p>
+
+</body>
+</html>

--- a/addons/binding/org.openhab.binding.wakeonlan/build.properties
+++ b/addons/binding/org.openhab.binding.wakeonlan/build.properties
@@ -1,0 +1,8 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/,\
+               about.html
+

--- a/addons/binding/org.openhab.binding.wakeonlan/pom.xml
+++ b/addons/binding/org.openhab.binding.wakeonlan/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.wakeonlan</artifactId>
   <name>Wake On LAN Binding OH2</name>
-  <version>2.2.0.001</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/addons/binding/org.openhab.binding.wakeonlan/pom.xml
+++ b/addons/binding/org.openhab.binding.wakeonlan/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>pom</artifactId>
+	<version>2.2.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.wakeonlan</artifactId>
+  <name>Wake On LAN Binding OH2</name>
+  <version>2.2.0.001</version>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/WakeOnLanBindingConstants.java
+++ b/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/WakeOnLanBindingConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wakeonlan;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link AirQualityBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Ganesh Ingle - Initial contribution
+ */
+public class WakeOnLanBindingConstants {
+
+    public static final String BINDING_ID = "wakeonlan";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_WOLDEVICE = new ThingTypeUID(BINDING_ID, "wol-device");
+
+    // List of all Channel id's
+    public static final String CHANNEL_WAKEUP = "wakeup";
+    public static final String CHANNEL_STATUS = "status";
+
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
+            Arrays.asList(THING_TYPE_WOLDEVICE));
+
+}

--- a/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/handler/WakeOnLanHandler.java
+++ b/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/handler/WakeOnLanHandler.java
@@ -1,0 +1,448 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wakeonlan.handler;
+
+import static org.openhab.binding.wakeonlan.WakeOnLanBindingConstants.*;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.PortUnreachableException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.regex.PatternSyntaxException;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.wakeonlan.internal.WakeOnLanConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WakeOnLanHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ * This is the main handler for openhab2 Wake On LAN binding.
+ *
+ * @author Ganesh Ingle - Initial contribution
+ */
+public class WakeOnLanHandler extends BaseThingHandler {
+
+    private Logger classLogger = LoggerFactory.getLogger(WakeOnLanHandler.class);
+    private Logger thingLogger = null;
+    public static final String DFLT_BROADCAST_ADDRESS = "255.255.255.255";
+    public static final Integer DFLT_UDP_WOL_PORT = 9;
+    protected String targetIP = DFLT_BROADCAST_ADDRESS;
+    protected InetAddress targetBroadcastIP = null;
+    protected String targetMACHex = null;
+    protected boolean invalidCfg = false;
+    protected Integer targetUDPPort = DFLT_UDP_WOL_PORT;
+    protected String outgoingInterface = null;
+    protected Boolean sendOnAllInterfaces = false;
+    protected Boolean setBroadcastFlag = false;
+    protected Timer statusUpdator = null;
+    protected String errorMsg = "";
+    protected byte[] magicPacket = null;
+    protected String sendOnInterface = null;
+    protected boolean setSO_BROADCAST = true;
+
+    public WakeOnLanHandler(Thing thing) {
+        super(thing);
+    }
+
+    // re-initialize fields after config update => dispose() => initialize()
+    protected void initFields() {
+        targetIP = DFLT_BROADCAST_ADDRESS;
+        targetUDPPort = DFLT_UDP_WOL_PORT;
+        targetMACHex = null;
+        targetBroadcastIP = null;
+        invalidCfg = false;
+        errorMsg = "";
+        // macBytes = null;
+        magicPacket = null;
+        sendOnInterface = null;
+        sendOnAllInterfaces = false;
+        thingLogger = null;
+        setSO_BROADCAST = true;
+    }
+
+    @Override
+    public void initialize() {
+        classLogger.debug("Initializing Wake On LAN OH2 handler for thing '{}'", getThing().getLabel());
+        initFields();
+        if (thingLogger == null || !getThing().getLabel().equals(thingLogger.getName())) {
+            thingLogger = LoggerFactory.getLogger(getThing().getLabel());
+        }
+        thingLogger.debug("Initializing Wake On LAN OH2 handler");
+        // updateState(CHANNEL_STATUS, new StringType("INITIALIZING"));
+        if (statusUpdator != null) {
+            statusUpdator.cancel();
+        }
+        statusUpdator = new Timer(true);
+        WakeOnLanConfiguration config = getConfigAs(WakeOnLanConfiguration.class);
+        if (config.targetIP != null && config.targetIP.trim().length() > 0) {
+            classLogger.debug("WOL Broadcast IP = {}", config.targetIP);
+            thingLogger.debug("WOL Broadcast IP = {}", config.targetIP);
+            targetIP = config.targetIP.trim();
+            try {
+                if (targetIP.matches("([0-9]{1,3}[.]){3}[0-9]{1,3}")) {
+                    targetBroadcastIP = InetAddress.getByName(targetIP);
+                } else {
+                    invalidCfg = true;
+                    errorMsg = "Invalid WOL Broadcast IP " + config.targetIP;
+                }
+            } catch (PatternSyntaxException | UnknownHostException | SecurityException e) {
+                classLogger.warn("Error validating targetBroadcastIP. ", e);
+                thingLogger.warn("Error validating targetBroadcastIP. ", e);
+                invalidCfg = true;
+                errorMsg = "Invalid WOL Broadcast IP " + config.targetIP + ". " + e.toString();
+            }
+        }
+        if (config.targetMAC != null && config.targetMAC.trim().length() > 0) {
+            targetMACHex = config.targetMAC.trim();
+            if (!targetMACHex.matches("([0-9a-fA-F]{2}[: -]?){5}[0-9a-fA-F]{2}")) {
+                errorMsg = "INVALID MAC " + config.targetMAC;
+                invalidCfg = true;
+            } else {
+                try {
+                    String maxHex = targetMACHex.replaceAll("[ ]|[:]|[-]", "");
+                    magicPacket = fillMagicBytes(getMacBytes(maxHex));
+                    classLogger.debug("WOL MAC {}", config.targetMAC);
+                    thingLogger.debug("WOL MAC {}", config.targetMAC);
+                } catch (NumberFormatException e) {
+                    invalidCfg = true;
+                    errorMsg = "INALID MAC " + config.targetMAC + ". " + e.toString();
+                    classLogger.warn("Error validating targetMAC. ", e);
+                    thingLogger.warn("Error validating targetMAC. ", e);
+                }
+            }
+        } else {
+            invalidCfg = true;
+            errorMsg = "No MAC configured";
+        }
+
+        if (config.targetUDPPort != null && config.targetUDPPort >= 1 && config.targetUDPPort <= 65535) {
+            targetUDPPort = config.targetUDPPort;
+            classLogger.debug("WOL UDP Port = {}", config.targetUDPPort);
+            thingLogger.debug("WOL UDP Port = {}", config.targetUDPPort);
+        } else if (config.targetUDPPort != null) {
+            invalidCfg = true;
+            errorMsg = "Invalid WOL UDP Port " + config.targetUDPPort;
+        }
+
+        if (config.sendOnInterface != null && config.sendOnInterface.trim().length() > 0) {
+            sendOnInterface = config.sendOnInterface;
+            NetworkInterface nif = null;
+            try {
+                nif = NetworkInterface.getByName(sendOnInterface);
+            } catch (SocketException e) {
+                classLogger.warn("Error getting N/W interface. ", e);
+                thingLogger.warn("Error getting N/W interface. ", e);
+            }
+            if (nif == null) {
+                errorMsg = "Invalid WOL N/W Interface " + config.sendOnInterface;
+                invalidCfg = true;
+            } else {
+                classLogger.debug("WOL N/W Interface = {}", config.sendOnInterface);
+                thingLogger.debug("WOL N/W Interface = {}", config.sendOnInterface);
+            }
+        }
+
+        if (config.sendOnAllInterfaces != null) {
+            sendOnAllInterfaces = config.sendOnAllInterfaces;
+            classLogger.debug("Send on ALL N/W Interfaces = {}", config.sendOnAllInterfaces);
+            thingLogger.debug("Send on ALL N/W Interfaces = {}", config.sendOnAllInterfaces);
+        }
+
+        if (config.setSO_BROADCAST != null) {
+            setSO_BROADCAST = config.setSO_BROADCAST;
+            classLogger.debug("Set SO_BROADCAST = {}", config.setSO_BROADCAST);
+            thingLogger.debug("Set SO_BROADCAST = {}", config.setSO_BROADCAST);
+        }
+
+        if (invalidCfg) {
+            try {
+                updateThingStatusDelayed(ThingStatus.OFFLINE, 800);
+                updateStateDelayed(CHANNEL_STATUS, new StringType(errorMsg), 1000);
+            } catch (InterruptedException e) {
+                return;
+            }
+            classLogger.warn("Config error while initializing Wake On LAN OH2 handler for thing '{}'. {}",
+                    getThing().getLabel(), errorMsg);
+            thingLogger.warn("Config error while initializing Wake On LAN OH2 handler, {}", errorMsg);
+        } else {
+            // Throws callback missing error occasionally
+            // super.initialize();
+            try {
+                updateThingStatusDelayed(ThingStatus.ONLINE, 800);
+                updateStateDelayed(CHANNEL_STATUS, new StringType("Ready"), 1000);
+            } catch (InterruptedException e) {
+                return;
+            }
+
+            classLogger.debug("Initialized Wake On LAN OH2 handler for thing '{}'", getThing().getLabel());
+            thingLogger.debug("Initialized Wake On LAN OH2 handler", getThing().getLabel());
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (statusUpdator != null) {
+            statusUpdator.cancel();
+            statusUpdator = null;
+        }
+        // updateState(CHANNEL_STATUS, new StringType("DISPOSED"));
+        super.dispose();
+    }
+
+    protected void updateStateDelayed(final String channel, final State state, long delayMs)
+            throws InterruptedException {
+        try {
+            statusUpdator.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    updateState(channel, state);
+                }
+            }, delayMs);
+        } catch (IllegalStateException e) {
+            statusUpdator = new Timer(true);
+            statusUpdator.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    updateState(channel, state);
+                }
+
+            }, delayMs);
+        }
+    }
+
+    protected void updateThingStatusDelayed(final ThingStatus thingStatus, long delayMs) throws InterruptedException {
+        try {
+            statusUpdator.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    updateStatus(thingStatus);
+                }
+            }, delayMs);
+        } catch (IllegalStateException e) {
+            statusUpdator = new Timer(true);
+            statusUpdator.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    updateStatus(thingStatus);
+                }
+
+            }, delayMs);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command == null || channelUID == null) {
+            return;
+        }
+        if (command == RefreshType.REFRESH) {
+            return;
+        }
+        if (!(command instanceof OnOffType)) {
+            String strCmd = command.toString();
+            if (strCmd.equalsIgnoreCase("on") || strCmd.equalsIgnoreCase("1")) {
+                command = OnOffType.ON;
+            }
+        }
+        if ((CHANNEL_WAKEUP.equals(channelUID.getId()) || CHANNEL_STATUS.equals(channelUID.getId()))
+                && command == OnOffType.ON) {
+            try {
+                if (!invalidCfg) {
+                    try {
+                        sendWolPacket();
+                        updateState(CHANNEL_STATUS, new StringType("Packet Sent"));
+                        updateStateDelayed(CHANNEL_STATUS, new StringType("Ready"), 5000);
+                    } catch (InterruptedException e) {
+                        return;
+                    } catch (IOException | SecurityException | java.nio.channels.IllegalBlockingModeException
+                            | IllegalArgumentException e) {
+                        classLogger.warn("Failed to send Wake on LAN packet to {} , MAC={}",
+                                targetBroadcastIP.getHostAddress() + ":" + targetUDPPort, targetMACHex);
+                        classLogger.warn("Failed to send Wake on LAN packet. ", e);
+                        thingLogger.warn("Failed to send Wake on LAN packet to {} , MAC={}",
+                                targetBroadcastIP.getHostAddress() + ":" + targetUDPPort, targetMACHex);
+                        thingLogger.warn("Failed to send Wake on LAN packet. ", e);
+                        updateState(CHANNEL_STATUS, new StringType(e.toString()));
+                        // Let user copy paste error message somewhere for diagnostics
+                        updateStateDelayed(CHANNEL_STATUS, new StringType("Ready"), 60000);
+                    }
+                } else {
+                    updateState(CHANNEL_STATUS, new StringType("Fix Config Error First"));
+                    updateStateDelayed(CHANNEL_STATUS, new StringType(errorMsg), 5000);
+                }
+                updateStateDelayed(channelUID.getId(), OnOffType.OFF, 1000);
+            } catch (InterruptedException e) {
+                return;
+            }
+        } else {
+            if (classLogger.isWarnEnabled()) {
+                classLogger.warn("Unsupported command {} on channel {}", command.toFullString(), channelUID.getId());
+            }
+        }
+    }
+
+    protected void sendWolPacket() throws IOException, SecurityException, PortUnreachableException, SocketException,
+            IOException, SecurityException, PortUnreachableException, java.nio.channels.IllegalBlockingModeException,
+            IllegalArgumentException {
+        if (sendOnAllInterfaces == true) {
+            sendWolPacketOnAllInterfaces();
+        } else if (sendOnInterface != null) {
+            sendWolPacketOnInterface(null, null, sendOnInterface);
+        } else {
+            sendWolPacketSimple();
+        }
+    }
+
+    protected void sendWolPacketSimple() throws IOException {
+        DatagramPacket packet = new DatagramPacket(magicPacket, magicPacket.length, targetBroadcastIP, targetUDPPort);
+        DatagramSocket socket = new DatagramSocket();
+        socket.setBroadcast(setSO_BROADCAST);
+        socket.send(packet);
+        if (thingLogger.isInfoEnabled() || classLogger.isDebugEnabled()) {
+            String localIP = socket.getLocalAddress() != null ? socket.getLocalAddress().getHostAddress() : "NULL";
+            String msg = "WOL Packet sent from local IP " + localIP + " to target IP:PORT "
+                    + targetBroadcastIP.getHostAddress() + ":" + targetUDPPort + ", target MAC " + targetMACHex
+                    + ", with SO_BROADCAST = " + setSO_BROADCAST;
+            thingLogger.info("{}", msg);
+            classLogger.debug("{}", msg);
+        }
+        socket.close();
+    }
+
+    protected void sendWolPacketOnAllInterfaces() throws IOException {
+        String messages = null;
+        Boolean partialSuccess = false;
+        Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
+        while (nifs.hasMoreElements()) {
+            NetworkInterface nif = nifs.nextElement();
+            try {
+                InetAddress validIP = hasValidIP(nif);
+                if (validIP != null) {
+                    sendWolPacketOnInterface(nif, validIP, nif.getName());
+                    partialSuccess = true;
+                }
+            } catch (IOException e) {
+                thingLogger.debug("Error while sending WOL packet on interface {} : {}", nif.getName(), e.toString());
+                thingLogger.debug("Stacktrace . ", e);
+                classLogger.debug("Error while sending WOL packet on interface {} : {}", nif.getName(), e.toString());
+                classLogger.debug("Stacktrace . ", e);
+                if (messages == null) {
+                    messages = e.toString();
+                } else {
+                    messages = messages + "; " + e.toString();
+                }
+            }
+        }
+        if (!partialSuccess) {
+            throw new IOException(messages);
+        }
+    }
+
+    private InetAddress hasValidIP(NetworkInterface nif) {
+        Enumeration<InetAddress> nifAddresses = nif.getInetAddresses();
+        InetAddress selectedAddress = null;
+        while (nifAddresses.hasMoreElements()) {
+            InetAddress ip = nifAddresses.nextElement();
+            if (!ip.isAnyLocalAddress() && !ip.isLinkLocalAddress() && !ip.isLoopbackAddress()
+                    && !ip.isMulticastAddress()) {
+                if (ip.getHostAddress().length() <= 15) {
+                    selectedAddress = ip;
+                }
+                // else { // TODO add IPv6 option later }
+            }
+        }
+        return selectedAddress;
+    }
+
+    protected void sendWolPacketOnInterface(NetworkInterface nif, InetAddress selectedAddress, String sendOnInterface)
+            throws IOException, SecurityException, PortUnreachableException,
+            java.nio.channels.IllegalBlockingModeException, IllegalArgumentException {
+        if (nif == null) {
+            nif = NetworkInterface.getByName(sendOnInterface);
+        }
+        if (nif == null) {
+            throw new IOException("Error getting the network interface " + sendOnInterface);
+        }
+        classLogger.debug("Trying to send WOL packet on interface {}", nif.getName());
+        thingLogger.debug("Trying to send WOL packet on interface {}", nif.getName());
+
+        if (selectedAddress == null) {
+            selectedAddress = hasValidIP(nif);
+        }
+
+        if (selectedAddress != null) {
+            InetSocketAddress inetAddr = new InetSocketAddress(selectedAddress, 0);
+            // socket.bind(new InetSocketAddress(nifAddresses.nextElement(), 0));
+            DatagramSocket socket = new DatagramSocket(inetAddr);
+            DatagramPacket packet = new DatagramPacket(magicPacket, magicPacket.length, targetBroadcastIP,
+                    targetUDPPort);
+            socket.setBroadcast(setSO_BROADCAST);
+            socket.send(packet);
+            classLogger.debug("Sent WOL packet on interface {}", nif.getName());
+            thingLogger.debug("Sent WOL packet on interface {}", nif.getName());
+            if (thingLogger.isInfoEnabled() || classLogger.isDebugEnabled()) {
+                String localIP = socket.getLocalAddress() != null ? socket.getLocalAddress().getHostAddress() : "NULL";
+                String msg = "WOL Packet sent from " + "local IP " + localIP + " to target IP:PORT "
+                        + targetBroadcastIP.getHostAddress() + ":" + targetUDPPort + ", target MAC " + targetMACHex
+                        + ", via NIC '" + nif.getName() + " (" + nif.getDisplayName() + ")', with SO_BROADCAST = "
+                        + setSO_BROADCAST;
+                thingLogger.info("{}", msg);
+                classLogger.debug("{}", msg);
+            }
+            socket.close();
+        } else {
+            throw new IOException("Interface NOT suitable " + nif.getName());
+        }
+    }
+
+    protected static byte[] fillMagicBytes(byte[] macBytes) {
+
+        byte[] bytes = new byte[6 + 16 * macBytes.length];
+
+        for (int i = 0; i < 6; i++) {
+            bytes[i] = (byte) 0xff;
+        }
+        for (int i = 6; i < bytes.length; i += macBytes.length) {
+            System.arraycopy(macBytes, 0, bytes, i, macBytes.length);
+        }
+
+        return bytes;
+    }
+
+    protected byte[] getMacBytes(String macHex) throws NumberFormatException {
+        byte[] bytes = new byte[6];
+        byte[] hex = macHex.getBytes();
+        for (int i = 0, j = 0; i < 6; i++, j += 2) {
+            byte[] hexByteStr = new byte[2];
+            hexByteStr[0] = hex[j];
+            hexByteStr[1] = hex[j + 1];
+            bytes[i] = (byte) Integer.parseInt(new String(hexByteStr), 16);
+        }
+        return bytes;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/internal/WakeOnLanConfiguration.java
+++ b/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/internal/WakeOnLanConfiguration.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wakeonlan.internal;
+
+/**
+ * The {@link WakeOnLanConfiguration} is the class used to match the
+ * thing configuration.
+ *
+ * @author Ganesh Ingle - Initial contribution
+ */
+public class WakeOnLanConfiguration {
+    public String targetIP;
+    public String targetMAC;
+    public Integer targetUDPPort;
+    public Boolean sendOnAllInterfaces;
+    public String sendOnInterface;
+    public Boolean setSO_BROADCAST;
+}

--- a/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/internal/WakeOnLanHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.wakeonlan/src/main/java/org/openhab/binding/wakeonlan/internal/WakeOnLanHandlerFactory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.wakeonlan.internal;
+
+import static org.openhab.binding.wakeonlan.WakeOnLanBindingConstants.*;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.wakeonlan.handler.WakeOnLanHandler;
+
+/**
+ * The {@link WakeOnLanHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Ganesh Ingle - Initial contribution
+ */
+public class WakeOnLanHandlerFactory extends BaseThingHandlerFactory {
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(Thing thing) {
+
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(THING_TYPE_WOLDEVICE)) {
+            return new WakeOnLanHandler(thing);
+        }
+
+        return null;
+    }
+
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -88,6 +88,7 @@
     <module>org.openhab.binding.toon</module>
     <module>org.openhab.binding.urtsi</module>
     <module>org.openhab.binding.vitotronic</module>
+    <module>org.openhab.binding.wakeonlan</module>
     <module>org.openhab.binding.wifiled</module>
     <module>org.openhab.binding.windcentrale</module>
     <module>org.openhab.binding.yamahareceiver</module>


### PR DESCRIPTION
[wakeonlan] Wake on LAN binding for OH2 Initial Contribution

DESCRIPTION

This is initial contribution for Wake on LAN protocol implementation for OH2.
The binding has several improvements over OH1 binding as discussed in community thread :
https://community.openhab.org/t/wake-on-lan-binding-for-oh2-developed/34602

The most important improvement being support for SO_BROADCAST socket option and associated security exceptions properly communicated to user on UI.

TESTING
It has been tested with Asus based computer, in both powered off mode and Kodi sleep mode.
Binding works properly for all kinds of broadcast addresses.
Static code analysis is passed. Build works ok.

LICENSE
The origin of this work is explained in both README.md and about.html.
Original work is licensed to the general public and Apache Software Foundation under Apache License v2.0 and it is hosted on different github account.
Original author is hereby granting a non-exclusive, royalty free license to openhab foundation under Apache License v2.0. The foundation is free to apply its own license and re-distribute / modify this work under that license. The foundation is not required to mention original Apache License v2.0 while re-destributing the work.