### PR TITLE
Return UnDefType.UNDEF instead UnDefType.NULL 

### DIFF
--- a/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/handler/AllPlayHandler.java
+++ b/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/handler/AllPlayHandler.java
@@ -448,13 +448,13 @@ public class AllPlayHandler extends BaseThingHandler
             PlaylistItem currentItem = items.iterator().next();
             updateCurrentItemState(currentItem);
         } else {
-            updateState(CURRENT_ARTIST, UnDefType.NULL);
-            updateState(CURRENT_ALBUM, UnDefType.NULL);
-            updateState(CURRENT_TITLE, UnDefType.NULL);
-            updateState(CURRENT_GENRE, UnDefType.NULL);
-            updateState(CURRENT_URL, UnDefType.NULL);
-            updateState(COVER_ART_URL, UnDefType.NULL);
-            updateState(COVER_ART, UnDefType.NULL);
+            updateState(CURRENT_ARTIST, UnDefType.UNDEF);
+            updateState(CURRENT_ALBUM, UnDefType.UNDEF);
+            updateState(CURRENT_TITLE, UnDefType.UNDEF);
+            updateState(CURRENT_GENRE, UnDefType.UNDEF);
+            updateState(CURRENT_URL, UnDefType.UNDEF);
+            updateState(COVER_ART_URL, UnDefType.UNDEF);
+            updateState(COVER_ART, UnDefType.UNDEF);
         }
     }
 
@@ -489,7 +489,7 @@ public class AllPlayHandler extends BaseThingHandler
             if (!coverArtUrl.isEmpty()) {
                 updateState(COVER_ART, new RawType(getRawDataFromUrl(coverArtUrl)));
             } else {
-                updateState(COVER_ART, UnDefType.NULL);
+                updateState(COVER_ART, UnDefType.UNDEF);
             }
         } catch (Exception e) {
             logger.warn("Error getting cover art", e);

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaThingHandler.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaThingHandler.java
@@ -129,7 +129,7 @@ public class GardenaThingHandler extends BaseThingHandler {
 
         if (StringUtils.trimToNull(value) == null || StringUtils.equals(value, "N/A")
                 || StringUtils.startsWith(value, "1970-01-01")) {
-            return UnDefType.NULL;
+            return UnDefType.UNDEF;
         }
 
         switch (getThing().getChannel(channelUID.getId()).getAcceptedItemType()) {
@@ -145,7 +145,7 @@ public class GardenaThingHandler extends BaseThingHandler {
                         case "excellent":
                             return new DecimalType(4);
                         default:
-                            return UnDefType.NULL;
+                            return UnDefType.UNDEF;
                     }
                 }
                 return new DecimalType(value);
@@ -157,7 +157,7 @@ public class GardenaThingHandler extends BaseThingHandler {
                     return new DateTimeType(cal);
                 }
         }
-        return UnDefType.NULL;
+        return UnDefType.UNDEF;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
@@ -108,7 +108,7 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestDevice
 
     protected State getAsDateTimeTypeOrNull(Date date) {
         if (date == null) {
-            return UnDefType.NULL;
+            return UnDefType.UNDEF;
         }
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
@@ -120,7 +120,7 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestDevice
     }
 
     protected State getAsStringTypeOrNull(Object value) {
-        return value == null ? UnDefType.NULL : new StringType(value.toString());
+        return value == null ? UnDefType.UNDEF : new StringType(value.toString());
     }
 
     protected boolean isNotHandling(NestIdentifiable nestIdentifiable) {

--- a/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/handler/Rego6xxHeatPumpHandler.java
+++ b/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/handler/Rego6xxHeatPumpHandler.java
@@ -187,7 +187,7 @@ abstract class Rego6xxHeatPumpHandler extends BaseThingHandler {
     private void readAndUpdateLastError(String channelIID, Function<ErrorLine, State> converter) {
         executeCommandAndUpdateState(channelIID, CommandFactory.createReadLastErrorCommand(),
                 ResponseParserFactory.ErrorLine, e -> {
-                    return e == null ? UnDefType.NULL : converter.apply(e);
+                    return e == null ? UnDefType.UNDEF : converter.apply(e);
                 });
     }
 


### PR DESCRIPTION
Return `UnDefType.UNDEF` instead `UnDefType.NULL` because `UnDefType.NULL` one is meant for internal ues/initialisation only.

Related to https://github.com/eclipse/smarthome/issues/4612