### PR TITLE
Change create_openhab_binding_skeleton from using version 0.9.0 to 0.10.0 of org.eclipse.smarthome.archetype.binding

### DIFF
--- a/addons/binding/create_openhab_binding_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_skeleton.cmd
@@ -10,7 +10,7 @@ IF %ARGC% NEQ 2 (
 	exit /B 1
 )
 
-call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2 -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2 -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
 
 COPY ..\..\src\etc\about.html org.openhab.binding.%2%\
 

--- a/addons/binding/create_openhab_binding_skeleton.sh
+++ b/addons/binding/create_openhab_binding_skeleton.sh
@@ -8,7 +8,7 @@ id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
 mvn -s ../archetype-settings.xml archetype:generate -N \
   -DarchetypeGroupId=org.eclipse.smarthome.archetype \
   -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding \
-  -DarchetypeVersion=0.9.0-SNAPSHOT \
+  -DarchetypeVersion=0.10.0-SNAPSHOT \
   -DgroupId=org.openhab.binding \
   -DartifactId=org.openhab.binding.$id \
   -Dpackage=org.openhab.binding.$id \

--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -15,7 +15,7 @@ If NOT exist "org.openhab.binding.%2" (
 	exit /B 1
 )
 
-call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
 
 COPY ..\..\src\etc\about.html org.openhab.binding.%2.test%\
 

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -10,7 +10,7 @@ id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
 mvn -s ../archetype-settings.xml archetype:generate -N \
   -DarchetypeGroupId=org.eclipse.smarthome.archetype \
   -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test \
-  -DarchetypeVersion=0.9.0-SNAPSHOT \
+  -DarchetypeVersion=0.10.0-SNAPSHOT \
   -DgroupId=org.openhab.binding \
   -DartifactId=org.openhab.binding.$id.test \
   -Dpackage=org.openhab.binding.$id \


### PR DESCRIPTION
Change create_openhab_binding_skeleton from using version 0.9.0 to 0.10.0 of org.eclipse.smarthome.archetype.binding


The current scripts try to get 0.9.0 of org.eclipse.smarthome.archetype.binding. This version is not available as can be confirmed [here](https://repo.eclipse.org/content/repositories/smarthome-snapshots/org/eclipse/smarthome/archetype/org.eclipse.smarthome.archetype.binding/). I confirmed that with this change the .sh script was able to run successfully. Note that I did not test the changes to the .cmd files, but it should follow the same pattern as the changes to the .sh file.