### PR TITLE
[Netatmo] Changed ZoneId from UTC to system default time

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.netatmo/ESH-INF/config/config.xml
@@ -85,21 +85,6 @@
 		</parameter>
 	</config-description>
 
-	<config-description uri="thing-type:netatmo:device">
-		<parameter name="id" type="text" pattern="([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})">
-			<label>Equipment ID</label>
-			<description>Id of the Device (mac address)</description>
-			<required>true</required>
-		</parameter>
-
-		<parameter name="refreshInterval" type="integer" required="false">
-			<label>Refresh Interval</label>
-			<description>The refresh interval to poll Netatmo API (in ms).</description>
-			<default>600000</default>
-			<advanced>true</advanced>
-		</parameter>
-	</config-description>
-
 	<config-description uri="thing-type:netatmo:module">
 		<parameter name="id" type="text" pattern="([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})">
 			<label>Module ID</label>

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/ChannelTypeUtils.java
@@ -10,7 +10,7 @@ package org.openhab.binding.netatmo.internal;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -36,7 +36,7 @@ public class ChannelTypeUtils {
 
     public static ZonedDateTime toZonedDateTime(Integer netatmoTS) {
         Instant i = Instant.ofEpochSecond(netatmoTS);
-        return ZonedDateTime.ofInstant(i, ZoneOffset.UTC);
+        return ZonedDateTime.ofInstant(i, ZoneId.systemDefault());
     }
 
     public static State toDateTimeType(@Nullable Integer netatmoTS) {


### PR DESCRIPTION
Closes #3032 

This solution works for the moment by using the system default timezone. The ESH framework provides a configuration for system independent timzone in the regional settings. Maybe we want to use that timezone for the calculation (see https://github.com/eclipse/smarthome/blob/master/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TimeZoneProvider.java).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>