### PR TITLE
[jeelink] do not propagate state changes when sensors are offline.

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
@@ -15,6 +15,7 @@ import java.math.RoundingMode;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.ReadingPublisher;
 import org.openhab.binding.jeelink.internal.RollingAveragePublisher;
@@ -45,7 +46,7 @@ public class Ec3kSensorHandler extends JeeLinkSensorHandler<Ec3kReading> {
         ReadingPublisher<Ec3kReading> publisher = new ReadingPublisher<Ec3kReading>() {
             @Override
             public void publish(Ec3kReading reading) {
-                if (reading != null) {
+                if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
                     BigDecimal currentWatt = new BigDecimal(reading.getCurrentWatt()).setScale(1, RoundingMode.HALF_UP);
                     BigDecimal maxWatt = new BigDecimal(reading.getMaxWatt()).setScale(1, RoundingMode.HALF_UP);
 

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -16,6 +16,7 @@ import java.math.RoundingMode;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.ReadingPublisher;
 import org.openhab.binding.jeelink.internal.RollingAveragePublisher;
@@ -46,7 +47,7 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
         ReadingPublisher<LaCrosseTemperatureReading> publisher = new ReadingPublisher<LaCrosseTemperatureReading>() {
             @Override
             public void publish(LaCrosseTemperatureReading reading) {
-                if (reading != null) {
+                if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
                     BigDecimal temp = new BigDecimal(reading.getTemperature()).setScale(1, RoundingMode.HALF_UP);
 
                     logger.debug(


### PR DESCRIPTION
Signed-off-by: Volker Bier <volker.bier@web.de>

If the user chooses to have only an average of the sensor readings propagated every n seconds, the binding previously continued to report the stale average when the sensor went offline.

This PR fixes this problem.