### PR TITLE
[Nest] Handle deletion of devices and structures from account

### DIFF
--- a/addons/binding/org.openhab.binding.nest/README.md
+++ b/addons/binding/org.openhab.binding.nest/README.md
@@ -213,8 +213,7 @@ String   Home_Time_Zone            "Time Zone [%s]"                             
 
 ## Known Issues
 
-1.   The binding uses Celsius as unit for all Themostat temperature channels.
-2.   Deletion of devices or structures from the connected Nest account is currently not properly handled. The channel and online states of affected Things keep their last known values.
+*   The binding uses Celsius as unit for all Themostat temperature channels.
 
 ## Attribution
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
@@ -15,8 +15,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -25,8 +27,10 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -35,6 +39,7 @@ import org.openhab.binding.nest.NestBindingConstants;
 import org.openhab.binding.nest.internal.config.NestBridgeConfiguration;
 import org.openhab.binding.nest.internal.data.ErrorData;
 import org.openhab.binding.nest.internal.data.NestDevices;
+import org.openhab.binding.nest.internal.data.NestIdentifiable;
 import org.openhab.binding.nest.internal.data.Structure;
 import org.openhab.binding.nest.internal.data.TopLevelData;
 import org.openhab.binding.nest.internal.exceptions.FailedResolvingNestUrlException;
@@ -390,7 +395,35 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
         if (data.getStructures() != null) {
             broadcastStructures(data.getStructures().values());
         }
+
+        setMissingThingsOffline(data);
         updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Receiving streaming data");
+    }
+
+    private void setMissingThingsOffline(TopLevelData data) {
+        Set<String> identifiers = new HashSet<>();
+        if (data.getDevices() != null) {
+            if (data.getDevices().getCameras() != null) {
+                identifiers.addAll(data.getDevices().getCameras().keySet());
+            }
+            if (data.getDevices().getSmokeDetectors() != null) {
+                identifiers.addAll(data.getDevices().getSmokeDetectors().keySet());
+            }
+            if (data.getDevices().getThermostats() != null) {
+                identifiers.addAll(data.getDevices().getThermostats().keySet());
+            }
+        }
+        if (data.getStructures() != null) {
+            identifiers.addAll(data.getStructures().keySet());
+        }
+
+        for (Thing thing : getThing().getThings()) {
+            String id = ((NestIdentifiable) thing.getHandler()).getId();
+            if (!identifiers.contains(id)) {
+                thing.setStatusInfo(new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.GONE,
+                        "Missing from streaming updates"));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Sets the Thing status of deleted devices and structures to offline/gone.

See also https://github.com/eclipse/smarthome/issues/3306. 