### PR TITLE
[Loxone] Added full support for Light Controller V2.

### DIFF
--- a/addons/binding/org.openhab.binding.loxone/README.md
+++ b/addons/binding/org.openhab.binding.loxone/README.md
@@ -85,7 +85,9 @@ This binding creates channels for controls that are [used in Loxone's user inter
 |InfoOnlyAnalog|Analog [virtual inputs](https://www.loxone.com/enen/kb/virtual-inputs-outputs/) (virtual state)|`Number`|none (read-only value)|
 |InfoOnlyDigital|Digital [virtual inputs](https://www.loxone.com/enen/kb/virtual-inputs-outputs/) (virtual state) |`String`|none (read-only value)|
 |Jalousie|Blinds, [Automatic Blinds](https://www.loxone.com/enen/kb/automatic-blinds/), Automatic Blinds Integrated|`Rollershutter`| `UpDown.*`<br>`StopMove.*`<br>`Percent`|
-|LightController|[Lighting controller](https://www.loxone.com/enen/kb/lighting-controller/), [Hotel lighting controller](https://www.loxone.com/enen/kb/hotel-lighting-controller/)<br>Additionally, for each configured output of a lighting controller, a new independent control (with own channel/item) will be created.|`Number`|`Decimal` (select lighting scene)<br>`OnOffType.*` (select all off or all on scene)|
+|LightController|[Lighting controller V1 (obsolete)](https://www.loxone.com/enen/kb/lighting-controller/), [Hotel lighting controller](https://www.loxone.com/enen/kb/hotel-lighting-controller/)<br>Additionally, for each configured output of a lighting controller, a new independent control (with own channel/item) will be created.|`Number`|`Decimal` (select lighting scene)<br>`UpDownType.*` (swipe through scenes)<br>`OnOffType.*` (select all off or all on scene)|
+|LightControllerV2| [Lighting controller](https://www.loxone.com/enen/kb/lighting-controller-v2/)<br>Additionally, for each configured output and for each mood of a lighting controller, a new independent control (with own channel/item) will be created.|`Number`|`Decimal` (select mood)<br>`UpDownType.*` (swipe through moods)|
+|LightControllerV2 Mood|A mood defined for a [Lighting controller](https://www.loxone.com/enen/kb/lighting-controller-v2/). Each mood will have own channel and can be operated independently in order to allow mixing of moods.|`Switch`|`OnOffType.*` (mixes mood in or out of the controller)
 |Pushbutton | [Virtual inputs](https://www.loxone.com/enen/kb/virtual-inputs-outputs/) of pushbutton type | `Switch` | `OnOffType.ON` (generates Pulse command)|
 |Radio|[Radio button 8x and 16x](https://www.loxone.com/enen/kb/radio-buttons/)|`Number`|`Decimal` (select output number 1-8/16 or 0 for all outputs off)<br>`OnOffType.OFF` (all outputs off)|
 |Switch | [Virtual inputs](https://www.loxone.com/enen/kb/virtual-inputs-outputs/) of switch type<br>[Push-button](https://www.loxone.com/enen/kb/push-button/) | `Switch` |`OnOffType.*`|
@@ -186,6 +188,10 @@ Switch        Reset_Lights    "Switch all lights off"                <switch>   
 Rollershutter Kitchen_Blinds  "Kitchen blinds"                       <blinds>                   {channel="loxone:miniserver:504F2414780F:0F2E2123-014D-3232-FFEF204EB3C24B9E"}
 Dimmer        Kitchen_Dimmer  "Kitchen dimmer"                       <slider>      ["lighting"] {channel="loxone:miniserver:504F2414780F:0F2E2123-014D-3232-FFEF207EB3C24B9E"}
 Number        Light_Scene     "Lighting scene"                       <light>                    {channel="loxone:miniserver:504F2414780F:0FC4E0DF-0255-6ABD-FFFE403FB0C34B9E"}
+Number        Mood_Selector   "Lighting mood"                        <light>                    {channel="loxone:miniserver:504F2414780F:0FC4E0DF-0255-6ABD-FFFE203EA0C34B9E"}
+Switch        Mood_Enter_Home "Entering home"                        <light>                    {channel="loxone:miniserver:504F2414780F:0FC4E0DF-0255-6ABD-FFFE203EA0C34B9E-M1"}
+Switch        Mood_Read_Book  "Reading book"                         <light>                    {channel="loxone:miniserver:504F2414780F:0FC4E0DF-0255-6ABD-FFFE203EA0C34B9E-M2"}
+Switch        Mood_Evening    "Evening setup"                        <light>                    {channel="loxone:miniserver:504F2414780F:0FC4E0DF-0255-6ABD-FFFE203EA0C34B9E-M3"}
 Number        Garden_Valve    "Garden watering section"              <garden>                   {channel="loxone:miniserver:504F2414780F:0FC5E0DF-0355-6AAD-FFFE403FB0C34B9E"}
 String        Alarm_State     "Alarm state [%s]"                     <alarm>                    {channel="loxone:miniserver:504F2414780F:0F2E2134-017D-3E82-FFFF433FB4A34B9E"}
 ```
@@ -205,6 +211,10 @@ sitemap loxone label="Loxone Example Menu"
         Switch    item=Stairs_Light
         Text      item=Stairs_Light-1
         Selection item=Light_Scene mappings=[0="All off", 1="My scene 1", 2="My scene 2", 9="All on"]
+        Selection item=Mood_Selector
+        Switch    item=Mood_Enter_Home
+        Switch    item=Mood_Read_Book
+        Switch    item=Mood_Evening
         Setpoint  item=Garden_Valve minValue=0 maxValue=8 step=1
         Text      item=Alarm_State
     }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +45,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.loxone.internal.LoxoneDynamicStateDescriptionProvider;
 import org.openhab.binding.loxone.internal.config.LoxoneMiniserverConfig;
 import org.openhab.binding.loxone.internal.core.LxCategory;
@@ -54,6 +56,8 @@ import org.openhab.binding.loxone.internal.core.LxControlInfoOnlyAnalog;
 import org.openhab.binding.loxone.internal.core.LxControlInfoOnlyDigital;
 import org.openhab.binding.loxone.internal.core.LxControlJalousie;
 import org.openhab.binding.loxone.internal.core.LxControlLightController;
+import org.openhab.binding.loxone.internal.core.LxControlLightControllerV2;
+import org.openhab.binding.loxone.internal.core.LxControlLightControllerV2.LxControlMood;
 import org.openhab.binding.loxone.internal.core.LxControlPushbutton;
 import org.openhab.binding.loxone.internal.core.LxControlRadio;
 import org.openhab.binding.loxone.internal.core.LxControlSwitch;
@@ -62,6 +66,7 @@ import org.openhab.binding.loxone.internal.core.LxControlTimedSwitch;
 import org.openhab.binding.loxone.internal.core.LxOfflineReason;
 import org.openhab.binding.loxone.internal.core.LxServer;
 import org.openhab.binding.loxone.internal.core.LxServerListener;
+import org.openhab.binding.loxone.internal.core.LxUuid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,7 +135,7 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
 
         try {
             if (command instanceof RefreshType) {
-                updateChannelStates(control);
+                updateChannelStates(channelUID, control);
                 return;
             }
 
@@ -213,6 +218,20 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
                 return;
             }
 
+            if (control instanceof LxControlLightControllerV2) {
+                LxControlLightControllerV2 controller = (LxControlLightControllerV2) control;
+                if (command instanceof UpDownType) {
+                    if ((UpDownType) command == UpDownType.UP) {
+                        controller.nextMood();
+                    } else {
+                        controller.previousMood();
+                    }
+                } else if (command instanceof DecimalType) {
+                    controller.setMood(((DecimalType) command).intValue());
+                }
+                return;
+            }
+
             if (control instanceof LxControlRadio) {
                 LxControlRadio radio = (LxControlRadio) control;
                 if (command instanceof OnOffType) {
@@ -235,7 +254,7 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
         logger.debug("Channel linked: {}", channelUID.getAsString());
         LxControl control = getControlFromChannelUID(channelUID);
         if (control != null) {
-            updateChannelStates(control);
+            updateChannelStates(channelUID, control);
         }
     }
 
@@ -299,8 +318,71 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
     }
 
     @Override
-    public void onControlStateUpdate(LxControl control) {
-        updateChannelStates(control);
+    public void onControlStateUpdate(LxControl control, String stateName) {
+        ChannelUID channelId = getChannelIdForControl(control, 0);
+
+        if (control instanceof LxControlLightController
+                && LxControlLightController.STATE_SCENE_LIST.equals(stateName)) {
+            LxControlLightController controller = (LxControlLightController) control;
+            setStateDescription(channelId, null, false, controller.getSceneNames(), BigDecimal.ZERO,
+                    new BigDecimal((LxControlLightController.NUM_OF_SCENES - 1)));
+            return;
+        } else if (control instanceof LxControlLightControllerV2) {
+            LxControlLightControllerV2 controller = (LxControlLightControllerV2) control;
+
+            if (LxControlLightControllerV2.STATE_MOODS_LIST.equals(stateName)) {
+                // A new list of moods arrived as state update - we update dynamic state description for the channel
+                // that represents single mood selection and we create new channels per mood and remove any obsolete
+                // mood channels for this controller
+                Map<LxUuid, LxControlMood> moods = controller.getMoods();
+                if (moods == null) {
+                    logger.debug("Moods list state was received, but mood list is null.");
+                    return;
+                }
+
+                // convert all moods to options list for state description
+                List<StateOption> optionsList = moods.values().stream()
+                        .map(mood -> new StateOption(mood.getId().toString(), mood.getName()))
+                        .collect(Collectors.toList());
+
+                // for all moods but 'all off' mood create and store channels
+                Map<Channel, LxControlMood> newChannels = new HashMap<>();
+                moods.values().stream().filter(mood -> !mood.isAllOffMood()).forEach(
+                        mood -> createChannelsForControl(mood).forEach(channel -> newChannels.put(channel, mood)));
+
+                dynamicStateDescriptionProvider.setDescription(channelId,
+                        new StateDescription(new BigDecimal(controller.getMinMoodId()),
+                                new BigDecimal(controller.getMaxMoodId()), BigDecimal.ONE, null, false, optionsList));
+
+                // collect all moods that currently belong to this controller
+                List<ChannelUID> toRemove = new ArrayList<>();
+                controls.forEach((k, v) -> {
+                    if (v instanceof LxControlMood
+                            && controller.getUuid().equals(((LxControlMood) v).getControllerUuid())) {
+                        toRemove.add(k);
+                    }
+                });
+
+                // remove the collected mood channels from the thing and controls
+                ThingBuilder builder = editThing();
+                logger.trace("Updating thing");
+                toRemove.forEach(k -> {
+                    builder.withoutChannel(k);
+                    controls.remove(k);
+                });
+
+                // add channels for the new moods
+                newChannels.forEach((k, v) -> {
+                    builder.withChannel(k);
+                    controls.put(k.getUID(), v);
+                });
+
+                updateThing(builder.build());
+                return;
+            }
+        }
+        // for all state updates not handled above just update the channel state the regular way
+        updateChannelStates(channelId, control);
     }
 
     @Override
@@ -355,12 +437,39 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
         }
     }
 
+    /**
+     * Create and add a new channel to the channels list.
+     *
+     * @param channels
+     *            list of channels to add the channel to
+     * @param itemType
+     *            item type for the channel
+     * @param typeId
+     *            channel type ID for the channel
+     * @param channelId
+     *            channel ID
+     * @param channelLabel
+     *            channel label
+     * @param channelDescription
+     *            channel description
+     * @param tags
+     *            tags for the channel or null if no tags needed
+     * @return
+     *         true if channel was created and added to the list
+     */
     private boolean addChannel(List<Channel> channels, String itemType, ChannelTypeUID typeId, ChannelUID channelId,
             String channelLabel, String channelDescription, Set<String> tags) {
         if (channelId != null && itemType != null && typeId != null && channelDescription != null) {
-            channels.add(ChannelBuilder.create(channelId, itemType).withType(typeId).withLabel(channelLabel)
-                    .withDescription(channelDescription + " : " + channelLabel).withDefaultTags(tags).build());
-            return true;
+            ChannelBuilder builder = ChannelBuilder.create(channelId, itemType).withType(typeId).withLabel(channelLabel)
+                    .withDescription(channelDescription + " : " + channelLabel);
+            if (tags != null) {
+                builder = builder.withDefaultTags(tags);
+            }
+            Channel newChannel = builder.build();
+            if (channels != null) {
+                channels.add(newChannel);
+                return true;
+            }
         }
         return false;
     }
@@ -384,13 +493,8 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
 
         List<Channel> channels = new ArrayList<>();
 
-        LxCategory category = control.getCategory();
-
         LxContainer room = control.getRoom();
-        String roomName = null;
-        if (room != null) {
-            roomName = room.getName();
-        }
+        String roomName = room != null ? room.getName() : null;
 
         String controlName = control.getName();
         if (controlName == null) {
@@ -399,42 +503,56 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
             controlName = "Undefined name";
         }
 
+        if (control instanceof LxControlMood) {
+            controlName = "Mood / " + controlName;
+        }
         if (roomName != null) {
             label = roomName + " / " + controlName;
         } else {
             label = controlName;
         }
 
-        Set<String> tags = Collections.singleton("");
+        Set<String> tags = new HashSet<>();
+        addAlexaTags(tags, control);
 
-        if (control instanceof LxControlPushbutton || control instanceof LxControlSwitch
-                || control instanceof LxControlTimedSwitch) {
-            if (category != null && category.getType() == LxCategory.CategoryType.LIGHTS) {
-                tags = Collections.singleton("Lighting");
-            }
-            addChannel(channels, "Switch", switchTypeId, id, label, "Switch", tags);
-            // adding a deactivation delay channel for timed switch
+        // LxControlSwitch covers LxControlPushbutton, LxControlMood and LxControlTimedSwitch as child classes
+        if (control instanceof LxControlSwitch) {
+            String description;
             if (control instanceof LxControlTimedSwitch) {
+                description = "Timed switch";
+                // adding a deactivation delay channel for timed switch, don't tag it
                 ChannelUID deactivationDelayChannelId = getChannelIdForControl(control, 1);
                 addChannel(channels, "Number", roTimedSwitchDeactivationDelayTypeId, deactivationDelayChannelId,
-                        label + " / Deactivation Delay", "Deactivation Delay", tags);
+                        label + " / Deactivation Delay", "Deactivation Delay", null);
+            } else if (control instanceof LxControlPushbutton) {
+                // this must be compared after LxControlTimedSwitch (pusbutton is parent class)
+                description = "Pushbutton";
+            } else if (control instanceof LxControlMood) {
+                description = "Mood mixer";
+            } else {
+                description = "Switch";
             }
+            addChannel(channels, "Switch", switchTypeId, id, label, description, tags);
         } else if (control instanceof LxControlJalousie) {
             addChannel(channels, "Rollershutter", rollershutterTypeId, id, label, "Rollershutter", tags);
         } else if (control instanceof LxControlInfoOnlyDigital) {
             addChannel(channels, "Switch", roSwitchTypeId, id, label, "Digital virtual state", tags);
         } else if (control instanceof LxControlInfoOnlyAnalog) {
+            // add both channel and state description (all needed configuration is available)
             if (addChannel(channels, "Number", roAnalogTypeId, id, label, "Analog virtual state", tags)) {
-                setStateDescription(id, ((LxControlInfoOnlyAnalog) control).getFormatString(), true, null, 0);
+                setStateDescription(id, ((LxControlInfoOnlyAnalog) control).getFormatString(), true, null, null, null);
             }
         } else if (control instanceof LxControlLightController) {
-            if (addChannel(channels, "Number", lightCtrlTypeId, id, label, "Light controller", tags)) {
-                setLightControllerStateDescription(id, (LxControlLightController) control);
-            }
+            // add only channel, state description will be added later when a control state update message is received
+            addChannel(channels, "Number", lightCtrlTypeId, id, label, "Light controller", tags);
+        } else if (control instanceof LxControlLightControllerV2) {
+            // add only channel, state description will be added later when a control state update message is received
+            addChannel(channels, "Number", lightCtrlTypeId, id, label, "Light controller V2", tags);
         } else if (control instanceof LxControlRadio) {
+            // add both channel and state description (all needed configuration is available)
             if (addChannel(channels, "Number", radioButtonTypeId, id, label, "Radio button", tags)) {
-                setStateDescription(id, null, false, ((LxControlRadio) control).getOutputs(),
-                        LxControlRadio.MAX_RADIO_OUTPUTS);
+                setStateDescription(id, null, false, ((LxControlRadio) control).getOutputs(), BigDecimal.ZERO,
+                        new BigDecimal(LxControlRadio.MAX_RADIO_OUTPUTS));
             }
         } else if (control instanceof LxControlTextState) {
             addChannel(channels, "String", roTextTypeId, id, label, "Text state", tags);
@@ -445,14 +563,32 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
     }
 
     /**
+     * Add tags that allow items to be managed by Amazon Alexa openHAB skill
+     *
+     * @param tags
+     *            collection to add tags to
+     * @param control
+     *            control object for which the tags are to be identified
+     */
+    private void addAlexaTags(Set<String> tags, LxControl control) {
+        if (control instanceof LxControlSwitch) {
+            // All switches that belong to the lights category can be turned on or off by voice
+            LxCategory category = control.getCategory();
+            if (category != null && category.getType() == LxCategory.CategoryType.LIGHTS) {
+                tags.add("Lighting");
+            }
+        }
+    }
+
+    /**
      * Update thing's states for all channels associated with the control
      *
+     * @param channelId
+     *            first channel for the control
      * @param control
      *            control to update states for
      */
-    private void updateChannelStates(LxControl control) {
-        ChannelUID channelId = getChannelIdForControl(control, 0);
-
+    private void updateChannelStates(ChannelUID channelId, LxControl control) {
         if (control instanceof LxControlSwitch) {
             Double value = ((LxControlSwitch) control).getState();
             if (value != null) {
@@ -462,22 +598,14 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
                     updateState(channelId, OnOffType.OFF);
                 }
             }
-        } else if (control instanceof LxControlTimedSwitch) {
-            LxControlTimedSwitch timedSwitch = ((LxControlTimedSwitch) control);
-            Double value = timedSwitch.getState();
-            if (value != null) {
-                if (value == 1d) {
-                    updateState(channelId, OnOffType.ON);
-                } else if (value == 0d) {
-                    updateState(channelId, OnOffType.OFF);
+            // timed switch is a child class of a switch
+            if (control instanceof LxControlTimedSwitch) {
+                // getting second channel for this control and update the state
+                LxControlTimedSwitch timedSwitch = (LxControlTimedSwitch) control;
+                Double deactivationValue = timedSwitch.getDeactivationDelay();
+                if (deactivationValue != null) {
+                    updateState(getChannelIdForControl(timedSwitch, 1), new DecimalType(deactivationValue));
                 }
-            }
-
-            // getting second channel for this control and update the state
-            Double deactivationValue = timedSwitch.getDeactivationDelay();
-            if (deactivationValue != null) {
-                ChannelUID deactivationDelayChannelId = getChannelIdForControl(control, 1);
-                updateState(deactivationDelayChannelId, new DecimalType(deactivationValue));
             }
         } else if (control instanceof LxControlJalousie) {
             Double value = ((LxControlJalousie) control).getPosition();
@@ -512,9 +640,21 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
             if (value != null && value >= 0 && value < LxControlLightController.NUM_OF_SCENES) {
                 updateState(channelId, new DecimalType(value));
             }
-            if (controller.sceneNamesUpdated()) {
-                setLightControllerStateDescription(channelId, controller);
+        } else if (control instanceof LxControlLightControllerV2) {
+            LxControlLightControllerV2 controller = (LxControlLightControllerV2) control;
+            List<Integer> activeMoods = controller.getActiveMoods();
+            // update the single mood channel state
+            if (activeMoods.size() == 1) {
+                updateState(channelId, new DecimalType(activeMoods.get(0)));
+            } else {
+                updateState(channelId, UnDefType.UNDEF);
             }
+            // update the individual mood mixing channels
+            Map<LxUuid, LxControlMood> allMoods = controller.getMoods();
+            allMoods.values().forEach(v -> {
+                // we update moods like all other switches with no special dedicated code
+                updateChannelStates(getChannelIdForControl(v, 0), v);
+            });
         } else if (control instanceof LxControlRadio) {
             LxControlRadio radio = (LxControlRadio) control;
             Integer output = radio.getActiveOutput();
@@ -542,35 +682,22 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
      *            true if this control does not accept commands
      * @param options
      *            collection of options, where key is option ID (number in reality) and value is option name
+     * @param minimum
+     *            minimum value an option ID can have
      * @param maximum
      *            maximum value an option ID can have
      */
     private void setStateDescription(ChannelUID channelUID, String format, boolean readOnly,
-            Map<String, String> options, int maximum) {
+            Map<String, String> options, BigDecimal minimum, BigDecimal maximum) {
         if (channelUID != null) {
             List<StateOption> optionsList = null;
             if (options != null) {
                 optionsList = options.entrySet().stream().map(e -> new StateOption(e.getKey(), e.getValue()))
                         .collect(Collectors.toList());
             }
-            dynamicStateDescriptionProvider.setDescription(channelUID, new StateDescription(BigDecimal.ZERO,
-                    new BigDecimal(maximum), BigDecimal.ONE, format, readOnly, optionsList));
+            dynamicStateDescriptionProvider.setDescription(channelUID,
+                    new StateDescription(minimum, maximum, BigDecimal.ONE, format, readOnly, optionsList));
         }
-    }
-
-    /**
-     * Sets a state description for light controller channel.
-     * This method is used when a channel has received a state update with light controller's scene names and when a
-     * light controller channel is created. A previous description, if existed, will be replaced.
-     *
-     * @param channelUID
-     *            light controller's channel UID
-     * @param control
-     *            light controller's object
-     */
-    private void setLightControllerStateDescription(ChannelUID channelUID, LxControlLightController control) {
-        setStateDescription(channelUID, null, false, control.getSceneNames(),
-                (LxControlLightController.NUM_OF_SCENES - 1));
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
@@ -459,17 +459,15 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
      */
     private boolean addChannel(List<Channel> channels, String itemType, ChannelTypeUID typeId, ChannelUID channelId,
             String channelLabel, String channelDescription, Set<String> tags) {
-        if (channelId != null && itemType != null && typeId != null && channelDescription != null) {
+        if (channels != null && channelId != null && itemType != null && typeId != null && channelDescription != null) {
             ChannelBuilder builder = ChannelBuilder.create(channelId, itemType).withType(typeId).withLabel(channelLabel)
                     .withDescription(channelDescription + " : " + channelLabel);
             if (tags != null) {
                 builder = builder.withDefaultTags(tags);
             }
             Channel newChannel = builder.build();
-            if (channels != null) {
-                channels.add(newChannel);
-                return true;
-            }
+            channels.add(newChannel);
+            return true;
         }
         return false;
     }
@@ -513,7 +511,7 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
         }
 
         Set<String> tags = new HashSet<>();
-        addAlexaTags(tags, control);
+        addChannelTags(tags, control);
 
         // LxControlSwitch covers LxControlPushbutton, LxControlMood and LxControlTimedSwitch as child classes
         if (control instanceof LxControlSwitch) {
@@ -563,14 +561,14 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
     }
 
     /**
-     * Add tags that allow items to be managed by Amazon Alexa openHAB skill
+     * Add tags that can be used by homekit transport and Alexa openHAB skill
      *
      * @param tags
      *            collection to add tags to
      * @param control
      *            control object for which the tags are to be identified
      */
-    private void addAlexaTags(Set<String> tags, LxControl control) {
+    private void addChannelTags(Set<String> tags, LxControl control) {
         if (control instanceof LxControlSwitch) {
             // All switches that belong to the lights category can be turned on or off by voice
             LxCategory category = control.getCategory();

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/handler/LoxoneMiniserverHandler.java
@@ -57,7 +57,7 @@ import org.openhab.binding.loxone.internal.core.LxControlInfoOnlyDigital;
 import org.openhab.binding.loxone.internal.core.LxControlJalousie;
 import org.openhab.binding.loxone.internal.core.LxControlLightController;
 import org.openhab.binding.loxone.internal.core.LxControlLightControllerV2;
-import org.openhab.binding.loxone.internal.core.LxControlLightControllerV2.LxControlMood;
+import org.openhab.binding.loxone.internal.core.LxControlMood;
 import org.openhab.binding.loxone.internal.core.LxControlPushbutton;
 import org.openhab.binding.loxone.internal.core.LxControlRadio;
 import org.openhab.binding.loxone.internal.core.LxControlSwitch;
@@ -358,14 +358,14 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
                 List<ChannelUID> toRemove = new ArrayList<>();
                 controls.forEach((k, v) -> {
                     if (v instanceof LxControlMood
-                            && controller.getUuid().equals(((LxControlMood) v).getControllerUuid())) {
+                            && controller.getUuid().equals(((LxControlMood) v).getControllerUuid())
+                            && !newChannels.containsKey(k)) {
                         toRemove.add(k);
                     }
                 });
 
                 // remove the collected mood channels from the thing and controls
                 ThingBuilder builder = editThing();
-                logger.trace("Updating thing");
                 toRemove.forEach(k -> {
                     builder.withoutChannel(k);
                     controls.remove(k);
@@ -463,7 +463,7 @@ public class LoxoneMiniserverHandler extends BaseThingHandler implements LxServe
             ChannelBuilder builder = ChannelBuilder.create(channelId, itemType).withType(typeId).withLabel(channelLabel)
                     .withDescription(channelDescription + " : " + channelLabel);
             if (tags != null) {
-                builder = builder.withDefaultTags(tags);
+                builder.withDefaultTags(tags);
             }
             Channel newChannel = builder.build();
             channels.add(newChannel);

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
@@ -26,12 +26,47 @@ import com.google.gson.JsonElement;
  * the Miniserver, that is marked as visible in the Loxone UI. Controls can belong to a {@link LxContainer} room and a
  * {@link LxCategory} category.
  *
- * @author Pawel Pieczul
+ * @author Pawel Pieczul - initial contribution
  *
  */
 public abstract class LxControl {
+
+    /**
+     * This class is used to instantiate a particular control object by the {@link LxControlFactory}
+     * 
+     * @author Pawel Pieczul - initial contribution
+     *
+     */
+    abstract static class LxControlInstance {
+        /**
+         * Creates an instance of a particular control class.
+         *
+         * @param client
+         *            websocket client to facilitate communication with Miniserver
+         * @param uuid
+         *            UUID of this control
+         * @param json
+         *            JSON describing the control as received from the Miniserver
+         * @param room
+         *            Room that this control belongs to
+         * @param category
+         *            Category that this control belongs to
+         * @return
+         *         a newly created control object
+         */
+        abstract LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
+                LxCategory category);
+
+        /**
+         * Return a type name for this control.
+         *
+         * @return
+         *         type name (as used on the Miniserver)
+         */
+        abstract String getType();
+    }
+
     private String name;
-    private String typeName;
     private LxContainer room;
     private LxCategory category;
     private Map<String, LxControlState> states = new HashMap<>();
@@ -59,50 +94,7 @@ public abstract class LxControl {
         logger.trace("Creating new LxControl: {}", json.type);
         socketClient = client;
         this.uuid = uuid;
-        if (json.type != null) {
-            this.typeName = json.type.toLowerCase();
-        }
         update(json, room, category);
-    }
-
-    /**
-     * Create a Miniserver's control object.
-     * To be used by the control object factory.
-     *
-     * @param typeName
-     *            name of the control type
-     */
-    LxControl(String typeName) {
-        this.typeName = typeName;
-    }
-
-    /**
-     * Creates an instance of a particular control class.
-     *
-     * @param client
-     *            websocket client to facilitate communication with Miniserver
-     * @param uuid
-     *            UUID of this control
-     * @param json
-     *            JSON describing the control as received from the Miniserver
-     * @param room
-     *            Room that this control belongs to
-     * @param category
-     *            Category that this control belongs to
-     * @return
-     *         a newly created control object
-     */
-    abstract LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
-            LxCategory category);
-
-    /**
-     * Gets the name of the control type
-     *
-     * @return
-     *         control type name
-     */
-    String getTypeName() {
-        return typeName;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.loxone.internal.core;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -32,24 +30,6 @@ import com.google.gson.JsonElement;
  *
  */
 public abstract class LxControl {
-
-    // Register child control classes
-    static {
-        controls = new HashMap<>();
-        addType(LxControlDimmer.class);
-        addType(LxControlInfoOnlyAnalog.class);
-        addType(LxControlInfoOnlyDigital.class);
-        addType(LxControlJalousie.class);
-        addType(LxControlLightController.class);
-        addType(LxControlLightControllerV2.class);
-        addType(LxControlPushbutton.class);
-        addType(LxControlRadio.class);
-        addType(LxControlSwitch.class);
-        addType(LxControlTextState.class);
-        addType(LxControlTimedSwitch.class);
-    }
-
-    private static Map<String, Class<?>> controls;
     private String name;
     private LxContainer room;
     private LxCategory category;
@@ -282,65 +262,10 @@ public abstract class LxControl {
         }
     }
 
-    /**
-     * Create a {@link LxControl} object for a control received from the Miniserver
-     *
-     * @param client
-     *            websocket client to facilitate communication with Miniserver
-     * @param uuid
-     *            UUID of the control to be created
-     * @param json
-     *            JSON describing the control as received from the Miniserver
-     * @param room
-     *            Room that this control belongs to
-     * @param category
-     *            Category that this control belongs to
-     * @return
-     *         created control object or null if error
-     */
-    static LxControl createControl(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
-            LxCategory category) {
-        if (json == null || json.type == null || json.name == null) {
-            return null;
-        }
-        String type = json.type.toLowerCase();
-        Class<?> c = controls.get(type);
-        if (c != null) {
-            try {
-                Constructor<?> constructor = c.getDeclaredConstructor(LxWsClient.class, LxUuid.class,
-                        LxJsonControl.class, LxContainer.class, LxCategory.class);
-                Object control = constructor.newInstance(client, uuid, json, room, category);
-                if (control instanceof LxControl) {
-                    return (LxControl) control;
-                }
-                getLogger().debug("Unexpected object constructed: {}", control.getClass().getSimpleName());
-            } catch (NoSuchMethodException | SecurityException | InvocationTargetException | IllegalAccessException
-                    | InstantiationException | IllegalArgumentException e) {
-                getLogger().debug("Failed to construct control object {}: {}", c.getSimpleName(), e.getMessage());
-            }
-        } else {
-            getLogger().debug("No registered control class for {}, uuid = {}", type, json.uuidAction);
-        }
-        return null;
-    }
-
     private LxControlState getState(String name) {
         if (states.containsKey(name)) {
             return states.get(name);
         }
         return null;
-    }
-
-    private static void addType(Class<?> c) {
-        try {
-            String name = (String) c.getDeclaredField("TYPE_NAME").get(null);
-            controls.put(name, c);
-        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
-            getLogger().debug("Error registering control class {}: {}", c.getSimpleName(), e.getMessage());
-        }
-    }
-
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(LxControl.class);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControl.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonElement;
  */
 public abstract class LxControl {
     private String name;
+    private String typeName;
     private LxContainer room;
     private LxCategory category;
     private Map<String, LxControlState> states = new HashMap<>();
@@ -58,7 +59,50 @@ public abstract class LxControl {
         logger.trace("Creating new LxControl: {}", json.type);
         socketClient = client;
         this.uuid = uuid;
+        if (json.type != null) {
+            this.typeName = json.type.toLowerCase();
+        }
         update(json, room, category);
+    }
+
+    /**
+     * Create a Miniserver's control object.
+     * To be used by the control object factory.
+     *
+     * @param typeName
+     *            name of the control type
+     */
+    LxControl(String typeName) {
+        this.typeName = typeName;
+    }
+
+    /**
+     * Creates an instance of a particular control class.
+     *
+     * @param client
+     *            websocket client to facilitate communication with Miniserver
+     * @param uuid
+     *            UUID of this control
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            Room that this control belongs to
+     * @param category
+     *            Category that this control belongs to
+     * @return
+     *         a newly created control object
+     */
+    abstract LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
+            LxCategory category);
+
+    /**
+     * Gets the name of the control type
+     *
+     * @return
+     *         control type name
+     */
+    String getTypeName() {
+        return typeName;
     }
 
     /**
@@ -263,9 +307,6 @@ public abstract class LxControl {
     }
 
     private LxControlState getState(String name) {
-        if (states.containsKey(name)) {
-            return states.get(name);
-        }
-        return null;
+        return states.get(name);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
@@ -65,7 +65,7 @@ abstract class LxControlAbstractController extends LxControl {
                 if (subControls.containsKey(uuid)) {
                     subControls.get(uuid).update(subControl, room, category);
                 } else {
-                    LxControl control = LxControl.createControl(socketClient, uuid, subControl, room, category);
+                    LxControl control = LxControlFactory.createControl(socketClient, uuid, subControl, room, category);
                     if (control != null) {
                         subControls.put(control.uuid, control);
                     }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
@@ -40,17 +40,6 @@ abstract class LxControlAbstractController extends LxControl {
     }
 
     /**
-     * Create control object.
-     * Used by control object factory.
-     *
-     * @param typeName
-     *            name of the control type
-     */
-    LxControlAbstractController(String typeName) {
-        super(typeName);
-    }
-
-    /**
      * Update Miniserver's controller in runtime.
      *
      * @param json

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
@@ -40,6 +40,17 @@ abstract class LxControlAbstractController extends LxControl {
     }
 
     /**
+     * Create control object.
+     * Used by control object factory.
+     *
+     * @param typeName
+     *            name of the control type
+     */
+    LxControlAbstractController(String typeName) {
+        super(typeName);
+    }
+
+    /**
      * Update Miniserver's controller in runtime.
      *
      * @param json
@@ -72,7 +83,7 @@ abstract class LxControlAbstractController extends LxControl {
                 }
             }
         }
-        List<LxUuid> toRemove = new ArrayList<>(subControls.size());
+        List<LxUuid> toRemove = new ArrayList<>();
         for (LxControl control : subControls.values()) {
             if (!control.uuid.getUpdate()) {
                 toRemove.add(control.uuid);

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlAbstractController.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.loxone.internal.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
+
+/**
+ * A class that represents controllers, which contain sub-controls, which are also {@link LxControl}
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+abstract class LxControlAbstractController extends LxControl {
+    /**
+     * Create controller object.
+     *
+     * @param client
+     *            communication client used to send commands to the Miniserver
+     * @param uuid
+     *            controller's UUID
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            room to which controller belongs
+     * @param category
+     *            category to which controller belongs
+     */
+    LxControlAbstractController(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
+            LxCategory category) {
+        super(client, uuid, json, room, category);
+    }
+
+    /**
+     * Update Miniserver's controller in runtime.
+     *
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            New room that this control belongs to
+     * @param category
+     *            New category that this control belongs to
+     */
+    @Override
+    void update(LxJsonControl json, LxContainer room, LxCategory category) {
+        super.update(json, room, category);
+
+        for (LxControl control : subControls.values()) {
+            control.uuid.setUpdate(false);
+        }
+        if (json.subControls != null) {
+            for (LxJsonControl subControl : json.subControls.values()) {
+                // recursively create a subcontrol as a new control
+                subControl.room = json.room;
+                subControl.cat = json.cat;
+                LxUuid uuid = new LxUuid(subControl.uuidAction);
+                if (subControls.containsKey(uuid)) {
+                    subControls.get(uuid).update(subControl, room, category);
+                } else {
+                    LxControl control = LxControl.createControl(socketClient, uuid, subControl, room, category);
+                    if (control != null) {
+                        subControls.put(control.uuid, control);
+                    }
+                }
+            }
+        }
+        List<LxUuid> toRemove = new ArrayList<>(subControls.size());
+        for (LxControl control : subControls.values()) {
+            if (!control.uuid.getUpdate()) {
+                toRemove.add(control.uuid);
+            }
+        }
+        for (LxUuid id : toRemove) {
+            subControls.remove(id);
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
@@ -28,7 +28,7 @@ public class LxControlDimmer extends LxControl {
     /**
      * A name by which Miniserver refers to dimmer controls
      */
-    static final String TYPE_NAME = "dimmer";
+    private static final String TYPE_NAME = "dimmer";
 
     /**
      * States
@@ -62,6 +62,15 @@ public class LxControlDimmer extends LxControl {
      */
     LxControlDimmer(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlDimmer() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlDimmer(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
@@ -25,11 +25,22 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlDimmer extends LxControl {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlDimmer(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to dimmer controls
      */
     private static final String TYPE_NAME = "dimmer";
-
     /**
      * States
      */
@@ -62,15 +73,6 @@ public class LxControlDimmer extends LxControl {
      */
     LxControlDimmer(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlDimmer() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlDimmer(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
@@ -28,7 +28,7 @@ public class LxControlDimmer extends LxControl {
     /**
      * A name by which Miniserver refers to dimmer controls
      */
-    private static final String TYPE_NAME = "dimmer";
+    static final String TYPE_NAME = "dimmer";
 
     /**
      * States
@@ -62,22 +62,6 @@ public class LxControlDimmer extends LxControl {
      */
     LxControlDimmer(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        if (type != null) {
-            return TYPE_NAME.equalsIgnoreCase(type);
-        } else {
-            return false;
-        }
     }
 
     /**
@@ -122,27 +106,15 @@ public class LxControlDimmer extends LxControl {
      *         0 - full off, 100 - full on
      */
     public Double getPosition() {
-        LxControlState state = getState(STATE_POSITION);
-        if (state != null) {
-            return mapLoxoneToOH(state.getValue());
-        }
-        return null;
+        return mapLoxoneToOH(getStateValue(STATE_POSITION));
     }
 
     private Double getMax() {
-        LxControlState state = getState(STATE_MAX);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_MAX);
     }
 
     private Double getMin() {
-        LxControlState state = getState(STATE_MIN);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_MIN);
     }
 
     private Double mapLoxoneToOH(Double loxoneValue) {

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlFactory.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlFactory.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.loxone.internal.core;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A factory of controls of Loxone Miniserver.
+ * It creates various types of control objects based on control type received from Miniserver.
+ *
+ * @author Pawel Pieczul
+ *
+ */
+class LxControlFactory {
+    static {
+        controls = new HashMap<>();
+        addType(LxControlDimmer.class);
+        addType(LxControlInfoOnlyAnalog.class);
+        addType(LxControlInfoOnlyDigital.class);
+        addType(LxControlJalousie.class);
+        addType(LxControlLightController.class);
+        addType(LxControlLightControllerV2.class);
+        addType(LxControlPushbutton.class);
+        addType(LxControlRadio.class);
+        addType(LxControlSwitch.class);
+        addType(LxControlTextState.class);
+        addType(LxControlTimedSwitch.class);
+    }
+
+    private static Map<String, Class<?>> controls;
+
+    /**
+     * Create a {@link LxControl} object for a control received from the Miniserver
+     *
+     * @param client
+     *            websocket client to facilitate communication with Miniserver
+     * @param uuid
+     *            UUID of the control to be created
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            Room that this control belongs to
+     * @param category
+     *            Category that this control belongs to
+     * @return
+     *         created control object or null if error
+     */
+    static LxControl createControl(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
+            LxCategory category) {
+        if (json == null || json.type == null || json.name == null) {
+            return null;
+        }
+        String type = json.type.toLowerCase();
+        Class<?> c = controls.get(type);
+        if (c != null) {
+            try {
+                Constructor<?> constructor = c.getDeclaredConstructor(LxWsClient.class, LxUuid.class,
+                        LxJsonControl.class, LxContainer.class, LxCategory.class);
+                Object control = constructor.newInstance(client, uuid, json, room, category);
+                if (control instanceof LxControl) {
+                    return (LxControl) control;
+                }
+                getLogger().debug("Unexpected object constructed: {}", control.getClass().getSimpleName());
+            } catch (NoSuchMethodException | SecurityException | InvocationTargetException | IllegalAccessException
+                    | InstantiationException | IllegalArgumentException e) {
+                getLogger().debug("Failed to construct control object {}: {}", c.getSimpleName(), e.getMessage());
+            }
+        } else {
+            getLogger().debug("No registered control class for {}, uuid = {}", type, json.uuidAction);
+        }
+        return null;
+    }
+
+    private static void addType(Class<?> c) {
+        try {
+            String name = (String) c.getDeclaredField("TYPE_NAME").get(null);
+            controls.put(name, c);
+        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+            getLogger().debug("Error registering control class {}: {}", c.getSimpleName(), e.getMessage());
+        }
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(LxControlFactory.class);
+    }
+}

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlFactory.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlFactory.java
@@ -11,6 +11,7 @@ package org.openhab.binding.loxone.internal.core;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.openhab.binding.loxone.internal.core.LxControl.LxControlInstance;
 import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
 
 /**
@@ -23,20 +24,20 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
 class LxControlFactory {
     static {
         controls = new HashMap<>();
-        add(new LxControlDimmer());
-        add(new LxControlInfoOnlyAnalog());
-        add(new LxControlInfoOnlyDigital());
-        add(new LxControlJalousie());
-        add(new LxControlLightController());
-        add(new LxControlLightControllerV2());
-        add(new LxControlPushbutton());
-        add(new LxControlRadio());
-        add(new LxControlSwitch());
-        add(new LxControlTextState());
-        add(new LxControlTimedSwitch());
+        add(new LxControlDimmer.Factory());
+        add(new LxControlInfoOnlyAnalog.Factory());
+        add(new LxControlInfoOnlyDigital.Factory());
+        add(new LxControlJalousie.Factory());
+        add(new LxControlLightController.Factory());
+        add(new LxControlLightControllerV2.Factory());
+        add(new LxControlPushbutton.Factory());
+        add(new LxControlRadio.Factory());
+        add(new LxControlSwitch.Factory());
+        add(new LxControlTextState.Factory());
+        add(new LxControlTimedSwitch.Factory());
     }
 
-    private static Map<String, LxControl> controls;
+    private static Map<String, LxControlInstance> controls;
 
     /**
      * Create a {@link LxControl} object for a control received from the Miniserver
@@ -60,14 +61,14 @@ class LxControlFactory {
             return null;
         }
         String type = json.type.toLowerCase();
-        LxControl control = controls.get(type);
+        LxControlInstance control = controls.get(type);
         if (control != null) {
             return control.create(client, uuid, json, room, category);
         }
         return null;
     }
 
-    private static void add(LxControl control) {
-        controls.put(control.getTypeName(), control);
+    private static void add(LxControlInstance control) {
+        controls.put(control.getType(), control);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
@@ -21,6 +21,18 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlInfoOnlyAnalog extends LxControl {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlInfoOnlyAnalog(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to analog virtual state controls
      */
@@ -53,15 +65,6 @@ public class LxControlInfoOnlyAnalog extends LxControl {
      */
     LxControlInfoOnlyAnalog(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlInfoOnlyAnalog() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlInfoOnlyAnalog(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
@@ -24,7 +24,7 @@ public class LxControlInfoOnlyAnalog extends LxControl {
     /**
      * A name by which Miniserver refers to analog virtual state controls
      */
-    static final String TYPE_NAME = "infoonlyanalog";
+    private static final String TYPE_NAME = "infoonlyanalog";
     /**
      * InfoOnlyAnalog state with current value
      */
@@ -53,6 +53,15 @@ public class LxControlInfoOnlyAnalog extends LxControl {
      */
     LxControlInfoOnlyAnalog(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlInfoOnlyAnalog() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlInfoOnlyAnalog(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyAnalog.java
@@ -24,7 +24,7 @@ public class LxControlInfoOnlyAnalog extends LxControl {
     /**
      * A name by which Miniserver refers to analog virtual state controls
      */
-    private static final String TYPE_NAME = "infoonlyanalog";
+    static final String TYPE_NAME = "infoonlyanalog";
     /**
      * InfoOnlyAnalog state with current value
      */
@@ -76,30 +76,15 @@ public class LxControlInfoOnlyAnalog extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
      * Obtain current value of an analog virtual state, expressed in a format configured on the Miniserver
      *
      * @return
      *         string for the value of the state or null if current value is not compatible with this control
      */
     public String getFormattedValue() {
-        LxControlState state = getState(STATE_VALUE);
-        if (state != null) {
-            Double value = state.getValue();
-            if (value != null) {
-                return String.format(format, value);
-            }
+        Double value = getStateValue(STATE_VALUE);
+        if (value != null) {
+            return String.format(format, value);
         }
         return null;
     }
@@ -121,10 +106,6 @@ public class LxControlInfoOnlyAnalog extends LxControl {
      *         value of the state or null if current value is not compatible with this control
      */
     public Double getValue() {
-        LxControlState state = getState(STATE_VALUE);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_VALUE);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
@@ -23,7 +23,7 @@ public class LxControlInfoOnlyDigital extends LxControl {
     /**
      * A name by which Miniserver refers to digital virtual state controls
      */
-    static final String TYPE_NAME = "infoonlydigital";
+    private static final String TYPE_NAME = "infoonlydigital";
     /**
      * InfoOnlyDigital has one state that can be on/off
      */
@@ -49,6 +49,15 @@ public class LxControlInfoOnlyDigital extends LxControl {
     LxControlInfoOnlyDigital(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
             LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    public LxControlInfoOnlyDigital() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlInfoOnlyDigital(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
@@ -20,6 +20,19 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  *
  */
 public class LxControlInfoOnlyDigital extends LxControl {
+
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlInfoOnlyDigital(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to digital virtual state controls
      */
@@ -49,15 +62,6 @@ public class LxControlInfoOnlyDigital extends LxControl {
     LxControlInfoOnlyDigital(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
             LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    public LxControlInfoOnlyDigital() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlInfoOnlyDigital(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlInfoOnlyDigital.java
@@ -23,7 +23,7 @@ public class LxControlInfoOnlyDigital extends LxControl {
     /**
      * A name by which Miniserver refers to digital virtual state controls
      */
-    private static final String TYPE_NAME = "infoonlydigital";
+    static final String TYPE_NAME = "infoonlydigital";
     /**
      * InfoOnlyDigital has one state that can be on/off
      */
@@ -71,33 +71,18 @@ public class LxControlInfoOnlyDigital extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
      * Obtain current value of the virtual state, expressed in a format configured on the Miniserver
      *
      * @return
      *         string for on/off value of the state or null if current value is not available
      */
     public String getFormattedValue() {
-        LxControlState state = getState(STATE_ACTIVE);
-        if (state != null) {
-            Double value = state.getValue();
-            if (value != null) {
-                if (value == 0) {
-                    return textOff;
-                } else if (value == 1) {
-                    return textOn;
-                }
+        Double value = getStateValue(STATE_ACTIVE);
+        if (value != null) {
+            if (value == 0) {
+                return textOff;
+            } else if (value == 1) {
+                return textOn;
             }
         }
         return null;
@@ -110,10 +95,6 @@ public class LxControlInfoOnlyDigital extends LxControl {
      *         1 for ON, 0 for OFF and -1 if current value is not available
      */
     public Double getValue() {
-        LxControlState state = getState(STATE_ACTIVE);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_ACTIVE);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlJalousie.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlJalousie.java
@@ -29,7 +29,7 @@ public class LxControlJalousie extends LxControl implements LxControlStateListen
     /**
      * A name by which Miniserver refers to jalousie controls
      */
-    static final String TYPE_NAME = "jalousie";
+    private static final String TYPE_NAME = "jalousie";
 
     /**
      * Jalousie is moving up
@@ -115,6 +115,15 @@ public class LxControlJalousie extends LxControl implements LxControlStateListen
     LxControlJalousie(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
         addStateListener(STATE_POSITION, this);
+    }
+
+    LxControlJalousie() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlJalousie(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlJalousie.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlJalousie.java
@@ -26,6 +26,19 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  *
  */
 public class LxControlJalousie extends LxControl implements LxControlStateListener {
+
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlJalousie(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to jalousie controls
      */
@@ -115,15 +128,6 @@ public class LxControlJalousie extends LxControl implements LxControlStateListen
     LxControlJalousie(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
         addStateListener(STATE_POSITION, this);
-    }
-
-    LxControlJalousie() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlJalousie(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
@@ -27,6 +27,19 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  *
  */
 public class LxControlLightController extends LxControlAbstractController implements LxControlStateListener {
+
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlLightController(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * Number of scenes supported by the Miniserver. Indexing starts with 0 to NUM_OF_SCENES-1.
      */
@@ -85,15 +98,6 @@ public class LxControlLightController extends LxControlAbstractController implem
         super(client, uuid, json, room, category);
         // sub-controls of this control have been created when update() method was called by super class constructor
         addStateListener(STATE_SCENE_LIST, this);
-    }
-
-    LxControlLightController() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlLightController(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
@@ -35,7 +35,7 @@ public class LxControlLightController extends LxControlAbstractController implem
     /**
      * A name by which Miniserver refers to light controller controls
      */
-    static final String TYPE_NAME = "lightcontroller";
+    private static final String TYPE_NAME = "lightcontroller";
 
     /**
      * Current active scene number (0-9)
@@ -85,6 +85,15 @@ public class LxControlLightController extends LxControlAbstractController implem
         super(client, uuid, json, room, category);
         // sub-controls of this control have been created when update() method was called by super class constructor
         addStateListener(STATE_SCENE_LIST, this);
+    }
+
+    LxControlLightController() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlLightController(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightController.java
@@ -9,8 +9,6 @@
 package org.openhab.binding.loxone.internal.core;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -28,7 +26,7 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  * @author Pawel Pieczul - initial contribution
  *
  */
-public class LxControlLightController extends LxControl implements LxControlStateListener {
+public class LxControlLightController extends LxControlAbstractController implements LxControlStateListener {
     /**
      * Number of scenes supported by the Miniserver. Indexing starts with 0 to NUM_OF_SCENES-1.
      */
@@ -37,16 +35,16 @@ public class LxControlLightController extends LxControl implements LxControlStat
     /**
      * A name by which Miniserver refers to light controller controls
      */
-    private static final String TYPE_NAME = "lightcontroller";
+    static final String TYPE_NAME = "lightcontroller";
 
     /**
      * Current active scene number (0-9)
      */
     private static final String STATE_ACTIVE_SCENE = "activescene";
     /**
-     * List of available scenes
+     * List of available scenes (public state, so user can monitor scene list updates)
      */
-    private static final String STATE_SCENE_LIST = "scenelist";
+    public static final String STATE_SCENE_LIST = "scenelist";
     /**
      * Command string used to set control's state to ON
      */
@@ -66,7 +64,6 @@ public class LxControlLightController extends LxControl implements LxControlStat
     private static final int SCENE_ALL_ON = 9;
 
     private Map<String, String> sceneNames = new TreeMap<>();
-    private boolean newSceneNames = false;
     private Integer movementScene;
 
     /**
@@ -86,12 +83,8 @@ public class LxControlLightController extends LxControl implements LxControlStat
     LxControlLightController(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
             LxCategory category) {
         super(client, uuid, json, room, category);
-
         // sub-controls of this control have been created when update() method was called by super class constructor
-        LxControlState sceneListState = getState(STATE_SCENE_LIST);
-        if (sceneListState != null) {
-            sceneListState.addListener(this);
-        }
+        addStateListener(STATE_SCENE_LIST, this);
     }
 
     /**
@@ -107,52 +100,9 @@ public class LxControlLightController extends LxControl implements LxControlStat
     @Override
     void update(LxJsonControl json, LxContainer room, LxCategory category) {
         super.update(json, room, category);
-
         if (json.details != null) {
             this.movementScene = json.details.movementScene;
         }
-
-        for (LxControl control : subControls.values()) {
-            control.uuid.setUpdate(false);
-        }
-
-        if (json.subControls != null) {
-            for (LxJsonControl subControl : json.subControls.values()) {
-                // recursively create a subcontrol as a new control
-                subControl.room = json.room;
-                subControl.cat = json.cat;
-                LxUuid uuid = new LxUuid(subControl.uuidAction);
-                if (subControls.containsKey(uuid)) {
-                    subControls.get(uuid).update(subControl, room, category);
-                } else {
-                    LxControl control = LxControl.createControl(socketClient, uuid, subControl, room, category);
-                    if (control != null) {
-                        subControls.put(control.uuid, control);
-                    }
-                }
-            }
-        }
-        List<LxUuid> toRemove = new ArrayList<>(subControls.size());
-        for (LxControl control : subControls.values()) {
-            if (!control.uuid.getUpdate()) {
-                toRemove.add(control.uuid);
-            }
-        }
-        for (LxUuid id : toRemove) {
-            subControls.remove(id);
-        }
-    }
-
-    /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
     }
 
     /**
@@ -218,12 +168,9 @@ public class LxControlLightController extends LxControl implements LxControlStat
      *         number of the active scene (0-9, 0-all off, 9-all on) or null if error
      */
     public Integer getCurrentScene() {
-        LxControlState state = getState(STATE_ACTIVE_SCENE);
-        if (state != null) {
-            Double value = state.getValue();
-            if (value != null) {
-                return value.intValue();
-            }
+        Double value = getStateValue(STATE_ACTIVE_SCENE);
+        if (value != null) {
+            return value.intValue();
         }
         return null;
     }
@@ -249,18 +196,6 @@ public class LxControlLightController extends LxControl implements LxControlStat
     }
 
     /**
-     * Check if scene names were updated since last check.
-     *
-     * @return
-     *         true if there are new scene names
-     */
-    public boolean sceneNamesUpdated() {
-        boolean ret = newSceneNames;
-        newSceneNames = false;
-        return ret;
-    }
-
-    /**
      * Get scene names from new state value received from the Miniserver
      */
     @Override
@@ -276,7 +211,6 @@ public class LxControlLightController extends LxControl implements LxControlStat
                     sceneNames.put(params[0], params[1]);
                 }
             }
-            newSceneNames = true;
         }
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightControllerV2.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightControllerV2.java
@@ -39,6 +39,19 @@ import com.google.gson.JsonSyntaxException;
  *
  */
 public class LxControlLightControllerV2 extends LxControlAbstractController implements LxControlStateListener {
+
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlLightControllerV2(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to light controller v2 controls
      */
@@ -102,15 +115,6 @@ public class LxControlLightControllerV2 extends LxControlAbstractController impl
         // sub-controls of this control have been created when update() method was called by the super class constructor
         addStateListener(STATE_MOODS_LIST, this);
         addStateListener(STATE_ACTIVE_MOODS_LIST, this);
-    }
-
-    LxControlLightControllerV2() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlLightControllerV2(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightControllerV2.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlLightControllerV2.java
@@ -1,0 +1,392 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.loxone.internal.core;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
+
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * A Light Controller V2 type of control on Loxone Miniserver.
+ * <p>
+ * This control has been introduced in Loxone Config 9 in 2017 and it makes the {@link LxControlLightController}
+ * obsolete. Both controls will exist for some time together.
+ * <p>
+ * Light controller V2 can have N outputs named AQ1...AQN that can function as Switch, Dimmer, RGB, Lumitech or Smart
+ * Actuator functional blocks. Individual controls will be created for these outputs so they can be operated directly
+ * and independently from the controller.
+ * <p>
+ * Controller can also have M moods configured. Each mood defines own subset of outputs and their settings, which will
+ * be engaged when the mood is active. A dedicated switch control object will be created for each mood.
+ * This effectively will allow for mixing various moods by individually enabling/disabling them.
+ * <p>
+ * It seems there is no imposed limitation for the number of outputs and moods.
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+public class LxControlLightControllerV2 extends LxControlAbstractController implements LxControlStateListener {
+
+    /**
+     * This class represents a mood belonging to a {@link LxControlLightControllerV2} object.
+     * A mood is effectively a switch. When the switch is set to ON, mood is active and mixed into a set of active
+     * moods.
+     *
+     * @author Pawel Pieczul - initial contribution
+     *
+     */
+    public class LxControlMood extends LxControlSwitch {
+        Integer moodId;
+        Boolean isStatic;
+
+        /**
+         * Create a control representing a single mood of a light controller V2.
+         *
+         * @param client
+         *            communication client used to send commands to the Miniserver
+         * @param uuid
+         *            controller's UUID
+         * @param json
+         *            JSON describing the control as received from the Miniserver
+         * @param room
+         *            room to which mood belongs
+         * @param category
+         *            category to which mood belongs
+         * @param moodId
+         *            mood ID withing the controller (received from the Miniserver)
+         * @param isStatic
+         *            true if this mood is static and can't be deleted or modified in any way
+         */
+        LxControlMood(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category,
+                Integer moodId, Boolean isStatic) {
+            super(client, uuid, json, room, category);
+            this.moodId = moodId;
+            this.isStatic = isStatic;
+        }
+
+        /**
+         * Get an ID of this mood. ID indentifies the mood within a light controller.
+         * It is equal to the mood ID received from the Miniserver.
+         *
+         * @return
+         *         mood ID
+         */
+        public Integer getId() {
+            return moodId;
+        }
+
+        /**
+         * Returns if mood is statically-defined 'all off' mood.
+         * Setting 'all off' mood on the Miniserver switches all outputs off, but it can't be mixed with other moods.
+         * Attempt to mix it results in no change in the active moods list.
+         *
+         * @return
+         *         true if this is static all outputs off mood
+         */
+        public boolean isAllOffMood() {
+            // currently the API does not give a hint how to figure out the 'all off' mood
+            // empirically this is the only mood that is not editable by the user and has a static flag set on
+            // we will assume that the only static mood is 'all off' mood
+            return isStatic == null ? false : isStatic;
+        }
+
+        /**
+         * Get controller's UUID that the mood belongs to.
+         *
+         * @return UUID of the lighting controller
+         */
+        public LxUuid getControllerUuid() {
+            return LxControlLightControllerV2.this.getUuid();
+        }
+
+        /**
+         * Mix the mood into active moods.
+         *
+         * @throws IOException
+         *             when something went wrong with communication
+         */
+        @Override
+        public void on() throws IOException {
+            addMood(moodId);
+        }
+
+        /**
+         * Mix the mood out of active moods.
+         *
+         * @throws IOException
+         *             when something went wrong with communication
+         */
+        @Override
+        public void off() throws IOException {
+            removeMood(moodId);
+        }
+
+        /**
+         * Return whether the mood is active of not.
+         *
+         * @return
+         *         1 if mood is active and 0 otherwise
+         */
+        @Override
+        public Double getState() {
+            if (isMoodActive(moodId)) {
+                return 1.0;
+            }
+            return 0.0;
+        }
+    }
+
+    /**
+     * A name by which Miniserver refers to light controller v2 controls
+     */
+    static final String TYPE_NAME = "lightcontrollerv2";
+
+    /**
+     * State with list of active moods
+     */
+    public static final String STATE_ACTIVE_MOODS_LIST = "activemoods";
+    /**
+     * State with list of available moods
+     */
+    public static final String STATE_MOODS_LIST = "moodlist";
+
+    /**
+     * Command string used to set a given mood
+     */
+    private static final String CMD_CHANGE_TO_MOOD = "changeTo";
+    /**
+     * Command string used to change to the next mood
+     */
+    private static final String CMD_NEXT_MOOD = "plus";
+    /**
+     * Command string used to change to the previous mood
+     */
+    private static final String CMD_PREVIOUS_MOOD = "minus";
+    /**
+     * Command string used to add mood to the active moods (mix it in)
+     */
+    private static final String CMD_ADD_MOOD = "addMood";
+    /**
+     * Command string used to remove mood from the active moods (mix it out)
+     */
+    private static final String CMD_REMOVE_MOOD = "removeMood";
+
+    // Following commands are not supported:
+    // moveFavoriteMood, moveAdditionalMood, moveMood, addToFavoriteMood, removeFromFavoriteMood, learn, delete
+
+    private Map<LxUuid, LxControlMood> moodList = new HashMap<>();
+    private List<Integer> activeMoods = new ArrayList<>();
+    private Integer minMoodId;
+    private Integer maxMoodId;
+
+    /**
+     * Create lighting controller v2 object.
+     *
+     * @param client
+     *            communication client used to send commands to the Miniserver
+     * @param uuid
+     *            controller's UUID
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            room to which controller belongs
+     * @param category
+     *            category to which controller belongs
+     */
+    LxControlLightControllerV2(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room,
+            LxCategory category) {
+        super(client, uuid, json, room, category);
+
+        // sub-controls of this control have been created when update() method was called by the super class constructor
+        addStateListener(STATE_MOODS_LIST, this);
+        addStateListener(STATE_ACTIVE_MOODS_LIST, this);
+    }
+
+    /**
+     * Set a mood, deactivate other moods
+     *
+     * @param moodId
+     *            ID of the mood to set
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    public void setMood(Integer moodId) throws IOException {
+        if (isMoodOk(moodId)) {
+            socketClient.sendAction(uuid, CMD_CHANGE_TO_MOOD + "/" + moodId);
+        }
+    }
+
+    /**
+     * Select next mood.
+     *
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    public void nextMood() throws IOException {
+        socketClient.sendAction(uuid, CMD_NEXT_MOOD);
+    }
+
+    /**
+     * Select previous mood.
+     *
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    public void previousMood() throws IOException {
+        socketClient.sendAction(uuid, CMD_PREVIOUS_MOOD);
+    }
+
+    /**
+     * Mix a mood into currently active moods.
+     *
+     * @param moodId
+     *            ID of the mood to add
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    public void addMood(Integer moodId) throws IOException {
+        if (isMoodOk(moodId)) {
+            socketClient.sendAction(uuid, CMD_ADD_MOOD + "/" + moodId);
+        }
+    }
+
+    /**
+     * Mix a mood out of currently active moods.
+     *
+     * @param moodId
+     *            ID of the mood to remove
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    public void removeMood(Integer moodId) throws IOException {
+        if (isMoodOk(moodId)) {
+            socketClient.sendAction(uuid, CMD_REMOVE_MOOD + "/" + moodId);
+        }
+    }
+
+    /**
+     * Get IDs of currently active moods.
+     *
+     * @return
+     *         list of IDs of active moods or null if active moods list is not available
+     */
+    public List<Integer> getActiveMoods() {
+        return activeMoods;
+    }
+
+    /**
+     * Get all configured moods.
+     *
+     * @return
+     *         Map with mood ID as key and mood control object as value or null if moods are not configured
+     */
+    public Map<LxUuid, LxControlMood> getMoods() {
+        return moodList;
+    }
+
+    /**
+     * Get minimum value a mood ID can have for the current list of moods.
+     *
+     * @return
+     *         minimum value of a mood ID for the current list of moods or null if not defined
+     */
+    public Integer getMinMoodId() {
+        return minMoodId;
+    }
+
+    /**
+     * Get maximum value a mood ID can have for the current list of moods.
+     *
+     * @return
+     *         maximum value of a mood ID for the current list of moods or null if not defined
+     */
+    public Integer getMaxMoodId() {
+        return maxMoodId;
+    }
+
+    /**
+     * Get scene names from a new state value received from the Miniserver
+     *
+     * @param state
+     *            state update from the Miniserver
+     */
+    @Override
+    public void onStateChange(LxControlState state) {
+        String stateName = state.getName();
+        String text = state.getTextValue();
+        logger.debug("Received state {} update to {}", stateName, text);
+        try {
+            if (STATE_MOODS_LIST.equals(stateName)) {
+                LxJsonMood[] array = socketClient.getGson().fromJson(text, LxJsonMood[].class);
+                moodList.clear();
+                minMoodId = null;
+                maxMoodId = null;
+                LxJsonControl json = new LxJsonApp3().new LxJsonControl();
+                for (LxJsonMood mood : array) {
+                    if (mood.id != null && mood.name != null) {
+                        logger.debug("Adding mood {} (name={}, isUsed={}, t5={}, static={}", mood.id, mood.name,
+                                mood.isUsed, mood.isT5Controlled, mood.isStatic);
+                        json.name = mood.name;
+                        // mood-UUID = <controller-UUID>-M<mood-ID>
+                        LxUuid moodUuid = new LxUuid(getUuid().toString() + "-M" + mood.id);
+                        LxControlMood control = new LxControlMood(socketClient, moodUuid, json, getRoom(),
+                                getCategory(), mood.id, mood.isStatic);
+                        moodList.put(moodUuid, control);
+                        if (minMoodId == null || minMoodId > mood.id) {
+                            minMoodId = mood.id;
+                        }
+                        if (maxMoodId == null || maxMoodId < mood.id) {
+                            maxMoodId = mood.id;
+                        }
+                    }
+                }
+            } else if (STATE_ACTIVE_MOODS_LIST.equals(stateName)) {
+                // this state can be received before list of moods, but it contains a valid list of IDs
+                Integer[] array = socketClient.getGson().fromJson(text, Integer[].class);
+                activeMoods = Arrays.asList(array);
+            }
+        } catch (JsonSyntaxException e) {
+            logger.debug("Error parsing state {}: {}", stateName, e.getMessage());
+        }
+    }
+
+    /**
+     * Check if mood ID is within allowed range
+     *
+     * @param moodId
+     *            mood ID to check
+     * @return
+     *         true if mood ID is within allowed range or range is not configured
+     */
+    private boolean isMoodOk(Integer moodId) {
+        if ((minMoodId != null && minMoodId > moodId) || (maxMoodId != null && maxMoodId < moodId)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check if mood is currently active.
+     *
+     * @param moodId
+     *            mood ID to check
+     * @return
+     *         true if mood is currently active
+     */
+    private boolean isMoodActive(Integer moodId) {
+        return activeMoods.contains(moodId);
+    }
+}

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlMood.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlMood.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.loxone.internal.core;
+
+import java.io.IOException;
+
+import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
+
+/**
+ * This class represents a mood belonging to a {@link LxControlMood} object.
+ * A mood is effectively a switch. When the switch is set to ON, mood is active and mixed into a set of active
+ * moods.
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+public class LxControlMood extends LxControlSwitch {
+    private Integer moodId;
+    private Boolean isStatic;
+    private LxControlLightControllerV2 controller;
+
+    /**
+     * Create a control representing a single mood of a light controller V2.
+     *
+     * @param client
+     *            communication client used to send commands to the Miniserver
+     * @param uuid
+     *            controller's UUID
+     * @param json
+     *            JSON describing the control as received from the Miniserver
+     * @param room
+     *            room to which mood belongs
+     * @param category
+     *            category to which mood belongs
+     * @param moodId
+     *            mood ID withing the controller (received from the Miniserver)
+     * @param isStatic
+     *            true if this mood is static and can't be deleted or modified in any way
+     * @param controller
+     *            light controller that this mood belongs to
+     */
+    LxControlMood(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category,
+            Integer moodId, Boolean isStatic, LxControlLightControllerV2 controller) {
+        super(client, uuid, json, room, category);
+        this.moodId = moodId;
+        this.isStatic = isStatic;
+        this.controller = controller;
+    }
+
+    /**
+     * Get an ID of this mood. ID indentifies the mood within a light controller.
+     * It is equal to the mood ID received from the Miniserver.
+     *
+     * @return
+     *         mood ID
+     */
+    public Integer getId() {
+        return moodId;
+    }
+
+    /**
+     * Returns if mood is statically-defined 'all off' mood.
+     * Setting 'all off' mood on the Miniserver switches all outputs off, but it can't be mixed with other moods.
+     * Attempt to mix it results in no change in the active moods list.
+     *
+     * @return
+     *         true if this is static all outputs off mood
+     */
+    public boolean isAllOffMood() {
+        // currently the API does not give a hint how to figure out the 'all off' mood
+        // empirically this is the only mood that is not editable by the user and has a static flag set on
+        // we will assume that the only static mood is 'all off' mood
+        return isStatic == null ? false : isStatic;
+    }
+
+    /**
+     * Get controller's UUID that the mood belongs to.
+     *
+     * @return UUID of the lighting controller
+     */
+    public LxUuid getControllerUuid() {
+        return LxControlMood.this.getUuid();
+    }
+
+    /**
+     * Mix the mood into active moods.
+     *
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    @Override
+    public void on() throws IOException {
+        controller.addMood(moodId);
+    }
+
+    /**
+     * Mix the mood out of active moods.
+     *
+     * @throws IOException
+     *             when something went wrong with communication
+     */
+    @Override
+    public void off() throws IOException {
+        controller.removeMood(moodId);
+    }
+
+    /**
+     * Return whether the mood is active of not.
+     *
+     * @return
+     *         1 if mood is active and 0 otherwise
+     */
+    @Override
+    public Double getState() {
+        if (controller.isMoodActive(moodId)) {
+            return 1.0;
+        }
+        return 0.0;
+    }
+}

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
@@ -21,6 +21,19 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  *
  */
 public class LxControlPushbutton extends LxControlSwitch {
+
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlPushbutton(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to pushbutton controls
      */
@@ -46,19 +59,6 @@ public class LxControlPushbutton extends LxControlSwitch {
      */
     LxControlPushbutton(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlPushbutton() {
-        super(TYPE_NAME);
-    }
-
-    LxControlPushbutton(String typeName) {
-        super(typeName);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlPushbutton(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
@@ -24,7 +24,7 @@ public class LxControlPushbutton extends LxControlSwitch {
     /**
      * A name by which Miniserver refers to pushbutton controls
      */
-    public static final String TYPE_NAME = "pushbutton";
+    static final String TYPE_NAME = "pushbutton";
     /**
      * Command string used to set control's state to ON and OFF (tap)
      */
@@ -46,18 +46,6 @@ public class LxControlPushbutton extends LxControlSwitch {
      */
     LxControlPushbutton(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlPushbutton.java
@@ -24,7 +24,7 @@ public class LxControlPushbutton extends LxControlSwitch {
     /**
      * A name by which Miniserver refers to pushbutton controls
      */
-    static final String TYPE_NAME = "pushbutton";
+    private static final String TYPE_NAME = "pushbutton";
     /**
      * Command string used to set control's state to ON and OFF (tap)
      */
@@ -46,6 +46,19 @@ public class LxControlPushbutton extends LxControlSwitch {
      */
     LxControlPushbutton(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlPushbutton() {
+        super(TYPE_NAME);
+    }
+
+    LxControlPushbutton(String typeName) {
+        super(typeName);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlPushbutton(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
@@ -31,7 +31,7 @@ public class LxControlRadio extends LxControl {
     /**
      * A name by which Miniserver refers to radio-button controls
      */
-    private static final String TYPE_NAME = "radio";
+    static final String TYPE_NAME = "radio";
 
     /**
      * Radio-button has one state that is a number representing current active output
@@ -86,18 +86,6 @@ public class LxControlRadio extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
      * Set radio-button control's active output
      * <p>
      * Sends a command to operate the radio-button control.
@@ -122,12 +110,9 @@ public class LxControlRadio extends LxControl {
      *         active output number 1-8 (or 1-16), or 0 if all outputs are off, or null if error occured
      */
     public Integer getActiveOutput() {
-        LxControlState state = getState(STATE_ACTIVE_OUTPUT);
-        if (state != null) {
-            Double value = state.getValue();
-            if (value != null) {
-                return value.intValue();
-            }
+        Double value = getStateValue(STATE_ACTIVE_OUTPUT);
+        if (value != null) {
+            return value.intValue();
         }
         return null;
     }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
@@ -23,6 +23,18 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlRadio extends LxControl {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlRadio(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * Number of outputs a radio controller may have
      */
@@ -60,15 +72,6 @@ public class LxControlRadio extends LxControl {
      */
     LxControlRadio(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlRadio() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlRadio(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlRadio.java
@@ -31,7 +31,7 @@ public class LxControlRadio extends LxControl {
     /**
      * A name by which Miniserver refers to radio-button controls
      */
-    static final String TYPE_NAME = "radio";
+    private static final String TYPE_NAME = "radio";
 
     /**
      * Radio-button has one state that is a number representing current active output
@@ -60,6 +60,15 @@ public class LxControlRadio extends LxControl {
      */
     LxControlRadio(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlRadio() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlRadio(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
@@ -63,6 +63,19 @@ public class LxControlSwitch extends LxControl {
         super(client, uuid, json, room, category);
     }
 
+    LxControlSwitch() {
+        super(TYPE_NAME);
+    }
+
+    LxControlSwitch(String typeName) {
+        super(typeName);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlSwitch(client, uuid, json, room, category);
+    }
+
     /**
      * Set switch to ON.
      * <p>

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
@@ -26,6 +26,18 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlSwitch extends LxControl {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlSwitch(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to switch controls
      */
@@ -61,19 +73,6 @@ public class LxControlSwitch extends LxControl {
      */
     LxControlSwitch(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlSwitch() {
-        super(TYPE_NAME);
-    }
-
-    LxControlSwitch(String typeName) {
-        super(typeName);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlSwitch(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlSwitch.java
@@ -29,7 +29,7 @@ public class LxControlSwitch extends LxControl {
     /**
      * A name by which Miniserver refers to switch controls
      */
-    private static final String TYPE_NAME = "switch";
+    static final String TYPE_NAME = "switch";
 
     /**
      * Switch has one state that can be on/off
@@ -64,18 +64,6 @@ public class LxControlSwitch extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
      * Set switch to ON.
      * <p>
      * Sends a command to operate the switch.
@@ -106,10 +94,6 @@ public class LxControlSwitch extends LxControl {
      *         0 - switch off, 1 - switch on
      */
     public Double getState() {
-        LxControlState state = getState(STATE_ACTIVE);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_ACTIVE);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
@@ -23,7 +23,7 @@ public class LxControlTextState extends LxControl {
     /**
      * A name by which Miniserver refers to text state controls
      */
-    private static final String TYPE_NAME = "textstate";
+    static final String TYPE_NAME = "textstate";
 
     /**
      * A state which will receive an update of possible Text State values)
@@ -49,28 +49,12 @@ public class LxControlTextState extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
      * Return current text value of the state
      *
      * @return
      *         string with current value
      */
     public String getText() {
-        LxControlState textState = getState(STATE_TEXT_AND_ICON);
-        if (textState != null) {
-            return textState.getTextValue();
-        }
-        return null;
+        return getStateTextValue(STATE_TEXT_AND_ICON);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
@@ -20,6 +20,18 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlTextState extends LxControl {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlTextState(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to text state controls
      */
@@ -46,15 +58,6 @@ public class LxControlTextState extends LxControl {
      */
     LxControlTextState(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlTextState() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlTextState(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTextState.java
@@ -23,7 +23,7 @@ public class LxControlTextState extends LxControl {
     /**
      * A name by which Miniserver refers to text state controls
      */
-    static final String TYPE_NAME = "textstate";
+    private static final String TYPE_NAME = "textstate";
 
     /**
      * A state which will receive an update of possible Text State values)
@@ -46,6 +46,15 @@ public class LxControlTextState extends LxControl {
      */
     LxControlTextState(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlTextState() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlTextState(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.loxone.internal.core;
 
-import java.io.IOException;
-
 import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
 
 /**
@@ -24,12 +22,12 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  * @author Stephan Brunner
  *
  */
-public class LxControlTimedSwitch extends LxControl {
+public class LxControlTimedSwitch extends LxControlPushbutton {
 
     /**
      * A name by which Miniserver refers to timed switch controls
      */
-    private static final String TYPE_NAME = "timedswitch";
+    static final String TYPE_NAME = "timedswitch";
 
     /**
      * deactivationDelay - countdown until the output is deactivated.
@@ -38,21 +36,6 @@ public class LxControlTimedSwitch extends LxControl {
      * otherwise it will count down from deactivationDelayTotal
      */
     private static final String STATE_DEACTIVATION_DELAY = "deactivationdelay";
-
-    /**
-     * Command string used to set timed switch to ON without deactivation delay
-     */
-    private static final String CMD_ON = "On";
-
-    /**
-     * Command string used to set timed switch to ON with deactivation delay
-     */
-    private static final String CMD_PULSE = "pulse";
-
-    /**
-     * Command string used to set timed switch to OFF
-     */
-    private static final String CMD_OFF = "Off";
 
     /**
      * Create timed switch control object.
@@ -73,70 +56,23 @@ public class LxControlTimedSwitch extends LxControl {
     }
 
     /**
-     * Check if control accepts provided type name from the Miniserver
-     *
-     * @param type
-     *            name of the type received from Miniserver
-     * @return
-     *         true if this control is suitable for this type
-     */
-    public static boolean accepts(String type) {
-        return type.equalsIgnoreCase(TYPE_NAME);
-    }
-
-    /**
-     * Set timed switch to ON without deactivation delay.
-     * <p>
-     * Sends a command to operate the timed switch.
-     *
-     * @throws IOException
-     *             when something went wrong with communication
-     */
-    public void on() throws IOException {
-        socketClient.sendAction(uuid, CMD_ON);
-    }
-
-    /**
-     * Set timed switch to ON with deactivation delay.
-     * <p>
-     * Sends a command to operate the timed switch.
-     *
-     * @throws IOException
-     *             when something went wrong with communication
-     */
-    public void pulse() throws IOException {
-        socketClient.sendAction(uuid, CMD_PULSE);
-    }
-
-    /**
-     * Set timed switch to OFF.
-     * <p>
-     * Sends a command to operate the timed switch.
-     *
-     * @throws IOException
-     *             when something went wrong with communication
-     */
-    public void off() throws IOException {
-        socketClient.sendAction(uuid, CMD_OFF);
-    }
-
-    /**
      * Get current value of the timed switch'es state.
      *
      * @return
      *         0 - switch off, 1 - switch on
      */
+    @Override
     public Double getState() {
         /**
          * 0 = the output is turned off
          * -1 = the output is permanently on
          * otherwise it will count down from deactivationDelayTotal
          **/
-        LxControlState state = getState(STATE_DEACTIVATION_DELAY);
-        if (state != null && state.getValue() != null) {
-            if (state.getValue() == -1 || state.getValue() > 0) { // mapping
+        Double value = getStateValue(STATE_DEACTIVATION_DELAY);
+        if (value != null) {
+            if (value == -1 || value > 0) { // mapping
                 return 1d;
-            } else if (state.getValue() == 0) {
+            } else if (value == 0) {
                 return 0d;
             }
         }
@@ -150,10 +86,6 @@ public class LxControlTimedSwitch extends LxControl {
      *         Loxone also returns floating point values for the delay e.g. 9.99 seconds
      */
     public Double getDeactivationDelay() {
-        LxControlState state = getState(STATE_DEACTIVATION_DELAY);
-        if (state != null) {
-            return state.getValue();
-        }
-        return null;
+        return getStateValue(STATE_DEACTIVATION_DELAY);
     }
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
@@ -27,7 +27,7 @@ public class LxControlTimedSwitch extends LxControlPushbutton {
     /**
      * A name by which Miniserver refers to timed switch controls
      */
-    static final String TYPE_NAME = "timedswitch";
+    private static final String TYPE_NAME = "timedswitch";
 
     /**
      * deactivationDelay - countdown until the output is deactivated.
@@ -53,6 +53,15 @@ public class LxControlTimedSwitch extends LxControlPushbutton {
      */
     LxControlTimedSwitch(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
+    }
+
+    LxControlTimedSwitch() {
+        super(TYPE_NAME);
+    }
+
+    @Override
+    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+        return new LxControlTimedSwitch(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlTimedSwitch.java
@@ -24,6 +24,18 @@ import org.openhab.binding.loxone.internal.core.LxJsonApp3.LxJsonControl;
  */
 public class LxControlTimedSwitch extends LxControlPushbutton {
 
+    static class Factory extends LxControlInstance {
+        @Override
+        LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
+            return new LxControlTimedSwitch(client, uuid, json, room, category);
+        }
+
+        @Override
+        String getType() {
+            return TYPE_NAME;
+        }
+    }
+
     /**
      * A name by which Miniserver refers to timed switch controls
      */
@@ -53,15 +65,6 @@ public class LxControlTimedSwitch extends LxControlPushbutton {
      */
     LxControlTimedSwitch(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
         super(client, uuid, json, room, category);
-    }
-
-    LxControlTimedSwitch() {
-        super(TYPE_NAME);
-    }
-
-    @Override
-    LxControl create(LxWsClient client, LxUuid uuid, LxJsonControl json, LxContainer room, LxCategory category) {
-        return new LxControlTimedSwitch(client, uuid, json, room, category);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxJsonMood.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxJsonMood.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.loxone.internal.core;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A JSON structure of a mood of {@link LxControlLightControllerV2}. This structure is an item of a JSON array received
+ * in moodList state update of this controller in the runtime.
+ * <p>
+ * This structure is used for parsing with Gson library.
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+class LxJsonMood {
+    /**
+     * The userfriendly name for this mood
+     */
+    String name;
+
+    /**
+     * An ID that uniquely identifies this mood (e.g. inside activeMoods)
+     */
+    Integer id;
+
+    /**
+     * Bitmask that tells if the mood is used for a specific purpose in the logic.
+     * If it’s not used, it can be removed without affecting the logic on the Miniserver.
+     * 0: not used
+     * 1: this mood is activated by a movement event
+     * 2: a T5 or other inputs activate/deactivate this mood
+     */
+    @SerializedName("used")
+    Integer isUsed;
+
+    /**
+     * Whether or not this mood can be controlled with a t5 input
+     */
+    @SerializedName("t5")
+    Boolean isT5Controlled;
+
+    /**
+     * If a mood is marked as static it cannot be deleted or modified in any way.
+     * But it can be moved within and between favorite and additional lists.
+     */
+    @SerializedName("static")
+    Boolean isStatic;
+}

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServer.java
@@ -685,7 +685,7 @@ public class LxServer {
         if (control != null) {
             control.update(json, room, category);
         } else {
-            control = LxControl.createControl(socketClient, id, json, room, category);
+            control = LxControlFactory.createControl(socketClient, id, json, room, category);
         }
         if (control != null) {
             updateControls(control);

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServer.java
@@ -11,11 +11,9 @@ package org.openhab.binding.loxone.internal.core;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,11 +68,14 @@ public class LxServer {
     private int comErrorDelay = 30;
 
     // Data structures
-    private Set<LxUuid> uuids = new HashSet<>();
     private Map<LxUuid, LxControl> controls = new HashMap<>();
     private Map<LxUuid, LxContainer> rooms = new HashMap<>();
     private Map<LxUuid, LxCategory> categories = new HashMap<>();
-    private Map<LxUuid, LxControlState> states = new HashMap<>();
+    // Map of state UUID to a map of control UUID and state objects
+    // State with a unique UUID can be configured in many controls and each control can even have a different name of
+    // the state. It must be ensured that updates received for this state UUID are passed to all controls that have this
+    // state UUID configured.
+    private Map<LxUuid, Map<LxUuid, LxControlState>> states = new HashMap<>();
     private List<LxServerListener> listeners = new ArrayList<>();
 
     // Services
@@ -390,21 +391,23 @@ public class LxServer {
                                 break;
                             case STATE_UPDATE:
                                 LxWsStateUpdateEvent update = (LxWsStateUpdateEvent) wsMsg.getObject();
-                                LxControlState state = findState(update.getUuid());
-                                if (state != null) {
-                                    state.setValue(update.getValue(), update.getText());
-                                    LxControl control = state.getControl();
-                                    if (control != null) {
-                                        logger.debug("[{}] State update {} ({}:{}) to value {}, text '{}'", debugId,
-                                                update.getUuid(), control.getName(), state.getName(), update.getValue(),
-                                                update.getText());
-                                        for (LxServerListener listener : listeners) {
-                                            listener.onControlStateUpdate(control);
+                                Map<LxUuid, LxControlState> perStateUuid = findState(update.getUuid());
+                                if (perStateUuid != null) {
+                                    perStateUuid.forEach((controlUuid, state) -> {
+                                        state.setValue(update.getValue(), update.getText());
+                                        LxControl control = state.getControl();
+                                        if (control != null) {
+                                            logger.debug("[{}] State update {} ({}:{}) to value {}, text '{}'", debugId,
+                                                    update.getUuid(), control.getName(), state.getName(),
+                                                    update.getValue(), update.getText());
+                                            for (LxServerListener listener : listeners) {
+                                                listener.onControlStateUpdate(control, state.getName().toLowerCase());
+                                            }
+                                        } else {
+                                            logger.debug("[{}] State update {} ({}) of unknown control", debugId,
+                                                    update.getUuid(), state.getName());
                                         }
-                                    } else {
-                                        logger.debug("[{}] State update {} ({}) of unknown control", debugId,
-                                                update.getUuid(), state.getName());
-                                    }
+                                    });
                                 }
                                 break;
                             case SERVER_ONLINE:
@@ -469,12 +472,10 @@ public class LxServer {
     private void updateConfig(LxJsonApp3 config) {
         logger.trace("[{}] Updating configuration from Miniserver", debugId);
 
-        for (LxUuid id : uuids) {
-            id.setUpdate(false);
-        }
-        for (LxUuid id : states.keySet()) {
-            id.setUpdate(false);
-        }
+        invalidateMap(rooms);
+        invalidateMap(categories);
+        invalidateMap(controls);
+        invalidateMap(states);
 
         if (config.msInfo != null) {
             logger.trace("[{}] updating global config", debugId);
@@ -532,7 +533,6 @@ public class LxServer {
         for (Iterator<Map.Entry<LxUuid, T>> it = map.entrySet().iterator(); it.hasNext();) {
             Map.Entry<LxUuid, T> entry = it.next();
             if (!entry.getKey().getUpdate()) {
-                uuids.remove(entry.getKey());
                 it.remove();
                 if (entry.getValue() instanceof LxControl) {
                     ((LxControl) entry.getValue()).dispose();
@@ -542,41 +542,15 @@ public class LxServer {
     }
 
     /**
-     * Searches for an UUID of an object (control, category, room, ...) that this server contains
+     * Sets all entries in a map to not updated
      *
-     * @param id
-     *            UUID to search for
-     * @return
-     *         found UUID object or null if not found
+     * @param map
+     *            map to invalidate entries in
      */
-    private LxUuid findUuid(LxUuid id) {
-        if (uuids == null || id == null) {
-            return null;
-        }
-        for (LxUuid i : uuids) {
-            if (id.equals(i)) {
-                return i;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Adds a new UUID object to server, if an object with same UUID value does not exist yet. Otherwise return
-     * already existing object.
-     *
-     * @param id
-     *            UUID to search for
-     * @return
-     *         object belonging to server (either same as provided as an argument or already existing one)
-     */
-    private LxUuid addUuid(LxUuid id) {
-        LxUuid i = findUuid(id);
-        if (i != null) {
-            return i;
-        }
-        uuids.add(id);
-        return id;
+    private void invalidateMap(Map<LxUuid, ?> map) {
+        map.keySet().forEach(k -> {
+            k.setUpdate(false);
+        });
     }
 
     /**
@@ -616,7 +590,6 @@ public class LxServer {
             r.setName(name);
             return r;
         }
-        id = addUuid(id);
         LxContainer nr = new LxContainer(id, name);
         rooms.put(id, nr);
         return nr;
@@ -628,9 +601,9 @@ public class LxServer {
      * @param id
      *            UUID of state to locate
      * @return
-     *         state object
+     *         map of all state objects with control UUID as key
      */
-    private LxControlState findState(LxUuid id) {
+    private Map<LxUuid, LxControlState> findState(LxUuid id) {
         if (states == null || id == null) {
             return null;
         }
@@ -680,7 +653,6 @@ public class LxServer {
             c.setType(type);
             return c;
         }
-        id = addUuid(id);
         LxCategory nc = new LxCategory(id, name, type);
         categories.put(id, nc);
         return nc;
@@ -713,7 +685,6 @@ public class LxServer {
         if (control != null) {
             control.update(json, room, category);
         } else {
-            id = addUuid(id);
             control = LxControl.createControl(socketClient, id, json, room, category);
         }
         if (control != null) {
@@ -730,7 +701,12 @@ public class LxServer {
     private void updateControls(LxControl control) {
         for (LxControlState state : control.getStates().values()) {
             state.getUuid().setUpdate(true);
-            states.put(state.getUuid(), state);
+            Map<LxUuid, LxControlState> perUuid = states.get(state.getUuid());
+            if (perUuid == null) {
+                perUuid = new HashMap<>();
+                states.put(state.getUuid(), perUuid);
+            }
+            perUuid.put(control.uuid, state);
         }
         controls.put(control.uuid, control);
         control.uuid.setUpdate(true);

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServerListener.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxServerListener.java
@@ -50,7 +50,9 @@ public interface LxServerListener {
      *
      * @param control
      *            control object, which state changed
+     * @param stateName
+     *            name of the state that was updated
      */
-    void onControlStateUpdate(LxControl control);
+    void onControlStateUpdate(LxControl control, String stateName);
 
 }

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxWsClient.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxWsClient.java
@@ -63,6 +63,7 @@ class LxWsClient {
     private int maxBinMsgSize = 3 * 1024; // 3 MB
     private int maxTextMsgSize = 512; // 512 KB
 
+    private Gson gson = new Gson();
     private ScheduledFuture<?> timeout;
     private LxWebSocket socket;
     private WebSocketClient wsClient;
@@ -406,6 +407,16 @@ class LxWsClient {
     }
 
     /**
+     * Returns {@link Gson} object so it can be reused without creating a new instance.
+     *
+     * @return
+     *         Gson object for reuse
+     */
+    Gson getGson() {
+        return gson;
+    }
+
+    /**
      * Sets a new websocket client state
      *
      * @param state
@@ -483,7 +494,6 @@ class LxWsClient {
     @WebSocket
     public class LxWebSocket {
         Session session;
-        Gson gson = new Gson();
         private ScheduledFuture<?> keepAlive;
         private LxWsBinaryHeader header;
 

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxWsClient.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxWsClient.java
@@ -63,7 +63,7 @@ class LxWsClient {
     private int maxBinMsgSize = 3 * 1024; // 3 MB
     private int maxTextMsgSize = 512; // 512 KB
 
-    private Gson gson = new Gson();
+    private final Gson gson = new Gson();
     private ScheduledFuture<?> timeout;
     private LxWebSocket socket;
     private WebSocketClient wsClient;


### PR DESCRIPTION
Main change of this PR is adding support for [Light Controller V2](https://www.loxone.com/enen/kb/lighting-controller-v2/) introduced in version 9 of Loxone Config. This controller has the following features:
  * Outputs (which are basically switches or dimmers). There is no limitation to the number of outputs.
  * Moods, which define how outputs are configured. There is no limitation to the number of moods. Each mood is identified by an integer ID. Enabling a mood sets a corresponding configuration of the outputs (e.g. on/off, dim level). The important feature of the moods is that there can be more than one mood active. In this case, the Miniserver will put an appropriate configuration of the outputs which is a mix of the individual moods. This means moods can be mixed in and mixed out. There is one mood that is treated differently than the other moods: the 'all off' mood. Setting it will disable all outputs, but an attempt to mix it into active moods will cause nothing (it will not be reported as one of active moods).

Lighting controller v2 is modeled in the following way in the binding:
  * Each controller has an 'single active mood' channel. When a mood ID is sent to this channel, it will set this mood and disable all other moods. This is a 'traditional' use case, where controller v2 behaves like previous version of the controller (v1), which had mutually exclusive lighting scenes. This channel will also report a mood ID, if only one mood is active. If more than one mood is active, it will be in undefined state. A mapping between mood ID and mood name is provided, so user can select human readable values.
  * Each output (aka subcontrol) has an individual channel created, which is just like any other switches or dimmers. This way each output can be operated individually like it was not connected to the light controller. 
  * Each mood has an individual channel too, which is a Switch channel. Using this channel we can enable and disable individual moods, so more than one mood can be active and we can utilize the feature of mixing in/out moods.

The consistency of the channel states is provided by the Loxone Miniserver, i.e. when someone enables a mood, a runtime state updates will be sent to the openHAB for the outputs and the current list of active moods. 

The list of all available moods is sent by the Miniserver not together will all other configuration, but as a runtime state update, following immediately the configuration. Dynamic state description provider is used to construct the available options for the single mood channel. Mood channels will be also created when this state update is received.

As outputs of this controller share the states, e.g. a state used to report the max brightness value for a dimmer is included by all dimmer outputs, as long as the value is shared by them, it was necessary to extend the support in the code for multiple controls having the same state UUID.

This PR contains also additional changes, which are mainly simplifications of the code, which became disturbing with growth:
  * Simplified Timed Switch implementation: it can inherit many features after Pushbutton 
  * Added some methods where code was repeated in many places
  * Simplified detection and disposal of unused runtime control objects
  * Improved creation of control objects, instead of long if else, there is a map with object classes now

@jatin-28 - would you agree to review this implementation? I would like to thank your for your PR #2818, which implements the core feature set of the v2 controller. Your experience in how Miniserver works will be invaluable here.

@Hilbrand and @tmrobert8 - if you find some time to provide your great feedback, it would be awesome, I hope I will be able to make it up for you in the next reviews. 

 Signed-off-by: Pawel Pieczul <pieczul@gmail.com> (github: ppieczul)

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  http://docs.openhab.org/developers/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  http://docs.openhab.org/developers/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  http://docs.openhab.org/developers/contributing/contributing#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
