### PR TITLE
Add serial-port context to config parameters of bindings

### DIFF
--- a/addons/binding/org.openhab.binding.cm11a/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.cm11a/ESH-INF/thing/thing-types.xml
@@ -12,8 +12,8 @@
         <config-description>
             <parameter name="serialPort" type="text" required="true" >
                 <label>Serial port</label>
-                <description>Serial port used to communicate with the CM11a
-                </description>
+                <context>serial-port</context>
+                <description>Serial port used to communicate with the CM11a</description>
             </parameter>
             <parameter name="refresh" type="integer" min="1">
                 <label>Refresh interval</label>

--- a/addons/binding/org.openhab.binding.lgtvserial/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lgtvserial/ESH-INF/thing/thing-types.xml
@@ -20,6 +20,7 @@
         <config-description>
             <parameter name="port" type="text">
                 <label>Serial port</label>
+                <context>serial-port</context>
                 <description>Select serial port (COM1, /dev/ttyS0, ...)</description>
                 <required>true</required>
             </parameter>

--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
 		<config-description>
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
+				<context>serial-port</context>
 				<description>Serial port that the Meteostick is plugged in to</description>
 			</parameter>
 			<parameter name="mode" type="integer" required="true">

--- a/addons/binding/org.openhab.binding.plugwise/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.plugwise/ESH-INF/config/config.xml
@@ -6,6 +6,7 @@
     <config-description uri="bridge-type:plugwise:stick">
         <parameter name="serialPort" type="text" required="true">
             <label>Serial port</label>
+            <context>serial-port</context>
             <description>The serial port of the Stick, e.g. "/dev/ttyUSB0" for Linux or "COM1" for Windows</description>
             <default>/dev/ttyUSB0</default>
         </parameter>

--- a/addons/binding/org.openhab.binding.regoheatpump/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.regoheatpump/ESH-INF/thing/thing-types.xml
@@ -54,6 +54,7 @@
         <config-description>
             <parameter name="portName" type="text" required="true">
                 <label>Port</label>
+                <context>serial-port</context>
                 <description>The serial port used to connect to the Rego controller.</description>
             </parameter>
             <parameter name="refreshInterval" type="integer" max="65535" min="10" required="false">
@@ -105,6 +106,7 @@
         <config-description>
             <parameter name="portName" type="text" required="true">
                 <label>Port</label>
+                <context>serial-port</context>
                 <description>The serial port used to connect to the Husdata interface.</description>
             </parameter>
         </config-description>        

--- a/addons/binding/org.openhab.binding.urtsi/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.urtsi/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
         <config-description>
             <parameter name="port" type="text" required="true">
                 <label>@text/urtsiDevicePortLabel</label>
+                <context>serial-port</context>
                 <description>@text/urtsiDevicePortDescription</description>
             </parameter>
             <parameter name="commandInterval" type="integer" required="false" min="50" max="5000">


### PR DESCRIPTION
Adds the serial-port context to the other bindings that have a serial port configuration parameter but were not part of #2852.