### PR TITLE
[Network] longer TTL for discovery results

### DIFF
--- a/addons/binding/org.openhab.binding.network/README.md
+++ b/addons/binding/org.openhab.binding.network/README.md
@@ -27,6 +27,8 @@ allowSystemPings=false
 
 Auto discovery can be used to scan the local network for **pingdevice** things by sending a ping to every IP on the network. Some network tools will identify this as a network intruder alarm, therefore automatic background discovery is disabled and a manual scan needs to be issued.
 
+Please note: things discovered by the network binding will be provided with a time to live (TTL) and will automatically disappear from the Inbox after 10 minutes. 
+
 ## Thing Configuration
 
 ```

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Sets;
 public class NetworkDiscoveryService extends AbstractDiscoveryService implements PresenceDetectionListener {
     static final int PING_TIMEOUT_IN_MS = 500;
     static final int MAXIMUM_IPS_PER_INTERFACE = 255;
+    private static final long DISCOVERY_RESULT_TTL = TimeUnit.MINUTES.toSeconds(10);
     private final Logger logger = LoggerFactory.getLogger(NetworkDiscoveryService.class);
 
     // TCP port 548 (Apple Filing Protocol (AFP))
@@ -208,7 +209,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
         Map<String, Object> properties = new HashMap<>();
         properties.put(PARAMETER_HOSTNAME, ip);
         properties.put(PARAMETER_PORT, tcpPort);
-        thingDiscovered(DiscoveryResultBuilder.create(createServiceUID(ip, tcpPort)).withTTL(120)
+        thingDiscovered(DiscoveryResultBuilder.create(createServiceUID(ip, tcpPort)).withTTL(DISCOVERY_RESULT_TTL)
                 .withProperties(properties).withLabel(label).build());
     }
 


### PR DESCRIPTION
Increased the TTL for discovery results
Documented the TTL for discovery results

See also: https://community.openhab.org/t/network-snapshot-inbox-being-filled-and-emptied/34968/2