### PR TITLE
[jeelink] fix difference check

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/DifferenceCheckingPublisher.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/DifferenceCheckingPublisher.java
@@ -39,6 +39,8 @@ public class DifferenceCheckingPublisher implements ReadingPublisher<LaCrosseTem
         } else {
             logger.debug("Ignoring reading {} differing too much from previous value", reading.getTemperature());
         }
+
+        lastReading = reading;
     }
 
     @Override


### PR DESCRIPTION
Fixes the discarding of values that differ too much from the previous value.

Problem has been reported here:
https://community.openhab.org/t/jeelink-strange-behavior/38203/9