### PR TITLE
[Plugwise] Fix potential NPE during startup

### DIFF
--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
@@ -212,7 +212,10 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
 
     private boolean isAlreadyDiscovered(MACAddress macAddress) {
         ThingUID thingUID = new ThingUID(THING_TYPE_STICK, macAddress.toString());
-        if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
+        if (discoveryServiceCallback == null) {
+            logger.debug("Assuming Stick ({}) has not yet been discovered (callback null)", macAddress);
+            return false;
+        } else if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
             logger.debug("Stick ({}) has existing discovery result: {}", macAddress, thingUID);
             return true;
         } else if (discoveryServiceCallback.getExistingThing(thingUID) != null) {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
@@ -240,7 +240,10 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     private boolean isAlreadyDiscovered(MACAddress macAddress) {
         for (ThingTypeUID thingTypeUID : DISCOVERED_THING_TYPES_UIDS) {
             ThingUID thingUID = new ThingUID(thingTypeUID, macAddress.toString());
-            if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
+            if (discoveryServiceCallback == null) {
+                logger.debug("Assuming Node ({}) has not yet been discovered (callback null)", macAddress);
+                return false;
+            } else if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
                 logger.debug("Node ({}) has existing discovery result: {}", macAddress, thingUID);
                 return true;
             } else if (discoveryServiceCallback.getExistingThing(thingUID) != null) {


### PR DESCRIPTION
When openHAB is started there is a brief moment when a NPE can occur when the Plugwise binding bundle is started before the `org.eclipse.smarthome.config.discovery` bundle.

When messages are handled before the `DiscoveryServiceCallback` is injected the following NPE would get logged:

```
java.lang.NullPointerException: null
    at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.isAlreadyDiscovered(PlugwiseThingDiscoveryService.java:243) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.discoverNewNodeDetails(PlugwiseThingDiscoveryService.java:143) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.discoverNodes(PlugwiseThingDiscoveryService.java:165) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.stickStatusChanged(PlugwiseThingDiscoveryService.java:360) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.handler.PlugwiseStickHandler.updateStatus(PlugwiseStickHandler.java:228) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.updateStatus(BaseThingHandler.java:437) [104:org.eclipse.smarthome.core.thing:0.9.0.201711101643]
    at org.openhab.binding.plugwise.handler.PlugwiseStickHandler.handleNetworkStatusResponse(PlugwiseStickHandler.java:141) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.handler.PlugwiseStickHandler.handleReponseMessage(PlugwiseStickHandler.java:160) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseFilteredMessageListenerList.notifyListeners(PlugwiseFilteredMessageListenerList.java:58) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseMessageProcessor.processMessage(PlugwiseMessageProcessor.java:143) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseMessageProcessor.access$2(PlugwiseMessageProcessor.java:142) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
    at org.openhab.binding.plugwise.internal.PlugwiseMessageProcessor$MessageProcessorThread.run(PlugwiseMessageProcessor.java:52) [181:org.openhab.binding.plugwise:2.2.0.201711121147]
```