### PR TITLE
[Nest] Add last_connection, last_online_change and last_manual_test_time channels

### DIFF
--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/camera.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/camera.xml
@@ -20,6 +20,7 @@
 			<channel id="public_share_enabled" typeId="PublicShareEnabled" />
 			<channel id="public_share_url" typeId="PublicShareUrl" />
 			<channel id="snapshot_url" typeId="SnapshotUrl" />
+			<channel id="last_online_change" typeId="LastOnlineChange" />
 		</channels>
 
 		<properties>

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/channels.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="nest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
-	<!-- structure -->
+
+	<!-- Common -->
+	<channel-type id="LastConnection" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Last Connection</label>
+		<description>Timestamp of the last successful interaction with Nest</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<!-- Structure -->
 	<channel-type id="Away">
 		<item-type>String</item-type>
 		<label>Away</label>
@@ -111,7 +120,14 @@
 		<description>The app URL for the camera, allows you to see the camera in an app</description>
 	</channel-type>
 
-	<!-- smoke detector -->
+	<channel-type id="LastOnlineChange" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Last Online Change</label>
+		<description>Timestamp of the last online status change</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<!-- Smoke detector -->
 	<channel-type id="UiColorState" advanced="true">
 		<item-type>String</item-type>
 		<label>Mode</label>
@@ -156,6 +172,13 @@
 		<item-type>Switch</item-type>
 		<label>Manual Test Active</label>
 		<description>If the manual test is currently active</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="LastManualTestTime" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Last Manual Test Time</label>
+		<description>Timestamp of the last successful manual test</description>
 		<state readOnly="true" />
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/smoke-detector.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/smoke-detector.xml
@@ -17,14 +17,16 @@
 			<channel id="co_alarm_state" typeId="CoAlarmState" />
 			<channel id="smoke_alarm_state" typeId="SmokeAlarmState" />
 			<channel id="manual_test_active" typeId="ManualTestActive" />
+			<channel id="last_manual_test_time" typeId="LastManualTestTime" />
+			<channel id="last_connection" typeId="LastConnection" />
 		</channels>
 
 		<properties>
 			<property name="vendor">Nest</property>
 		</properties>
 
-        <representation-property>deviceId</representation-property>
+		<representation-property>deviceId</representation-property>
 
-        <config-description-ref uri="thing-type:nest:device" />
+		<config-description-ref uri="thing-type:nest:device" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/thing/thermostat.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/thing/thermostat.xml
@@ -34,6 +34,7 @@
 			<channel id="locked_max_set_point" typeId="LockedMaxSetPoint" />
 			<channel id="locked_min_set_point" typeId="LockedMinSetPoint" />
 			<channel id="time_to_target_mins" typeId="TimeToTarget" />
+			<channel id="last_connection" typeId="LastConnection" />
 		</channels>
 
 		<properties>

--- a/addons/binding/org.openhab.binding.nest/README.md
+++ b/addons/binding/org.openhab.binding.nest/README.md
@@ -61,6 +61,7 @@ The account Thing Type does not have any channels.
 |-----------------------|-----------|---------------------------------------------------|:----------:|
 | app_url               | String    | The app URL to see the camera                     |      R     |
 | audio_input_enabled   | Switch    | If the audio input is currently enabled           |      R     |
+| last_online_change    | DateTime  | Timestamp of the last online status change        |      R     |
 | public_share_enabled  | Switch    | If public sharing is currently enabled            |      R     |
 | public_share_url      | String    | The URL to see the public share of the camera     |      R     |
 | snapshot_url          | String    | The URL to use for a snapshot of the video stream |      R     |
@@ -70,13 +71,15 @@ The account Thing Type does not have any channels.
 
 ### Smoke Detector Channels
 
-| Channel Type ID    | Item Type | Description                                                                       | Read Write |
-|--------------------|-----------|-----------------------------------------------------------------------------------|:----------:|
-| co_alarm_state     | String    | The carbon monoxide alarm state of the Nest Protect (OK, EMERGENCY, WARNING)      |      R     |
-| low_battery        | Switch    | Reports whether the battery of the Nest protect is low (if it is battery powered) |      R     |
-| manual_test_active | Switch    | Manual test active at the moment                                                  |      R     |
-| smoke_alarm_state  | String    | The smoke alarm state of the Nest Protect (OK, EMERGENCY, WARNING)                |      R     |
-| ui_color_state     | String    | The current color of the ring on the smoke detector (GRAY, GREEN, YELLOW, RED)    |      R     |
+| Channel Type ID       | Item Type | Description                                                                       | Read Write |
+|-----------------------|-----------|-----------------------------------------------------------------------------------|:----------:|
+| co_alarm_state        | String    | The carbon monoxide alarm state of the Nest Protect (OK, EMERGENCY, WARNING)      |      R     |
+| last_connection       | DateTime  | Timestamp of the last successful interaction with Nest                            |      R     |
+| last_manual_test_time | DateTime  | Timestamp of the last successful manual test                                      |      R     |
+| low_battery           | Switch    | Reports whether the battery of the Nest protect is low (if it is battery powered) |      R     |
+| manual_test_active    | Switch    | Manual test active at the moment                                                  |      R     |
+| smoke_alarm_state     | String    | The smoke alarm state of the Nest Protect (OK, EMERGENCY, WARNING)                |      R     |
+| ui_color_state        | String    | The current color of the ring on the smoke detector (GRAY, GREEN, YELLOW, RED)    |      R     |
 
 ### Structure Channels
 
@@ -105,6 +108,7 @@ The account Thing Type does not have any channels.
 | has_fan                     | Switch    | If the thermostat can control the fan                                                       |      R     |
 | has_leaf                    | Switch    | If the thermostat is currently in a leaf mode                                               |      R     |
 | humidity                    | Number    | Indicates the current relative humidity                                                     |      R     |
+| last_connection             | DateTime  | Timestamp of the last successful interaction with Nest                                      |      R     |
 | locked                      | Switch    | If the thermostat has the temperature locked to only be within a set range                  |      R     |
 | locked_max_set_point        | Number    | The locked range max set point in degrees Celsius                                           |     R/W    |
 | locked_min_set_point        | Number    | The locked range min set point in degrees Celsius                                           |     R/W    |
@@ -150,57 +154,61 @@ Bridge nest:account:demo_account [ productId="8fdf9885-ca07-4252-1aa3-f3d5ca9589
 
 ```
 /* Camera */
-String Cam_App_URL               "App URL [%s]"          { channel="nest:camera:demo_account:fish_cam:app_url" }
-Switch Cam_Audio_Input_Enabled   "Audio Input Enabled"   { channel="nest:camera:demo_account:fish_cam:audio_input_enabled" }
-String Cam_Snapshot_URL          "Snapshot URL [%s]"     { channel="nest:camera:demo_account:fish_cam:snapshot_url" }
-Switch Cam_Streaming             "Streaming"             { channel="nest:camera:demo_account:fish_cam:streaming" }
-Switch Cam_Public_Share_Enabled  "Public Share Enabled"  { channel="nest:camera:demo_account:fish_cam:public_share_enabled" }
-String Cam_Public_Share_URL      "Public Share URL [%s]" { channel="nest:camera:demo_account:fish_cam:public_share_url" }
-Switch Cam_Video_History_Enabled "Video History Enabled" { channel="nest:camera:demo_account:fish_cam:video_history_enabled" }
-String Cam_Web_URL               "Web URL [%s]"          { channel="nest:camera:demo_account:fish_cam:web_url" }
+String   Cam_App_URL               "App URL [%s]"                                             { channel="nest:camera:demo_account:fish_cam:app_url" }
+Switch   Cam_Audio_Input_Enabled   "Audio Input Enabled"                                      { channel="nest:camera:demo_account:fish_cam:audio_input_enabled" }
+DateTime Cam_Last_Online_Change    "Last Online Change [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]" { channel="nest:camera:demo_account:fish_cam:last_online_change" }
+String   Cam_Snapshot_URL          "Snapshot URL [%s]"                                        { channel="nest:camera:demo_account:fish_cam:snapshot_url" }
+Switch   Cam_Streaming             "Streaming"                                                { channel="nest:camera:demo_account:fish_cam:streaming" }
+Switch   Cam_Public_Share_Enabled  "Public Share Enabled"                                     { channel="nest:camera:demo_account:fish_cam:public_share_enabled" }
+String   Cam_Public_Share_URL      "Public Share URL [%s]"                                    { channel="nest:camera:demo_account:fish_cam:public_share_url" }
+Switch   Cam_Video_History_Enabled "Video History Enabled"                                    { channel="nest:camera:demo_account:fish_cam:video_history_enabled" }
+String   Cam_Web_URL               "Web URL [%s]"                                             { channel="nest:camera:demo_account:fish_cam:web_url" }
 
 /* Smoke Detector */
-String Smoke_CO_Alarm    "CO Alarm [%s]"    { channel="nest:smoke_detector:demo_account:hallway_smoke:co_alarm_state" }
-Switch Smoke_Battery_Low "Battery Low"      { channel="nest:smoke_detector:demo_account:hallway_smoke:low_battery" }
-Switch Smoke_Manual_Test "Manual Test"      { channel="nest:smoke_detector:demo_account:hallway_smoke:manual_test_active" }
-String Smoke_Smoke_Alarm "Smoke Alarm [%s]" { channel="nest:smoke_detector:demo_account:hallway_smoke:smoke_alarm_state" }
-String Smoke_UI_Color    "UI Color [%s]"    { channel="nest:smoke_detector:demo_account:hallway_smoke:ui_color_state" }
+String   Smoke_CO_Alarm            "CO Alarm [%s]"                                            { channel="nest:smoke_detector:demo_account:hallway_smoke:co_alarm_state" }
+Switch   Smoke_Battery_Low         "Battery Low"                                              { channel="nest:smoke_detector:demo_account:hallway_smoke:low_battery" }
+Switch   Smoke_Manual_Test         "Manual Test"                                              { channel="nest:smoke_detector:demo_account:hallway_smoke:manual_test_active" }
+DateTime Smoke_Last_Connection     "Last Connection [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"    { channel="nest:smoke_detector:demo_account:hallway_smoke:last_connection" }
+DateTime Smoke_Last_Manual_Test    "Last Manual Test [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"   { channel="nest:smoke_detector:demo_account:hallway_smoke:last_manual_test_time" }
+String   Smoke_Smoke_Alarm         "Smoke Alarm [%s]"                                         { channel="nest:smoke_detector:demo_account:hallway_smoke:smoke_alarm_state" }
+String   Smoke_UI_Color            "UI Color [%s]"                                            { channel="nest:smoke_detector:demo_account:hallway_smoke:ui_color_state" }
 
 /* Thermostat */
-Switch Thermostat_Can_Cool     "Can Cool"                       { channel="nest:thermostat:demo_account:living_thermostat:can_cool" }
-Switch Thermostat_Can_Heat     "Can Heat"                       { channel="nest:thermostat:demo_account:living_thermostat:can_heat" }
-Switch Thermostat_FT_Active    "Fan Timer Active"               { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_active" }
-Number Thermostat_FT_Duration  "Fan Timer Duration"             { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_duration" }
-DateTime Thermostat_FT_Timeout "Fan Timer Timeout [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]" { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_timeout" }
-Switch Thermostat_Has_Fan      "Has Fan"                        { channel="nest:thermostat:demo_account:living_thermostat:has_fan" }
-Switch Thermostat_Has_Leaf     "Has Leaf"                       { channel="nest:thermostat:demo_account:living_thermostat:has_leaf" }
-Number Thermostat_Humidity     "Humidity [%.1f %%]"             { channel="nest:thermostat:demo_account:living_thermostat:humidity" }
-Switch Thermostat_Locked       "Locked"                         { channel="nest:thermostat:demo_account:living_thermostat:locked" }
-Number Thermostat_LMaxSP       "Locked Max Set Point [%.1f °C]" { channel="nest:thermostat:demo_account:living_thermostat:locked_max_set_point" }
-Number Thermostat_LMinSP       "Locked Min Set Point [%.1f °C]" { channel="nest:thermostat:demo_account:living_thermostat:locked_min_set_point" }
-Number Thermostat_Max_SP       "Max Set Point [%.1f °C]"        { channel="nest:thermostat:demo_account:living_thermostat:max_set_point" }
-Number Thermostat_Min_SP       "Min Set Point [%.1f °C]"        { channel="nest:thermostat:demo_account:living_thermostat:min_set_point" }
-String Thermostat_Mode         "Mode [%s]"                      { channel="nest:thermostat:demo_account:living_thermostat:mode" }
-String Thermostat_PreviousMode "Previous Mode [%s]"             { channel="nest:thermostat:demo_account:living_thermostat:previous_mode" }
-String Thermostat_State        "State [%s]"                     { channel="nest:thermostat:demo_account:living_thermostat:state" }
-Number Thermostat_Set_Point    "Set Point [%.1f °C]"            { channel="nest:thermostat:demo_account:living_thermostat:set_point" }
-Switch Thermostat_SunlightCA   "Sunlight Correction Active"     { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_active" }
-Switch Thermostat_SunlightCE   "Sunlight Correction Enabled"    { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_enabled" }
-Number Thermostat_Temperature  "Temperature [%.1f °C]"          { channel="nest:thermostat:demo_account:living_thermostat:temperature" }
-Number Thermostat_TimeToTarget "Time To Target [%s]"            { channel="nest:thermostat:demo_account:living_thermostat:time_to_target_mins" }
-Switch Thermostat_UsingEmHeat  "Using Emergency Heat"           { channel="nest:thermostat:demo_account:living_thermostat:using_emergency_heat" }
+Switch   Thermostat_Can_Cool       "Can Cool"                                                 { channel="nest:thermostat:demo_account:living_thermostat:can_cool" }
+Switch   Thermostat_Can_Heat       "Can Heat"                                                 { channel="nest:thermostat:demo_account:living_thermostat:can_heat" }
+Switch   Thermostat_FT_Active      "Fan Timer Active"                                         { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_active" }
+Number   Thermostat_FT_Duration    "Fan Timer Duration"                                       { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_duration" }
+DateTime Thermostat_FT_Timeout     "Fan Timer Timeout [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"  { channel="nest:thermostat:demo_account:living_thermostat:fan_timer_timeout" }
+Switch   Thermostat_Has_Fan        "Has Fan"                                                  { channel="nest:thermostat:demo_account:living_thermostat:has_fan" }
+Switch   Thermostat_Has_Leaf       "Has Leaf"                                                 { channel="nest:thermostat:demo_account:living_thermostat:has_leaf" }
+Number   Thermostat_Humidity       "Humidity [%.1f %%]"                                       { channel="nest:thermostat:demo_account:living_thermostat:humidity" }
+DateTime Thermostat_Last_Conn      "Last Connection [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"    { channel="nest:thermostat:demo_account:living_thermostat:last_connection" }
+Switch   Thermostat_Locked         "Locked"                                                   { channel="nest:thermostat:demo_account:living_thermostat:locked" }
+Number   Thermostat_LMaxSP         "Locked Max Set Point [%.1f °C]"                           { channel="nest:thermostat:demo_account:living_thermostat:locked_max_set_point" }
+Number   Thermostat_LMinSP         "Locked Min Set Point [%.1f °C]"                           { channel="nest:thermostat:demo_account:living_thermostat:locked_min_set_point" }
+Number   Thermostat_Max_SP         "Max Set Point [%.1f °C]"                                  { channel="nest:thermostat:demo_account:living_thermostat:max_set_point" }
+Number   Thermostat_Min_SP         "Min Set Point [%.1f °C]"                                  { channel="nest:thermostat:demo_account:living_thermostat:min_set_point" }
+String   Thermostat_Mode           "Mode [%s]"                                                { channel="nest:thermostat:demo_account:living_thermostat:mode" }
+String   Thermostat_Previous_Mode  "Previous Mode [%s]"                                       { channel="nest:thermostat:demo_account:living_thermostat:previous_mode" }
+String   Thermostat_State          "State [%s]"                                               { channel="nest:thermostat:demo_account:living_thermostat:state" }
+Number   Thermostat_Set_Point      "Set Point [%.1f °C]"                                      { channel="nest:thermostat:demo_account:living_thermostat:set_point" }
+Switch   Thermostat_Sunlight_CA    "Sunlight Correction Active"                               { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_active" }
+Switch   Thermostat_Sunlight_CE    "Sunlight Correction Enabled"                              { channel="nest:thermostat:demo_account:living_thermostat:sunlight_correction_enabled" }
+Number   Thermostat_Temperature    "Temperature [%.1f °C]"                                    { channel="nest:thermostat:demo_account:living_thermostat:temperature" }
+Number   Thermostat_Time_To_Target "Time To Target [%s]"                                      { channel="nest:thermostat:demo_account:living_thermostat:time_to_target_mins" }
+Switch   Thermostat_Using_Em_Heat  "Using Emergency Heat"                                     { channel="nest:thermostat:demo_account:living_thermostat:using_emergency_heat" }
 
 /* Structure */
-String   Home_Away "Away [%s]"                                                      { channel="nest:structure:demo_account:home:away" }
-String   Home_CC   "Country Code [%s]"                                              { channel="nest:structure:demo_account:home:country_code" }
-String   Home_COAS "CO Alarm State [%s]"                                            { channel="nest:structure:demo_account:home:co_alarm_state" }
-DateTime Home_ETA  "ETA [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"                      { channel="nest:structure:demo_account:home:eta_begin" }
-DateTime Home_PPET "Peak Period End Time [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"     { channel="nest:structure:demo_account:home:peak_period_end_time" }
-DateTime Home_PPST "Peak Period Start Time [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"   { channel="nest:structure:demo_account:home:peak_period_start_time" }
-String   Home_PC   "Postal Code [%s]"                                               { channel="nest:structure:demo_account:home:postal_code" }
-Switch   Home_RHR  "Rush Hour Rewards"                                              { channel="nest:structure:demo_account:home:rush_hour_rewards_enrollment" }
-String   Home_SAS  "Smoke Alarm State [%s]"                                         { channel="nest:structure:demo_account:home:smoke_alarm_state" }
-String   Home_TZ   "Time Zone [%s]"                                                 { channel="nest:structure:demo_account:home:time_zone" }
+String   Home_Away                 "Away [%s]"                                                { channel="nest:structure:demo_account:home:away" }
+String   Home_Country_Code         "Country Code [%s]"                                        { channel="nest:structure:demo_account:home:country_code" }
+String   Home_CO_Alarm_State       "CO Alarm State [%s]"                                      { channel="nest:structure:demo_account:home:co_alarm_state" }
+DateTime Home_ETA                  "ETA [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"                { channel="nest:structure:demo_account:home:eta_begin" }
+DateTime Home_PP_End_Time          "PP End Time [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"        { channel="nest:structure:demo_account:home:peak_period_end_time" }
+DateTime Home_PP_Start_Time        "PP Start Time [%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS]"      { channel="nest:structure:demo_account:home:peak_period_start_time" }
+String   Home_Postal_Code          "Postal Code [%s]"                                         { channel="nest:structure:demo_account:home:postal_code" }
+Switch   Home_Rush_Hour_Rewards    "Rush Hour Rewards"                                        { channel="nest:structure:demo_account:home:rush_hour_rewards_enrollment" }
+String   Home_Smoke_Alarm_State    "Smoke Alarm State [%s]"                                   { channel="nest:structure:demo_account:home:smoke_alarm_state" }
+String   Home_Time_Zone            "Time Zone [%s]"                                           { channel="nest:structure:demo_account:home:time_zone" }
 ```
 
 ## Known Issues

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/NestBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/NestBindingConstants.java
@@ -54,6 +54,9 @@ public class NestBindingConstants {
     public static final ThingTypeUID THING_TYPE_STRUCTURE = new ThingTypeUID(BINDING_ID, "structure");
 
     // List of all Channel IDs
+    // read only channels (common)
+    public static final String CHANNEL_LAST_CONNECTION = "last_connection";
+
     // read/write channels (thermostat)
     public static final String CHANNEL_MODE = "mode";
     public static final String CHANNEL_SET_POINT = "set_point";
@@ -91,6 +94,7 @@ public class NestBindingConstants {
     public static final String CHANNEL_PUBLIC_SHARE_ENABLED = "public_share_enabled";
     public static final String CHANNEL_PUBLIC_SHARE_URL = "public_share_url";
     public static final String CHANNEL_SNAPSHOT_URL = "snapshot_url";
+    public static final String CHANNEL_LAST_ONLINE_CHANGE = "last_online_change";
 
     // read/write channels (smoke detector)
 
@@ -100,6 +104,7 @@ public class NestBindingConstants {
     public static final String CHANNEL_CO_ALARM_STATE = "co_alarm_state"; // Also in structure
     public static final String CHANNEL_SMOKE_ALARM_STATE = "smoke_alarm_state"; // Also in structure
     public static final String CHANNEL_MANUAL_TEST_ACTIVE = "manual_test_active";
+    public static final String CHANNEL_LAST_MANUAL_TEST_TIME = "last_manual_test_time";
 
     // read/write channel (structure)
     public static final String CHANNEL_AWAY = "away";

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
@@ -8,13 +8,15 @@
  */
 package org.openhab.binding.nest.handler;
 
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.TimeZone;
 
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -101,7 +103,8 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestDevice
     }
 
     protected NestBridgeHandler getNestBridgeHandler() {
-        return getBridge() != null ? (NestBridgeHandler) getBridge().getHandler() : null;
+        Bridge bridge = getBridge();
+        return bridge != null ? (NestBridgeHandler) bridge.getHandler() : null;
     }
 
     protected abstract State getChannelState(ChannelUID channelUID, T data);
@@ -110,9 +113,10 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestDevice
         if (date == null) {
             return UnDefType.NULL;
         }
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.setTime(date);
-        return new DateTimeType(cal);
+
+        long offsetMillis = TimeZone.getDefault().getOffset(date.getTime());
+        Instant instant = date.toInstant().plusMillis(offsetMillis);
+        return new DateTimeType(ZonedDateTime.ofInstant(instant, TimeZone.getDefault().toZoneId()));
     }
 
     protected OnOffType getAsOnOffType(boolean value) {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestCameraHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestCameraHandler.java
@@ -44,6 +44,8 @@ public class NestCameraHandler extends NestBaseHandler<Camera> {
                 return getAsStringTypeOrNull(camera.getAppUrl());
             case CHANNEL_AUDIO_INPUT_ENABLED:
                 return getAsOnOffType(camera.isAudioInputEnabled());
+            case CHANNEL_LAST_ONLINE_CHANGE:
+                return getAsDateTimeTypeOrNull(camera.getLastIsOnlineChange());
             case CHANNEL_PUBLIC_SHARE_ENABLED:
                 return getAsOnOffType(camera.isPublicShareEnabled());
             case CHANNEL_PUBLIC_SHARE_URL:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestSmokeDetectorHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestSmokeDetectorHandler.java
@@ -42,6 +42,10 @@ public class NestSmokeDetectorHandler extends NestBaseHandler<SmokeDetector> {
         switch (channelUID.getId()) {
             case CHANNEL_CO_ALARM_STATE:
                 return new StringType(smokeDetector.getCoAlarmState().toString());
+            case CHANNEL_LAST_CONNECTION:
+                return getAsDateTimeTypeOrNull(smokeDetector.getLastConnection());
+            case CHANNEL_LAST_MANUAL_TEST_TIME:
+                return getAsDateTimeTypeOrNull(smokeDetector.getLastManualTestTime());
             case CHANNEL_LOW_BATTERY:
                 return getAsOnOffType(smokeDetector.getBatteryHealth() == BatteryHealth.REPLACE);
             case CHANNEL_MANUAL_TEST_ACTIVE:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
@@ -59,6 +59,8 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
                 return getAsOnOffType(thermostat.isHasLeaf());
             case CHANNEL_HUMIDITY:
                 return new DecimalType(thermostat.getHumidity());
+            case CHANNEL_LAST_CONNECTION:
+                return getAsDateTimeTypeOrNull(thermostat.getLastConnection());
             case CHANNEL_LOCKED:
                 return getAsOnOffType(thermostat.isLocked());
             case CHANNEL_LOCKED_MAX_SET_POINT:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/SmokeDetector.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/SmokeDetector.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.nest.internal.data;
 
+import java.util.Date;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -20,6 +22,8 @@ public class SmokeDetector extends BaseNestDevice {
     private BatteryHealth batteryHealth;
     @SerializedName("co_alarm_state")
     private AlarmState coAlarmState;
+    @SerializedName("last_manual_test_time")
+    private Date lastManualTestTime;
     @SerializedName("smoke_alarm_state")
     private AlarmState smokeAlarmState;
     @SerializedName("is_manual_test_active")
@@ -37,6 +41,10 @@ public class SmokeDetector extends BaseNestDevice {
 
     public AlarmState getCoAlarmState() {
         return coAlarmState;
+    }
+
+    public Date getLastManualTestTime() {
+        return lastManualTestTime;
     }
 
     public AlarmState getSmokeAlarmState() {
@@ -78,14 +86,14 @@ public class SmokeDetector extends BaseNestDevice {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("SmokeDetector [batteryHealth=").append(batteryHealth).append(", coAlarmState=")
-                .append(coAlarmState).append(", smokeAlarmState=").append(smokeAlarmState)
-                .append(", isManualTestActive=").append(isManualTestActive).append(", uiColorState=")
-                .append(uiColorState).append(", getId()=").append(getId()).append(", getName()=").append(getName())
-                .append(", getDeviceId()=").append(getDeviceId()).append(", getLastConnection()=")
-                .append(getLastConnection()).append(", isOnline()=").append(isOnline()).append(", getNameLong()=")
-                .append(getNameLong()).append(", getSoftwareVersion()=").append(getSoftwareVersion())
-                .append(", getStructureId()=").append(getStructureId()).append(", getWhereId()=").append(getWhereId())
-                .append("]");
+                .append(coAlarmState).append(", lastManualTestTime=").append(lastManualTestTime)
+                .append(", smokeAlarmState=").append(smokeAlarmState).append(", isManualTestActive=")
+                .append(isManualTestActive).append(", uiColorState=").append(uiColorState).append(", getId()=")
+                .append(getId()).append(", getName()=").append(getName()).append(", getDeviceId()=")
+                .append(getDeviceId()).append(", getLastConnection()=").append(getLastConnection())
+                .append(", isOnline()=").append(isOnline()).append(", getNameLong()=").append(getNameLong())
+                .append(", getSoftwareVersion()=").append(getSoftwareVersion()).append(", getStructureId()=")
+                .append(getStructureId()).append(", getWhereId()=").append(getWhereId()).append("]");
         return builder.toString();
     }
 


### PR DESCRIPTION
Adds the following channels:
* last_connection (thermostat, smoke detector)
* last_online_change (camera)
* last_manual_test_time (smoke detector)

Also fixed:
* Creating DateTimeType using a ZonedDateTime instead of using deprecated Date constructor
* Potential NPE in `getNestBridgeHandler()`

