### PR TITLE
[homematic] Added piVCCU to README of homematic binding

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/README.md
+++ b/addons/binding/org.openhab.binding.homematic/README.md
@@ -8,6 +8,7 @@ This binding allows you to integrate, view, control and configure all Homematic 
 All gateways which provides the Homematic BIN- or XML-RPC API: 
 * CCU 1+2 
 * [Homegear](https://www.homegear.eu)
+* [piVCCU](https://github.com/alexreinert/piVCCU)
 * [YAHM](https://github.com/leonsio/YAHM)
 * [Windows BidCos service](http://www.eq-3.de/downloads.html?kat=download&id=125)
 * [OCCU](https://github.com/eq-3/occu)


### PR DESCRIPTION
piVCCU is an additional virtual CCU project, which can be used as bridge between Openhab and the Homematic devices. So I think, it should be mentioned in the README, too.