### PR TITLE
[Translation] German translation for exec Binding

### DIFF
--- a/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
+++ b/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
@@ -1,0 +1,33 @@
+###############
+# binding
+binding.exec.name = Exec Binding
+binding.exec.description = Binding zur Ausführung von Befehlen und zur Verarbeitung des Rückgabewerts
+
+###############
+# thing types
+thing-type.exec.command.label = Befehl
+thing-type.exec.command.description = Verarbeitung des Rückgabewertes bei Ausführung des Befehls
+
+# thing type configuration
+thing-type.config.exec.command.command.label = Befehl
+thing-type.config.exec.command.command.description = Der auszuführende Befehl
+thing-type.config.exec.command.transform.label = Transformation
+thing-type.config.exec.command.transform.description = Transformation des Rückgabewerts des Befehls, z.B. REGEX((.*)) liefert den Rückgabewert unverändert
+thing-type.config.exec.command.interval.label = Intervall
+thing-type.config.exec.command.interval.description = Intervall in Sekunden in welchem der Befehl ausgeführt wird
+thing-type.config.exec.command.timeout.label = Timeout
+thing-type.config.exec.command.timeout.description = Timeout in Sekunden nachdem die Ausführung des Befehls abgebrochen wird
+thing-type.config.exec.command.autorun.label = Autorun
+thing-type.config.exec.command.autorun.description = Wenn aktiv, dann wird der Befehl jedes Mal ausgeführt wenn sich der Eingabewert ändert
+
+# channel type
+channel-type.exec.output.label = Rückgabewert
+channel-type.exec.output.description = Rückgabewertes bei Ausführung des Befehls
+channel-type.exec.input.label = Eingabewert
+channel-type.exec.input.description = Eingabewert der als zweiter Parameter an den Befehl übergeben wird
+channel-type.exec.exit.label = Rückgabe Status
+channel-type.exec.exit.description = Dokumentiert die erfolgreiche Ausführung
+channel-type.exec.run.label = Ausführung
+channel-type.exec.run.description = Steht auf AN, wenn der Befehl aktuell ausgeführt wird; durch Setzen auf AN wird der Befehl sofort ausgeführt
+channel-type.exec.lastexecution.label = Datum der letzten Ausführung
+channel-type.exec.lastexecution.description = Datum und Uhrzeit der letzten Ausführung des Befehls im Format yyyy-MM-dd'T'HH:mm:ss.SSSZ

--- a/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
+++ b/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
@@ -16,7 +16,7 @@ thing-type.config.exec.command.transform.description = Transformation des Rückga
 thing-type.config.exec.command.interval.label = Intervall
 thing-type.config.exec.command.interval.description = Intervall in Sekunden, in welchem der Befehl ausgeführt wird
 thing-type.config.exec.command.timeout.label = Timeout
-thing-type.config.exec.command.timeout.description = Timeout in Sekunden nachdem die Ausführung des Befehls abgebrochen wird
+thing-type.config.exec.command.timeout.description = Timeout in Sekunden, nach dem die Ausführung des Befehls abgebrochen wird
 thing-type.config.exec.command.autorun.label = Autorun
 thing-type.config.exec.command.autorun.description = Wenn aktiv, dann wird der Befehl jedes Mal ausgeführt, wenn sich der Eingabewert ändert
 

--- a/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
+++ b/addons/binding/org.openhab.binding.exec/ESH-INF/i18n/exec_de.properties
@@ -6,28 +6,28 @@ binding.exec.description = Binding zur Ausführung von Befehlen und zur Verarbeit
 ###############
 # thing types
 thing-type.exec.command.label = Befehl
-thing-type.exec.command.description = Verarbeitung des Rückgabewertes bei Ausführung des Befehls
+thing-type.exec.command.description = Befehl zur Ausführung und Verarbeitung des Rückgabewertes
 
 # thing type configuration
 thing-type.config.exec.command.command.label = Befehl
 thing-type.config.exec.command.command.description = Der auszuführende Befehl
 thing-type.config.exec.command.transform.label = Transformation
-thing-type.config.exec.command.transform.description = Transformation des Rückgabewerts des Befehls, z.B. REGEX((.*)) liefert den Rückgabewert unverändert
+thing-type.config.exec.command.transform.description = Transformation des Rückgabewertes des Befehls, z.B. REGEX((.*)) liefert den Rückgabewert unverändert
 thing-type.config.exec.command.interval.label = Intervall
-thing-type.config.exec.command.interval.description = Intervall in Sekunden in welchem der Befehl ausgeführt wird
+thing-type.config.exec.command.interval.description = Intervall in Sekunden, in welchem der Befehl ausgeführt wird
 thing-type.config.exec.command.timeout.label = Timeout
 thing-type.config.exec.command.timeout.description = Timeout in Sekunden nachdem die Ausführung des Befehls abgebrochen wird
 thing-type.config.exec.command.autorun.label = Autorun
-thing-type.config.exec.command.autorun.description = Wenn aktiv, dann wird der Befehl jedes Mal ausgeführt wenn sich der Eingabewert ändert
+thing-type.config.exec.command.autorun.description = Wenn aktiv, dann wird der Befehl jedes Mal ausgeführt, wenn sich der Eingabewert ändert
 
 # channel type
 channel-type.exec.output.label = Rückgabewert
-channel-type.exec.output.description = Rückgabewertes bei Ausführung des Befehls
+channel-type.exec.output.description = Rückgabewert der Befehlsausführung
 channel-type.exec.input.label = Eingabewert
-channel-type.exec.input.description = Eingabewert der als zweiter Parameter an den Befehl übergeben wird
-channel-type.exec.exit.label = Rückgabe Status
+channel-type.exec.input.description = Eingabewert, der als zweiter Parameter an den Befehl übergeben wird
+channel-type.exec.exit.label = Rückgabestatus
 channel-type.exec.exit.description = Dokumentiert die erfolgreiche Ausführung
 channel-type.exec.run.label = Ausführung
-channel-type.exec.run.description = Steht auf AN, wenn der Befehl aktuell ausgeführt wird; durch Setzen auf AN wird der Befehl sofort ausgeführt
-channel-type.exec.lastexecution.label = Datum der letzten Ausführung
+channel-type.exec.run.description = Steht während der Befehlsausführung auf ON; durch Setzen auf ON wird der Befehl sofort ausgeführt
+channel-type.exec.lastexecution.label = Zeitpunkt der letzten Ausführung
 channel-type.exec.lastexecution.description = Datum und Uhrzeit der letzten Ausführung des Befehls im Format yyyy-MM-dd'T'HH:mm:ss.SSSZ


### PR DESCRIPTION
As the exec binding had no (German) translation I created one.

As I couldn't find any script generating a translation template (which is as much work as the translation) for bindings without any translation I generated an XSLT file to start with.
[Thing Translation Template - DRAFT.zip](https://github.com/openhab/openhab2-addons/files/1604935/Thing.Translation.Template.-.DRAFT.zip)
