### PR TITLE
[avmfritz] Revert use of JAXB Unmarshaller as singleton instance to improve performance

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzModelTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzModelTest.java
@@ -11,10 +11,12 @@ package org.openhab.binding.avmfritz.internal.ahamodel;
 import static org.junit.Assert.*;
 import static org.openhab.binding.avmfritz.BindingConstants.*;
 
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.Optional;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.junit.Before;
@@ -50,7 +52,8 @@ public class AVMFritzModelTest {
                 + "</devicelist>";
 
         try {
-            devices = JAXBUtils.buildResult(xml);
+            Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+            devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         } catch (JAXBException e) {
             logger.error("Exception creating Unmarshaller: {}", e.getLocalizedMessage(), e);
         }

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -15,10 +15,12 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.avmfritz.BindingConstants.*;
 
+import java.io.StringReader;
 import java.util.Collection;
 import java.util.Collections;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryListener;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -99,7 +101,8 @@ public class AVMFritzDiscoveryServiceTest {
     public void invalidDiscoveryResult() throws JAXBException {
         String xml = "<devicelist version=\"1\"><group identifier=\"F0:A3:7F-900\" id=\"20001\" functionbitmask=\"640\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\"><present>1</present><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><power>0</power><energy>2087</energy></powermeter><groupinfo><masterdeviceid>1000</masterdeviceid><members>20000</members></groupinfo></group></devicelist>";
 
-        DevicelistModel devices = JAXBUtils.buildResult(xml);
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         assertNotNull(devices);
         assertThat(devices.getDevicelist().size(), is(0));
     }
@@ -108,7 +111,8 @@ public class AVMFritzDiscoveryServiceTest {
     public void validDECTRepeater100Result() throws JAXBException {
         String xml = "<devicelist version=\"1\"><device identifier=\"08761 0954669\" id=\"20\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"FRITZ!DECT Repeater 100\"><present>1</present><name>FRITZ!DECT Repeater 100 #5</name><temperature><celsius>230</celsius><offset>0</offset></temperature></device></devicelist>";
 
-        DevicelistModel devices = JAXBUtils.buildResult(xml);
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         assertNotNull(devices);
         assertThat(devices.getDevicelist().size(), is(1));
 
@@ -134,7 +138,8 @@ public class AVMFritzDiscoveryServiceTest {
     public void validDECT200DiscoveryResult() throws JAXBException {
         String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 200\"><present>1</present><name>FRITZ!DECT 200 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
 
-        DevicelistModel devices = JAXBUtils.buildResult(xml);
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         assertNotNull(devices);
         assertThat(devices.getDevicelist().size(), is(1));
 
@@ -160,7 +165,8 @@ public class AVMFritzDiscoveryServiceTest {
     public void validCometDECTDiscoveryResult() throws JAXBException {
         String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000435\" id=\"18\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"Comet DECT\"><present>1</present><name>Comet DECT #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>0</lock><devicelock>0</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device></devicelist>";
 
-        DevicelistModel devices = JAXBUtils.buildResult(xml);
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         assertNotNull(devices);
         assertThat(devices.getDevicelist().size(), is(1));
 
@@ -186,7 +192,8 @@ public class AVMFritzDiscoveryServiceTest {
     public void validPowerline546EDiscoveryResult() throws JAXBException {
         String xml = "<devicelist version=\"1\"><device identifier=\"5C:49:79:F0:A3:84\" id=\"19\" functionbitmask=\"640\" fwversion=\"06.92\" manufacturer=\"AVM\" productname=\"FRITZ!Powerline 546E\"><present>1</present><name>FRITZ!Powerline 546E #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>0</power><energy>2087</energy></powermeter></device></devicelist>";
 
-        DevicelistModel devices = JAXBUtils.buildResult(xml);
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
         assertNotNull(devices);
         assertThat(devices.getDevicelist().size(), is(1));
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaDiscoveryCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaDiscoveryCallback.java
@@ -8,7 +8,10 @@
  */
 package org.openhab.binding.avmfritz.internal.hardware.callbacks;
 
+import java.io.StringReader;
+
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.DevicelistModel;
@@ -52,7 +55,8 @@ public class FritzAhaDiscoveryCallback extends FritzAhaReauthCallback {
         logger.trace("Received discovery callback response: {}", response);
         if (isValidRequest()) {
             try {
-                DevicelistModel model = JAXBUtils.buildResult(response);
+                Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+                DevicelistModel model = (DevicelistModel) u.unmarshal(new StringReader(response));
                 if (model != null) {
                     for (DeviceModel device : model.getDevicelist()) {
                         service.onDeviceAddedInternal(device);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
@@ -8,7 +8,10 @@
  */
 package org.openhab.binding.avmfritz.internal.hardware.callbacks;
 
+import java.io.StringReader;
+
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
@@ -54,7 +57,8 @@ public class FritzAhaUpdateXmlCallback extends FritzAhaReauthCallback {
         logger.trace("Received State response {}", response);
         if (isValidRequest()) {
             try {
-                DevicelistModel model = JAXBUtils.buildResult(response);
+                Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+                DevicelistModel model = (DevicelistModel) u.unmarshal(new StringReader(response));
                 if (model != null) {
                     for (DeviceModel device : model.getDevicelist()) {
                         handler.addDeviceList(device);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/util/JAXBUtils.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/util/JAXBUtils.java
@@ -8,11 +8,8 @@
  */
 package org.openhab.binding.avmfritz.internal.util;
 
-import java.io.StringReader;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 
 import org.openhab.binding.avmfritz.internal.ahamodel.DevicelistModel;
 import org.slf4j.Logger;
@@ -21,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation for a static use of JAXBContext as singleton instance.
  *
- * @author Christoph Weitkamp
+ * @author Christoph Weitkamp - Initial contribution
  *
  */
 public class JAXBUtils {
@@ -30,8 +27,6 @@ public class JAXBUtils {
 
     public static final JAXBContext JAXBCONTEXT = initJAXBContext();
 
-    public static Unmarshaller JAXBUnmarshaller;
-
     private static JAXBContext initJAXBContext() {
         try {
             return JAXBContext.newInstance(DevicelistModel.class);
@@ -39,12 +34,5 @@ public class JAXBUtils {
             logger.error("Exception creating JAXBContext: {}", e.getLocalizedMessage(), e);
             return null;
         }
-    }
-
-    public static DevicelistModel buildResult(final String xml) throws JAXBException {
-        if (JAXBUnmarshaller == null) {
-            JAXBUnmarshaller = JAXBCONTEXT.createUnmarshaller();
-        }
-        return (DevicelistModel) JAXBUnmarshaller.unmarshal(new StringReader(xml));
     }
 }


### PR DESCRIPTION
Introduced in #2820

Unmarshaller class is not thread save (see https://javaee.github.io/jaxb-v2/doc/user-guide/ch03.html#other-miscellaneous-topics-performance-and-thread-safety). I ran into some NPEs afterwards.
```
2018-01-08 19:55:05.075 [ERROR] [.callbacks.FritzAhaUpdateXmlCallback] - Exception creating Unmarshaller: null
javax.xml.bind.UnmarshalException: null
        at javax.xml.bind.helpers.AbstractUnmarshallerImpl.createUnmarshalException(AbstractUnmarshallerImpl.java:335) [?:?]
        at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.createUnmarshalException(UnmarshallerImpl.java:563) [?:?]
        at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:249) [?:?]
        at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:214) [?:?]
        at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:157) [?:?]
        at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:214) [?:?]
        at org.openhab.binding.avmfritz.internal.util.JAXBUtils.buildResult(JAXBUtils.java:48) [273:org.openhab.binding.avmfritz:2.3.0.201801041032]
        at org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaUpdateXmlCallback.execute(FritzAhaUpdateXmlCallback.java:57) [273:org.open
hab.binding.avmfritz:2.3.0.201801041032]
        at org.openhab.binding.avmfritz.internal.hardware.FritzahaContentExchange.onComplete(FritzahaContentExchange.java:71) [273:org.openhab.binding.avmfritz:2.3.0.201801041032]
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:193) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:185) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.HttpReceiver.terminateResponse(HttpReceiver.java:458) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.HttpReceiver.responseSuccess(HttpReceiver.java:405) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.messageComplete(HttpReceiverOverHTTP.java:277) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.http.HttpParser.parseContent(HttpParser.java:1617) [82:org.eclipse.jetty.http:9.3.22.v20171030]
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:1350) [82:org.eclipse.jetty.http:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.parse(HttpReceiverOverHTTP.java:159) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.process(HttpReceiverOverHTTP.java:120) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.receive(HttpReceiverOverHTTP.java:70) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpChannelOverHTTP.receive(HttpChannelOverHTTP.java:90) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.onFillable(HttpConnectionOverHTTP.java:115) [79:org.eclipse.jetty.client:9.3.22.v20171030]
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:283) [83:org.eclipse.jetty.io:9.3.22.v20171030]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:108) [83:org.eclipse.jetty.io:9.3.22.v20171030]
        at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:93) [83:org.eclipse.jetty.io:9.3.22.v20171030]
        at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.executeProduceConsume(ExecuteProduceConsume.java:303) [94:org.eclipse.jetty.util:9.3.22.v20171030]
        at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:148) [94:org.eclipse.jetty.util:9.3.22.v20171030]
        at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:136) [94:org.eclipse.jetty.util:9.3.22.v20171030]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:671) [94:org.eclipse.jetty.util:9.3.22.v20171030]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:589) [94:org.eclipse.jetty.util:9.3.22.v20171030]
        at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: org.xml.sax.SAXException: FWK005 parse may not be called while parsing.
        at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1253) ~[?:?]
        at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643) ~[?:?]
        at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:243) ~[?:?]
        ... 27 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  http://docs.openhab.org/developers/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  http://docs.openhab.org/developers/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  http://docs.openhab.org/developers/contributing/contributing#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
