### PR TITLE
[Gardena] removed non-existant temperature channel

### DIFF
--- a/addons/binding/org.openhab.binding.gardena/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.gardena/ESH-INF/thing/thing-types.xml
@@ -16,7 +16,6 @@
 			<channel-group id="device_info" typeId="deviceInfo" />
 			<channel-group id="battery" typeId="rechargeableBattery" />
 			<channel-group id="radio" typeId="radio" />
-			<channel-group id="internal_temperature" typeId="internalTemperature" />
 			<channel-group id="mower" typeId="mower" />
 			<channel-group id="firmware" typeId="firmware" />
 		</channel-groups>
@@ -75,15 +74,6 @@
 			<channel id="duration_property" typeId="mowerDurationProperty" />
 		</channels>
 	</channel-group-type>
-
-	<channel-group-type id="internalTemperature">
-		<label>Internal Temperature</label>
-		<description>The internal temperature of the robotic mower</description>
-		<channels>
-			<channel id="temperature" typeId="temperature" />
-		</channels>
-	</channel-group-type>
-
 
 	<channel-type id="mowerDurationProperty">
 		<item-type>Number</item-type>

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaAccountHandler.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaAccountHandler.java
@@ -69,23 +69,19 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
      */
     private void initializeGardena() {
         final GardenaAccountHandler instance = this;
-        scheduler.execute(new Runnable() {
-
-            @Override
-            public void run() {
-                try {
-                    String id = getThing().getUID().getId();
-                    gardenaSmart.init(id, gardenaConfig, instance, scheduler);
-                    registerDeviceDiscoveryService();
-                    discoveryService.startScan(null);
-                    discoveryService.waitForScanFinishing();
-                    updateStatus(ThingStatus.ONLINE);
-                } catch (GardenaException ex) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
-                    disposeGardena();
-                    scheduleReinitialize();
-                    logger.debug("{}", ex.getMessage(), ex);
-                }
+        scheduler.execute(() -> {
+            try {
+                String id = getThing().getUID().getId();
+                gardenaSmart.init(id, gardenaConfig, instance, scheduler);
+                registerDeviceDiscoveryService();
+                discoveryService.startScan(null);
+                discoveryService.waitForScanFinishing();
+                updateStatus(ThingStatus.ONLINE);
+            } catch (GardenaException ex) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
+                disposeGardena();
+                scheduleReinitialize();
+                logger.debug("{}", ex.getMessage(), ex);
             }
         });
     }
@@ -94,12 +90,8 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
      * Schedules a reinitialization, if Gardea Smart Home account is not reachable at startup.
      */
     private void scheduleReinitialize() {
-        scheduler.schedule(new Runnable() {
-
-            @Override
-            public void run() {
-                initializeGardena();
-            }
+        scheduler.schedule(() -> {
+            initializeGardena();
         }, REINITIALIZE_DELAY_SECONDS, TimeUnit.SECONDS);
     }
 

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaThingHandler.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaThingHandler.java
@@ -118,7 +118,10 @@ public class GardenaThingHandler extends BaseThingHandler {
      */
     protected void updateChannel(ChannelUID channelUID) throws GardenaException, AccountHandlerNotAvailableException {
         Device device = getDevice();
-        updateState(channelUID, convertToState(device, channelUID));
+        State state = convertToState(device, channelUID);
+        if (state != null) {
+            updateState(channelUID, state);
+        }
     }
 
     /**
@@ -127,39 +130,45 @@ public class GardenaThingHandler extends BaseThingHandler {
     private State convertToState(Device device, ChannelUID channelUID) throws GardenaException {
         String abilityName = channelUID.getGroupId();
         String propertyName = channelUID.getIdWithoutGroup();
-        String value = device.getAbility(abilityName).getProperty(propertyName).getValue();
 
-        if (StringUtils.trimToNull(value) == null || StringUtils.equals(value, "N/A")
-                || StringUtils.startsWith(value, "1970-01-01")) {
-            return UnDefType.NULL;
-        }
+        try {
+            String value = device.getAbility(abilityName).getProperty(propertyName).getValue();
 
-        switch (getThing().getChannel(channelUID.getId()).getAcceptedItemType()) {
-            case "String":
-                return new StringType(value);
-            case "Number":
-                if (ABILITY_RADIO.equals(abilityName) && PROPERTY_STATE.equals(propertyName)) {
-                    switch (value) {
-                        case "poor":
-                            return new DecimalType(1);
-                        case "good":
-                            return new DecimalType(2);
-                        case "excellent":
-                            return new DecimalType(4);
-                        default:
-                            return UnDefType.NULL;
+            if (StringUtils.trimToNull(value) == null || StringUtils.equals(value, "N/A")
+                    || StringUtils.startsWith(value, "1970-01-01")) {
+                return null;
+            }
+
+            switch (getThing().getChannel(channelUID.getId()).getAcceptedItemType()) {
+                case "String":
+                    return new StringType(value);
+                case "Number":
+                    if (ABILITY_RADIO.equals(abilityName) && PROPERTY_STATE.equals(propertyName)) {
+                        switch (value) {
+                            case "poor":
+                                return new DecimalType(1);
+                            case "good":
+                                return new DecimalType(2);
+                            case "excellent":
+                                return new DecimalType(4);
+                            default:
+                                return UnDefType.NULL;
+                        }
                     }
-                }
-                return new DecimalType(value);
-            case "Switch":
-                return Boolean.TRUE.toString().equalsIgnoreCase(value) ? OnOffType.ON : OnOffType.OFF;
-            case "DateTime":
-                Calendar cal = DateUtils.parseToCalendar(value);
-                if (cal != null) {
-                    return new DateTimeType(cal);
-                }
+                    return new DecimalType(value);
+                case "Switch":
+                    return Boolean.TRUE.toString().equalsIgnoreCase(value) ? OnOffType.ON : OnOffType.OFF;
+                case "DateTime":
+                    Calendar cal = DateUtils.parseToCalendar(value);
+                    if (cal != null) {
+                        return new DateTimeType(cal);
+                    }
+            }
+        } catch (GardenaException e) {
+            logger.warn("Channel '{}' cannot be updated as device does not contain property '{}:{}'", channelUID,
+                    abilityName, propertyName);
         }
-        return UnDefType.NULL;
+        return null;
     }
 
     /**


### PR DESCRIPTION
- the internal_temperature ability is not included in the Gardena JSON response anymore, so the channel group is removed
- the implementation is hardened to not fully crash the binding, if a channel cannot be identified anymore - instead, a warning is now logged and the rest keeps working as normal
- replaced some runnables by lambdas

Signed-off-by: Kai Kreuzer <kai@openhab.org>
