### PR TITLE
[Harmony] Update Readme.md, wrong channel name

### DIFF
--- a/addons/binding/org.openhab.binding.harmonyhub/README.md
+++ b/addons/binding/org.openhab.binding.harmonyhub/README.md
@@ -59,7 +59,7 @@ Hubs can report and change the current activity:
 items:
 
 ```
-String HarmonyGreatRoomActivity              "Current Activity [%s]"  (gMain) { channel="harmonyhub:hub:GreatRoom:activity" }
+String HarmonyGreatRoomActivity              "Current Activity [%s]"  (gMain) { channel="harmonyhub:hub:GreatRoom:currentActivity" }
 ```
 
 Devices can send button presses


### PR DESCRIPTION
channel name needs to be currentActivity

Signed-off-by: Siegfried Huismann <github: sihui62>
