### PR TITLE
[tplinksmarthome] Added support for HS110v2 devices

### DIFF
--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EnergySwitchDeviceV2Test.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EnergySwitchDeviceV2Test.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.device;
+
+import static org.junit.Assert.*;
+import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants.*;
+
+import java.io.IOException;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
+
+/**
+ * Test class for {@link EnergySwitchDevice} class.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+public class EnergySwitchDeviceV2Test {
+
+    private EnergySwitchDevice device = new EnergySwitchDevice();
+    private DeviceState deviceState;
+
+    @Before
+    public void setUp() throws IOException {
+        deviceState = new DeviceState(ModelTestUtil.readJson("plug_v2_get_realtime_response"));
+    }
+
+    @Test
+    public void testUpdateChannelEnergyCurrent() {
+        assertEquals("Energy current should have valid state value", 1,
+                ((DecimalType) device.updateChannel(CHANNEL_ENERGY_CURRENT, deviceState)).intValue());
+    }
+
+    @Test
+    public void testUpdateChannelEnergyTotal() {
+        assertEquals("Energy total should have valid state value", 10,
+                ((DecimalType) device.updateChannel(CHANNEL_ENERGY_TOTAL, deviceState)).intValue());
+    }
+
+    @Test
+    public void testUpdateChannelEnergyVoltage() {
+        State state = device.updateChannel(CHANNEL_ENERGY_VOLTAGE, deviceState);
+        assertEquals("Energy voltage should have valid state value", 230, ((DecimalType) state).intValue());
+        assertEquals("Channel patten to display as int", "230 V", state.format("%.0f V"));
+    }
+
+    @Test
+    public void testUpdateChanneEnergyPowerl() {
+        assertEquals("Energy power should have valid state value", 20,
+                ((DecimalType) device.updateChannel(CHANNEL_ENERGY_POWER, deviceState)).intValue());
+    }
+
+    @Test
+    public void testUpdateChannelOther() {
+        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF, device.updateChannel("OTHER", deviceState));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/plug_v2_get_realtime_response.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/plug_v2_get_realtime_response.json
@@ -1,0 +1,11 @@
+{
+	"emeter": {
+		"get_realtime": {
+			"current_ma": 1.000000,
+			"voltage_mv": 230.123456,
+			"power_mw": 20.000000,
+			"total_wh": 10.00000,
+			"err_code": 0
+		}
+	}
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Realtime.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Realtime.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.model;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Data class for reading tp-Link Smart Plug energy monitoring.
  * Only getter methods as the values are set by gson based on the retrieved json.
@@ -16,9 +18,22 @@ package org.openhab.binding.tplinksmarthome.internal.model;
  */
 public class Realtime extends ErrorResponse {
 
+    /* 
+     * for devices like:
+     *   {"system":{"get_sysinfo":{"sw_ver":"1.0.10 Build 161012 Rel.165510","hw_ver":"2.0","type":"IOT.SMARTPLUGSWITCH","model":"HS110(AU)"
+     * The get_realtime json response looks like:
+     *   "emeter":{"get_realtime":{"voltage_mv":239425,"current_ma":1234,"power_mw":123456,"total_wh":12345,"err_code":0}}}
+     *
+     * use gson's alternate {@link com.google.gson.annotations.SerializedName} so both are valid
+     */
+
+    @SerializedName(value="current", alternate={"current_ma"})
     private double current;
+    @SerializedName(value="power", alternate={"power_mw"})
     private double power;
+    @SerializedName(value="total", alternate={"total_wh"})
     private double total;
+    @SerializedName(value="voltage", alternate={"voltage_mv"})
     private double voltage;
 
     public double getCurrent() {


### PR DESCRIPTION
- Added basic support for HS110v2 devices returning different get_realtime json

Specifically this tiny enhancement handles the alternative text for voltage_mv, current_ma, power_mw, total_wh. 

Example decrypted JSON from a smartplug HS110 with the new get_realtime result names:
`{"system":{"get_sysinfo":{"sw_ver":"1.0.10 Build 161012 Rel.165510","hw_ver":"2.0","type":"IOT.SMARTPLUGSWITCH","model":"HS110(AU)","mac":"50:C7:BF:FF:FF:FF","dev_name":"Wi-Fi Smart Plug With Energy Monitoring","alias":"Plug2","relay_state":1,"on_time":352205,"active_mode":"none","feature":"TIM:ENE","updating":0,"icon_hash":"","rssi":-12,"led_off":0,"longitude_i":0,"latitude_i":-0,"hwId":"A28C8BB92AFCB6CAFB83A8C00145F7E2","fwId":"00000000000000000000000000000000","deviceId":"xxxxxxx","oemId":"xxxxxxx","err_code":0}},"emeter":{"get_realtime":{"voltage_mv":240364,"current_ma":123456,"power_mw":123456,"total_wh":123456,"err_code":0}}}
`

Note, that I don't have access to other devices, so I'm unsure the new get_realtime result is specific to the v2 hardware and/or the firmware version.  Regardless, the use of the SerializedName#alternate should reliably ensure compatibility between the different versions.

Signed-off-by: KC Stonacek <source@stonacek.nz> (github: kcstonacek)
