### PR TITLE
[SqueezeBox] Refactoring to simplify player handler code, also solves issue #3080

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
@@ -127,8 +127,8 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
         }
 
         int newVolume = this.volume.get() + volumeChange;
-        newVolume = Math.max(newVolume, 100);
-        newVolume = Math.min(newVolume, 0);
+        newVolume = Math.min(newVolume, 100);
+        newVolume = Math.max(newVolume, 0);
 
         this.volume.set(newVolume);
         logger.trace("Volume changed [{}] for player {}. New volume: {}", volumeChange, mac, volume);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -128,8 +128,9 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
 
         int newVolume = this.volume.get() + volumeChange;
         newVolume = Math.max(newVolume, 100);
-        newVolume = Math.max(newVolume, 0);
+        newVolume = Math.min(newVolume, 0);
 
+        this.volume.set(newVolume);
         logger.trace("Volume changed [{}] for player {}. New volume: {}", volumeChange, mac, volume);
     }
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
@@ -130,7 +130,7 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
         newVolume = Math.max(newVolume, 100);
         newVolume = Math.max(newVolume, 0);
 
-        logger.trace("Volume changed {} for player {}. New volume: {}", volume, mac, volumeChange);
+        logger.trace("Volume changed [{}] for player {}. New volume: {}", volumeChange, mac, volume);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationListener.java
@@ -112,12 +112,25 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
      * Monitor for when the volume is updated to a specific target value
      */
     @Override
-    public void volumeChangeEvent(String mac, int volume) {
+    public void absoluteVolumeChangeEvent(String mac, int volume) {
         if (!this.playerMAC.equals(mac)) {
             return;
         }
         this.volume.set(volume);
         logger.trace("Volume is {} for player {}", volume, mac);
+    }
+
+    @Override
+    public void relativeVolumeChangeEvent(String mac, int volumeChange) {
+        if (!this.playerMAC.equals(mac)) {
+            return;
+        }
+
+        int newVolume = this.volume.get() + volumeChange;
+        newVolume = Math.max(newVolume, 100);
+        newVolume = Math.max(newVolume, 0);
+
+        logger.trace("Volume changed {} for player {}. New volume: {}", volume, mac, volumeChange);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.squeezebox.handler;
+
+import java.io.Closeable;
+
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.openhab.binding.squeezebox.internal.utils.SqueezeBoxTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * Utility class to play a notification message. The message is added
+ * to the playlist, played and the previous state of the playlist and the
+ * player is restored.
+ *
+ * @author Mark Hilbush - Initial Contribution
+ * @author Patrik Gfeller - Utility class added reduce complexity and length of SqueezeBoxPlayerHandler.java
+ *
+ */
+class SqueezeBoxNotificationPlayer implements Closeable {
+    // An exception is thrown if we do not receive an acknowledge
+    // for a volume set command in the given amount of time [s].
+    final int volumeCommandTimeout = 4;
+
+    // We expect the media server to acknowledge a playlist command.
+    // An exception is thrown if the playlist command was not processed
+    // after the defined amount in [s]
+    final int playlistCommandTimeout = 5;
+
+    // Max length of the message in [s]. An exception is thrown if we did not
+    // receive a "stop" message from the media server.
+    final int notificationLengthTimeout = 90;
+
+    private Logger logger = LoggerFactory.getLogger(SqueezeBoxNotificationPlayer.class);
+    private SqueezeBoxPlayerState playerState;
+    private SqueezeBoxPlayerHandler squeezeBoxPlayerHandler;
+    private SqueezeBoxServerHandler squeezeBoxServerHandler;
+    private StringType uri;
+    private String mac;
+
+    boolean playlistModified;
+
+    private int notificationMessagePlaylistsIndex;
+
+    SqueezeBoxNotificationPlayer(SqueezeBoxPlayerHandler squeezeBoxPlayerHandler,
+            SqueezeBoxServerHandler squeezeBoxServerHandler, StringType uri) {
+        this.squeezeBoxPlayerHandler = squeezeBoxPlayerHandler;
+        this.squeezeBoxServerHandler = squeezeBoxServerHandler;
+        this.mac = squeezeBoxPlayerHandler.getMac();
+        this.uri = uri;
+        this.playerState = new SqueezeBoxPlayerState(squeezeBoxPlayerHandler);
+    }
+
+    void play() throws InterruptedException, SqueezeBoxTimeoutException {
+        if (squeezeBoxServerHandler == null) {
+            logger.warn("Server handler is null");
+            return;
+        }
+
+        setupPlayerForNotification();
+
+        try {
+            addNotificationMessageToPlaylist();
+            playNotification();
+        } finally {
+            if (playlistModified) {
+                // Mute the player to prevent any noise during the transition
+                // to previous state.
+                setVolume(0);
+                removeNotificationMessageFromPlaylist();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        restorePlayerState();
+    }
+
+    private void setupPlayerForNotification() throws InterruptedException, SqueezeBoxTimeoutException {
+        logger.debug("Setting up player for notification");
+        if (!playerState.isPoweredOn()) {
+            logger.debug("Powering on the player");
+            squeezeBoxServerHandler.powerOn(mac);
+        }
+        if (playerState.isShuffling()) {
+            logger.debug("Turning off shuffle");
+            squeezeBoxServerHandler.setShuffleMode(mac, 0);
+        }
+        if (playerState.isRepeating()) {
+            logger.debug("Turning off repeat");
+            squeezeBoxServerHandler.setRepeatMode(mac, 0);
+        }
+        if (playerState.isPlaying()) {
+            squeezeBoxServerHandler.stop(mac);
+        }
+
+        int notificationVolume = squeezeBoxPlayerHandler.getNotificationSoundVolume().intValue();
+        setVolume(notificationVolume);
+    }
+
+    /**
+     * Sends a volume set command if target volume is not equal to the current volume.
+     *
+     * @param requestedVolume The requested volume value.
+     * @throws InterruptedException Thread interrupted during while we were waiting for an answer from the media server.
+     * @throws SqueezeBoxTimeoutException Volume command was not acknowledged by the media server.
+     */
+    private void setVolume(int requestedVolume) throws InterruptedException, SqueezeBoxTimeoutException {
+        if (playerState.getVolume() == requestedVolume) {
+            return;
+        }
+
+        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
+        listener.resetVolumeUpdated();
+
+        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
+        squeezeBoxServerHandler.setVolume(mac, requestedVolume);
+
+        logger.trace("Waiting up to {} ms for volume to be updated...", volumeCommandTimeout * 1000);
+
+        try {
+            int timeoutCount = 0;
+
+            while (!listener.isVolumeUpdated(requestedVolume)) {
+                Thread.sleep(100);
+                if (timeoutCount++ > volumeCommandTimeout * 10) {
+                    throw new SqueezeBoxTimeoutException("Unable to update volume.");
+                }
+            }
+        } finally {
+            squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
+        }
+    }
+
+    private void addNotificationMessageToPlaylist() throws InterruptedException, SqueezeBoxTimeoutException {
+        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
+        listener.resetPlaylistUpdated();
+
+        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
+        squeezeBoxServerHandler.addPlaylistItem(mac, uri.toString());
+
+        try {
+            waitForPlaylistUpdate(listener);
+        } finally {
+            squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
+        }
+    }
+
+    private void removeNotificationMessageFromPlaylist() throws InterruptedException, SqueezeBoxTimeoutException {
+        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
+        listener.resetPlaylistUpdated();
+
+        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
+        squeezeBoxServerHandler.deletePlaylistItem(mac, notificationMessagePlaylistsIndex);
+
+        try {
+            waitForPlaylistUpdate(listener);
+        } finally {
+            squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
+        }
+    }
+
+    /**
+     * Monitor the number of playlist entries. When it changes, then we know the playlist
+     * has been updated with the notification URL. There's probably an edge case here where
+     * someone is updating the playlist at the same time, but that should be rare.
+     *
+     * @param listener
+     * @throws InterruptedException
+     * @throws SqueezeBoxTimeoutException
+     */
+    private void waitForPlaylistUpdate(SqueezeBoxNotificationListener listener)
+            throws InterruptedException, SqueezeBoxTimeoutException {
+        logger.trace("Waiting up to {} ms for playlist to be updated...", playlistCommandTimeout * 1000);
+
+        int timeoutCount = 0;
+
+        while (!listener.isPlaylistUpdated()) {
+            Thread.sleep(100);
+            if (timeoutCount++ > playlistCommandTimeout * 10) {
+                throw new SqueezeBoxTimeoutException("Unable to update playlist.");
+            }
+        }
+
+        this.playlistModified = true;
+    }
+
+    private void playNotification() throws InterruptedException, SqueezeBoxTimeoutException {
+        logger.debug("Playing notification");
+
+        notificationMessagePlaylistsIndex = squeezeBoxPlayerHandler.currentNumberPlaylistTracks() - 1;
+        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
+        listener.resetStopped();
+
+        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
+        squeezeBoxServerHandler.playPlaylistItem(mac, notificationMessagePlaylistsIndex);
+
+        logger.trace("Waiting up to {} ms for stop...", notificationLengthTimeout * 1000);
+
+        try {
+            int timeoutCount = 0;
+
+            while (!listener.isStopped()) {
+                Thread.sleep(100);
+                if (timeoutCount++ > notificationLengthTimeout * 10) {
+                    throw new SqueezeBoxTimeoutException("Unable to play message.");
+                }
+            }
+        } finally {
+            squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
+        }
+    }
+
+    private void restorePlayerState() {
+        logger.debug("Restoring player state");
+
+        // Resume playing save playlist item if player wasn't stopped.
+        // Note that setting the time doesn't work for remote streams.
+        if (!playerState.isStopped()) {
+            logger.debug("Resuming last item playing");
+            squeezeBoxServerHandler.playPlaylistItem(mac, playerState.getPlaylistIndex());
+            squeezeBoxServerHandler.setPlayingTime(mac, playerState.getPlayingTime());
+        } else if (!playerState.isPlaying()) {
+            logger.debug("Pausing the player");
+            squeezeBoxServerHandler.pause(mac);
+        } else {
+            logger.debug("Stopping the player");
+            squeezeBoxServerHandler.stop(mac);
+        }
+
+        // We do not wait for the volume acknowledge to avoid exceptions during
+        // clean up. If we are not able to set the volume there´s nothing we can
+        // do about it.
+        squeezeBoxServerHandler.setVolume(mac, playerState.getVolume());
+
+        if (playerState.isShuffling()) {
+            logger.debug("Restoring shuffle mode");
+            squeezeBoxServerHandler.setShuffleMode(mac, playerState.getShuffle());
+        }
+        if (playerState.isRepeating()) {
+            logger.debug("Restoring repeat mode");
+            squeezeBoxServerHandler.setRepeatMode(mac, playerState.getRepeat());
+        }
+        if (playerState.isMuted()) {
+            logger.debug("Re-muting the player");
+            squeezeBoxServerHandler.mute(mac);
+        }
+        if (!playerState.isPoweredOn()) {
+            logger.debug("Powering off the player");
+            squeezeBoxServerHandler.powerOff(mac);
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -103,6 +103,9 @@ class SqueezeBoxNotificationPlayer implements Closeable {
         }
 
         int notificationVolume = squeezeBoxPlayerHandler.getNotificationSoundVolume().intValue();
+        if (notificationVolume == 0) {
+            logger.warn("Player volume is 0.");
+        }
         setVolume(notificationVolume);
     }
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerEventListener.java
@@ -22,7 +22,21 @@ public interface SqueezeBoxPlayerEventListener {
 
     void modeChangeEvent(String mac, String mode);
 
-    void volumeChangeEvent(String mac, int volume);
+    /**
+     * Reports a new absolute volume for a given player.
+     * 
+     * @param mac
+     * @param volume
+     */
+    void absoluteVolumeChangeEvent(String mac, int volume);
+
+    /**
+     * Reports a relative volume change for a given player.
+     * 
+     * @param mac
+     * @param volumeChange
+     */
+    void relativeVolumeChangeEvent(String mac, int volumeChange);
 
     void muteChangeEvent(String mac, boolean mute);
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.openhab.binding.squeezebox.SqueezeBoxBindingConstants;
 import org.openhab.binding.squeezebox.internal.config.SqueezeBoxPlayerConfig;
+import org.openhab.binding.squeezebox.internal.utils.HttpUtils;
 import org.openhab.binding.squeezebox.internal.utils.SqueezeBoxTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -318,6 +318,10 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         newVolume = Math.min(100, newVolume);
         newVolume = Math.max(0, newVolume);
         updateChannel(mac, CHANNEL_VOLUME, new PercentType(newVolume));
+
+        if (isMe(mac)) {
+            logger.trace("Volume changed [{}] for player {}. New volume: {}", volumeChange, mac, newVolume);
+        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -43,7 +43,6 @@ import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.openhab.binding.squeezebox.SqueezeBoxBindingConstants;
 import org.openhab.binding.squeezebox.internal.config.SqueezeBoxPlayerConfig;
-import org.openhab.binding.squeezebox.internal.utils.HttpUtils;
 import org.openhab.binding.squeezebox.internal.utils.SqueezeBoxTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -307,9 +306,10 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
 
     @Override
     public void volumeChangeEvent(String mac, int volume) {
-        volume = Math.min(100, volume);
-        volume = Math.max(0, volume);
-        updateChannel(mac, CHANNEL_VOLUME, new PercentType(volume));
+        int newVolume = volume;
+        newVolume = Math.min(100, newVolume);
+        newVolume = Math.max(0, newVolume);
+        updateChannel(mac, CHANNEL_VOLUME, new PercentType(newVolume));
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -305,8 +305,16 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     }
 
     @Override
-    public void volumeChangeEvent(String mac, int volume) {
+    public void absoluteVolumeChangeEvent(String mac, int volume) {
         int newVolume = volume;
+        newVolume = Math.min(100, newVolume);
+        newVolume = Math.max(0, newVolume);
+        updateChannel(mac, CHANNEL_VOLUME, new PercentType(newVolume));
+    }
+
+    @Override
+    public void relativeVolumeChangeEvent(String mac, int volumeChange) {
+        int newVolume = currentVolume() + volumeChange;
         newVolume = Math.min(100, newVolume);
         newVolume = Math.max(0, newVolume);
         updateChannel(mac, CHANNEL_VOLUME, new PercentType(newVolume));

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.openhab.binding.squeezebox.SqueezeBoxBindingConstants;
 import org.openhab.binding.squeezebox.internal.config.SqueezeBoxPlayerConfig;
+import org.openhab.binding.squeezebox.internal.utils.SqueezeBoxTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -469,7 +470,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
      *
      * @return
      */
-    private int currentVolume() {
+    int currentVolume() {
         if (stateMap.containsKey(CHANNEL_VOLUME)) {
             return ((DecimalType) stateMap.get(CHANNEL_VOLUME)).intValue();
         } else {
@@ -477,7 +478,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private int currentPlayingTime() {
+    int currentPlayingTime() {
         if (stateMap.containsKey(CHANNEL_CURRENT_PLAYING_TIME)) {
             return ((DecimalType) stateMap.get(CHANNEL_CURRENT_PLAYING_TIME)).intValue();
         } else {
@@ -485,7 +486,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private int currentNumberPlaylistTracks() {
+    int currentNumberPlaylistTracks() {
         if (stateMap.containsKey(CHANNEL_NUMBER_PLAYLIST_TRACKS)) {
             return ((DecimalType) stateMap.get(CHANNEL_NUMBER_PLAYLIST_TRACKS)).intValue();
         } else {
@@ -493,7 +494,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private int currentPlaylistIndex() {
+    int currentPlaylistIndex() {
         if (stateMap.containsKey(CHANNEL_PLAYLIST_INDEX)) {
             return ((DecimalType) stateMap.get(CHANNEL_PLAYLIST_INDEX)).intValue();
         } else {
@@ -501,7 +502,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private boolean currentPower() {
+    boolean currentPower() {
         if (stateMap.containsKey(CHANNEL_POWER)) {
             return (stateMap.get(CHANNEL_POWER).equals(OnOffType.ON) ? true : false);
         } else {
@@ -509,7 +510,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private boolean currentStop() {
+    boolean currentStop() {
         if (stateMap.containsKey(CHANNEL_STOP)) {
             return (stateMap.get(CHANNEL_STOP).equals(OnOffType.ON) ? true : false);
         } else {
@@ -517,7 +518,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private boolean currentControl() {
+    boolean currentControl() {
         if (stateMap.containsKey(CHANNEL_CONTROL)) {
             return (stateMap.get(CHANNEL_CONTROL).equals(PlayPauseType.PLAY) ? true : false);
         } else {
@@ -525,7 +526,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private boolean currentMute() {
+    boolean currentMute() {
         if (stateMap.containsKey(CHANNEL_MUTE)) {
             return (stateMap.get(CHANNEL_MUTE).equals(OnOffType.ON) ? true : false);
         } else {
@@ -533,7 +534,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private int currentShuffle() {
+    int currentShuffle() {
         if (stateMap.containsKey(CHANNEL_CURRENT_PLAYLIST_SHUFFLE)) {
             return ((DecimalType) stateMap.get(CHANNEL_CURRENT_PLAYLIST_SHUFFLE)).intValue();
         } else {
@@ -541,7 +542,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         }
     }
 
-    private int currentRepeat() {
+    int currentRepeat() {
         if (stateMap.containsKey(CHANNEL_CURRENT_PLAYLIST_REPEAT)) {
             return ((DecimalType) stateMap.get(CHANNEL_CURRENT_PLAYLIST_REPEAT)).intValue();
         } else {
@@ -611,231 +612,17 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     }
 
     /*
-     * Play the notification by 1) saving the state of the player, 2) stopping the current
-     * playlist item, 3) adding the notification as a new playlist item, 4) playing the
-     * new playlist item, and 5) restoring the player to its previous state.
+     * Play the notification.
      */
     public void playNotificationSoundURI(StringType uri) {
         logger.debug("Play notification sound on player {} at URI {}", mac, uri);
 
-        SqueezeBoxPlayerState playerState = new SqueezeBoxPlayerState();
-        playNotification(playerState, uri);
-    }
-
-    private void playNotification(SqueezeBoxPlayerState playerState, StringType uri) {
-        if (squeezeBoxServerHandler == null) {
-            logger.warn("Server handler is null in playNotification");
-            return;
+        try (SqueezeBoxNotificationPlayer notificationPlayer = new SqueezeBoxNotificationPlayer(this,
+                squeezeBoxServerHandler, uri)) {
+            notificationPlayer.play();
+        } catch (InterruptedException | SqueezeBoxTimeoutException e) {
+            logger.warn("Problem during notification playback.", e);
         }
-
-        logger.debug("Setting up player for notification");
-        if (!playerState.isPoweredOn()) {
-            logger.debug("Powering on the player");
-            squeezeBoxServerHandler.powerOn(mac);
-        }
-        if (playerState.isShuffling()) {
-            logger.debug("Turning off shuffle");
-            squeezeBoxServerHandler.setShuffleMode(mac, 0);
-        }
-        if (playerState.isRepeating()) {
-            logger.debug("Turning off repeat");
-            squeezeBoxServerHandler.setRepeatMode(mac, 0);
-        }
-        if (playerState.isPlaying()) {
-            squeezeBoxServerHandler.stop(mac);
-        }
-
-        int notificationVolume = getNotificationSoundVolume().intValue();
-        squeezeBoxServerHandler.setVolume(mac, notificationVolume);
-        waitForVolume(notificationVolume);
-
-        // Add the notification uri to the playlist, get the playlist item index, then play
-        logger.debug("Playing notification");
-        squeezeBoxServerHandler.addPlaylistItem(mac, uri.toString());
-        if (!waitForPlaylistUpdate()) {
-            // Give up since we timed out waiting for playlist to update
-            squeezeBoxServerHandler.setVolume(mac, playerState.getVolume());
-            waitForVolume(playerState.getVolume());
-            return;
-        }
-        int newNumberPlaylistTracks = currentNumberPlaylistTracks();
-        squeezeBoxServerHandler.playPlaylistItem(mac, newNumberPlaylistTracks - 1);
-        waitForNotification();
-
-        logger.debug("Restoring player state");
-        // Mute the player to prevent any noise during the transition to previous state
-        squeezeBoxServerHandler.setVolume(mac, 0);
-        waitForVolume(0);
-        // Remove the notification uri from the playlist
-        squeezeBoxServerHandler.deletePlaylistItem(mac, newNumberPlaylistTracks - 1);
-        waitForPlaylistUpdate();
-
-        // Resume playing save playlist item if player wasn't stopped
-        if (!playerState.isStopped()) {
-            logger.debug("Resuming last item playing");
-            squeezeBoxServerHandler.playPlaylistItem(mac, playerState.getPlaylistIndex());
-            waitForPlaylistUpdate();
-            // Note that setting the time doesn't work for remote streams
-            squeezeBoxServerHandler.setPlayingTime(mac, playerState.getPlayingTime());
-        }
-
-        if (playerState.isStopped()) {
-            logger.debug("Stopping the player");
-            squeezeBoxServerHandler.stop(mac);
-        } else if (playerState.isPlaying()) {
-            logger.debug("Playing the playlist item");
-            // Nothing to do; should already be playing due to call to playPlaylistItem above
-        } else {
-            logger.debug("Pausing the player");
-            // Sometimes the first couple pauses don't work (really!)
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-            }
-            int count;
-            final int maxPauseAttempts = 4;
-            for (count = 0; count < maxPauseAttempts; count++) {
-                squeezeBoxServerHandler.pause(mac);
-                if (waitForPause()) {
-                    break;
-                }
-            }
-            if (count == maxPauseAttempts) {
-                // Unable to pause, try to stop
-                squeezeBoxServerHandler.stop(mac);
-            }
-        }
-        // Now we can restore the volume and the remaining state items
-        squeezeBoxServerHandler.setVolume(mac, playerState.getVolume());
-        waitForVolume(playerState.getVolume());
-
-        if (playerState.isShuffling()) {
-            logger.debug("Restoring shuffle mode");
-            squeezeBoxServerHandler.setShuffleMode(mac, playerState.getShuffle());
-        }
-        if (playerState.isRepeating()) {
-            logger.debug("Restoring repeat mode");
-            squeezeBoxServerHandler.setRepeatMode(mac, playerState.getRepeat());
-        }
-        if (playerState.isMuted()) {
-            logger.debug("Re-muting the player");
-            squeezeBoxServerHandler.mute(mac);
-        }
-        if (!playerState.isPoweredOn()) {
-            logger.debug("Powering off the player");
-            squeezeBoxServerHandler.powerOff(mac);
-        }
-    }
-
-    /*
-     * Monitor the number of playlist entries. When it changes, then we know the playlist
-     * has been updated with the notification URL. There's probably an edge case here where
-     * someone is updating the playlist at the same time, but that should be rare.
-     */
-    private boolean waitForPlaylistUpdate() {
-        final int timeoutMaxCount = 50;
-
-        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
-        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
-
-        logger.trace("Waiting up to {} ms for playlist to be updated...", timeoutMaxCount * 100);
-        listener.resetPlaylistUpdated();
-        int timeoutCount = 0;
-        while (!listener.isPlaylistUpdated() && timeoutCount < timeoutMaxCount) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                break;
-            }
-            timeoutCount++;
-        }
-        squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
-        listener = null;
-        return checkForTimeout(timeoutCount, timeoutMaxCount, "playlist to update");
-    }
-
-    /*
-     * Monitor the status of the notification so that we know when it has finished playing
-     */
-    private boolean waitForNotification() {
-        final int timeoutMaxCount = 900;
-
-        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
-        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
-
-        logger.trace("Waiting up to {} ms for stop...", timeoutMaxCount * 100);
-        listener.resetStopped();
-        int timeoutCount = 0;
-        while (!listener.isStopped() && timeoutCount < timeoutMaxCount) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                break;
-            }
-            timeoutCount++;
-        }
-        squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
-        listener = null;
-        return checkForTimeout(timeoutCount, timeoutMaxCount, "stop");
-    }
-
-    /*
-     * Wait for the volume status to equal the targetVolume
-     */
-    private boolean waitForVolume(int targetVolume) {
-        final int timeoutMaxCount = 40;
-
-        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
-        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
-
-        logger.trace("Waiting up to {} ms for volume to update...", timeoutMaxCount * 100);
-        listener.resetVolumeUpdated();
-        int timeoutCount = 0;
-        while (!listener.isVolumeUpdated(targetVolume) && timeoutCount < timeoutMaxCount) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                break;
-            }
-            timeoutCount++;
-        }
-        squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
-        listener = null;
-        return checkForTimeout(timeoutCount, timeoutMaxCount, "volume to update");
-    }
-
-    /*
-     * Wait for the mode to reflect that the player is paused
-     */
-    private boolean waitForPause() {
-        final int timeoutMaxCount = 25;
-
-        SqueezeBoxNotificationListener listener = new SqueezeBoxNotificationListener(mac);
-        squeezeBoxServerHandler.registerSqueezeBoxPlayerListener(listener);
-
-        logger.trace("Waiting up to {} ms for player to pause...", timeoutMaxCount * 100);
-        listener.resetPaused();
-        int timeoutCount = 0;
-        while (!listener.isPaused() && timeoutCount < timeoutMaxCount) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                break;
-            }
-            timeoutCount++;
-        }
-        squeezeBoxServerHandler.unregisterSqueezeBoxPlayerListener(listener);
-        listener = null;
-        return checkForTimeout(timeoutCount, timeoutMaxCount, "player to pause");
-    }
-
-    private boolean checkForTimeout(int timeoutCount, int timeoutLimit, String message) {
-        if (timeoutCount >= timeoutLimit) {
-            logger.warn("TIMEOUT after {} waiting for {}!", timeoutCount * 100, message);
-            return false;
-        }
-        logger.debug("Done waiting {} ms for {}", timeoutCount * 100, message);
-        return true;
     }
 
     /*
@@ -843,128 +630,5 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
      */
     public String getHostAndPort() {
         return callbackUrl;
-    }
-
-    /**
-     * The {@link SqueezeBoxPlayerState} is responsible for saving the state of a player.
-     *
-     * @author Mark Hilbush - Added support for AudioSink and notifications
-     */
-    public class SqueezeBoxPlayerState {
-        int savedVolume;
-        boolean savedMute;
-        boolean savedPower;
-        boolean savedStop;
-        boolean savedControl;
-        int savedShuffle;
-        int savedRepeat;
-        int savedPlaylistIndex;
-        int savedNumberPlaylistTracks;
-        int savedPlayingTime;
-
-        public SqueezeBoxPlayerState() {
-            save();
-        }
-
-        private boolean isMuted() {
-            return savedMute;
-        }
-
-        private boolean isPoweredOn() {
-            return savedPower;
-        }
-
-        private boolean isStopped() {
-            return savedStop;
-        }
-
-        private boolean isPlaying() {
-            return savedControl;
-        }
-
-        private boolean isShuffling() {
-            return savedShuffle == 0 ? false : true;
-        }
-
-        private int getShuffle() {
-            return savedShuffle;
-        }
-
-        private boolean isRepeating() {
-            return savedRepeat == 0 ? false : true;
-        }
-
-        private int getRepeat() {
-            return savedRepeat;
-        }
-
-        private int getVolume() {
-            return savedVolume;
-        }
-
-        private int getPlaylistIndex() {
-            return savedPlaylistIndex;
-        }
-
-        private int getNumberPlaylistTracks() {
-            return savedNumberPlaylistTracks;
-        }
-
-        private int getPlayingTime() {
-            return savedPlayingTime;
-        }
-
-        private void save() {
-            savedVolume = currentVolume();
-            savedMute = currentMute();
-            savedPower = currentPower();
-            savedStop = currentStop();
-            savedControl = currentControl();
-            savedShuffle = currentShuffle();
-            savedRepeat = currentRepeat();
-            savedPlaylistIndex = currentPlaylistIndex();
-            savedNumberPlaylistTracks = currentNumberPlaylistTracks();
-            savedPlayingTime = currentPlayingTime();
-
-            logger.debug("Cur State: vol={}, mut={}, pwr={}, stp={}, ctl={}, shf={}, rpt={}, tix={}, tnm={}, tim={}",
-                    savedVolume, muteAsString(), powerAsString(), stopAsString(), controlAsString(), shuffleAsString(),
-                    repeatAsString(), getPlaylistIndex(), getNumberPlaylistTracks(), getPlayingTime());
-        }
-
-        private String muteAsString() {
-            return isMuted() ? "MUTED" : "NOT MUTED";
-        }
-
-        private String powerAsString() {
-            return isPoweredOn() ? "ON" : "OFF";
-        }
-
-        private String stopAsString() {
-            return isStopped() ? "STOPPED" : "NOT STOPPED";
-        }
-
-        private String controlAsString() {
-            return isPlaying() ? "PLAYING" : "PAUSED";
-        }
-
-        private String shuffleAsString() {
-            String shuffle = "OFF";
-            if (getShuffle() == 1) {
-                shuffle = "SONG";
-            } else if (getShuffle() == 2) {
-                shuffle = "ALBUM";
-            }
-            return shuffle;
-        }
-
-        private String repeatAsString() {
-            String repeat = "OFF";
-            if (getRepeat() == 1) {
-                repeat = "SONG";
-            } else if (getRepeat() == 2) {
-                repeat = "PLAYLIST";
-            }
-            return repeat;
-        }
     }
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerState.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerState.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerState.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.squeezebox.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SqueezeBoxPlayerState} is responsible for saving the state of a player.
+ *
+ * @author Mark Hilbush - Added support for AudioSink and notifications
+ * @author Patrik Gfeller - Moved class to its own file.
+ */
+class SqueezeBoxPlayerState {
+    boolean savedMute;
+    boolean savedPower;
+    boolean savedStop;
+    boolean savedControl;
+
+    int savedVolume;
+    int savedShuffle;
+    int savedRepeat;
+    int savedPlaylistIndex;
+    int savedNumberPlaylistTracks;
+    int savedPlayingTime;
+
+    private SqueezeBoxPlayerHandler playerHandler;
+    private Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerState.class);
+
+    public SqueezeBoxPlayerState(SqueezeBoxPlayerHandler playerHandler) {
+        this.playerHandler = playerHandler;
+        save();
+    }
+
+    boolean isMuted() {
+        return savedMute;
+    }
+
+    boolean isPoweredOn() {
+        return savedPower;
+    }
+
+    boolean isStopped() {
+        return savedStop;
+    }
+
+    boolean isPlaying() {
+        return savedControl;
+    }
+
+    boolean isShuffling() {
+        return savedShuffle == 0 ? false : true;
+    }
+
+    int getShuffle() {
+        return savedShuffle;
+    }
+
+    boolean isRepeating() {
+        return savedRepeat == 0 ? false : true;
+    }
+
+    int getRepeat() {
+        return savedRepeat;
+    }
+
+    int getVolume() {
+        return savedVolume;
+    }
+
+    int getPlaylistIndex() {
+        return savedPlaylistIndex;
+    }
+
+    private int getNumberPlaylistTracks() {
+        return savedNumberPlaylistTracks;
+    }
+
+    int getPlayingTime() {
+        return savedPlayingTime;
+    }
+
+    private void save() {
+        savedVolume = playerHandler.currentVolume();
+        savedMute = playerHandler.currentMute();
+        savedPower = playerHandler.currentPower();
+        savedStop = playerHandler.currentStop();
+        savedControl = playerHandler.currentControl();
+        savedShuffle = playerHandler.currentShuffle();
+        savedRepeat = playerHandler.currentRepeat();
+        savedPlaylistIndex = playerHandler.currentPlaylistIndex();
+        savedNumberPlaylistTracks = playerHandler.currentNumberPlaylistTracks();
+        savedPlayingTime = playerHandler.currentPlayingTime();
+
+        logger.debug("Cur State: vol={}, mut={}, pwr={}, stp={}, ctl={}, shf={}, rpt={}, tix={}, tnm={}, tim={}",
+                savedVolume, muteAsString(), powerAsString(), stopAsString(), controlAsString(), shuffleAsString(),
+                repeatAsString(), getPlaylistIndex(), getNumberPlaylistTracks(), getPlayingTime());
+    }
+
+    private String muteAsString() {
+        return isMuted() ? "MUTED" : "NOT MUTED";
+    }
+
+    private String powerAsString() {
+        return isPoweredOn() ? "ON" : "OFF";
+    }
+
+    private String stopAsString() {
+        return isStopped() ? "STOPPED" : "NOT STOPPED";
+    }
+
+    private String controlAsString() {
+        return isPlaying() ? "PLAYING" : "PAUSED";
+    }
+
+    private String shuffleAsString() {
+        String shuffle = "OFF";
+        if (getShuffle() == 1) {
+            shuffle = "SONG";
+        } else if (getShuffle() == 2) {
+            shuffle = "ALBUM";
+        }
+        return shuffle;
+    }
+
+    private String repeatAsString() {
+        String repeat = "OFF";
+        if (getRepeat() == 1) {
+            repeat = "SONG";
+        } else if (getRepeat() == 2) {
+            repeat = "PLAYLIST";
+        }
+        return repeat;
+    }
+}

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -584,11 +584,26 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
             switch (action) {
                 case "volume":
-                    String value = messageParts[3];
+                    String volumeStringValue = decode(messageParts[3]);
+
                     updatePlayer(new PlayerUpdateEvent() {
                         @Override
                         public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                            listener.volumeChangeEvent(mac, Integer.parseInt(value));
+                            try {
+                                int volume = Integer.parseInt(volumeStringValue);
+
+                                // Check if we received a relative volume change, or an absolute
+                                // volume value.
+                                if (volumeStringValue.contains("+") || (volumeStringValue.contains("-"))) {
+                                    listener.relativeVolumeChangeEvent(mac, volume);
+                                } else {
+                                    listener.absoluteVolumeChangeEvent(mac, volume);
+                                }
+
+                            } catch (NumberFormatException e) {
+                                logger.warn("Unable to parse volume [{}] received from mixer message. {}",
+                                        volumeStringValue, e);
+                            }
                         }
                     });
                     break;
@@ -622,7 +637,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     updatePlayer(new PlayerUpdateEvent() {
                         @Override
                         public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                            listener.volumeChangeEvent(mac, volume);
+                            listener.absoluteVolumeChangeEvent(mac, volume);
                         }
                     });
                 }
@@ -815,7 +830,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     updatePlayer(new PlayerUpdateEvent() {
                         @Override
                         public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                            listener.volumeChangeEvent(mac, volume);
+                            listener.absoluteVolumeChangeEvent(mac, volume);
                         }
                     });
                 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -601,7 +601,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                                 }
 
                             } catch (NumberFormatException e) {
-                                logger.warn("Unable to parse volume [{}] received from mixer message. {}",
+                                logger.warn("Unable to parse volume [{}] received from mixer message.",
                                         volumeStringValue, e);
                             }
                         }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -227,12 +227,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     }
 
     public void setVolume(String mac, int volume) {
-        if (0 > volume) {
-            volume = 0;
-        } else if (volume > 100) {
-            volume = 100;
-        }
-        sendCommand(mac + " mixer volume " + String.valueOf(volume));
+        int newVolume = volume;
+        newVolume = Math.min(100, newVolume);
+        newVolume = Math.max(0, newVolume);
+        sendCommand(mac + " mixer volume " + String.valueOf(newVolume));
     }
 
     public void showString(String mac, String line) {

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxAudioSink.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxAudioSink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxServerConfig.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxServerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -128,7 +128,11 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
     }
 
     @Override
-    public void volumeChangeEvent(String mac, int volume) {
+    public void absoluteVolumeChangeEvent(String mac, int volume) {
+    }
+
+    @Override
+    public void relativeVolumeChangeEvent(String mac, int volumeChange) {
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxServerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxServerDiscoveryParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxNotAuthorizedException.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxNotAuthorizedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
@@ -10,6 +10,9 @@ package org.openhab.binding.squeezebox.internal.utils;
 
 /***
  *
+ * Exception class to indicate a timeout during comminication with
+ * the media server.
+ *
  * @author Patrik Gfeller
  *
  */

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,9 +17,9 @@ package org.openhab.binding.squeezebox.internal.utils;
  *
  */
 public class SqueezeBoxTimeoutException extends Exception {
+    private static final long serialVersionUID = 4542388088266882905L;
+
     public SqueezeBoxTimeoutException(String message) {
         super(message);
     }
-
-    private static final long serialVersionUID = 4542388088266882905L;
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxTimeoutException.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.squeezebox.internal.utils;
+
+/***
+ *
+ * @author Patrik Gfeller
+ *
+ */
+public class SqueezeBoxTimeoutException extends Exception {
+    public SqueezeBoxTimeoutException(String message) {
+        super(message);
+    }
+
+    private static final long serialVersionUID = 4542388088266882905L;
+}


### PR DESCRIPTION
Utility class "SqueezeBoxNotificationPlayer" added and "SqueezeBoxPlayerState" moved to its own file to reduce complexity and length of SqueezeBoxPlayerHandler.java

Signed-off-by: Patrik Gfeller <patrik.gfeller@gmail.com>
