### PR TITLE
[homekit] Making the temperature range more realistic

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -28,8 +28,8 @@ public class HomekitSettings {
     private int port = 9123;
     private String pin = "031-45-154";
     private boolean useFahrenheitTemperature = false;
-    private double minimumTemperature = -100;
-    private double maximumTemperature = 100;
+    private double minimumTemperature = -30;
+    private double maximumTemperature = 95;
     private String thermostatHeatMode = "HeatOn";
     private String thermostatCoolMode = "CoolOn";
     private String thermostatAutoMode = "Auto";


### PR DESCRIPTION
When using range -100 to 100 for temperature, it's hard to set particular temperature in the Home app, as because of the large range, adjusting is too sensitive. Minimum of 30 and maximum of 95  Fahrenheit/Celsia should be enough. The ideal case would be to have these values separated based on unit type - Fahrenheit/Celsia, but I'm not able to do it.