### PR TITLE
[homematic] Fix for #3183

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
+import org.openhab.binding.homematic.internal.misc.MiscUtils;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDevice;
 import org.openhab.binding.homematic.internal.model.HmInterface;
@@ -45,7 +46,7 @@ public class ListDevicesParser extends CommonRpcParser<Object[], Collection<HmDe
 
             if (isDevice) {
                 String address = getAddress(data.get("ADDRESS"));
-                String type = toString(data.get("TYPE"));
+                String type = MiscUtils.validateCharacters(toString(data.get("TYPE")), "Device type", "-");
                 String id = toString(data.get("ID"));
                 String firmware = toString(data.get("FIRMWARE"));
 


### PR DESCRIPTION
Previously, invalid names like those provided by additional homegear
modules where converted:

`Sonos PLAY:1` -> `Sonos-PLAY-1`

This was accidentially dropped in PR #3140, this commits fixes this by
reintroducing the validation / correction.


