### PR TITLE
[homematic] Dynamically assign reconfigurable channels

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
@@ -40,6 +40,7 @@ Import-Package:
  org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.link,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
@@ -50,4 +50,5 @@ public class HomematicBindingConstants {
 
     public static final String PROPERTY_BATTERY_TYPE = "batteryType";
     public static final String PROPERTY_AES_KEY = "aesKey";
+    public static final String PROPERTY_DYNAMIC_FUNCTION_FORMAT = "dynamicFunction-%d";
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
@@ -105,9 +105,9 @@ public class HomematicThingHandler extends BaseThingHandler {
                     // update configurations
                     Configuration config = editConfiguration();
                     for (HmChannel channel : device.getChannels()) {
+                        loadHomematicChannelValues(channel);
                         for (HmDatapoint dp : channel.getDatapoints().values()) {
                             if (dp.getParamsetType() == HmParamsetType.MASTER) {
-                                loadHomematicChannelValues(dp.getChannel());
                                 config.put(MetadataUtils.getParameterName(dp),
                                         dp.isEnumType() ? dp.getOptionValue() : dp.getValue());
                             }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
@@ -92,6 +92,16 @@ public class HomematicThingHandler extends BaseThingHandler {
                     setProperty(properties, channelZero, PROPERTY_AES_KEY, DATAPOINT_NAME_AES_KEY);
                     updateProperties(properties);
 
+                    // update data point list for reconfigurable channels
+                    for (HmChannel channel : device.getChannels()) {
+                        if (channel.isReconfigurable()) {
+                            loadHomematicChannelValues(channel);
+                            if (channel.checkForChannelFunctionChange()) {
+                                gateway.updateChannelValueDatapoints(channel);
+                            }
+                        }
+                    }
+
                     // update configurations
                     Configuration config = editConfiguration();
                     for (HmChannel channel : device.getChannels()) {

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -360,7 +360,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                             if ((DEVICE_TYPE_VIRTUAL.equals(device.getType())
                                     || DEVICE_TYPE_VIRTUAL_WIRED.equals(device.getType())) && channel.getNumber() > 1) {
                                 HmChannel previousChannel = device.getChannel(channel.getNumber() - 1);
-                                cloneAllDatapointsIntoChannel(channel, previousChannel.getDatapoints().values());
+                                cloneAllDatapointsIntoChannel(channel, previousChannel.getDatapoints());
                             } else {
                                 String channelId = String.format("%s:%s:%s", channel.getDevice().getType(),
                                         channel.getDevice().getFirmware(), channel.getNumber());
@@ -376,7 +376,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                                     // Make sure to only cache non-reconfigurable channels. For reconfigurable channels,
                                     // the data point set might change depending on the selected mode.
                                     if (!channel.isReconfigurable()) {
-                                        datapointsByChannelIdCache.put(channelId, channel.getDatapoints().values());
+                                        datapointsByChannelIdCache.put(channelId, channel.getDatapoints());
                                     }
                                 }
                             }
@@ -443,7 +443,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
     public void loadChannelValues(HmChannel channel) throws IOException {
         if (channel.getDevice().isGatewayExtras()) {
             if (channel.getNumber() != HmChannel.CHANNEL_NUMBER_EXTRAS) {
-                Map<HmDatapointInfo, HmDatapoint> datapoints = channel.getDatapoints();
+                List<HmDatapoint> datapoints = channel.getDatapoints();
 
                 if (channel.getNumber() == HmChannel.CHANNEL_NUMBER_VARIABLE) {
                     loadVariables(channel);
@@ -459,7 +459,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
             setChannelDatapointValues(channel, HmParamsetType.VALUES);
         }
 
-        for (HmDatapoint dp : channel.getDatapoints().values()) {
+        for (HmDatapoint dp : channel.getDatapoints()) {
             handleVirtualDatapointEvent(dp, false);
         }
 
@@ -726,7 +726,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
             logger.trace("{}", device);
             for (HmChannel channel : device.getChannels()) {
                 logger.trace("  {}", channel);
-                for (HmDatapoint dp : channel.getDatapoints().values()) {
+                for (HmDatapoint dp : channel.getDatapoints()) {
                     logger.trace("    {}", dp);
                 }
             }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -375,8 +375,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
 
                                     // Make sure to only cache non-reconfigurable channels. For reconfigurable channels,
                                     // the data point set might change depending on the selected mode.
-                                    if (channel.getDatapoint(HmParamsetType.MASTER,
-                                            DATAPOINT_NAME_CHANNEL_FUNCTION) == null) {
+                                    if (!channel.isReconfigurable()) {
                                         datapointsByChannelIdCache.put(channelId, channel.getDatapoints().values());
                                     }
                                 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -685,27 +685,14 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
      * Creates a virtual device for handling variables, scripts and other special gateway functions.
      */
     private HmDevice createGatewayDevice() {
-        HmDevice device = new HmDevice();
-        device.setAddress(HmDevice.ADDRESS_GATEWAY_EXTRAS);
-        device.setHmInterface(getDefaultInterface());
-        device.setGatewayId(config.getGatewayInfo().getId());
-        device.setType(String.format("%s-%s", HmDevice.TYPE_GATEWAY_EXTRAS, StringUtils.upperCase(id)));
+        String type = String.format("%s-%s", HmDevice.TYPE_GATEWAY_EXTRAS, StringUtils.upperCase(id));
+        HmDevice device = new HmDevice(HmDevice.ADDRESS_GATEWAY_EXTRAS, getDefaultInterface(), type,
+                config.getGatewayInfo().getId(), null, null);
         device.setName(HmDevice.TYPE_GATEWAY_EXTRAS);
 
-        HmChannel channel = new HmChannel();
-        channel.setNumber(HmChannel.CHANNEL_NUMBER_EXTRAS);
-        channel.setType(HmChannel.TYPE_GATEWAY_EXTRAS);
-        device.addChannel(channel);
-
-        channel = new HmChannel();
-        channel.setNumber(HmChannel.CHANNEL_NUMBER_VARIABLE);
-        channel.setType(HmChannel.TYPE_GATEWAY_VARIABLE);
-        device.addChannel(channel);
-
-        channel = new HmChannel();
-        channel.setNumber(HmChannel.CHANNEL_NUMBER_SCRIPT);
-        channel.setType(HmChannel.TYPE_GATEWAY_SCRIPT);
-        device.addChannel(channel);
+        device.addChannel(new HmChannel(HmChannel.TYPE_GATEWAY_EXTRAS, HmChannel.CHANNEL_NUMBER_EXTRAS));
+        device.addChannel(new HmChannel(HmChannel.TYPE_GATEWAY_VARIABLE, HmChannel.CHANNEL_NUMBER_VARIABLE));
+        device.addChannel(new HmChannel(HmChannel.TYPE_GATEWAY_SCRIPT, HmChannel.CHANNEL_NUMBER_SCRIPT));
 
         return device;
     }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -466,6 +466,20 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         channel.setInitialized(true);
     }
 
+    @Override
+    public void updateChannelValueDatapoints(HmChannel channel) throws IOException {
+        logger.debug("Updating value datapoints for channel {} of device '{}', has {} datapoints before", channel,
+                channel.getDevice().getAddress(), channel.getDatapoints().size());
+
+        channel.removeValueDatapoints();
+        addChannelDatapoints(channel, HmParamsetType.VALUES);
+        setChannelDatapointValues(channel, HmParamsetType.VALUES);
+
+        logger.debug("Updated value datapoints for channel {} of device '{}' (function {}), now has {} datapoints",
+                channel, channel.getDevice().getAddress(), channel.getCurrentFunction(),
+                channel.getDatapoints().size());
+    }
+
     /**
      * Sets all datapoint values for the given channel.
      */

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -122,7 +122,7 @@ public class CcuGateway extends AbstractHomematicGateway {
                     channel.getDevice().getAddress(), channel.getNumber(), paramsetType);
 
             Collection<String> dpNames = new ArrayList<String>();
-            for (HmDatapoint dp : channel.getDatapoints().values()) {
+            for (HmDatapoint dp : channel.getDatapoints()) {
                 if (!dp.isVirtual() && dp.isReadable() && dp.getParamsetType() == HmParamsetType.VALUES) {
                     dpNames.add(dp.getName());
                 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
@@ -60,6 +60,11 @@ public interface HomematicGateway {
     public void loadChannelValues(HmChannel channel) throws IOException;
 
     /**
+     * Reenumerates the set of VALUES datapoints for the given channel.
+     */
+    public void updateChannelValueDatapoints(HmChannel channel) throws IOException;
+
+    /**
      * Prepares the device for reloading all values from the gateway.
      */
     public void triggerDeviceValuesReload(HmDevice device);

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -201,7 +201,7 @@ public abstract class RpcClient<T> {
      * exception.
      */
     private void setChannelDatapointValues(HmChannel channel) throws IOException {
-        for (HmDatapoint dp : channel.getDatapoints().values()) {
+        for (HmDatapoint dp : channel.getDatapoints()) {
             if (dp.isReadable() && !dp.isVirtual() && dp.getParamsetType() == HmParamsetType.VALUES) {
                 RpcRequest<T> request = createRpcRequest("getValue");
                 request.addArg(getRpcAddress(channel.getDevice().getAddress()) + ":" + channel.getNumber());

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
@@ -138,7 +138,7 @@ public class DisplayOptionsParser extends CommonRpcParser<Object, Void> {
      */
     private String[] getAvailableSymbols(HmChannel channel) {
         List<String> symbols = new ArrayList<String>();
-        for (HmDatapoint datapoint : channel.getDatapoints().values()) {
+        for (HmDatapoint datapoint : channel.getDatapoints()) {
             if (!datapoint.isReadOnly() && datapoint.isBooleanType()
                     && datapoint.getParamsetType() == HmParamsetType.VALUES
                     && !DATAPOINT_NAME_SUBMIT.equals(datapoint.getName())

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
@@ -44,25 +44,22 @@ public class ListDevicesParser extends CommonRpcParser<Object[], Collection<HmDe
             boolean isDevice = !StringUtils.contains(toString(data.get("ADDRESS")), ":");
 
             if (isDevice) {
-                HmDevice device = new HmDevice();
-                device.setAddress(getAddress(data.get("ADDRESS")));
-                device.setType(toString(data.get("TYPE")));
-                device.setHomegearId(toString(data.get("ID")));
-                device.setFirmware(toString(data.get("FIRMWARE")));
-                device.setHmInterface(hmInterface);
-                device.setGatewayId(config.getGatewayInfo().getId());
+                String address = getAddress(data.get("ADDRESS"));
+                String type = toString(data.get("TYPE"));
+                String id = toString(data.get("ID"));
+                String firmware = toString(data.get("FIRMWARE"));
 
-                devices.put(device.getAddress(), device);
+                devices.put(address,
+                        new HmDevice(address, hmInterface, type, config.getGatewayInfo().getId(), id, firmware));
             } else {
                 // channel
                 String deviceAddress = getAddress(data.get("PARENT"));
                 HmDevice device = devices.get(deviceAddress);
 
-                HmChannel channel = new HmChannel();
-                channel.setNumber(toInteger(data.get("INDEX")));
-                channel.setType(toString(data.get("TYPE")));
+                String type = toString(data.get("TYPE"));
+                Integer number = toInteger(data.get("INDEX"));
 
-                device.addChannel(channel);
+                device.addChannel(new HmChannel(type, number));
             }
         }
         return devices.values();

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
@@ -28,24 +28,22 @@ public class HmChannel {
     public static final Integer CHANNEL_NUMBER_VARIABLE = 1;
     public static final Integer CHANNEL_NUMBER_SCRIPT = 2;
 
-    private Integer number;
-    private String type;
+    private final Integer number;
+    private final String type;
     private HmDevice device;
     private boolean initialized;
     private Map<HmDatapointInfo, HmDatapoint> datapoints = new HashMap<HmDatapointInfo, HmDatapoint>();
+
+    public HmChannel(String type, Integer number) {
+        this.type = type;
+        this.number = number;
+    }
 
     /**
      * Returns the channel number.
      */
     public Integer getNumber() {
         return number;
-    }
-
-    /**
-     * Sets the channel number.
-     */
-    public void setNumber(Integer number) {
-        this.number = number;
     }
 
     /**
@@ -67,13 +65,6 @@ public class HmChannel {
      */
     public String getType() {
         return type;
-    }
-
-    /**
-     * Returns the type of the channel.
-     */
-    public void setType(String type) {
-        this.type = type;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.openhab.binding.homematic.internal.misc.HomematicConstants;
 
 /**
  * Object that represents a Homematic channel.
@@ -131,6 +132,14 @@ public class HmChannel {
      */
     public boolean hasDatapoint(HmDatapointInfo dpInfo) {
         return datapoints.get(dpInfo) != null;
+    }
+
+    /**
+     * Returns true, if the channel's datapoint set contains a
+     * channel function datapoint.
+     */
+    public boolean isReconfigurable() {
+        return getDatapoint(HmParamsetType.MASTER, HomematicConstants.DATAPOINT_NAME_CHANNEL_FUNCTION) != null;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.homematic.internal.model;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -33,6 +34,7 @@ public class HmChannel {
     private final String type;
     private HmDevice device;
     private boolean initialized;
+    private Integer lastFunction;
     private Map<HmDatapointInfo, HmDatapoint> datapoints = new HashMap<HmDatapointInfo, HmDatapoint>();
 
     public HmChannel(String type, Integer number) {
@@ -114,6 +116,18 @@ public class HmChannel {
     }
 
     /**
+     * Removes all datapoints with VALUES param set type from the channel.
+     */
+    public void removeValueDatapoints() {
+        Iterator<Map.Entry<HmDatapointInfo, HmDatapoint>> iterator = datapoints.entrySet().iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().getKey().getParamsetType() == HmParamsetType.VALUES) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
      * Returns the HmDatapoint with the given HmDatapointInfo.
      */
     public HmDatapoint getDatapoint(HmDatapointInfo dpInfo) {
@@ -140,6 +154,38 @@ public class HmChannel {
      */
     public boolean isReconfigurable() {
         return getDatapoint(HmParamsetType.MASTER, HomematicConstants.DATAPOINT_NAME_CHANNEL_FUNCTION) != null;
+    }
+
+    /**
+     * Returns the numeric value of the function this channel is currently configured to.
+     * Returns null if the channel is not yet initialized or does not support dynamic reconfiguration.
+     */
+    public Integer getCurrentFunction() {
+        HmDatapoint functionDp = getDatapoint(HmParamsetType.MASTER,
+                HomematicConstants.DATAPOINT_NAME_CHANNEL_FUNCTION);
+        return functionDp == null ? null : (Integer) functionDp.getValue();
+    }
+
+    /**
+     * Checks whether the function this channel is configured to changed since this method was last invoked.
+     * Returns false if the channel is not reconfigurable or was not initialized yet.
+     */
+    public boolean checkForChannelFunctionChange() {
+        Integer currentFunction = getCurrentFunction();
+        if (currentFunction == null) {
+            return false;
+        }
+        if (lastFunction == null) {
+            // We were called from initialization, which was preceded by initial metadata fetch, so everything
+            // should be fine by now
+            lastFunction = currentFunction;
+            return false;
+        }
+        if (lastFunction.equals(currentFunction)) {
+            return false;
+        }
+        lastFunction = currentFunction;
+        return true;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDevice.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDevice.java
@@ -28,15 +28,25 @@ public class HmDevice {
     public static final String TYPE_GATEWAY_EXTRAS = "GATEWAY-EXTRAS";
     public static final String ADDRESS_GATEWAY_EXTRAS = "GWE00000000";
 
-    private HmInterface hmInterface;
-    private String address;
-    private String type;
+    private final HmInterface hmInterface;
+    private final String address;
+    private final String type;
     private String name;
-    private String firmware;
-    private String gatewayId;
-    private String homegearId;
+    private final String firmware;
+    private final String gatewayId;
+    private final String homegearId;
 
     private List<HmChannel> channels = new ArrayList<HmChannel>();
+
+    public HmDevice(String address, HmInterface hmInterface, String type, String gatewayId, String homegearId,
+            String firmware) {
+        this.address = address;
+        this.hmInterface = hmInterface;
+        this.type = type;
+        this.gatewayId = gatewayId;
+        this.homegearId = homegearId;
+        this.firmware = firmware;
+    }
 
     /**
      * Returns the address of the device.
@@ -46,24 +56,10 @@ public class HmDevice {
     }
 
     /**
-     * Sets the address of the device.
-     */
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    /**
      * Returns the interface of the device.
      */
     public HmInterface getHmInterface() {
         return hmInterface;
-    }
-
-    /**
-     * Sets the interface of the device.
-     */
-    public void setHmInterface(HmInterface hmInterface) {
-        this.hmInterface = hmInterface;
     }
 
     /**
@@ -88,13 +84,6 @@ public class HmDevice {
     }
 
     /**
-     * Sets the type of the device.
-     */
-    public void setType(String type) {
-        this.type = MiscUtils.validateCharacters(type, "Device type", "-");
-    }
-
-    /**
      * Returns all channels of the device.
      */
     public List<HmChannel> getChannels() {
@@ -109,13 +98,6 @@ public class HmDevice {
     }
 
     /**
-     * Sets the firmware of the device.
-     */
-    public void setFirmware(String firmware) {
-        this.firmware = firmware;
-    }
-
-    /**
      * Returns the gatewayId of the device.
      */
     public String getGatewayId() {
@@ -123,24 +105,10 @@ public class HmDevice {
     }
 
     /**
-     * Sets the gatewayId of the device.
-     */
-    public void setGatewayId(String gatewayId) {
-        this.gatewayId = gatewayId;
-    }
-
-    /**
      * Returns the homegearId of the device.
      */
     public String getHomegearId() {
         return homegearId;
-    }
-
-    /**
-     * Sets the homegearId of the device.
-     */
-    public void setHomegearId(String homegearId) {
-        this.homegearId = homegearId;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -136,7 +136,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     // those will be populated dynamically during thing initialization
                     if (!channel.isReconfigurable()) {
                         // generate channel
-                        for (HmDatapoint dp : channel.getDatapoints().values()) {
+                        for (HmDatapoint dp : channel.getDatapoints()) {
                             if (!isIgnoredDatapoint(dp) && dp.getParamsetType() == HmParamsetType.VALUES) {
                                 ChannelTypeUID channelTypeUID = UidUtils.generateChannelTypeUID(dp);
                                 ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID,
@@ -305,7 +305,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
             String groupLabel = MetadataUtils.getDescription("CHANNEL_NAME") + " " + channel.getNumber();
             groups.add(new ConfigDescriptionParameterGroup(groupName, null, false, groupLabel, null));
 
-            for (HmDatapoint dp : channel.getDatapoints().values()) {
+            for (HmDatapoint dp : channel.getDatapoints()) {
                 if (dp.getParamsetType() == HmParamsetType.MASTER) {
                     ConfigDescriptionParameterBuilder builder = ConfigDescriptionParameterBuilder.create(
                             MetadataUtils.getParameterName(dp), MetadataUtils.getConfigDescriptionParameterType(dp));

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -132,19 +132,24 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 List<ChannelGroupType> groupTypes = new ArrayList<ChannelGroupType>();
                 for (HmChannel channel : device.getChannels()) {
                     List<ChannelDefinition> channelDefinitions = new ArrayList<ChannelDefinition>();
-                    // generate channel
-                    for (HmDatapoint dp : channel.getDatapoints().values()) {
-                        if (!isIgnoredDatapoint(dp) && dp.getParamsetType() == HmParamsetType.VALUES) {
-                            ChannelTypeUID channelTypeUID = UidUtils.generateChannelTypeUID(dp);
-                            ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID,
-                                    Locale.getDefault());
-                            if (channelType == null) {
-                                channelType = createChannelType(dp, channelTypeUID);
-                                channelTypeProvider.addChannelType(channelType);
-                            }
+                    // Omit thing channel definitions for reconfigurable channels;
+                    // those will be populated dynamically during thing initialization
+                    if (!channel.isReconfigurable()) {
+                        // generate channel
+                        for (HmDatapoint dp : channel.getDatapoints().values()) {
+                            if (!isIgnoredDatapoint(dp) && dp.getParamsetType() == HmParamsetType.VALUES) {
+                                ChannelTypeUID channelTypeUID = UidUtils.generateChannelTypeUID(dp);
+                                ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID,
+                                        Locale.getDefault());
+                                if (channelType == null) {
+                                    channelType = createChannelType(dp, channelTypeUID);
+                                    channelTypeProvider.addChannelType(channelType);
+                                }
 
-                            ChannelDefinition channelDef = new ChannelDefinition(dp.getName(), channelType.getUID());
-                            channelDefinitions.add(channelDef);
+                                ChannelDefinition channelDef = new ChannelDefinition(dp.getName(),
+                                        channelType.getUID());
+                                channelDefinitions.add(channelDef);
+                            }
                         }
                     }
 


### PR DESCRIPTION
HM-MOD-EM-8 devices have reconfigurable channels, whose data point set (and thus set of available thing channels) varies depending on what type the channel is configured to. For such devices, put the list of available channel types not in the ThingType, but assign it to each Thing when initializing it.