### PR TITLE
[globalcache/bigassfan] Fix configurability of background discovery

### DIFF
--- a/addons/binding/org.openhab.binding.bigassfan/README.md
+++ b/addons/binding/org.openhab.binding.bigassfan/README.md
@@ -19,7 +19,7 @@ Background discovery is **enabled** by default.
 To **disable** background discovery, add the following line to the *conf/services/runtime.cfg* file:
 
 ```text
-org.openhab.binding.bigassfan.discovery.BigAssFanDiscoveryService:backgroundDiscovery.enabled=false
+discovery.bigassfan:background=false
 ```
 
 ## Thing Configuration

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/discovery/BigAssFanDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/discovery/BigAssFanDiscoveryService.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Mark Hilbush - Initial contribution
  */
-@Component(service = DiscoveryService.class, immediate = true)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.bigassfan")
 public class BigAssFanDiscoveryService extends AbstractDiscoveryService {
     private final Logger logger = LoggerFactory.getLogger(BigAssFanDiscoveryService.class);
 
@@ -89,6 +90,12 @@ public class BigAssFanDiscoveryService extends AbstractDiscoveryService {
     protected void deactivate() {
         super.deactivate();
         logger.trace("BigAssFan discovery service DEACTIVATED");
+    }
+
+    @Override
+    @Modified
+    protected void modified(Map<String, Object> configProperties) {
+        super.modified(configProperties);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.globalcache/README.md
+++ b/addons/binding/org.openhab.binding.globalcache/README.md
@@ -36,7 +36,7 @@ Background discovery is **enabled** by default.
 To disable background discovery, add the following line to the *conf/services/runtime.cfg* file:
 
 ```text
-org.openhab.binding.globalcache.discovery.GlobalCacheDiscoveryService:backgroundDiscovery.enabled=false
+discovery.globalcache:background=false
 ```
 
 Note that automatic device discovery **will not work** with GC-100's running firmware earlier than v3.0 as those versions do not emit announcement beacons on the multicast address.

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/GlobalCacheDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/GlobalCacheDiscoveryService.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Mark Hilbush - Initial contribution
  */
-@Component(service = DiscoveryService.class, immediate = true)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.globalcache")
 public class GlobalCacheDiscoveryService extends AbstractDiscoveryService {
     private final Logger logger = LoggerFactory.getLogger(GlobalCacheDiscoveryService.class);
 
@@ -82,6 +83,12 @@ public class GlobalCacheDiscoveryService extends AbstractDiscoveryService {
         logger.debug("Globalcache discovery service deactivated");
         stopBackgroundDiscovery();
         super.deactivate();
+    }
+
+    @Override
+    @Modified
+    protected void modified(Map<String, Object> configProperties) {
+        super.modified(configProperties);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

This [ESH PR](https://github.com/eclipse/smarthome/pull/4079) broke the ability to configure (enable/disable) background discovery for globalcache and bigassfan bindings.

This PR fixes the problem based on the information in [this discussion](https://github.com/eclipse/smarthome/pull/4079#issuecomment-358981113).
