### PR TITLE
[SqueezeBox] Support for mixer volume command added

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Improved handling of player status, prevent REFRESH from causing exception
  * @author Mark Hilbush - Implement AudioSink and notifications
  * @author Mark Hilbush - Added duration channel
+ * @author Patrik Gfeller - Timeout for TTS messages increased from 30 to 90s.
  */
 public class SqueezeBoxPlayerHandler extends BaseThingHandler implements SqueezeBoxPlayerEventListener {
 
@@ -720,7 +721,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
      * Monitor the status of the notification so that we know when it has finished playing
      */
     private boolean waitForNotification() {
-        final int timeoutMaxCount = 300;
+        final int timeoutMaxCount = 900;
 
         SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
         squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Added duration channel
  * @author Mark Hilbush - Added login/password authentication for LMS
  * @author Philippe Siem - Improve refresh of cover art url,remote title, artist, album, genre, year.
+ * @author Patrik Gfeller - Support for mixer volume message added
  */
 public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
@@ -527,23 +528,31 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
             // get the message type
             String messageType = messageParts[1];
+            switch (messageType) {
+                case "status":
+                    handleStatusMessage(mac, messageParts);
+                    break;
+                case "playlist":
+                    handlePlaylistMessage(mac, messageParts);
+                    break;
+                case "prefset":
+                    handlePrefsetMessage(mac, messageParts);
+                    break;
+                case "mixer":
+                    handleMixerMessage(mac, messageParts);
+                    break;
+                case "ir":
+                    final String ircode = messageParts[2];
+                    updatePlayer(new PlayerUpdateEvent() {
+                        @Override
+                        public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                            listener.irCodeChangeEvent(mac, ircode);
+                        }
+                    });
+                    break;
+                default:
+                    logger.trace("Unhandled player update message type '{}'.", messageType);
 
-            if (messageType.equals("status")) {
-                handleStatusMessage(mac, messageParts);
-            } else if (messageType.equals("playlist")) {
-                handlePlaylistMessage(mac, messageParts);
-            } else if (messageType.equals("prefset")) {
-                handlePrefsetMessage(mac, messageParts);
-            } else if (messageType.equals("ir")) {
-                final String ircode = messageParts[2];
-                updatePlayer(new PlayerUpdateEvent() {
-                    @Override
-                    public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                        listener.irCodeChangeEvent(mac, ircode);
-                    }
-                });
-            } else {
-                logger.trace("Unhandled player update message type '{}'.", messageType);
             }
         }
 
@@ -570,6 +579,26 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
         private String fetchUrl(final String mac) {
             return fetchUrl(null, mac);
+        }
+
+        private void handleMixerMessage(String mac, String[] messageParts) {
+            String action = messageParts[2];
+
+            switch (action) {
+                case "volume":
+                    String value = messageParts[3];
+                    updatePlayer(new PlayerUpdateEvent() {
+                        @Override
+                        public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                            listener.volumeChangeEvent(mac, Integer.parseInt(value));
+                        }
+                    });
+                    break;
+                default:
+                    logger.trace("Unhandled mixer message type '{}'", Arrays.toString(messageParts));
+
+            }
+
         }
 
         private void handleStatusMessage(final String mac, String[] messageParts) {


### PR DESCRIPTION
On configurations with multiple squeezebox players (hardware) the mixer volume command needs to be handled to avoid timeouts during text-to-speech.

Signed-off-by: Patrik Gfeller <patrik.gfeller@gmail.com>