### PR TITLE
[avmfritz] Added missing channel 'device_locked' to FRITZ!DECT 301

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="avmfritz"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+<thing:thing-descriptions bindingId="avmfritz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<!-- Supported FRITZ! devices and features -->
@@ -45,6 +45,7 @@
 		<channels>
 			<channel id="mode" typeId="mode" />
 			<channel id="locked" typeId="locked" />
+			<channel id="device_locked" typeId="device_locked" />
 			<channel id="temperature" typeId="temperature" />
 			<channel id="actual_temp" typeId="actual_temp" />
 			<channel id="set_temp" typeId="set_temp" />


### PR DESCRIPTION
See https://community.openhab.org/t/avm-fritz-binding-dect-301-no-device-locked-channel-any-more/37976

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>