### PR TITLE
Fix license format for several files

### DIFF
--- a/addons/binding/org.openhab.binding.cm11a/OSGI-INF/CM11AHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.cm11a/OSGI-INF/CM11AHandlerFactory.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2017 by the respective copyright holders.
+    Copyright (c) 2010-2017 by the respective copyright holders.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.icloud/OSGI-INF/org.openhab.binding.icloud.internal.ICloudHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.icloud/OSGI-INF/org.openhab.binding.icloud.internal.ICloudHandlerFactory.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" configuration-pid="binding.icloud" immediate="true" name="org.openhab.binding.icloud.internal.ICloudHandlerFactory">
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomePersonHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomePersonHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/addons/binding/org.openhab.binding.systeminfo/OSGI-INF/SysteminfoInterfaceService.xml
+++ b/addons/binding/org.openhab.binding.systeminfo/OSGI-INF/SysteminfoInterfaceService.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.systeminfo">
    <implementation class="org.openhab.binding.systeminfo.internal.model.OshiSysteminfo"/>
    <service>


### PR DESCRIPTION
Fix license format for several files

Simple fix to the license headers so people can run `mvn license:format` without changing files outside of the scope of what they're developing. This is performing the fix on the other files that would get fixed up at the same time.

Signed-off-by: Tim Waterhouse <tim@timwaterhouse.com>