### PR TITLE
[Squeezebox] Switch to ESH HttpUtil for downloading images

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
@@ -10,9 +10,7 @@ Export-Package:
  org.openhab.binding.squeezebox,
  org.openhab.binding.squeezebox.handler
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
- org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.jetty.client,
@@ -24,11 +22,13 @@ Import-Package:
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.audio,
  org.eclipse.smarthome.core.audio.utils,
+ org.eclipse.smarthome.core.cache,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.net.http,
  org.eclipse.smarthome.io.transport.upnp,
  org.jupnp,
  org.jupnp.model,

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
@@ -15,6 +15,8 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.audio.AudioHTTPServer;
@@ -39,8 +41,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Sets;
-
 /**
  * The {@link SqueezeBoxHandlerFactory} is responsible for creating things and
  * thing handlers.
@@ -53,8 +53,10 @@ public class SqueezeBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxHandlerFactory.class);
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.union(
-            SqueezeBoxServerHandler.SUPPORTED_THING_TYPES_UIDS, SqueezeBoxPlayerHandler.SUPPORTED_THING_TYPES_UIDS);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .concat(SqueezeBoxServerHandler.SUPPORTED_THING_TYPES_UIDS.stream(),
+                    SqueezeBoxPlayerHandler.SUPPORTED_THING_TYPES_UIDS.stream())
+            .collect(Collectors.toSet());
 
     private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
@@ -8,11 +8,8 @@
  */
 package org.openhab.binding.squeezebox.internal.utils;
 
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.util.StringContentProvider;
@@ -75,18 +72,6 @@ public class HttpUtils {
         }
 
         return response.getContentAsString();
-    }
-
-    /**
-     * Returns a byte array from a URL string
-     *
-     * @param urlString
-     * @return byte array of data
-     */
-    public static byte[] getData(String urlString) throws Exception {
-        URL url = new URL(urlString);
-        URLConnection connection = url.openConnection();
-        return IOUtils.toByteArray(connection.getInputStream());
     }
 
     /**


### PR DESCRIPTION
- Switch to ESH HttpUtil for downloading images
- Added cache for downloaded images
- Removed `com.google.common.collect` dependency

Closes #2989

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>