### PR TITLE
Adjusted skeleton scripts to be compliant with ESH versions

### DIFF
--- a/addons/binding/create_openhab_binding_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_skeleton.cmd
@@ -6,13 +6,34 @@ SET ARGC=0
 FOR %%x IN (%*) DO SET /A ARGC+=1
 
 IF %ARGC% NEQ 2 (
-	echo Usage: %0 BindingIdInCamelCase BindingIdInLowerCase
+	echo Usage: %0 BindingIdInCamelCase Author
 	exit /B 1
 )
 
-call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2 -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
+SET BindingVersion="2.3.0-SNAPSHOT"
+SET ArchetypeVersion="0.10.0-SNAPSHOT"
 
-COPY ..\..\src\etc\about.html org.openhab.binding.%2%\
+SET BindingIdInCamelCase=%1
+SET BindingIdInLowerCase=%BindingIdInCamelCase%
+SET Author=%2
+
+call :LoCase BindingIdInLowerCase
+
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=%ArchetypeVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase% -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%BindingVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%"
+
+COPY ..\..\src\etc\about.html org.openhab.binding.%BindingIdInLowerCase%\
+
+(SET BindingIdInLowerCase=)
+(SET BindingIdInCamelCase=)
+(SET Author=)
+
+GOTO:EOF
+
+
+:LoCase
+:: Subroutine to convert a variable VALUE to all lower case.
+:: The argument for this subroutine is the variable NAME.
+FOR %%i IN ("A=a" "B=b" "C=c" "D=d" "E=e" "F=f" "G=g" "H=h" "I=i" "J=j" "K=k" "L=l" "M=m" "N=n" "O=o" "P=p" "Q=q" "R=r" "S=s" "T=t" "U=u" "V=v" "W=w" "X=x" "Y=y" "Z=z") DO CALL SET "%1=%%%1:%%~i%%"
+GOTO:EOF
 
 ENDLOCAL
-

--- a/addons/binding/create_openhab_binding_skeleton.sh
+++ b/addons/binding/create_openhab_binding_skeleton.sh
@@ -24,7 +24,7 @@ mvn -s ../archetype-settings.xml archetype:generate -N \
   -Dnamespace=org.openhab \
   -Dauthor="$author"
 
-directory=`echo "org.openhab.binding."$id/`
+directory="org.openhab.binding.$id/"
 
 cp ../../src/etc/about.html "$directory"
 

--- a/addons/binding/create_openhab_binding_skeleton.sh
+++ b/addons/binding/create_openhab_binding_skeleton.sh
@@ -1,23 +1,30 @@
 #!/bin/bash
 
-camelcaseId=$1
-[ $# -eq 0 ] && { echo "Usage: $0 <BindingIdInCamelCase>"; exit 1; }
+[ $# -lt 2 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author>"; exit 1; }
 
-id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'` 
+bindingVersion=2.3.0-SNAPSHOT
+archetypeVersion=0.10.0-SNAPSHOT
+
+camelcaseId=$1
+id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
+
+author=$2
 
 mvn -s ../archetype-settings.xml archetype:generate -N \
   -DarchetypeGroupId=org.eclipse.smarthome.archetype \
   -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding \
-  -DarchetypeVersion=0.10.0-SNAPSHOT \
+  -DarchetypeVersion=$archetypeVersion \
   -DgroupId=org.openhab.binding \
   -DartifactId=org.openhab.binding.$id \
   -Dpackage=org.openhab.binding.$id \
-  -Dversion=2.3.0-SNAPSHOT \
+  -Dversion=$bindingVersion \
   -DbindingId=$id \
   -DbindingIdCamelCase=$camelcaseId \
   -DvendorName=openHAB \
-  -Dnamespace=org.openhab
+  -Dnamespace=org.openhab \
+  -Dauthor="$author"
 
 directory=`echo "org.openhab.binding."$id/`
 
 cp ../../src/etc/about.html "$directory"
+

--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -26,7 +26,7 @@ If NOT exist "org.openhab.binding.%BindingIdInLowerCase%" (
 
 call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=%ArchetypeVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase%.test -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%BindingVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%"
 
-COPY ..\..\src\etc\about.html org.openhab.binding.%2.test%\
+COPY ..\..\src\etc\about.html org.openhab.binding.%BindingIdInLowerCase%.test\
 
 (SET BindingIdInLowerCase=)
 (SET BindingIdInCamelCase=)

--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -6,18 +6,39 @@ SET ARGC=0
 FOR %%x IN (%*) DO SET /A ARGC+=1
 
 IF %ARGC% NEQ 2 (
-	echo Usage: %0 BindingIdInCamelCase BindingIdInLowerCase
+	echo Usage: %0 BindingIdInCamelCase Author
 	exit /B 1
 )
 
-If NOT exist "org.openhab.binding.%2" (
-	echo The binding with the id must exist: org.openhab.binding.%2
+SET BindingVersion="2.3.0-SNAPSHOT" 
+SET ArchetypeVersion="0.10.0-SNAPSHOT"
+
+SET BindingIdInCamelCase=%1
+SET BindingIdInLowerCase=%BindingIdInCamelCase%
+SET Author=%2
+
+call :LoCase BindingIdInLowerCase
+
+If NOT exist "org.openhab.binding.%BindingIdInLowerCase%" (
+	echo The binding with the id must exist: org.openhab.binding.%BindingIdInLowerCase%
 	exit /B 1
 )
 
-call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%2.test -Dpackage=org.openhab.binding.%2 -Dversion=2.3.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1 -DvendorName=openHAB -Dnamespace=org.openhab
+call mvn -s ../archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=%ArchetypeVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase%.test -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%BindingVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%"
 
 COPY ..\..\src\etc\about.html org.openhab.binding.%2.test%\
 
-ENDLOCAL
+(SET BindingIdInLowerCase=)
+(SET BindingIdInCamelCase=)
+(SET Author=)
 
+GOTO:EOF
+
+
+:LoCase
+:: Subroutine to convert a variable VALUE to all lower case.
+:: The argument for this subroutine is the variable NAME.
+FOR %%i IN ("A=a" "B=b" "C=c" "D=d" "E=e" "F=f" "G=g" "H=h" "I=i" "J=j" "K=k" "L=l" "M=m" "N=n" "O=o" "P=p" "Q=q" "R=r" "S=s" "T=t" "U=u" "V=v" "W=w" "X=x" "Y=y" "Z=z") DO CALL SET "%1=%%%1:%%~i%%"
+GOTO:EOF
+
+ENDLOCAL

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -26,7 +26,7 @@ mvn -s ../archetype-settings.xml archetype:generate -N \
   -Dnamespace=org.openhab \
   -Dauthor="$author"
 
-directory=`echo "org.openhab.binding."$id".test"/`
+directory="org.openhab.binding.$id.test/"
 
 cp ../../src/etc/about.html "$directory"
 

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -1,25 +1,32 @@
 #!/bin/bash
 
-camelcaseId=$1
-[ $# -eq 0 ] && { echo "Usage: $0 <BindingIdInCamelCase>"; exit 1; }
+[ $# -lt 2 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author>"; exit 1; }
 
+bindingVersion=2.3.0-SNAPSHOT
+archetypeVersion=0.10.0-SNAPSHOT
+
+camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
+
+author=$2
 
 [ -d org.openhab.binding.$id ] || { echo "The binding with the id must exist: org.openhab.binding.$id"; exit 1; }
 
 mvn -s ../archetype-settings.xml archetype:generate -N \
   -DarchetypeGroupId=org.eclipse.smarthome.archetype \
   -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test \
-  -DarchetypeVersion=0.10.0-SNAPSHOT \
+  -DarchetypeVersion=$archetypeVersion \
   -DgroupId=org.openhab.binding \
   -DartifactId=org.openhab.binding.$id.test \
   -Dpackage=org.openhab.binding.$id \
-  -Dversion=2.3.0-SNAPSHOT \
+  -Dversion=$bindingVersion \
   -DbindingId=$id \
   -DbindingIdCamelCase=$camelcaseId \
   -DvendorName=openHAB \
-  -Dnamespace=org.openhab
+  -Dnamespace=org.openhab \
+  -Dauthor="$author"
 
 directory=`echo "org.openhab.binding."$id".test"/`
 
 cp ../../src/etc/about.html "$directory"
+


### PR DESCRIPTION
- Removed required `BindingIdInLowerCase` argument in *.cmd scripts
- Added required `Author` in all scripts
- Added variables for binding and archetype version in all scripts

Preparations for closing openhab/openhab-docs#482

Can anyone please test the *.cmd scripts? Thank you in advance.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>