### PR TITLE
[cm11a] Add missing org.eclipse.jdt.annotation to manifest

### DIFF
--- a/addons/binding/org.openhab.binding.cm11a/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.cm11a/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-ClassPath: .
 Import-Package: gnu.io,
  org.openhab.binding.cm11a,
  org.openhab.binding.cm11a.handler,
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,


### PR DESCRIPTION
Just did a clean checkout of the openhab2-addons repo, noticed this import is missing in the cm11a binding. 