### PR TITLE
[onebusaway] The OneBusAway binding is not clearing the alreadyFetchi…

### DIFF
--- a/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/internal/handler/StopHandler.java
+++ b/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/internal/handler/StopHandler.java
@@ -174,59 +174,67 @@ public class StopHandler extends BaseBridgeHandler {
     }
 
     private boolean fetchAndUpdateStopData() {
-        ApiHandler apiHandler = getApiHandler();
-        if (apiHandler == null) {
-            // We must be offline.
-            return false;
-        }
-        boolean alreadyFetching = !fetchInProgress.compareAndSet(false, true);
-        if (alreadyFetching) {
-            return false;
-        }
-        logger.debug("Fetching data for stop ID {}", config.getStopId());
-        String url = String.format("http://%s/api/where/arrivals-and-departures-for-stop/%s.json?key=%s",
-                apiHandler.getApiServer(), config.getStopId(), apiHandler.getApiKey());
-        URI uri;
         try {
-            uri = new URI(url);
-        } catch (URISyntaxException e) {
-            logger.error("Unable to parse {} as a URI.", url);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
-                    "stopId or apiKey is set to a bogus value");
-            return false;
-        }
-        ContentResponse response;
-        try {
-            response = httpClient.newRequest(uri).send();
-        } catch (InterruptedException | TimeoutException | ExecutionException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
-            return false;
-        }
-        if (response.getStatus() != HttpStatus.OK_200) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    String.format("While fetching stop data: %d: %s", response.getStatus(), response.getReason()));
-            return false;
-        }
-        ObaStopArrivalResponse data = gson.fromJson(response.getContentAsString(), ObaStopArrivalResponse.class);
-        routeDataLastUpdateMs = data.currentTime;
-        updateStatus(ThingStatus.ONLINE);
+            ApiHandler apiHandler = getApiHandler();
+            if (apiHandler == null) {
+                // We must be offline.
+                return false;
+            }
+            boolean alreadyFetching = !fetchInProgress.compareAndSet(false, true);
+            if (alreadyFetching) {
+                return false;
+            }
+            logger.debug("Fetching data for stop ID {}", config.getStopId());
+            String url = String.format("http://%s/api/where/arrivals-and-departures-for-stop/%s.json?key=%s",
+                    apiHandler.getApiServer(), config.getStopId(), apiHandler.getApiKey());
+            URI uri;
+            try {
+                uri = new URI(url);
+            } catch (URISyntaxException e) {
+                logger.error("Unable to parse {} as a URI.", url);
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                        "stopId or apiKey is set to a bogus value");
+                return false;
+            }
+            ContentResponse response;
+            try {
+                response = httpClient.newRequest(uri).send();
+            } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
+                return false;
+            }
+            if (response.getStatus() != HttpStatus.OK_200) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
+                        String.format("While fetching stop data: %d: %s", response.getStatus(), response.getReason()));
+                return false;
+            }
+            ObaStopArrivalResponse data = gson.fromJson(response.getContentAsString(), ObaStopArrivalResponse.class);
+            routeDataLastUpdateMs = data.currentTime;
+            updateStatus(ThingStatus.ONLINE);
 
-        ArrayListMultimap<String, ObaStopArrivalResponse.ArrivalAndDeparture> copiedRouteData = ArrayListMultimap
-                .create();
-        synchronized (routeData) {
-            routeData = ArrayListMultimap.create();
-            for (ObaStopArrivalResponse.ArrivalAndDeparture d : data.data.entry.arrivalsAndDepartures) {
-                routeData.put(d.routeId, d);
+            ArrayListMultimap<String, ObaStopArrivalResponse.ArrivalAndDeparture> copiedRouteData = ArrayListMultimap
+                    .create();
+            synchronized (routeData) {
+                routeData = ArrayListMultimap.create();
+                for (ObaStopArrivalResponse.ArrivalAndDeparture d : data.data.entry.arrivalsAndDepartures) {
+                    routeData.put(d.routeId, d);
+                }
+                for (String key : routeData.keySet()) {
+                    List<ObaStopArrivalResponse.ArrivalAndDeparture> copy = Lists.newArrayList(routeData.get(key));
+                    Collections.sort(copy);
+                    copiedRouteData.putAll(key, copy);
+                }
             }
-            for (String key : routeData.keySet()) {
-                List<ObaStopArrivalResponse.ArrivalAndDeparture> copy = Lists.newArrayList(routeData.get(key));
-                Collections.sort(copy);
-                copiedRouteData.putAll(key, copy);
+            for (RouteDataListener listener : routeDataListeners) {
+                listener.onNewRouteData(routeDataLastUpdateMs, copiedRouteData.get(listener.getRouteId()));
             }
+            return true;
+        } catch (Exception e) {
+            logger.debug("Exception refreshing route data", e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            return false;
+        } finally {
+            fetchInProgress.set(false);
         }
-        for (RouteDataListener listener : routeDataListeners) {
-            listener.onNewRouteData(routeDataLastUpdateMs, copiedRouteData.get(listener.getRouteId()));
-        }
-        return true;
     }
 }


### PR DESCRIPTION
[onebusaway] Fix polling cycle of the OBA API
This PR Replaces PR #3057 

As it exists in the OpenHAB 2.2 distribution, the OneBusAway binding has a bug that prevents it from refreshing the binding's data once OpenHAB has started.
The code uses an atomic boolean variable to prevent multiple threads from polling the OneBusAway simultaneously, and it correctly sets it to True when the first polling starts, but it never sets it to false once the polling is done. As a consequence, the OneBusAway data is only fetched once (when the binding is initialized) and never again.
This patch fixes that problem and also catches and logs any exceptions that the code might throw in the poll cycle.