### PR TITLE
Remove org.osgi.service.component.annotations from manifests

### DIFF
--- a/addons/binding/org.openhab.binding.allplay/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.allplay/META-INF/MANIFEST.MF
@@ -40,6 +40,5 @@ Import-Package:
  org.openhab.binding.allplay.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
@@ -34,6 +34,5 @@ Import-Package:
  org.openhab.binding.avmfritz,
  org.openhab.binding.avmfritz.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.bigassfan/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.bigassfan/META-INF/MANIFEST.MF
@@ -28,6 +28,5 @@ Import-Package:
  org.openhab.binding.bigassfan,
  org.openhab.binding.bigassfan.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.chromecast/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.chromecast/META-INF/MANIFEST.MF
@@ -38,6 +38,5 @@ Import-Package:
  org.openhab.binding.chromecast.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -43,6 +43,5 @@ Import-Package:
  org.openhab.binding.freebox.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.globalcache/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.globalcache/META-INF/MANIFEST.MF
@@ -29,6 +29,5 @@ Import-Package:
  org.openhab.binding.globalcache.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
@@ -44,6 +44,5 @@ Import-Package:
  org.openhab.binding.harmonyhub,
  org.openhab.binding.harmonyhub.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
@@ -48,6 +48,5 @@ Import-Package:
  org.openhab.binding.homematic.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.kodi/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.kodi/META-INF/MANIFEST.MF
@@ -37,6 +37,5 @@ Import-Package:
  org.openhab.binding.kodi.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.loxone/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.loxone/META-INF/MANIFEST.MF
@@ -43,6 +43,5 @@ Import-Package:
  org.openhab.binding.loxone,
  org.openhab.binding.loxone.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
@@ -39,6 +39,5 @@ Import-Package:
  org.openhab.binding.nest,
  org.openhab.binding.nest.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
@@ -27,6 +27,5 @@ Import-Package:
  org.openhab.binding.network,
  org.openhab.binding.network.handler,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
@@ -30,6 +30,5 @@ Import-Package:
  org.openhab.binding.onkyo.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
@@ -29,6 +29,5 @@ Import-Package:
  org.openhab.binding.plugwise,
  org.openhab.binding.plugwise.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.sensebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.sensebox/META-INF/MANIFEST.MF
@@ -28,6 +28,5 @@ Import-Package:
  org.openhab.binding.sensebox,
  org.openhab.binding.sensebox.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
@@ -37,6 +37,5 @@ Import-Package:
  org.openhab.binding.squeezebox,
  org.openhab.binding.squeezebox.handler,
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.synopanalyzer/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.synopanalyzer/META-INF/MANIFEST.MF
@@ -20,6 +20,5 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.net.http,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
@@ -34,6 +34,5 @@ Import-Package:
  org.openhab.binding.yamahareceiver.handler,
  org.osgi.framework,
  org.osgi.service.component,
- org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
See https://github.com/openhab/openhab2-addons/pull/2878#issuecomment-346804361
