### PR TITLE
[Kodi] Updated readme - preparation section

### DIFF
--- a/addons/binding/org.openhab.binding.kodi/README.md
+++ b/addons/binding/org.openhab.binding.kodi/README.md
@@ -13,7 +13,9 @@ The Kodi binding is the successor to the openHAB 1.x xbmc binding.
 In order to allow control of Kodi by this binding, you need to enable the Kodi application remote control feature.
 Please enable "Allow remote control from applications on this/other systems" in the Kodi settings menu under:
 
-*   Settings ➔ Services ➔ Control ➔ Allow remote control from applications on this/other systems
+*   Settings ➔ Services ➔ Control ➔
+    * Allow remote control from applications on **this** systems
+    * Allow remote control from applications on **other** systems
 
 To make use of the auto-discovery feature, you additionally need to enable "Allow control of Kodi via UPnP" in the Kodi settings menu.
 


### PR DESCRIPTION
Clarified that there have to be two different settings.

Corresponding discussion -> https://community.openhab.org/t/kodi-wont-change-to-online/39261

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>
