### PR TITLE
[coolmasternet] fixed incorrect class name (case)

### DIFF
--- a/addons/binding/org.openhab.binding.coolmasternet/OSGI-INF/coolmasternetHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.coolmasternet/OSGI-INF/coolmasternetHandlerFactory.xml
@@ -11,7 +11,7 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.coolmasternet">
 
-   <implementation class="org.openhab.binding.coolmasternet.internal.coolmasternetHandlerFactory"/>
+   <implementation class="org.openhab.binding.coolmasternet.internal.CoolMasterNetHandlerFactory"/>
 
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>


### PR DESCRIPTION

<!-- DESCRIPTION -->
Fix to issue 2240
goal : make CoolMasterNet binding work
effect : it works

changed the factory handler to the correct case to that reference in OSGi manifest matches the actual class name.
<!-- TESTING -->
tested fine.  this is a ridiculously trivial change and a shame it was left for so long but I guess since not a lot of openhab users own this particular device.
[org.openhab.binding.coolmasternet-2.2.0-SNAPSHOT.zip](https://github.com/openhab/openhab2-addons/files/1398802/org.openhab.binding.coolmasternet-2.2.0-SNAPSHOT.zip)

