### PR TITLE
[globalcache/bigassfan] Fix discovery due to previous commit

### DIFF
--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
@@ -19,6 +19,7 @@ import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.nio.BufferOverflowException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -1118,6 +1119,9 @@ public class BigAssFanHandler extends BaseThingHandler {
                 nextToken = null;
             } catch (IllegalStateException e) {
                 logger.debug("Scanner for {} threw IllegalStateException; scanner possibly closed", thing.getUID());
+                nextToken = null;
+            } catch (BufferOverflowException e) {
+                logger.debug("Scanner for {} threw BufferOverflowException", thing.getUID());
                 nextToken = null;
             }
             return nextToken;


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

It appears [this ](https://github.com/openhab/openhab2-addons/commit/52f768a3f8f80ac30d98dfb286bac134116baf99#diff-20d869adac9ab48b4a6bfc46a34d68ae)commit broke discovery for these two bindings. Reference discussion on [this issue](https://github.com/eclipse/smarthome/issues/4751#issuecomment-358416890). The fix is to change the DS annotation for the discovery service.

In addition, remove the use of ExtendedDiscoveryService. This was originally used to avoid spamming openhab.log with "Thing already exists" messages from the framework every time a device sent a discovery packet for an existing thing; however, those messages are no longer at INFO level.

Finally, in the BigAssFan handler, catch BufferOverflowException generated by Scanner.next. This will protect against a fan or fan controller sending a poorly formatted or corrupt message that exceeds Scanner's buffer.
