### PR TITLE
[Nest] Fix NFE and add state and fan_timer_timeout channels to Thermostat

### DIFF
--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
@@ -114,12 +114,12 @@ public class GsonParsingTest {
         assertEquals((Integer) 10, Thermostat.parseTimeToTarget("<10"));
         assertEquals((Integer) 15, Thermostat.parseTimeToTarget("~15"));
         assertEquals((Integer) 90, Thermostat.parseTimeToTarget("~90"));
-        assertEquals((Integer) 120, Thermostat.parseTimeToTarget("120"));
+        assertEquals((Integer) 120, Thermostat.parseTimeToTarget(">120"));
     }
 
     @Test(expected = NumberFormatException.class)
     public void thermostatTimeToTargetUnsupportedValueParsing() {
-        Thermostat.parseTimeToTarget(">5");
+        Thermostat.parseTimeToTarget("#5");
     }
 
     @Test

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/channels.xml
@@ -174,7 +174,7 @@
 		<label>Set Point</label>
 		<description>The set point in degrees Celsius</description>
 		<category>Temperature</category>
-        <state pattern="%.1f °C" step="0.5" />
+		<state pattern="%.1f °C" step="0.5" />
 	</channel-type>
 
 	<channel-type id="MaxSetPoint">
@@ -182,7 +182,7 @@
 		<label>Max Set Point</label>
 		<description>The max set point in degrees Celsius</description>
 		<category>Temperature</category>
-        <state pattern="%.1f °C" step="0.5" />
+		<state pattern="%.1f °C" step="0.5" />
 	</channel-type>
 
 	<channel-type id="MinSetPoint">
@@ -190,7 +190,7 @@
 		<label>Min Set Point</label>
 		<description>The min set point in degrees Celsius</description>
 		<category>Temperature</category>
-        <state pattern="%.1f °C" step="0.5" />
+		<state pattern="%.1f °C" step="0.5" />
 	</channel-type>
 
 	<channel-type id="LockedMaxSetPoint" advanced="true">
@@ -206,7 +206,7 @@
 		<label>Locked Min Set Point</label>
 		<description>The locked range min set point in degrees Celsius</description>
 		<category>Temperature</category>
-        <state pattern="%.1f °C" step="0.5" />
+		<state pattern="%.1f °C" step="0.5" />
 	</channel-type>
 
 	<channel-type id="Locked" advanced="true">
@@ -246,6 +246,19 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="State" advanced="true">
+		<item-type>String</item-type>
+		<label>State</label>
+		<description>The active state of the Nest thermostat</description>
+		<state readOnly="true">
+			<options>
+				<option value="OFF">off</option>
+				<option value="HEATING">heating</option>
+				<option value="COOLING">cooling</option>
+			</options>
+		</state>
+	</channel-type>
+
 	<channel-type id="Humidity">
 		<item-type>Number</item-type>
 		<label>Humidity</label>
@@ -279,14 +292,21 @@
 		<item-type>Switch</item-type>
 		<label>Fan Timer Active</label>
 		<description>If the fan timer is engaged</description>
-		<state/>
+		<state />
 	</channel-type>
 
 	<channel-type id="FanTimerDuration" advanced="true">
 		<item-type>Number</item-type>
 		<label>Fan Timer Duration</label>
 		<description>Length of time (in minutes) that the fan is set to run</description>
-		<state/>
+		<state />
+	</channel-type>
+
+	<channel-type id="FanTimerTimeout" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Fan Timer Timeout</label>
+		<description>Timestamp when the fan stops running</description>
+		<state readOnly="true" />
 	</channel-type>
 
 	<channel-type id="HasFan" advanced="true">

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/thermostat.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/thermostat.xml
@@ -16,6 +16,7 @@
 			<channel id="humidity" typeId="Humidity" />
 			<channel id="mode" typeId="Mode" />
 			<channel id="previous_mode" typeId="PreviousMode" />
+			<channel id="state" typeId="State" />
 			<channel id="set_point" typeId="SetPoint" />
 			<channel id="max_set_point" typeId="MaxSetPoint" />
 			<channel id="min_set_point" typeId="MinSetPoint" />
@@ -23,6 +24,7 @@
 			<channel id="can_cool" typeId="CanCool" />
 			<channel id="fan_timer_active" typeId="FanTimerActive" />
 			<channel id="fan_timer_duration" typeId="FanTimerDuration" />
+			<channel id="fan_timer_timeout" typeId="FanTimerTimeout" />
 			<channel id="has_fan" typeId="HasFan" />
 			<channel id="has_leaf" typeId="HasLeaf" />
 			<channel id="sunlight_correction_enabled" typeId="SunlightCorrectionEnabled" />

--- a/addons/binding/org.openhab.binding.nest/README.md
+++ b/addons/binding/org.openhab.binding.nest/README.md
@@ -8,13 +8,13 @@ Because the Nest API runs on Nest's servers a connection with the Internet is re
 
 The table below lists the Nest binding thing types:
 
-| Things                                  | Description                              | Thing Type     |
-| --------------------------------------- | ---------------------------------------- | -------------- |
-| Nest Account                            | An account for using the Nest REST API   | account        |
-| Nest Cam (Indoor, IQ, Outdoor), Dropcam | A Nest Cam registered with your account  | camera         |
-| Nest Protect                            | The smoke detector/Nest Protect for the account | smoke_detector |
-| Structure                               | The Nest structure defines the house the account has setup on Nest.	You will only have more than one structure if you have more than one house | structure      |
-| Nest Thermostat (E)                     | A Thermostat to control the various aspects of the house's HVAC system | thermostat     |
+| Things                                  | Description                                                                                                                                    | Thing Type     |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| Nest Account                            | An account for using the Nest REST API                                                                                                         | account        |
+| Nest Cam (Indoor, IQ, Outdoor), Dropcam | A Nest Cam registered with your account                                                                                                        | camera         |
+| Nest Protect                            | The smoke detector/Nest Protect for the account                                                                                                | smoke_detector |
+| Structure                               | The Nest structure defines the house the account has setup on Nest. You will only have more than one structure if you have more than one house | structure      |
+| Nest Thermostat (E)                     | A Thermostat to control the various aspects of the house's HVAC system                                                                         | thermostat     |
 
 ## Authorization
 
@@ -47,67 +47,68 @@ The account Thing Type does not have any channels.
 
 ### Camera Channels
 
-
-| Channel Type ID       | Item Type | Description                              | Read Write |
-| --------------------- | --------- | ---------------------------------------- | :--------: |
-| app_url               | String    | The app URL to see the camera            |     R      |
-| audio_input_enabled   | Switch    | If the audio input is currently enabled  |     R      |
-| public_share_enabled  | Switch    | If public sharing is currently enabled   |     R      |
-| public_share_url      | String    | The URL to see the public share of the camera |     R      |
-| snapshot_url          | String    | The URL to use for a snapshot of the video stream |     R      |
-| streaming             | Switch    | If the camera is currently streaming     |    R/W     |
-| video_history_enabled | Switch    | If the video history is currently enabled |     R      |
-| web_url               | String    | The web URL to see the camera            |     R      |
+| Channel Type ID       | Item Type | Description                                       | Read Write |
+|-----------------------|-----------|---------------------------------------------------|:----------:|
+| app_url               | String    | The app URL to see the camera                     |      R     |
+| audio_input_enabled   | Switch    | If the audio input is currently enabled           |      R     |
+| public_share_enabled  | Switch    | If public sharing is currently enabled            |      R     |
+| public_share_url      | String    | The URL to see the public share of the camera     |      R     |
+| snapshot_url          | String    | The URL to use for a snapshot of the video stream |      R     |
+| streaming             | Switch    | If the camera is currently streaming              |     R/W    |
+| video_history_enabled | Switch    | If the video history is currently enabled         |      R     |
+| web_url               | String    | The web URL to see the camera                     |      R     |
 
 ### Smoke Detector Channels
 
-| Channel Type ID    | Item Type | Description                              | Read Write |
-| ------------------ | --------- | ---------------------------------------- | :--------: |
-| co_alarm_state     | String    | The carbon monoxide alarm state of the Nest Protect (OK, EMERGENCY, WARNING) |     R      |
-| low_battery        | Switch    | Reports whether the battery of the Nest protect is low (if it is battery powered) |     R      |
-| manual_test_active | Switch    | Manual test active at the moment         |     R      |
-| smoke_alarm_state  | String    | The smoke alarm state of the Nest Protect (OK, EMERGENCY, WARNING) |     R      |
-| ui_color_state     | String    | The current color of the ring on the smoke detector (GRAY, GREEN, YELLOW, RED) |     R      |
+| Channel Type ID    | Item Type | Description                                                                       | Read Write |
+|--------------------|-----------|-----------------------------------------------------------------------------------|:----------:|
+| co_alarm_state     | String    | The carbon monoxide alarm state of the Nest Protect (OK, EMERGENCY, WARNING)      |      R     |
+| low_battery        | Switch    | Reports whether the battery of the Nest protect is low (if it is battery powered) |      R     |
+| manual_test_active | Switch    | Manual test active at the moment                                                  |      R     |
+| smoke_alarm_state  | String    | The smoke alarm state of the Nest Protect (OK, EMERGENCY, WARNING)                |      R     |
+| ui_color_state     | String    | The current color of the ring on the smoke detector (GRAY, GREEN, YELLOW, RED)    |      R     |
 
 ### Structure Channels
 
-| Channel Type ID              | Item Type | Description                              | Read Write |
-| ---------------------------- | --------- | ---------------------------------------- | :--------: |
-| away                         | String    | Away state of the structure (HOME, AWAY, AUTO_AWAY) |    R/W     |
-| country_code                 | String    | Country code of the structure ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) |     R      |
-| co_alarm_state               | String    | Carbon Monoxide alarm state (OK, EMERGENCY, WARNING) |     R      |
-| eta_begin                    | DateTime  | Estimated time of arrival at home, will setup the heat to turn on and be warm |     R      |
-| peak_period_end_time         | DateTime  | Peak period end for the Rush Hour Rewards program |     R      |
-| peak_period_start_time       | DateTime  | Peak period start for the Rush Hour Rewards program |     R      |
-| postal_code                  | String    | Postal code of the structure             |     R      |
-| rush_hour_rewards_enrollment | Switch    | If rush hour rewards system is enabled or not |     R      |
-| smoke_alarm_state            | String    | Smoke alarm state (OK, EMERGENCY, WARNING) |     R      |
-| time_zone                    | String    | The time zone for the structure ([IANA time zone format](http://www.iana.org/time-zones)) |     R      |
+| Channel Type ID              | Item Type | Description                                                                                            | Read Write |
+|------------------------------|-----------|--------------------------------------------------------------------------------------------------------|:----------:|
+| away                         | String    | Away state of the structure (HOME, AWAY, AUTO_AWAY)                                                    |     R/W    |
+| country_code                 | String    | Country code of the structure ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) |      R     |
+| co_alarm_state               | String    | Carbon Monoxide alarm state (OK, EMERGENCY, WARNING)                                                   |      R     |
+| eta_begin                    | DateTime  | Estimated time of arrival at home, will setup the heat to turn on and be warm                          |      R     |
+| peak_period_end_time         | DateTime  | Peak period end for the Rush Hour Rewards program                                                      |      R     |
+| peak_period_start_time       | DateTime  | Peak period start for the Rush Hour Rewards program                                                    |      R     |
+| postal_code                  | String    | Postal code of the structure                                                                           |      R     |
+| rush_hour_rewards_enrollment | Switch    | If rush hour rewards system is enabled or not                                                          |      R     |
+| smoke_alarm_state            | String    | Smoke alarm state (OK, EMERGENCY, WARNING)                                                             |      R     |
+| time_zone                    | String    | The time zone for the structure ([IANA time zone format](http://www.iana.org/time-zones))              |      R     |
 
 ### Thermostat Channels
 
-| Channel Type ID             | Item Type | Description                              | Read Write |
-| --------------------------- | --------- | ---------------------------------------- | :--------: |
-| can_cool                    | Switch    | If the thermostat can actually turn on cooling |     R      |
-| can_heat                    | Switch    | If the thermostat can actually turn on heating |     R      |
-| fan_timer_active            | Switch    | If the fan timer is engaged              |    R/W     |
-| fan_timer_duration          | Number    | Length of time (in minutes) that the fan is set to run (15, 30, 45, 60, 120, 240, 480, 960) |    R/W     |
-| has_fan                     | Switch    | If the thermostat can control the fan    |     R      |
-| has_leaf                    | Switch    | If the thermostat is currently in a leaf mode |     R      |
-| humidity                    | Number    | Indicates the current relative humidity  |     R      |
-| locked                      | Switch    | If the thermostat has the temperature locked to only be within a set range |    R     |
-| locked_max_set_point        | Number    | The locked range max set point in degrees Celsius |    R/W     |
-| locked_min_set_point        | Number    | The locked range min set point in degrees Celsius |    R/W     |
-| max_set_point               | Number    | The max set point in degrees Celsius     |    R/W     |
-| min_set_point               | Number    | The min set point in degrees Celsius     |    R/W     |
-| mode                        | String    | Current mode of the Nest thermostat (HEAT, COOL, HEAT_COOL, ECO, OFF) |    R/W     |
-| previous_mode               | String    | The previous mode of the Nest thermostat (HEAT, COOL, HEAT_COOL, ECO, OFF) |     R      |
-| temperature                 | Number    | Current temperature in degrees Celsius   |     R      |
-| time_to_target_mins         | Number    | Time left to the target temperature (mins) approximately |     R      |
-| set_point                   | Number    | The set point in degrees Celsius         |    R/W     |
-| sunlight_correction_active  | Switch    | If sunlight correction is active         |     R      |
-| sunlight_correction_enabled | Switch    | If sunlight correction is enabled        |     R      |
-| using_emergency_heat        | Switch    | If the system is currently using emergency heat |     R      |
+| Channel Type ID             | Item Type | Description                                                                                 | Read Write |
+|-----------------------------|-----------|---------------------------------------------------------------------------------------------|:----------:|
+| can_cool                    | Switch    | If the thermostat can actually turn on cooling                                              |      R     |
+| can_heat                    | Switch    | If the thermostat can actually turn on heating                                              |      R     |
+| fan_timer_active            | Switch    | If the fan timer is engaged                                                                 |     R/W    |
+| fan_timer_duration          | Number    | Length of time (in minutes) that the fan is set to run (15, 30, 45, 60, 120, 240, 480, 960) |     R/W    |
+| fan_timer_timeout           | DateTime  | Timestamp when the fan stops running                                                        |      R     |
+| has_fan                     | Switch    | If the thermostat can control the fan                                                       |      R     |
+| has_leaf                    | Switch    | If the thermostat is currently in a leaf mode                                               |      R     |
+| humidity                    | Number    | Indicates the current relative humidity                                                     |      R     |
+| locked                      | Switch    | If the thermostat has the temperature locked to only be within a set range                  |      R     |
+| locked_max_set_point        | Number    | The locked range max set point in degrees Celsius                                           |     R/W    |
+| locked_min_set_point        | Number    | The locked range min set point in degrees Celsius                                           |     R/W    |
+| max_set_point               | Number    | The max set point in degrees Celsius                                                        |     R/W    |
+| min_set_point               | Number    | The min set point in degrees Celsius                                                        |     R/W    |
+| mode                        | String    | Current mode of the Nest thermostat (HEAT, COOL, HEAT_COOL, ECO, OFF)                       |     R/W    |
+| previous_mode               | String    | The previous mode of the Nest thermostat (HEAT, COOL, HEAT_COOL, ECO, OFF)                  |      R     |
+| state                       | String    | The active state of the Nest thermostat (HEATING, COOLING, OFF)                             |      R     |
+| temperature                 | Number    | Current temperature in degrees Celsius                                                      |      R     |
+| time_to_target_mins         | Number    | Time left to the target temperature (mins) approximately                                    |      R     |
+| set_point                   | Number    | The set point in degrees Celsius                                                            |     R/W    |
+| sunlight_correction_active  | Switch    | If sunlight correction is active                                                            |      R     |
+| sunlight_correction_enabled | Switch    | If sunlight correction is enabled                                                           |      R     |
+| using_emergency_heat        | Switch    | If the system is currently using emergency heat                                             |      R     |
 
 Note that the Nest API rounds Thermostat values so they will differ from what shows up in the Nest App. The Nest API applies the following rounding:
 
@@ -156,6 +157,9 @@ String Smoke_UI_Color    "UI Color [%s]"    { channel="nest:smoke_detector:demo_
 /* Thermostat */
 Switch Thermostat_Can_Cool     "Can Cool"                       { channel="nest:thermostat:demo_account:living_thermostat:can_cool" }
 Switch Thermostat_Can_Heat     "Can Heat"                       { channel="nest:thermostat:demo_account:living_thermostat:can_heat" }
+Switch Thermostat_FT_Active    "Fan Timer Active"               { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_active" }
+Number Thermostat_FT_Duration  "Fan Timer Duration"             { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_duration" }
+DateTime Thermostat_FT_Timeout "Fan Timer Timeout [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]" { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_timeout" }
 Switch Thermostat_Has_Fan      "Has Fan"                        { channel="nest:thermostat:demo_account:living_thermostat:has_fan" }
 Switch Thermostat_Has_Leaf     "Has Leaf"                       { channel="nest:thermostat:demo_account:living_thermostat:has_leaf" }
 Number Thermostat_Humidity     "Humidity [%.1f %%]"             { channel="nest:thermostat:demo_account:living_thermostat:humidity" }
@@ -166,6 +170,7 @@ Number Thermostat_Max_SP       "Max Set Point [%.1f °C]"        { channel="nest
 Number Thermostat_Min_SP       "Min Set Point [%.1f °C]"        { channel="nest:thermostat:demo_account:living_thermostat:min_set_point" }
 String Thermostat_Mode         "Mode [%s]"                      { channel="nest:thermostat:demo_account:living_thermostat:mode" }
 String Thermostat_PreviousMode "Previous Mode [%s]"             { channel="nest:thermostat:demo_account:living_thermostat:previous_mode" }
+String Thermostat_State        "State [%s]"                     { channel="nest:thermostat:demo_account:living_thermostat:state" }
 Number Thermostat_Set_Point    "Set Point [%.1f °C]"            { channel="nest:thermostat:demo_account:living_thermostat:set_point" }
 Switch Thermostat_SunlightCA   "Sunlight Correction Active"     { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_active" }
 Switch Thermostat_SunlightCE   "Sunlight Correction Enabled"    { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_enabled" }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/NestBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/NestBindingConstants.java
@@ -69,8 +69,10 @@ public class NestBindingConstants {
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_PREVIOUS_MODE = "previous_mode";
+    public static final String CHANNEL_STATE = "state";
     public static final String CHANNEL_CAN_HEAT = "can_heat";
     public static final String CHANNEL_CAN_COOL = "can_cool";
+    public static final String CHANNEL_FAN_TIMER_TIMEOUT = "fan_timer_timeout";
     public static final String CHANNEL_HAS_FAN = "has_fan";
     public static final String CHANNEL_HAS_LEAF = "has_leaf";
     public static final String CHANNEL_SUNLIGHT_CORRECTION_ENABLED = "sunlight_correction_enabled";

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
@@ -51,6 +51,8 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
                 return getAsOnOffType(thermostat.isFanTimerActive());
             case CHANNEL_FAN_TIMER_DURATION:
                 return new DecimalType(thermostat.getFanTimerDuration());
+            case CHANNEL_FAN_TIMER_TIMEOUT:
+                return getAsDateTimeTypeOrNull(thermostat.getFanTimerTimeout());
             case CHANNEL_HAS_FAN:
                 return getAsOnOffType(thermostat.isHasFan());
             case CHANNEL_HAS_LEAF:
@@ -73,6 +75,8 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
                 Mode previousMode = thermostat.getPreviousMode() != null ? thermostat.getPreviousMode()
                         : thermostat.getMode();
                 return new StringType(previousMode.name());
+            case CHANNEL_STATE:
+                return new StringType(thermostat.getState().name());
             case CHANNEL_SET_POINT:
                 return new DecimalType(thermostat.getTargetTemperature());
             case CHANNEL_SUNLIGHT_CORRECTION_ACTIVE:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
@@ -191,7 +191,7 @@ public class Thermostat extends BaseNestDevice {
      * Turns the time to target string into a real value.
      */
     static Integer parseTimeToTarget(String timeToTarget) {
-        if (timeToTarget.startsWith("~") || timeToTarget.startsWith("<")) {
+        if (timeToTarget.startsWith("~") || timeToTarget.startsWith("<") || timeToTarget.startsWith(">")) {
             return Integer.valueOf(timeToTarget.substring(1));
         }
         return Integer.valueOf(timeToTarget);


### PR DESCRIPTION
* Fixes NumberFormatException (see [Community](https://community.openhab.org/t/openhab2-nest-binding-2-2-0-snapshot-an-updated-2-0-binding-that-works/34972/39?u=wborn))
```
2017-10-29 18:12:31.068 [WARN ] [nternal.rest.NestStreamingRestClient] - An exception occurred while processing the inbound event
java.lang.NumberFormatException: For input string: ">120"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:580) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:615) ~[?:?]
	at org.openhab.binding.nest.internal.data.Thermostat.getTimeToTarget(Thermostat.java:193) ~[?:?]
	at org.openhab.binding.nest.handler.NestThermostatHandler.getChannelState(NestThermostatHandler.java:85) ~[?:?]
	at org.openhab.binding.nest.handler.NestThermostatHandler.getChannelState(NestThermostatHandler.java:1) ~[?:?]
	at org.openhab.binding.nest.handler.NestBaseHandler.lambda$0(NestBaseHandler.java:131) ~[?:?]
```

* Add `state` and `fan_timer_timeout` channels to Thermostat (see [Community](https://community.openhab.org/t/openhab2-nest-binding-2-2-0-snapshot-an-updated-2-0-binding-that-works/34972/47?u=wborn))
