### PR TITLE
[Harmony] Asynchronously retrieve Hub configuration to fix timeout exceptions

### DIFF
--- a/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
@@ -34,6 +34,7 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.cache,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
@@ -144,7 +144,11 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
         if (bridgeStatus == ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.ONLINE) {
             bridge = (HarmonyHubHandler) getBridge().getHandler();
             updateStatus(ThingStatus.ONLINE);
-            bridge.getConfigFuture().thenAcceptAsync(this::updateChannel, scheduler);
+            bridge.getConfigFuture().thenAcceptAsync(this::updateChannel, scheduler).exceptionally(e -> {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Getting config failed: " + e.getMessage());
+                return null;
+            });
         } else if (bridgeStatus != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
@@ -144,7 +144,7 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
         if (bridgeStatus == ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.ONLINE) {
             bridge = (HarmonyHubHandler) getBridge().getHandler();
             updateStatus(ThingStatus.ONLINE);
-            updateChannel();
+            bridge.getConfigFuture().thenAcceptAsync(this::updateChannel, scheduler);
         } else if (bridgeStatus != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
@@ -153,11 +153,10 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
     /**
      * Updates our channel with the available buttons as option states
      */
-    private void updateChannel() {
+    private void updateChannel(HarmonyConfig config) {
         try {
             logger.debug("updateChannel for device {}", logName);
 
-            HarmonyConfig config = bridge.getCachedConfig();
             if (config == null) {
                 logger.debug("updateChannel: could not get config from bridge {}", logName);
                 return;

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyDeviceDiscoveryService.java
@@ -75,17 +75,20 @@ public class HarmonyDeviceDiscoveryService extends AbstractDiscoveryService impl
      * Discovers devices connected to a hub
      */
     private void discoverDevices() {
-        if (bridge.getClient() == null) {
-            logger.debug("Harmony client not connected, scanning postponed.");
+        if (bridge.getThing().getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Harmony Hub not online, scanning postponed");
             return;
         }
         logger.debug("getting devices on {}", bridge.getThing().getUID().getId());
-        HarmonyConfig config = null;
-
-        try {
-            config = bridge.getCachedConfig();
-        } catch (Exception e) {
+        bridge.getConfigFuture().thenAccept(this::addDiscoveryResults).exceptionally(e -> {
             logger.debug("Could not get harmony config for discovery, skipping");
+            return null;
+        });
+    }
+
+    private void addDiscoveryResults(HarmonyConfig config) {
+        if (config == null) {
+            logger.debug("addDiscoveryResults: skipping null config");
             return;
         }
 


### PR DESCRIPTION
Fixes #2573.

The main issue is that retrieving the full Harmony Hub configuration is an expensive operation. At startup (or when saving a .things file) all Harmony Hub and Device Handlers would start retrieving this configuration synchronously using the Thread calling `initialize()`. This causes the timeout exceptions/warnings and may block other handlers from making progress while retrieving the configuration. This can even consume the whole thread pool for people having a lot of hubs and devices.

The code now asynchronously retrieves the Hub configuration by reusing the `ExpiringCacheAsync` with a thread from the default Thing handler thread pool. This should fix the exceptions and also allow other handlers to be initialized while the configuration is being retrieved.