### PR TITLE
[Oceanic] Extend documentation for work-around via socat

### DIFF
--- a/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/handler/OceanicThingHandler.java
+++ b/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/handler/OceanicThingHandler.java
@@ -99,28 +99,6 @@ public class OceanicThingHandler extends BaseThingHandler {
 
         if (serialPort == null && port != null && baud != 0) {
 
-            // Cfr. https://github.com/NeuronRobotics/nrjavaserial/issues/96
-            //
-            // On Ubuntu 17.10 nrjavaserial seems to return only HEX 00 characters through the InputStream of the
-            // SerialPort. The solution is to implement a workaround with socat
-            // and pipe the data from the Serial Port to a pseudo tty, which has to be manipulated in a
-            // CommPortIdentifier.PORT_RAW manner.
-            //
-            // For example : /usr/bin/socat -v /dev/ttyUSB0,raw,echo=0 pty,link=/dev/ttyS1,raw,echo=0
-            //
-            // The workaround can be implemented using a systemd system manager script, for example:
-            //
-            // [Install]
-            // WantedBy=multi-user.target
-            //
-            // [Service]
-            // #Type=forking
-            // ExecStart=/usr/bin/socat -v /dev/ttyUSB0,raw,echo=0 pty,link=/dev/ttyS1,raw,echo=0
-            // #PIDFile=/var/run/socat.pid
-            // User=root
-            // Restart=always
-            // RestartSec=10
-
             if (portId == null) {
                 try {
                     RXTXCommDriver rxtxCommDriver = new RXTXCommDriver();


### PR DESCRIPTION
Replaces https://github.com/openhab/openhab2-addons/pull/2404

Signed-off-by: Karel Goderis <karel.goderis@me.com>