### PR TITLE
Fix https://github.com/openhab/openhab2-addons/issues/3070

### DIFF
--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/KebaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/KebaBindingConstants.java
@@ -25,7 +25,7 @@ public class KebaBindingConstants {
     public static final String BINDING_ID = "keba";
 
     // List of all Thing Type UIDs
-    public static final ThingTypeUID THING_TYPE_KECONTACTP20 = new ThingTypeUID(BINDING_ID, "kecontactp20");
+    public static final ThingTypeUID THING_TYPE_KECONTACTP20 = new ThingTypeUID(BINDING_ID, "kecontact");
 
     // List of all Channel ids
     public static final String CHANNEL_MODEL = "model";


### PR DESCRIPTION
Short-term fix for https://github.com/openhab/openhab2-addons/issues/3070

(a more consistent solution would also require THING_TYPE_KECONTACTP20 to be renamed to THING_TYPE_KECONTACT, and an update of the README but this is part https://github.com/openhab/openhab2-addons/pull/2844)

Signed-off-by: Karel Goderis <karel.goderis@me.com>