### PR TITLE
Don't cache data points of reconfigurable channels.

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -372,7 +372,13 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                                     logger.trace("    Loading datapoints into channel {}", channel);
                                     addChannelDatapoints(channel, HmParamsetType.MASTER);
                                     addChannelDatapoints(channel, HmParamsetType.VALUES);
-                                    datapointsByChannelIdCache.put(channelId, channel.getDatapoints().values());
+
+                                    // Make sure to only cache non-reconfigurable channels. For reconfigurable channels,
+                                    // the data point set might change depending on the selected mode.
+                                    if (channel.getDatapoint(HmParamsetType.MASTER,
+                                            DATAPOINT_NAME_CHANNEL_FUNCTION) == null) {
+                                        datapointsByChannelIdCache.put(channelId, channel.getDatapoints().values());
+                                    }
                                 }
                             }
                         }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicConstants.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicConstants.java
@@ -72,6 +72,7 @@ public class HomematicConstants {
     public static final String DATAPOINT_NAME_VALUE = "VALUE";
     public static final String DATAPOINT_NAME_CALIBRATION = "CALIBRATION";
     public static final String DATAPOINT_NAME_LOWBAT_IP = "LOW_BAT";
+    public static final String DATAPOINT_NAME_CHANNEL_FUNCTION = "CHANNEL_FUNCTION";
 
     public static final String VIRTUAL_DATAPOINT_NAME_BATTERY_TYPE = "BATTERY_TYPE";
     public static final String VIRTUAL_DATAPOINT_NAME_DELETE_DEVICE_MODE = "DELETE_DEVICE_MODE";


### PR DESCRIPTION
Channels that allow changing their type (e.g. the KEY channels in
HM-MOD-EM-8) have different data point sets depending on the selected
function. If multiple of such devices are present and are configured to
have differing functions, caching the data points of those channels can
lead to us enumerating wrong data points, as the configuration of the
first device will be implied for all subsequent devices.

Closes #2930

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  http://docs.openhab.org/developers/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  http://docs.openhab.org/developers/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  http://docs.openhab.org/developers/contributing/contributing#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
