### PR TITLE
[MIHOME] Update sensor switch actionName values in example rule

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/README.md
+++ b/addons/binding/org.openhab.binding.mihome/README.md
@@ -175,16 +175,16 @@ when
 then
     var actionName = receivedEvent.getEvent()
     switch(actionName) {
-        case "SHORT_PRESSED": {
+        case "CLICK": {
             <ACTION>
         }
-        case "DOUBLE_PRESSED": {
+        case "DOUBLE_CLICK": {
             <ACTION>
         }
-        case "LONG_PRESSED": {
+        case "LONG_CLICK_PRESS": {
             <ACTION>
         }
-        case "LONG_RELEASED": {
+        case "LONG_CLICK_RELEASE": {
             <ACTION>
         }
     }


### PR DESCRIPTION
I noticed that the actionName values have changed from PRESSED to CLICK with openHab 2.2.0. This is just to update the readme