### PR TITLE
[avmfritz] small fixes in logic and documentation

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -23,7 +23,11 @@ This [powerline adapter](http://avm.de/produkte/fritzpowerline/fritzpowerline-54
 
 ### FRITZ!DECT 301 / FRITZ!DECT 300 / Comet DECT
 
-These devices [FRITZ!DECT 301](https://avm.de/produkte/fritzdect/fritzdect-301/), [FRITZ!DECT 300](https://avm.de/produkte/fritzdect/fritzdect-300/) and [Comet DECT](https://www.eurotronic.org/produkte/comet-dect.html) ( [EUROtronic Technology GmbH](https://www.eurotronic.org) ) are used to regulate radiators via DECT protocol. The FRITZ!Box can handle up to twelve heating thermostats. The binding provides channels for reading and setting the temperature. Additionally you can check the eco temperature, the comfort temperature and the battery level of the device. The FRITZ!Box has to run at least on firmware FRITZ!OS 6.35.
+These devices [FRITZ!DECT 301](https://avm.de/produkte/fritzdect/fritzdect-301/), FRITZ!DECT 300 and [Comet DECT](https://www.eurotronic.org/produkte/comet-dect.html) ( [EUROtronic Technology GmbH](https://www.eurotronic.org) ) are used to regulate radiators via DECT protocol.
+The FRITZ!Box can handle up to twelve heating thermostats.
+The binding provides channels for reading and setting the temperature.
+Additionally you can check the eco temperature, the comfort temperature and the battery level of the device.
+The FRITZ!Box has to run at least on firmware FRITZ!OS 6.35.
 
 ## Discovery
 
@@ -62,23 +66,23 @@ If correct credentials are set in the bridge configuration, connected AHA device
 
 ## Supported Channels
 
-| Channel Type ID | Item Type | Description                                                                                            | Available on thing                                                                  |
-|-----------------|-----------|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| mode            | String    | States the mode of the device (MANUAL/AUTOMATIC)                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 300, Comet DECT    |
-| locked          | Contact   | Device is locked for switching over external sources (OPEN/CLOSE)                                      | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 300, Comet DECT    |
-| device_locked   | Contact   | Device is locked for switching manually (OPEN/CLOSE) - FRITZ!OS 6.90                                   | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 300, Comet DECT    |
-| temperature     | Number    | Actual measured temperature (in °C)                                                                    | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!DECT Repeater 100, FRITZ!DECT 300, Comet DECT |
-| energy          | Number    | Accumulated energy consumption (in kWh)                                                                | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                |
-| power           | Number    | Current power consumption (in W)                                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                |
-| outlet          | Switch    | Switchable outlet (ON/OFF)                                                                             | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                |
-| actual_temp     | Number    | Actual Temperature of heating thermostat (in °C)                                                       | FRITZ!DECT 300, Comet DECT                                                          |
-| set_temp        | Number    | Set Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 300, Comet DECT                                                          |
-| eco_temp        | Number    | Eco Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 300, Comet DECT                                                          |
-| comfort_temp    | Number    | Comfort Temperature of heating thermostat (in °C)                                                      | FRITZ!DECT 300, Comet DECT                                                          |
-| radiator_mode   | String    | Mode of heating thermostat (ON/OFF/COMFORT/ECO/BOOST)                                                  | FRITZ!DECT 300, Comet DECT                                                          |
-| next_change     | DateTime  | Next change of the Set Temperature if scheduler is activated in the FRITZ!Box settings - FRITZ!OS 6.80 | FRITZ!DECT 300, Comet DECT                                                          |
-| next_temp       | Number    | Next Set Temperature if scheduler is activated in the FRITZ!Box settings (in °C) - FRITZ!OS 6.80       | FRITZ!DECT 300, Comet DECT                                                          |
-| battery_low     | Switch    | Battery Level Low (ON/OFF) - FRITZ!OS 6.80                                                             | FRITZ!DECT 300, Comet DECT                                                          |
+| Channel Type ID | Item Type | Description                                                                                            | Available on thing                                                                                  |
+|-----------------|-----------|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| mode            | String    | States the mode of the device (MANUAL/AUTOMATIC)                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
+| locked          | Contact   | Device is locked for switching over external sources (OPEN/CLOSE)                                      | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
+| device_locked   | Contact   | Device is locked for switching manually (OPEN/CLOSE) - FRITZ!OS 6.90                                   | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
+| temperature     | Number    | Actual measured temperature (in °C)                                                                    | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!DECT Repeater 100, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT |
+| energy          | Number    | Accumulated energy consumption (in kWh)                                                                | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
+| power           | Number    | Current power consumption (in W)                                                                       | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
+| outlet          | Switch    | Switchable outlet (ON/OFF)                                                                             | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
+| actual_temp     | Number    | Actual Temperature of heating thermostat (in °C)                                                       | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| set_temp        | Number    | Set Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| eco_temp        | Number    | Eco Temperature of heating thermostat (in °C)                                                          | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| comfort_temp    | Number    | Comfort Temperature of heating thermostat (in °C)                                                      | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| radiator_mode   | String    | Mode of heating thermostat (ON/OFF/COMFORT/ECO/BOOST)                                                  | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| next_change     | DateTime  | Next change of the Set Temperature if scheduler is activated in the FRITZ!Box settings - FRITZ!OS 6.80 | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| next_temp       | Number    | Next Set Temperature if scheduler is activated in the FRITZ!Box settings (in °C) - FRITZ!OS 6.80       | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| battery_low     | Switch    | Battery Level Low (ON/OFF) - FRITZ!OS 6.80                                                             | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 
 
 ## Full Example

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -183,7 +183,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             case CHANNEL_SETTEMP:
                 if (command instanceof DecimalType) {
                     BigDecimal temperature = new BigDecimal(command.toString());
-                    state.getHkr().setTist(temperature);
+                    state.getHkr().setTsoll(temperature);
                     fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(temperature));
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else if (command instanceof IncreaseDecreaseType) {
@@ -193,13 +193,13 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                     } else {
                         temperature.subtract(BigDecimal.ONE);
                     }
-                    state.getHkr().setTist(temperature);
+                    state.getHkr().setTsoll(temperature);
                     fritzBox.setSetTemp(ain, temperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else if (command instanceof OnOffType) {
                     BigDecimal temperature = OnOffType.ON.equals(command) ? HeatingModel.TEMP_FRITZ_ON
                             : HeatingModel.TEMP_FRITZ_OFF;
-                    state.getHkr().setTist(temperature);
+                    state.getHkr().setTsoll(temperature);
                     fritzBox.setSetTemp(ain, temperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else {
@@ -209,27 +209,27 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             case CHANNEL_RADIATOR_MODE:
                 if (command instanceof StringType) {
                     if (command.equals(MODE_ON)) {
-                        state.getHkr().setTist(HeatingModel.TEMP_FRITZ_ON);
+                        state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_ON);
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_ON);
                         updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_ON)));
                     } else if (command.equals(MODE_OFF)) {
-                        state.getHkr().setTist(HeatingModel.TEMP_FRITZ_OFF);
+                        state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_OFF);
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_OFF);
                         updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_OFF)));
                     } else if (command.equals(MODE_COMFORT)) {
                         BigDecimal comfort_temp = state.getHkr().getKomfort();
-                        state.getHkr().setTist(comfort_temp);
+                        state.getHkr().setTsoll(comfort_temp);
                         fritzBox.setSetTemp(ain, comfort_temp);
                         updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(comfort_temp)));
                     } else if (command.equals(MODE_ECO)) {
                         BigDecimal eco_temp = state.getHkr().getAbsenk();
-                        state.getHkr().setTist(eco_temp);
+                        state.getHkr().setTsoll(eco_temp);
                         fritzBox.setSetTemp(ain, eco_temp);
                         updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(eco_temp)));
                     } else if (command.equals(MODE_BOOST)) {
-                        state.getHkr().setTist(HeatingModel.TEMP_FRITZ_MAX);
+                        state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_MAX);
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_MAX);
                         updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_MAX)));
@@ -305,8 +305,9 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             }
             if (device.isSwitchableOutlet() && device.getSwitch() != null) {
                 updateThingChannelState(thing, CHANNEL_MODE, new StringType(device.getSwitch().getMode()));
-                updateThingChannelState(thing, CHANNEL_LOCKED, device.getSwitch().getLock().equals(BigDecimal.ONE)
-                        ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
+                updateThingChannelState(thing, CHANNEL_LOCKED,
+                        device.getSwitch().getLock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED
+                                : OpenClosedType.OPEN);
                 updateThingChannelState(thing, CHANNEL_DEVICE_LOCKED,
                         device.getSwitch().getDevicelock().equals(BigDecimal.ONE) ? OpenClosedType.CLOSED
                                 : OpenClosedType.OPEN);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -153,24 +153,28 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.debug("Handle command {} for channel {}", channelUID.getIdWithoutGroup(), command);
+        String channelId = channelUID.getIdWithoutGroup();
+        logger.debug("Handle command {} for channel {}", channelId, command);
         FritzahaWebInterface fritzBox = getWebInterface();
         if (fritzBox == null) {
             return;
         }
         String ain = getThing().getConfiguration().get(THING_AIN).toString();
-        switch (channelUID.getIdWithoutGroup()) {
+        switch (channelId) {
+            case CHANNEL_MODE:
+            case CHANNEL_LOCKED:
+            case CHANNEL_DEVICE_LOCKED:
             case CHANNEL_TEMP:
             case CHANNEL_ENERGY:
             case CHANNEL_POWER:
+            case CHANNEL_ACTUALTEMP:
             case CHANNEL_ECOTEMP:
             case CHANNEL_COMFORTTEMP:
-            case CHANNEL_MODE:
-            case CHANNEL_LOCKED:
-            case CHANNEL_ACTUALTEMP:
             case CHANNEL_NEXTCHANGE:
             case CHANNEL_NEXTTEMP:
             case CHANNEL_BATTERY:
+                logger.debug("Channel {} is a read-only channel and cannot handle command '{}'.", channelId, command);
+                logger.warn("Received unknown command {} for channel {}", command, CHANNEL_SWITCH);
                 break;
             case CHANNEL_SWITCH:
                 if (command instanceof OnOffType) {
@@ -239,7 +243,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                 }
                 break;
             default:
-                logger.debug("Received unknown channel {}", channelUID.getIdWithoutGroup());
+                logger.debug("Received unknown channel {}", channelId);
                 break;
         }
     }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -154,7 +154,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String channelId = channelUID.getIdWithoutGroup();
-        logger.debug("Handle command {} for channel {}", channelId, command);
+        logger.debug("Handle command '{}' for channel {}", command, channelId);
         FritzahaWebInterface fritzBox = getWebInterface();
         if (fritzBox == null) {
             return;
@@ -174,14 +174,13 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             case CHANNEL_NEXTTEMP:
             case CHANNEL_BATTERY:
                 logger.debug("Channel {} is a read-only channel and cannot handle command '{}'.", channelId, command);
-                logger.warn("Received unknown command {} for channel {}", command, CHANNEL_SWITCH);
                 break;
             case CHANNEL_SWITCH:
                 if (command instanceof OnOffType) {
                     state.getSwitch().setState(OnOffType.ON.equals(command) ? SwitchModel.ON : SwitchModel.OFF);
                     fritzBox.setSwitch(ain, OnOffType.ON.equals(command));
                 } else {
-                    logger.warn("Received unknown command {} for channel {}", command, CHANNEL_SWITCH);
+                    logger.warn("Received unknown command '{}' for channel {}", command, CHANNEL_SWITCH);
                 }
                 break;
             case CHANNEL_SETTEMP:
@@ -207,7 +206,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                     fritzBox.setSetTemp(ain, temperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else {
-                    logger.warn("Received unknown command {} for channel {}", command, CHANNEL_SETTEMP);
+                    logger.warn("Received unknown command '{}' for channel {}", command, CHANNEL_SETTEMP);
                 }
                 break;
             case CHANNEL_RADIATOR_MODE:
@@ -238,7 +237,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                         updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_MAX)));
                     } else {
-                        logger.warn("Received unknown command {} for channel {}", command, CHANNEL_RADIATOR_MODE);
+                        logger.warn("Received unknown command '{}' for channel {}", command, CHANNEL_RADIATOR_MODE);
                     }
                 }
                 break;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/HeatingModel.java
@@ -103,7 +103,7 @@ public class HeatingModel {
         } else if (TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
             return MODE_BOOST;
         } else {
-            return MODE_UNKNOWN;
+            return MODE_ON;
         }
     }
 


### PR DESCRIPTION
- Changed 'radiator_mode' to 'MODE_ON' if no matching temperature can be found
- Store new temperature in 'Tsoll' instead of 'Tist'
- Minor fixes in 'handleCommand' method
- README: Removed dead link; Added FRITZ!DECT 301 to channel matrix

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>