### PR TITLE
[Homematic] Remove the dependency to org.apache.commons.io

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 # For how it is generated, see `project-orga/generate-authors.sh`.
 
 Dancho Penev <dpslavov@hotmail.com>
+Florian Stolte <fstolte@gmx.de>
 Gerhard Riegler <gerhard.riegler@gmail.com>
 Gaël L'hopital <glhopital@gmail.com>
 Gideon le Grange <gideon@legrange.me>

--- a/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Import-Package:
  javax.servlet,
  javax.servlet.http,
  javax.xml.bind,
- org.apache.commons.io,
  org.apache.commons.lang,
  org.apache.commons.lang.builder,
  org.apache.commons.lang.math,

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +81,9 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
             throw new EOFException("Only " + length + " bytes received reading message length");
         }
         int datasize = (new BigInteger(ArrayUtils.subarray(sig, 4, 8))).intValue();
-        byte[] message = ArrayUtils.addAll(sig, IOUtils.toByteArray(is, datasize));
+        byte payload[] = new byte[datasize];
+        is.read(payload, 0, datasize);
+        byte[] message = ArrayUtils.addAll(sig, payload);
         decodeMessage(message, methodHeader);
     }
 


### PR DESCRIPTION
Improvement: Refactored the only line in the homematic binding that made use of the org.apache.commons.io library. As a result, the dependency on that library was removed.

Closes #3193

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
-->

