### PR TITLE
[tellstick] Added support for Power and Lux sensor values from the Telldus Live.

### DIFF
--- a/addons/binding/org.openhab.binding.tellstick/.classpath
+++ b/addons/binding/org.openhab.binding.tellstick/.classpath
@@ -11,6 +11,6 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry exported="true" kind="lib" path="lib/jna-4.0.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/javatellstick-1.0.jar"/>
+	<classpathentry kind="lib" path="lib/javatellstick-1.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/bridge.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tellstick" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tellstick"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/devices.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/devices.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tellstick" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tellstick"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/sensor.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/sensor.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="tellstick"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-		xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="sensor">
 		<supported-bridge-type-refs>
@@ -10,50 +10,50 @@
 			<bridge-type-ref id="telldus-live" />
 		</supported-bridge-type-refs>
 
-        <label>Sensor</label>
-        <description>This Thing defines a Sensor</description>
-        <channels>
-            <channel id="humidity" typeId="humidity" />
-            <channel id="timestamp" typeId="timestamp" />
-            <channel id="temperature" typeId="temperature" />
-            <channel id="lux" typeId="lux" />
-        </channels>
-        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
-    </thing-type>
-    <thing-type id="rainsensor">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="telldus-core" />
-            <bridge-type-ref id="telldus-live" />
-        </supported-bridge-type-refs>
+		<label>Sensor</label>
+		<description>This Thing defines a Sensor</description>
+		<channels>
+			<channel id="humidity" typeId="humidity" />
+			<channel id="timestamp" typeId="timestamp" />
+			<channel id="temperature" typeId="temperature" />
+			<channel id="lux" typeId="lux" />
+		</channels>
+		<config-description-ref uri="thing-type:tellstick:sensor-config" />
+	</thing-type>
+	<thing-type id="rainsensor">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="telldus-core" />
+			<bridge-type-ref id="telldus-live" />
+		</supported-bridge-type-refs>
 
-        <label>RainSensor</label>
-        <description>This Thing defines a Rain Sensor</description>
-        <channels>
-            <channel id="timestamp" typeId="timestamp" />
-            <channel id="rainrate" typeId="rainrate" />
-            <channel id="raintotal" typeId="raintotal" />
-        </channels>
-        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
-    </thing-type>
-    <thing-type id="powersensor">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="telldus-live" />
-        </supported-bridge-type-refs>
+		<label>RainSensor</label>
+		<description>This Thing defines a Rain Sensor</description>
+		<channels>
+			<channel id="timestamp" typeId="timestamp" />
+			<channel id="rainrate" typeId="rainrate" />
+			<channel id="raintotal" typeId="raintotal" />
+		</channels>
+		<config-description-ref uri="thing-type:tellstick:sensor-config" />
+	</thing-type>
+	<thing-type id="powersensor">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="telldus-live" />
+		</supported-bridge-type-refs>
 
-        <label>PowerSensor</label>
-        <description>This Thing defines a Power Sensor</description>
-        <channels>
-            <channel id="timestamp" typeId="timestamp" />
-            <channel id="watt" typeId="watt" />
-            <channel id="ampere" typeId="ampere" />
-        </channels>
-        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
-    </thing-type>
-    <thing-type id="windsensor">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="telldus-core" />
-            <bridge-type-ref id="telldus-live" />
-        </supported-bridge-type-refs>
+		<label>PowerSensor</label>
+		<description>This Thing defines a Power Sensor</description>
+		<channels>
+			<channel id="timestamp" typeId="timestamp" />
+			<channel id="watt" typeId="watt" />
+			<channel id="ampere" typeId="ampere" />
+		</channels>
+		<config-description-ref uri="thing-type:tellstick:sensor-config" />
+	</thing-type>
+	<thing-type id="windsensor">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="telldus-core" />
+			<bridge-type-ref id="telldus-live" />
+		</supported-bridge-type-refs>
 
 		<label>RainSensor</label>
 		<description>This Thing defines a Rain Sensor</description>
@@ -63,7 +63,7 @@
 			<channel id="winddirection" typeId="winddirection" />
 			<channel id="windaverage" typeId="windaverage" />
 		</channels>
-		<config-description-ref uri="thing-type:tellstick:sensor-config"/>
+		<config-description-ref uri="thing-type:tellstick:sensor-config" />
 	</thing-type>
 	<channel-type id="temperature">
 		<item-type>Number</item-type>
@@ -73,80 +73,80 @@
 		<state pattern="%f °C" readOnly="true">
 		</state>
 
-    </channel-type>
-    <channel-type id="humidity">
-        <item-type>Number</item-type>
-        <label>Actual Humidity</label>
-        <description>Actual measured room Humidity</description>
-        <category>Humidity</category>
-        <state pattern="%d %%" readOnly="true">
-        </state>
-    </channel-type>
-    
-    <channel-type id="rainrate">
-        <item-type>Number</item-type>
-        <label>Rainrate</label>
-        <description>The current rain rate</description>
-        <state pattern="%d" readOnly="true"/>
-    </channel-type>
-    
-    <channel-type id="raintotal">
-        <item-type>Number</item-type>
-        <label>Total Rain</label>
-        <description>Total rain</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>
-    
-    <channel-type id="windgust">
-        <item-type>Number</item-type>
-        <label>Wind Gust</label>
-        <description>Current wind gust</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>
-    
-    <channel-type id="watt">
-        <item-type>Number</item-type>
-        <label>Watt</label>
-        <description>Current kWatt</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>  
-    <channel-type id="lux">
-        <item-type>Number</item-type>
-        <label>Lux</label>
-        <description>Current lumination</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>       
-    <channel-type id="ampere">
-        <item-type>Number</item-type>
-        <label>Ampere</label>
-        <description>Current ampere</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>
-    <channel-type id="windaverage">
-        <item-type>Number</item-type>
-        <label>Wind Average</label>
-        <description>Current wind average</description>
-        <state pattern="%d" readOnly="true">
-        </state>
-    </channel-type>
-    
-    <channel-type id="winddirection">
-        <item-type>String</item-type>
-        <label>Wind Direction</label>
-        <description>Current wind directoin</description>
-        <state readOnly="true"/>
-    </channel-type>
-    
-    <channel-type id="timestamp">
-        <item-type>DateTime</item-type>
-        <label>Last device update</label>
-        <description>Last device update</description>
-         <state readOnly="true">
-        </state>
-    </channel-type>
+	</channel-type>
+	<channel-type id="humidity">
+		<item-type>Number</item-type>
+		<label>Actual Humidity</label>
+		<description>Actual measured room Humidity</description>
+		<category>Humidity</category>
+		<state pattern="%d %%" readOnly="true">
+		</state>
+	</channel-type>
+
+	<channel-type id="rainrate">
+		<item-type>Number</item-type>
+		<label>Rainrate</label>
+		<description>The current rain rate</description>
+		<state pattern="%d" readOnly="true" />
+	</channel-type>
+
+	<channel-type id="raintotal">
+		<item-type>Number</item-type>
+		<label>Total Rain</label>
+		<description>Total rain</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+
+	<channel-type id="windgust">
+		<item-type>Number</item-type>
+		<label>Wind Gust</label>
+		<description>Current wind gust</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+
+	<channel-type id="watt">
+		<item-type>Number</item-type>
+		<label>Watt</label>
+		<description>Current kWatt</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="lux">
+		<item-type>Number</item-type>
+		<label>Lux</label>
+		<description>Current lumination</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="ampere">
+		<item-type>Number</item-type>
+		<label>Ampere</label>
+		<description>Current ampere</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="windaverage">
+		<item-type>Number</item-type>
+		<label>Wind Average</label>
+		<description>Current wind average</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+
+	<channel-type id="winddirection">
+		<item-type>String</item-type>
+		<label>Wind Direction</label>
+		<description>Current wind directoin</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="timestamp">
+		<item-type>DateTime</item-type>
+		<label>Last device update</label>
+		<description>Last device update</description>
+		<state readOnly="true">
+		</state>
+	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/sensor.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/sensor.xml
@@ -10,35 +10,50 @@
 			<bridge-type-ref id="telldus-live" />
 		</supported-bridge-type-refs>
 
-		<label>Sensor</label>
-		<description>This Thing defines a Sensor</description>
-		<channels>
-			<channel id="humidity" typeId="humidity" />
-			<channel id="timestamp" typeId="timestamp" />
-			<channel id="temperature" typeId="temperature" />
-		</channels>
-		<config-description-ref uri="thing-type:tellstick:sensor-config"/>
-	</thing-type>
-	<thing-type id="rainsensor">
-		<supported-bridge-type-refs>
-			<bridge-type-ref id="telldus-core" />
-			<bridge-type-ref id="telldus-live" />
-		</supported-bridge-type-refs>
+        <label>Sensor</label>
+        <description>This Thing defines a Sensor</description>
+        <channels>
+            <channel id="humidity" typeId="humidity" />
+            <channel id="timestamp" typeId="timestamp" />
+            <channel id="temperature" typeId="temperature" />
+            <channel id="lux" typeId="lux" />
+        </channels>
+        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
+    </thing-type>
+    <thing-type id="rainsensor">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="telldus-core" />
+            <bridge-type-ref id="telldus-live" />
+        </supported-bridge-type-refs>
 
-		<label>RainSensor</label>
-		<description>This Thing defines a Rain Sensor</description>
-		<channels>
-			<channel id="timestamp" typeId="timestamp" />
-			<channel id="rainrate" typeId="rainrate" />
-			<channel id="raintotal" typeId="raintotal" />
-		</channels>
-		<config-description-ref uri="thing-type:tellstick:sensor-config"/>
-	</thing-type>
-	<thing-type id="windsensor">
-		<supported-bridge-type-refs>
-			<bridge-type-ref id="telldus-core" />
-			<bridge-type-ref id="telldus-live" />
-		</supported-bridge-type-refs>
+        <label>RainSensor</label>
+        <description>This Thing defines a Rain Sensor</description>
+        <channels>
+            <channel id="timestamp" typeId="timestamp" />
+            <channel id="rainrate" typeId="rainrate" />
+            <channel id="raintotal" typeId="raintotal" />
+        </channels>
+        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
+    </thing-type>
+    <thing-type id="powersensor">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="telldus-live" />
+        </supported-bridge-type-refs>
+
+        <label>PowerSensor</label>
+        <description>This Thing defines a Power Sensor</description>
+        <channels>
+            <channel id="timestamp" typeId="timestamp" />
+            <channel id="watt" typeId="watt" />
+            <channel id="ampere" typeId="ampere" />
+        </channels>
+        <config-description-ref uri="thing-type:tellstick:sensor-config"/>
+    </thing-type>
+    <thing-type id="windsensor">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="telldus-core" />
+            <bridge-type-ref id="telldus-live" />
+        </supported-bridge-type-refs>
 
 		<label>RainSensor</label>
 		<description>This Thing defines a Rain Sensor</description>
@@ -58,60 +73,80 @@
 		<state pattern="%f °C" readOnly="true">
 		</state>
 
-	</channel-type>
-	<channel-type id="humidity">
-		<item-type>Number</item-type>
-		<label>Actual Humidity</label>
-		<description>Actual measured room Humidity</description>
-		<category>Humidity</category>
-		<state pattern="%d %%" readOnly="true">
-		</state>
-	</channel-type>
-
-	<channel-type id="rainrate">
-		<item-type>Number</item-type>
-		<label>Rainrate</label>
-		<description>The current rain rate</description>
-		<state pattern="%d" readOnly="true"/>
-	</channel-type>
-
-	<channel-type id="raintotal">
-		<item-type>Number</item-type>
-		<label>Total Rain</label>
-		<description>Total rain</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
-
-	<channel-type id="windgust">
-		<item-type>Number</item-type>
-		<label>Wind Gust</label>
-		<description>Current wind gust</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
-
-	<channel-type id="windaverage">
-		<item-type>Number</item-type>
-		<label>Wind Average</label>
-		<description>Current wind average</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
-
-	<channel-type id="winddirection">
-		<item-type>String</item-type>
-		<label>Wind Direction</label>
-		<description>Current wind directoin</description>
-		<state readOnly="true"/>
-	</channel-type>
-
-	<channel-type id="timestamp">
-		<item-type>DateTime</item-type>
-		<label>Last device update</label>
-		<description>Last device update</description>
-		<state readOnly="true">
-		</state>
-	</channel-type>
-
+    </channel-type>
+    <channel-type id="humidity">
+        <item-type>Number</item-type>
+        <label>Actual Humidity</label>
+        <description>Actual measured room Humidity</description>
+        <category>Humidity</category>
+        <state pattern="%d %%" readOnly="true">
+        </state>
+    </channel-type>
+    
+    <channel-type id="rainrate">
+        <item-type>Number</item-type>
+        <label>Rainrate</label>
+        <description>The current rain rate</description>
+        <state pattern="%d" readOnly="true"/>
+    </channel-type>
+    
+    <channel-type id="raintotal">
+        <item-type>Number</item-type>
+        <label>Total Rain</label>
+        <description>Total rain</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>
+    
+    <channel-type id="windgust">
+        <item-type>Number</item-type>
+        <label>Wind Gust</label>
+        <description>Current wind gust</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>
+    
+    <channel-type id="watt">
+        <item-type>Number</item-type>
+        <label>Watt</label>
+        <description>Current kWatt</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>  
+    <channel-type id="lux">
+        <item-type>Number</item-type>
+        <label>Lux</label>
+        <description>Current lumination</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>       
+    <channel-type id="ampere">
+        <item-type>Number</item-type>
+        <label>Ampere</label>
+        <description>Current ampere</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>
+    <channel-type id="windaverage">
+        <item-type>Number</item-type>
+        <label>Wind Average</label>
+        <description>Current wind average</description>
+        <state pattern="%d" readOnly="true">
+        </state>
+    </channel-type>
+    
+    <channel-type id="winddirection">
+        <item-type>String</item-type>
+        <label>Wind Direction</label>
+        <description>Current wind directoin</description>
+        <state readOnly="true"/>
+    </channel-type>
+    
+    <channel-type id="timestamp">
+        <item-type>DateTime</item-type>
+        <label>Last device update</label>
+        <description>Last device update</description>
+         <state readOnly="true">
+        </state>
+    </channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tellstick/README.md
+++ b/addons/binding/org.openhab.binding.tellstick/README.md
@@ -26,9 +26,9 @@ Additionally the binding have two types of bridge things which correspond to ava
 *   *Telldus Live Bridge* - Telldus Cloud service, all devices with online access. `telldus-live`
 
 
-***Switchbased sensors workaround*** <br>
-*   Some 433MHz magnetic & PIR sensors, for example, magnetic door sensors, are detected as regular `switch` Things instead of type `contact`. There is technically no way of distinguish them apart from regulur `switch` Things.
-For using them as sensors only (not paired to a lamp) please consult the workaround in the channel section.
+***Switchbased sensors workaround***
+
+*   Some 433MHz magnetic & PIR sensors, for example, magnetic door sensors, are detected as regular `switch` Things instead of type `contact`. There is technically no way of distinguish them apart from regulur `switch` Things. For using them as sensors only (not paired to a lamp) please consult the workaround in the channel section.
 
 ## Discovery
 
@@ -56,7 +56,7 @@ Use the option `repeat` for that. Default resend count is 2.
 ### Bridges
 
 Depending on your tellstick device type there is different ways of using this binding.
-The binding implements two different API:  
+The binding implements two different API:
 **1)** *Telldus Core* which is a local only interface supported by USB based device. <br>
 **2)** *Telldus Live* which is a REST based cloud service maintained by Telldus. <br>
 
@@ -65,16 +65,14 @@ The binding implements two different API:
 
 Depending on your Tellstick model, different bridge-types are available:
 
-<table>
-<tr><td><b>Model</b></td> <td><b>Telldus Core</b></td> <td><b>Telldus Live</b></td> <td>Local REST API</td> <td><b>Verified working with openHAB</b></td></tr>
-<tr><td>Tellstick Basic</td><td>X</td><td>X</td><td></td><td>X</td></tr>
-<tr><td>Tellstick Duo</td><td>X</td><td>X</td><td></td><td>X</td></tr>
-<tr><td>Tellstick Net v.1</td><td></td><td>X</td><td></td><td></td></tr>
-<tr><td>Tellstick Net v.2</td><td></td><td>X</td><td>X</td><td></td></tr>
-<tr><td>Tellstick ZNet Lite v.1</td><td></td><td>X</td><td>X</td><td>X</td></tr>
-<tr><td>Tellstick ZNet Lite v.2</td><td></td><td>X</td><td>X</td><td></td></tr>
-<tr><td><i>Tellstick ZNet Pro (Not released)</i></td><td></td><td>X</td><td>X</td><td>X</td></tr>
-</table>
+| Model                   | Telldus Core | Telldus Live | Local REST API | Verified working with openHAB |
+|-------------------------|:------------:|:------------:|:--------------:|:-----------------------------:|
+| Tellstick Basic         |       X      |       X      |                |               X               |
+| Tellstick Duo           |       X      |       X      |                |               X               |
+| Tellstick Net v.1       |              |       X      |                |                               |
+| Tellstick Net v.2       |              |       X      |        X       |                               |
+| Tellstick ZNet Lite v.1 |              |       X      |        X       |               X               |
+| Tellstick ZNet Lite v.2 |              |       X      |        X       |                               |
 
 #### Telldus Core Bridge
 
@@ -117,53 +115,47 @@ Optional:
 
 Actuators (dimmer/switch) support the following channels:
 
-<table>
-<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
-<tr><td>dimmer</td><td>Number</td><td>This channel indicates the current dim level</td></tr>
-<tr><td>state</td><td>Switch</td><td>This channel indicates whether a device is turned on or off.</td></tr>
-<tr><td>timestamp</td><td>DateTime</td><td>This channel reports the last time this device state changed.</td></tr>
-</table>
+| Channel Type ID | Item Type | Description                                                   |
+|-----------------|-----------|---------------------------------------------------------------|
+| dimmer          | Number    | This channel indicates the current dim level                  |
+| state           | Switch    | This channel indicates whether a device is turned on or off.  |
+| timestamp       | DateTime  | This channel reports the last time this device state changed. |
 
 Sensors (sensor) support the following channels:
 
-<table>
-<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
-<tr><td>humidity</td><td>Number</td><td>This channel reports the current humidity in percentage.</td></tr>
-<tr><td>temperature</td><td>Number</td><td>This channel reports the current temperature in celsius.</td></tr>
-<tr><td>timestamp</td><td>DateTime</td><td> This channel reports the last time this sensor was updates.</td></tr>
-</table>
+| Channel Type ID | Item Type | Description                                                 |
+|-----------------|-----------|-------------------------------------------------------------|
+| humidity        | Number    | This channel reports the current humidity in percentage.    |
+| temperature     | Number    | This channel reports the current temperature in celsius.    |
+| timestamp       | DateTime  | This channel reports the last time this sensor was updates. |
 
 PowerSensors ([powersensor]) support the following channels:
 
-<table>
-<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
-<tr><td>watt</td><td>Number</td><td>This channel reports the current watt.</td></tr>
-<tr><td>ampere</td><td>Number</td><td>This channel reports the current ampere.</td></tr>
-<tr><td>timestamp</td><td>DateTime</td><td> This channel reports the last time this sensor was updates.</td></tr>
-</table>
+| Channel Type ID | Item Type | Description                                                 |
+|-----------------|-----------|-------------------------------------------------------------|
+| watt            | Number    | This channel reports the current watt.                      |
+| ampere          | Number    | This channel reports the current ampere.                    |
+| timestamp       | DateTime  | This channel reports the last time this sensor was updates. |
 
 WindSensors ([windsensor]) support the following channels:
 
-<table>
-<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
-<tr><td>windgust</td><td>Number</td><td>This current peak wind gust.</td></tr>
-<tr><td>winddirection</td><td>Number</td><td>The current wind direction.</td></tr>
-<tr><td>windaverage</td><td>DateTime</td><td> The current wind avarage.</td></tr>
-</table>
+| Channel Type ID | Item Type | Description                  |
+|-----------------|-----------|------------------------------|
+| windgust        | Number    | This current peak wind gust. |
+| winddirection   | Number    | The current wind direction.  |
+| windaverage     | DateTime  | The current wind avarage.    |
 
 RainSensors ([rainsensor]) support the following channels:
 
-<table>
-<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
-<tr><td>rainrate</td><td>Number</td><td>This current rate of rain.</td></tr>
-<tr><td>raintotal</td><td>Number</td><td>The total rain.</td></tr>
-</table>
+| Channel Type ID | Item Type | Description                |
+|-----------------|-----------|----------------------------|
+| rainrate        | Number    | This current rate of rain. |
+| raintotal       | Number    | The total rain.            |
 
 ### Switchbased sensor workaround
 
-All switchbased sensors are binary and the goal is to represent them as a `contact` item in openhab. Eg. a door is open or closed and can't be altered by sending a radio signal.
+All switchbased sensors are binary and the goal is to represent them as a `contact` item in openHAB. Eg. a door is open or closed and can't be altered by sending a radio signal.
 To achive that we will create a proxy item which is updated by a rule.
-
 
 First create another proxy item for every sensor:
 

--- a/addons/binding/org.openhab.binding.tellstick/README.md
+++ b/addons/binding/org.openhab.binding.tellstick/README.md
@@ -25,8 +25,6 @@ Additionally the binding have two types of bridge things which correspond to ava
 *   *Telldus Core Bridge* - Oldest API, used by USB devices. `telldus-core`
 *   *Telldus Live Bridge* - Telldus Cloud service, all devices with online access. `telldus-live`
 
-The attentive reader discovers that there is many missing sensor types; `UV`, `Luminance`, `Dew point`, `Barometic pressure` `Rainrate`, `Raintotal`, `Winddirection`, `Windaverage` and `Windgust` which is supported by the Tellstick devices.
-Support have not been implemented on the openhab side yet, contributions are welcome.  
 
 ***Switchbased sensors workaround*** <br>
 *   Some 433MHz magnetic & PIR sensors, for example, magnetic door sensors, are detected as regular `switch` Things instead of type `contact`. There is technically no way of distinguish them apart from regulur `switch` Things.
@@ -69,12 +67,13 @@ Depending on your Tellstick model, different bridge-types are available:
 
 <table>
 <tr><td><b>Model</b></td> <td><b>Telldus Core</b></td> <td><b>Telldus Live</b></td> <td>Local REST API</td> <td><b>Verified working with openHAB</b></td></tr>
-<tr><td>Tellstick Basic</td><td>X</td><td>X</td><td></td><td></td></tr>
+<tr><td>Tellstick Basic</td><td>X</td><td>X</td><td></td><td>X</td></tr>
 <tr><td>Tellstick Duo</td><td>X</td><td>X</td><td></td><td>X</td></tr>
 <tr><td>Tellstick Net v.1</td><td></td><td>X</td><td></td><td></td></tr>
 <tr><td>Tellstick Net v.2</td><td></td><td>X</td><td>X</td><td></td></tr>
 <tr><td>Tellstick ZNet Lite v.1</td><td></td><td>X</td><td>X</td><td>X</td></tr>
 <tr><td>Tellstick ZNet Lite v.2</td><td></td><td>X</td><td>X</td><td></td></tr>
+<tr><td><i>Tellstick ZNet Pro (Not released)</i></td><td></td><td>X</td><td>X</td><td>X</td></tr>
 </table>
 
 #### Telldus Core Bridge
@@ -132,6 +131,32 @@ Sensors (sensor) support the following channels:
 <tr><td>humidity</td><td>Number</td><td>This channel reports the current humidity in percentage.</td></tr>
 <tr><td>temperature</td><td>Number</td><td>This channel reports the current temperature in celsius.</td></tr>
 <tr><td>timestamp</td><td>DateTime</td><td> This channel reports the last time this sensor was updates.</td></tr>
+</table>
+
+PowerSensors ([powersensor]) support the following channels:
+
+<table>
+<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
+<tr><td>watt</td><td>Number</td><td>This channel reports the current watt.</td></tr>
+<tr><td>ampere</td><td>Number</td><td>This channel reports the current ampere.</td></tr>
+<tr><td>timestamp</td><td>DateTime</td><td> This channel reports the last time this sensor was updates.</td></tr>
+</table>
+
+WindSensors ([windsensor]) support the following channels:
+
+<table>
+<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
+<tr><td>windgust</td><td>Number</td><td>This current peak wind gust.</td></tr>
+<tr><td>winddirection</td><td>Number</td><td>The current wind direction.</td></tr>
+<tr><td>windaverage</td><td>DateTime</td><td> The current wind avarage.</td></tr>
+</table>
+
+RainSensors ([rainsensor]) support the following channels:
+
+<table>
+<tr><td><b>Channel Type ID</b></td> <td><b>Item Type</b></td> <td><b>Description</b></td> </tr>
+<tr><td>rainrate</td><td>Number</td><td>This current rate of rain.</td></tr>
+<tr><td>raintotal</td><td>Number</td><td>The total rain.</td></tr>
 </table>
 
 ### Switchbased sensor workaround

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/TellstickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/TellstickBindingConstants.java
@@ -38,6 +38,7 @@ public class TellstickBindingConstants {
     public static final String DEVICE_SENSOR = "sensor";
     public static final String DEVICE_WINDSENSOR = "windsensor";
     public static final String DEVICE_RAINSENSOR = "rainsensor";
+    public static final String DEVICE_POWERSENSOR = "powersensor";
     public static final String DEVICE_DIMMER = "dimmer";
     public static final String DEVICE_SWITCH = "switch";
     // List of all Thing Type UIDs
@@ -45,6 +46,7 @@ public class TellstickBindingConstants {
     public static final ThingTypeUID SWITCH_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_SWITCH);
     public static final ThingTypeUID SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_SENSOR);
     public static final ThingTypeUID RAINSENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_RAINSENSOR);
+    public static final ThingTypeUID POWERSENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_POWERSENSOR);
     public static final ThingTypeUID WINDSENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_WINDSENSOR);
 
     public static final ThingTypeUID TELLDUSBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, BRIDGE_TELLDUS_CORE);
@@ -61,13 +63,16 @@ public class TellstickBindingConstants {
     public static final String CHANNEL_WINDAVERAGE = "windaverage";
     public static final String CHANNEL_WINDDIRECTION = "winddirection";
     public static final String CHANNEL_WINDGUST = "windgust";
+    public static final String CHANNEL_WATT = "watt";
+    public static final String CHANNEL_AMPERE = "ampere";
+    public static final String CHANNEL_LUX = "lux";
 
     public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS = Sets
             .newHashSet(TELLDUSCOREBRIDGE_THING_TYPE, TELLDUSLIVEBRIDGE_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = Sets.newHashSet(DIMMER_THING_TYPE,
-            SWITCH_THING_TYPE, SENSOR_THING_TYPE, RAINSENSOR_THING_TYPE, WINDSENSOR_THING_TYPE);
+            SWITCH_THING_TYPE, SENSOR_THING_TYPE, RAINSENSOR_THING_TYPE, WINDSENSOR_THING_TYPE, POWERSENSOR_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(DIMMER_THING_TYPE,
-            SWITCH_THING_TYPE, SENSOR_THING_TYPE, RAINSENSOR_THING_TYPE, WINDSENSOR_THING_TYPE,
+            SWITCH_THING_TYPE, SENSOR_THING_TYPE, RAINSENSOR_THING_TYPE, WINDSENSOR_THING_TYPE, POWERSENSOR_THING_TYPE,
             TELLDUSCOREBRIDGE_THING_TYPE, TELLDUSLIVEBRIDGE_THING_TYPE);
 
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/DeviceStatusListener.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/DeviceStatusListener.java
@@ -17,7 +17,6 @@ import org.tellstick.device.iface.TellstickEvent;
  * or a device has been removed or added.
  *
  * @author Jarle Hjortland - Initial contribution
- *
  */
 public interface DeviceStatusListener {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusBridgeHandler.java
@@ -15,8 +15,7 @@ import org.tellstick.device.iface.Device;
 /**
  * Interface for the telldus bridge modules
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public interface TelldusBridgeHandler {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDeviceController.java
@@ -18,8 +18,7 @@ import org.tellstick.device.iface.Device;
 /**
  * Interface for telldus controllers. This is used to send and get status of devices from the controller.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public interface TelldusDeviceController {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDevicesHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDevicesHandler.java
@@ -31,8 +31,10 @@ import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.tellstick.TellstickBindingConstants;
 import org.openhab.binding.tellstick.internal.live.xml.DataTypeValue;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensor;
+import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensorEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tellstick.device.TellstickDeviceEvent;
 import org.tellstick.device.TellstickException;
 import org.tellstick.device.TellstickSensor;
 import org.tellstick.device.TellstickSensorEvent;
@@ -64,6 +66,9 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
     private final ChannelUID windAverageChannel;
     private final ChannelUID windDirectionChannel;
     private final ChannelUID windGuestChannel;
+    private final ChannelUID wattChannel;
+    private final ChannelUID ampereChannel;
+    private final ChannelUID luxChannel;
     private final ChannelUID timestampChannel;
 
     public TelldusDevicesHandler(Thing thing) {
@@ -77,7 +82,11 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
         windAverageChannel = new ChannelUID(getThing().getUID(), CHANNEL_WINDAVERAGE);
         windDirectionChannel = new ChannelUID(getThing().getUID(), CHANNEL_WINDDIRECTION);
         windGuestChannel = new ChannelUID(getThing().getUID(), CHANNEL_WINDGUST);
+        wattChannel = new ChannelUID(getThing().getUID(), CHANNEL_WATT);
+        ampereChannel = new ChannelUID(getThing().getUID(), CHANNEL_AMPERE);
         timestampChannel = new ChannelUID(getThing().getUID(), CHANNEL_TIMESTAMP);
+        luxChannel = new ChannelUID(getThing().getUID(), CHANNEL_LUX);
+
     }
 
     @Override
@@ -207,14 +216,15 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
     private boolean isSensor() {
         return (getThing().getThingTypeUID().equals(TellstickBindingConstants.SENSOR_THING_TYPE)
                 || getThing().getThingTypeUID().equals(TellstickBindingConstants.RAINSENSOR_THING_TYPE)
-                || getThing().getThingTypeUID().equals(TellstickBindingConstants.WINDSENSOR_THING_TYPE));
+                || getThing().getThingTypeUID().equals(TellstickBindingConstants.WINDSENSOR_THING_TYPE)
+                || getThing().getThingTypeUID().equals(TellstickBindingConstants.POWERSENSOR_THING_TYPE));
     }
 
     private void updateSensorStates(Device dev) {
         if (dev instanceof TellstickSensor) {
             updateStatus(ThingStatus.ONLINE);
             for (DataType type : ((TellstickSensor) dev).getData().keySet()) {
-                updateSensorDateState(type, ((TellstickSensor) dev).getData(type));
+                updateSensorDataState(type, ((TellstickSensor) dev).getData(type));
             }
         } else if (dev instanceof TellstickNetSensor) {
             if (((TellstickNetSensor) dev).getOnline()) {
@@ -223,7 +233,7 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateStatus(ThingStatus.OFFLINE);
             }
             for (DataTypeValue type : ((TellstickNetSensor) dev).getData()) {
-                updateSensorDateState(type.getName(), type.getValue());
+                updateSensorDataState(type);
             }
         }
     }
@@ -242,28 +252,26 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 device.getUUId(), getThing().getUID(), deviceId);
         if (device.getUUId().equals(deviceId)) {
 
-            switch (device.getDeviceType()) {
-                case DEVICE:
-                    updateDeviceState(device);
-                    break;
-                case SENSOR:
-                    TellstickSensorEvent sensorevent = (TellstickSensorEvent) event;
-                    updateSensorDateState(sensorevent.getDataType(), sensorevent.getData());
-                    break;
-
-                default:
-                    logger.debug("Unhandled Device {}.", device.getDeviceType());
-                    break;
-
+            if (event instanceof TellstickDeviceEvent) {
+                updateDeviceState(device);
+            } else if (event instanceof TellstickNetSensorEvent) {
+                TellstickNetSensorEvent sensorevent = (TellstickNetSensorEvent) event;
+                updateSensorDataState(sensorevent.getLiveDataType());
+            } else if (event instanceof TellstickSensorEvent) {
+                TellstickSensorEvent sensorevent = (TellstickSensorEvent) event;
+                updateSensorDataState(sensorevent.getDataType(), sensorevent.getData());
+            } else {
+                logger.debug("Unhandled Device {}.", device.getDeviceType());
             }
             Calendar cal = Calendar.getInstance();
             cal.setTimeInMillis(event.getTimestamp());
             updateState(timestampChannel, new DateTimeType(cal));
 
         }
+
     }
 
-    private void updateSensorDateState(DataType dataType, String data) {
+    private void updateSensorDataState(DataType dataType, String data) {
         switch (dataType) {
             case HUMIDITY:
                 updateState(humidityChannel, new DecimalType(data));
@@ -285,6 +293,43 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 break;
             case WINDGUST:
                 updateState(windGuestChannel, new DecimalType(data));
+                break;
+            default:
+        }
+    }
+
+    private void updateSensorDataState(DataTypeValue dataType) {
+        switch (dataType.getName()) {
+            case HUMIDITY:
+                updateState(humidityChannel, new DecimalType(dataType.getValue()));
+                break;
+            case TEMPERATURE:
+                updateState(tempChannel, new DecimalType(dataType.getValue()));
+                break;
+            case RAINRATE:
+                updateState(rainRateChannel, new DecimalType(dataType.getValue()));
+                break;
+            case RAINTOTAL:
+                updateState(raintTotChannel, new DecimalType(dataType.getValue()));
+                break;
+            case WINDAVERAGE:
+                updateState(windAverageChannel, new DecimalType(dataType.getValue()));
+                break;
+            case WINDDIRECTION:
+                updateState(windDirectionChannel, new StringType(dataType.getValue()));
+                break;
+            case WINDGUST:
+                updateState(windGuestChannel, new DecimalType(dataType.getValue()));
+                break;
+            case WATT:
+                if (dataType.getUnit() != null && dataType.getUnit().equals("A")) {
+                    updateState(ampereChannel, new DecimalType(dataType.getValue()));
+                } else {
+                    updateState(wattChannel, new DecimalType(dataType.getValue()));
+                }
+                break;
+            case LUMINATION:
+                updateState(luxChannel, new DecimalType(dataType.getValue()));
                 break;
             default:
         }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDevicesHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDevicesHandler.java
@@ -47,8 +47,7 @@ import org.tellstick.enums.DeviceType;
 /**
  * Handler for telldus and tellstick devices. This sends the commands to the correct bridge.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TelldusDevicesHandler extends BaseThingHandler implements DeviceStatusListener {
 
@@ -256,7 +255,7 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateDeviceState(device);
             } else if (event instanceof TellstickNetSensorEvent) {
                 TellstickNetSensorEvent sensorevent = (TellstickNetSensorEvent) event;
-                updateSensorDataState(sensorevent.getLiveDataType());
+                updateSensorDataState(sensorevent.getDataTypeValue());
             } else if (event instanceof TellstickSensorEvent) {
                 TellstickSensorEvent sensorevent = (TellstickSensorEvent) event;
                 updateSensorDataState(sensorevent.getDataType(), sensorevent.getData());

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TelldusBindingException.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TelldusBindingException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tellstick.internal;
+
+import org.tellstick.device.TellstickException;
+
+/**
+ * {@link TelldusBindingException} is used when there is exception communicating with Telldus Live.
+ * This exception extends the Telldus Core exception.
+ *
+ * @author Jarle Hjortland
+ */
+public class TelldusBindingException extends TellstickException {
+
+    private String msg;
+
+    public TelldusBindingException(String message) {
+        super(null, 0);
+        this.msg = message;
+    }
+
+    private static final long serialVersionUID = 30671795474333158L;
+
+    @Override
+    public String getMessage() {
+        return msg;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TelldusBindingException.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TelldusBindingException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,9 +14,11 @@ import org.tellstick.device.TellstickException;
  * {@link TelldusBindingException} is used when there is exception communicating with Telldus Live.
  * This exception extends the Telldus Core exception.
  *
- * @author Jarle Hjortland
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TelldusBindingException extends TellstickException {
+
+    private static final long serialVersionUID = 30671795474333158L;
 
     private String msg;
 
@@ -24,8 +26,6 @@ public class TelldusBindingException extends TellstickException {
         super(null, 0);
         this.msg = message;
     }
-
-    private static final long serialVersionUID = 30671795474333158L;
 
     @Override
     public String getMessage() {

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickRuntimeException.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickRuntimeException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tellstick.internal;
+
+/**
+ * Runtime exception in tellstick binding.
+ *
+ * @author jarle hjortland
+ */
+public class TellstickRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = -1644730263645760297L;
+
+    public TellstickRuntimeException(String msg) {
+        super(msg);
+    }
+}

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickRuntimeException.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickRuntimeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@ package org.openhab.binding.tellstick.internal;
 /**
  * Runtime exception in tellstick binding.
  *
- * @author jarle hjortland
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TellstickRuntimeException extends RuntimeException {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreBridgeHandler.java
@@ -47,8 +47,7 @@ import org.tellstick.enums.DataType;
  * to the framework. All {@link TelldusDevicesHandler}s use the
  * {@link TelldusCoreDeviceController} to execute the actual commands.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TelldusCoreBridgeHandler extends BaseBridgeHandler
         implements DeviceChangeListener, SensorListener, TelldusBridgeHandler {

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreDeviceController.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.tellstick.handler.TelldusDeviceController;
+import org.openhab.binding.tellstick.internal.TelldusBindingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tellstick.JNA;
@@ -204,7 +205,7 @@ public class TelldusCoreDeviceController implements DeviceChangeListener, Sensor
             long tdVal = Math.round((value / 100) * 255);
             ((DimmableDevice) dev).dim((int) tdVal);
         } else {
-            throw new RuntimeException("Cannot send DIM to " + dev);
+            throw new TelldusBindingException("Cannot send DIM to " + dev);
         }
     }
 
@@ -212,7 +213,7 @@ public class TelldusCoreDeviceController implements DeviceChangeListener, Sensor
         if (dev instanceof SwitchableDevice) {
             ((SwitchableDevice) dev).off();
         } else {
-            throw new RuntimeException("Cannot send OFF to " + dev);
+            throw new TelldusBindingException("Cannot send OFF to " + dev);
         }
     }
 
@@ -220,7 +221,7 @@ public class TelldusCoreDeviceController implements DeviceChangeListener, Sensor
         if (dev instanceof SwitchableDevice) {
             ((SwitchableDevice) dev).on();
         } else {
-            throw new RuntimeException("Cannot send ON to " + dev);
+            throw new TelldusBindingException("Cannot send ON to " + dev);
         }
     }
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/core/TelldusCoreDeviceController.java
@@ -38,9 +38,8 @@ import org.tellstick.device.iface.SwitchableDevice;
  * This communicates with the telldus DLL using the javatellstick
  * library.
  *
- * @author Jarle Hjortland
+ * @author Jarle Hjortland - Initial contribution
  * @author Elias Gabrielsson
- *
  */
 public class TelldusCoreDeviceController implements DeviceChangeListener, SensorListener, TelldusDeviceController {
     private final Logger logger = LoggerFactory.getLogger(TelldusCoreDeviceController.class);

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.tellstick.TellstickBindingConstants;
 import org.openhab.binding.tellstick.handler.TelldusBridgeHandler;
+import org.openhab.binding.tellstick.internal.live.xml.LiveDataType;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetDevice;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensor;
 import org.slf4j.Logger;
@@ -157,10 +158,12 @@ public class TellstickDiscoveryService extends AbstractDiscoveryService
             }
         } else {
             TellstickNetSensor sensor = (TellstickNetSensor) device;
-            if (sensor.isWindSensor()) {
+            if (sensor.isSensorOfType(LiveDataType.WINDAVERAGE)) {
                 sensorThingId = TellstickBindingConstants.WINDSENSOR_THING_TYPE;
-            } else if (sensor.isRainSensor()) {
+            } else if (sensor.isSensorOfType(LiveDataType.RAINRATE)) {
                 sensorThingId = TellstickBindingConstants.RAINSENSOR_THING_TYPE;
+            } else if (sensor.isSensorOfType(LiveDataType.WATT)) {
+                sensorThingId = TellstickBindingConstants.POWERSENSOR_THING_TYPE;
             } else {
                 sensorThingId = TellstickBindingConstants.SENSOR_THING_TYPE;
             }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
@@ -44,8 +44,7 @@ import org.tellstick.device.iface.Device;
  * to the framework. All {@link TelldusDevicesHandler}s use the
  * {@link TelldusLiveDeviceController} to execute the actual commands.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements TelldusBridgeHandler {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
@@ -31,12 +31,12 @@ import org.openhab.binding.tellstick.internal.live.xml.DataTypeValue;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetDevice;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetDevices;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensor;
+import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensorEvent;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetSensors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tellstick.device.TellstickDeviceEvent;
 import org.tellstick.device.TellstickException;
-import org.tellstick.device.TellstickSensorEvent;
 import org.tellstick.device.iface.Device;
 
 /**
@@ -71,6 +71,9 @@ public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements Telld
         if (pollingJob != null) {
             pollingJob.cancel(true);
         }
+        if (this.controller != null) {
+            this.controller.dispose();
+        }
         deviceList = null;
         sensorList = null;
         super.dispose();
@@ -80,9 +83,6 @@ public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements Telld
     public void initialize() {
         logger.debug("Initializing TelldusLive bridge handler.");
         TelldusLiveConfiguration configuration = getConfigAs(TelldusLiveConfiguration.class);
-        // workaround for issue #92: getHandler() returns NULL after
-        // configuration update. :
-        getThing().setHandler(this);
         this.controller = new TelldusLiveDeviceController();
         this.controller.connectHttpClient(configuration.publicKey, configuration.privateKey, configuration.token,
                 configuration.tokenSecret);
@@ -222,7 +222,7 @@ public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements Telld
                     for (DeviceStatusListener listener : deviceStatusListeners) {
                         for (DataTypeValue type : sensor.getData()) {
                             listener.onDeviceStateChanged(getThing(), sensor,
-                                    new TellstickSensorEvent(sensor.getId(), type.getValue(), type.getName(),
+                                    new TellstickNetSensorEvent(sensor.getId(), type.getValue(), type,
                                             sensor.getProtocol(), sensor.getModel(), System.currentTimeMillis()));
                         }
                     }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveDeviceController.java
@@ -36,6 +36,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.tellstick.handler.TelldusDeviceController;
+import org.openhab.binding.tellstick.internal.TelldusBindingException;
 import org.openhab.binding.tellstick.internal.live.xml.TelldusLiveResponse;
 import org.openhab.binding.tellstick.internal.live.xml.TellstickNetDevice;
 import org.slf4j.Logger;
@@ -66,7 +67,8 @@ public class TelldusLiveDeviceController implements DeviceChangeListener, Sensor
     static final String HTTP_API_TELLDUS_COM_XML = "http://api.telldus.com/xml/";
     static final String HTTP_TELLDUS_CLIENTS = HTTP_API_TELLDUS_COM_XML + "clients/list";
     static final String HTTP_TELLDUS_DEVICES = HTTP_API_TELLDUS_COM_XML + "devices/list?supportedMethods=19";
-    static final String HTTP_TELLDUS_SENSORS = HTTP_API_TELLDUS_COM_XML + "sensors/list?includeValues=1&includeScale=1";
+    static final String HTTP_TELLDUS_SENSORS = HTTP_API_TELLDUS_COM_XML
+            + "sensors/list?includeValues=1&includeScale=1&includeUnit=1";
     static final String HTTP_TELLDUS_SENSOR_INFO = HTTP_API_TELLDUS_COM_XML + "sensor/info";
     static final String HTTP_TELLDUS_DEVICE_DIM = HTTP_API_TELLDUS_COM_XML + "device/dim?id=%d&level=%d";
     static final String HTTP_TELLDUS_DEVICE_TURNOFF = HTTP_API_TELLDUS_COM_XML + "device/turnOff?id=%d";
@@ -168,7 +170,7 @@ public class TelldusLiveDeviceController implements DeviceChangeListener, Sensor
                     TelldusLiveResponse.class);
             handleResponse((TellstickNetDevice) dev, response);
         } else {
-            throw new RuntimeException("Cannot send DIM to " + dev);
+            throw new TelldusBindingException("Cannot send DIM to " + dev);
         }
     }
 
@@ -178,21 +180,21 @@ public class TelldusLiveDeviceController implements DeviceChangeListener, Sensor
                     TelldusLiveResponse.class);
             handleResponse((TellstickNetDevice) dev, response);
         } else {
-            throw new RuntimeException("Cannot send OFF to " + dev);
+            throw new TelldusBindingException("Cannot send OFF to " + dev);
         }
     }
 
-    private void handleResponse(TellstickNetDevice device, TelldusLiveResponse response) {
+    private void handleResponse(TellstickNetDevice device, TelldusLiveResponse response) throws TellstickException {
         if (response == null || (response.status == null && response.error == null)) {
-            throw new RuntimeException("No response " + response);
+            throw new TelldusBindingException("No response " + response);
         } else if (response.error != null) {
             if (response.error.equals("The client for this device is currently offline")) {
                 device.setOnline(false);
                 device.setUpdated(true);
             }
-            throw new RuntimeException("Error " + response.error);
+            throw new TelldusBindingException("Error " + response.error);
         } else if (!response.status.trim().equals("success")) {
-            throw new RuntimeException("Response " + response.status);
+            throw new TelldusBindingException("Response " + response.status);
         }
     }
 
@@ -202,7 +204,7 @@ public class TelldusLiveDeviceController implements DeviceChangeListener, Sensor
                     TelldusLiveResponse.class);
             handleResponse((TellstickNetDevice) dev, response);
         } else {
-            throw new RuntimeException("Cannot send ON to " + dev);
+            throw new TelldusBindingException("Cannot send ON to " + dev);
         }
     }
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveDeviceController.java
@@ -55,9 +55,8 @@ import org.tellstick.device.iface.SwitchableDevice;
  * {@link TelldusLiveDeviceController} is the communication with Telldus Live service (Tellstick.NET and ZNET)
  * This controller uses XML based Rest API to communicate with Telldus Live.
  *
- * @author Jarle Hjortland
+ * @author Jarle Hjortland - Initial contribution
  */
-
 public class TelldusLiveDeviceController implements DeviceChangeListener, SensorListener, TelldusDeviceController {
     private final Logger logger = LoggerFactory.getLogger(TelldusLiveDeviceController.class);
     private long lastSend = 0;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveException.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveException.java
@@ -14,7 +14,7 @@ import org.tellstick.device.TellstickException;
  * {@link TelldusLiveException} is used when there is exception communicating with Telldus Live.
  * This exception extends the Telldus Core exception.
  *
- * @author Jarle Hjortland
+ * @author Jarle Hjortland - Initial contribution
  */
 public class TelldusLiveException extends TellstickException {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/DataTypeValue.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/DataTypeValue.java
@@ -12,8 +12,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.tellstick.enums.DataType;
-
 /**
  * Class used to deserialize XML from Telldus Live.
  *
@@ -25,15 +23,20 @@ public class DataTypeValue {
 
     @XmlAttribute(name = "name")
     @XmlJavaTypeAdapter(value = NameToDataType.class)
-    private DataType dataType;
+    private LiveDataType dataType;
+
     @XmlAttribute(name = "value")
     private String data;
 
-    public DataType getName() {
+    private String unit;
+
+    private Integer scale;
+
+    public LiveDataType getName() {
         return dataType;
     }
 
-    public void setName(DataType dataType) {
+    public void setName(LiveDataType dataType) {
         this.dataType = dataType;
     }
 
@@ -47,6 +50,24 @@ public class DataTypeValue {
 
     @Override
     public String toString() {
-        return "DataTypeValue [dataType=" + dataType + ", data=" + data + "]";
+        return "DataTypeValue [dataType=" + dataType + ", data=" + data + ", unit=" + unit + "]";
+    }
+
+    @XmlAttribute(name = "unit")
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    @XmlAttribute(name = "scale")
+    public Integer getScale() {
+        return scale;
+    }
+
+    public void setScale(Integer scale) {
+        this.scale = scale;
     }
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/DataTypeValue.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/DataTypeValue.java
@@ -15,8 +15,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlRootElement(name = "data")
 public class DataTypeValue {
@@ -48,11 +47,6 @@ public class DataTypeValue {
         this.data = data;
     }
 
-    @Override
-    public String toString() {
-        return "DataTypeValue [dataType=" + dataType + ", data=" + data + ", unit=" + unit + "]";
-    }
-
     @XmlAttribute(name = "unit")
     public String getUnit() {
         return unit;
@@ -69,5 +63,10 @@ public class DataTypeValue {
 
     public void setScale(Integer scale) {
         this.scale = scale;
+    }
+
+    @Override
+    public String toString() {
+        return "DataTypeValue [dataType=" + dataType + ", data=" + data + ", unit=" + unit + "]";
     }
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tellstick.internal.live.xml;
+
+/**
+ * This enum is used to describe the value types in the Live API from telldus.
+ *
+ * @author jarle hjortland
+ *
+ */
+public enum LiveDataType {
+    HUMIDITY("humidity"),
+    TEMPERATURE("temp"),
+    WINDAVERAGE("windaverage"),
+    WINDDIRECTION("winddirection"),
+    WINDGUST("temp"),
+    RAINRATE("rainrate"),
+    RAINTOTAL("rainttotal"),
+    WATT("watt"),
+    LUMINATION("lum"),
+    UNKOWN("unkown");
+
+    private String name;
+
+    LiveDataType(String name) {
+        this.name = name;
+    }
+
+    public static LiveDataType fromName(String name) {
+        LiveDataType result = LiveDataType.UNKOWN;
+        for (LiveDataType m : LiveDataType.values()) {
+            if (m.name.equals(name)) {
+                result = m;
+                break;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,7 @@ package org.openhab.binding.tellstick.internal.live.xml;
 /**
  * This enum is used to describe the value types in the Live API from telldus.
  *
- * @author jarle hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public enum LiveDataType {
     HUMIDITY("humidity"),

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NameToDataType.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NameToDataType.java
@@ -10,56 +10,20 @@ package org.openhab.binding.tellstick.internal.live.xml;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-import org.tellstick.enums.DataType;
-
 /**
  * Class used to deserialize XML from Telldus Live.
  *
  * @author Jarle Hjortland
  */
-public class NameToDataType extends XmlAdapter<String, DataType> {
+public class NameToDataType extends XmlAdapter<String, LiveDataType> {
     @Override
-    public DataType unmarshal(String v) throws Exception {
-        switch (v) {
-            case "temp":
-                return DataType.TEMPERATURE;
-            case "humidity":
-                return DataType.HUMIDITY;
-            case "rainrate":
-                return DataType.RAINRATE;
-            case "rainttotal":
-                return DataType.RAINTOTAL;
-            case "windaverage":
-                return DataType.WINDAVERAGE;
-            case "winddirection":
-                return DataType.WINDDIRECTION;
-            case "windgust":
-                return DataType.WINDGUST;
-            default:
-                return null;
-        }
+    public LiveDataType unmarshal(String v) throws Exception {
+        return LiveDataType.fromName(v);
     }
 
     @Override
-    public String marshal(DataType v) throws Exception {
-        switch (v) {
-            case TEMPERATURE:
-                return "temp";
-            case HUMIDITY:
-                return "humidity";
-            case RAINRATE:
-                return "rainrate";
-            case RAINTOTAL:
-                return "raintotal";
-            case WINDAVERAGE:
-                return "windaverage";
-            case WINDDIRECTION:
-                return "winddirection";
-            case WINDGUST:
-                return "windgust";
-            default:
-                return null;
-        }
+    public String marshal(LiveDataType v) throws Exception {
+        return v.toString();
     }
 
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NameToDataType.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NameToDataType.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
+ * @author Jarle Hjortland - Initial contribution
  */
 public class NameToDataType extends XmlAdapter<String, LiveDataType> {
     @Override

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NumberToBooleanMapper.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/NumberToBooleanMapper.java
@@ -13,8 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 public class NumberToBooleanMapper extends XmlAdapter<Integer, Boolean> {
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TelldusLiveResponse.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TelldusLiveResponse.java
@@ -14,8 +14,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlRootElement(name = "device")
 public class TelldusLiveResponse {

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetDevice.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetDevice.java
@@ -19,8 +19,7 @@ import org.tellstick.enums.DeviceType;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TellstickNetDevice implements Device {
@@ -95,12 +94,6 @@ public class TellstickNetDevice implements Device {
         this.name = name;
     }
 
-    @Override
-    public String toString() {
-        return "TellstickNetDevice [deviceId=" + deviceId + ", name=" + name + ", online=" + online + ", state=" + state
-                + ", statevalue=" + statevalue + ", updated=" + updated + "]";
-    }
-
     public boolean getOnline() {
         return online;
     }
@@ -136,7 +129,7 @@ public class TellstickNetDevice implements Device {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        int prime = 31;
         int result = 1;
         result = prime * result + deviceId;
         return result;
@@ -167,4 +160,11 @@ public class TellstickNetDevice implements Device {
     public void setMethods(int methods) {
         this.methods = methods;
     }
+
+    @Override
+    public String toString() {
+        return "TellstickNetDevice [deviceId=" + deviceId + ", name=" + name + ", online=" + online + ", state=" + state
+                + ", statevalue=" + statevalue + ", updated=" + updated + "]";
+    }
+
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetDevices.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetDevices.java
@@ -16,15 +16,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlRootElement(name = "devices")
 public class TellstickNetDevices {
-
-    public TellstickNetDevices() {
-        super();
-    }
 
     List<TellstickNetDevice> devices;
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensor.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensor.java
@@ -18,7 +18,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.tellstick.device.iface.Device;
-import org.tellstick.enums.DataType;
 import org.tellstick.enums.DeviceType;
 
 /**
@@ -44,6 +43,8 @@ public class TellstickNetSensor implements Device {
     @XmlAttribute()
     private Long lastUpdated;
     private boolean updated;
+    @XmlAttribute()
+    private Long battery;
 
     public TellstickNetSensor() {
     }
@@ -162,25 +163,24 @@ public class TellstickNetSensor implements Device {
         return updated;
     }
 
-    public boolean isWindSensor() {
+    public boolean isSensorOfType(LiveDataType type) {
         boolean res = false;
-        for (DataTypeValue val : data) {
-            if (val.getName() == DataType.WINDAVERAGE) {
-                res = true;
-
+        if (data != null) {
+            for (DataTypeValue val : data) {
+                if (val.getName() == type) {
+                    res = true;
+                    break;
+                }
             }
         }
         return res;
     }
 
-    public boolean isRainSensor() {
-        boolean res = false;
-        for (DataTypeValue val : data) {
-            if (val.getName() == DataType.RAINTOTAL) {
-                res = true;
+    public Long getBattery() {
+        return battery;
+    }
 
-            }
-        }
-        return res;
+    public void setBattery(Long battery) {
+        this.battery = battery;
     }
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensor.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensor.java
@@ -23,8 +23,7 @@ import org.tellstick.enums.DeviceType;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "sensor")
@@ -90,15 +89,6 @@ public class TellstickNetSensor implements Device {
         this.name = name;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("TellstickNetSensor [deviceId=").append(deviceId).append(", protocol=").append(protocol)
-                .append(", name=").append(name).append(", online=").append(online).append(", data=").append(data)
-                .append(", lastUpdated=").append(lastUpdated).append(", updated=").append(updated).append("]");
-        return builder.toString();
-    }
-
     public boolean getOnline() {
         return online;
     }
@@ -131,7 +121,7 @@ public class TellstickNetSensor implements Device {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        int prime = 31;
         int result = 1;
         result = prime * result + deviceId;
         return result;
@@ -182,5 +172,14 @@ public class TellstickNetSensor implements Device {
 
     public void setBattery(Long battery) {
         this.battery = battery;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("TellstickNetSensor [deviceId=").append(deviceId).append(", protocol=").append(protocol)
+                .append(", name=").append(name).append(", online=").append(online).append(", data=").append(data)
+                .append(", lastUpdated=").append(lastUpdated).append(", updated=").append(updated).append("]");
+        return builder.toString();
     }
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensorEvent.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensorEvent.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tellstick.internal.live.xml;
+
+import org.openhab.binding.tellstick.internal.TellstickRuntimeException;
+import org.tellstick.device.iface.TellstickEvent;
+import org.tellstick.enums.DataType;
+
+/**
+ * This class is used for events for the telldus live sensors.
+ *
+ * @author jarle hjortland
+ *
+ */
+public class TellstickNetSensorEvent extends org.tellstick.device.TellstickSensorEvent implements TellstickEvent {
+
+    private DataTypeValue dataType;
+
+    public TellstickNetSensorEvent(int sensorId, String data, DataTypeValue dataValue, String protocol, String model,
+            long timeStamp) {
+        super(sensorId, data, null, protocol, model, timeStamp);
+        this.dataType = dataValue;
+    }
+
+    public DataTypeValue getLiveDataType() {
+        return dataType;
+    }
+
+    @Override
+    public DataType getDataType() {
+        throw new TellstickRuntimeException("Should not call this method");
+    }
+}

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensorEvent.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensorEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,16 +9,16 @@
 package org.openhab.binding.tellstick.internal.live.xml;
 
 import org.openhab.binding.tellstick.internal.TellstickRuntimeException;
+import org.tellstick.device.TellstickSensorEvent;
 import org.tellstick.device.iface.TellstickEvent;
 import org.tellstick.enums.DataType;
 
 /**
  * This class is used for events for the telldus live sensors.
  *
- * @author jarle hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
-public class TellstickNetSensorEvent extends org.tellstick.device.TellstickSensorEvent implements TellstickEvent {
+public class TellstickNetSensorEvent extends TellstickSensorEvent implements TellstickEvent {
 
     private DataTypeValue dataType;
 
@@ -28,7 +28,7 @@ public class TellstickNetSensorEvent extends org.tellstick.device.TellstickSenso
         this.dataType = dataValue;
     }
 
-    public DataTypeValue getLiveDataType() {
+    public DataTypeValue getDataTypeValue() {
         return dataType;
     }
 

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensors.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/TellstickNetSensors.java
@@ -16,15 +16,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Class used to deserialize XML from Telldus Live.
  *
- * @author Jarle Hjortland
- *
+ * @author Jarle Hjortland - Initial contribution
  */
 @XmlRootElement(name = "sensors")
 public class TellstickNetSensors {
-
-    public TellstickNetSensors() {
-        super();
-    }
 
     List<TellstickNetSensor> sensors;
 


### PR DESCRIPTION
This pull request adds support for Power and Lux sensors values in [tellstick] binding, also fixes some null pointers when these value types are sent 

This pull request adds a new sensor: PowerSensor. Any sensor with a "watt" data type will be treated as a powersensor, these are normally devices that can report on current watt usage.
Also included are a new channel for normal sensors, lux. This channel will report the current detected lux if the sensor has this value type.

