### PR TITLE
[Homematic] Load resource via bundle

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 # For how it is generated, see `project-orga/generate-authors.sh`.
 
 Dancho Penev <dpslavov@hotmail.com>
+Florian Stolte <fstolte@gmx.de>
 Gerhard Riegler <gerhard.riegler@gmail.com>
 Gaël L'hopital <glhopital@gmail.com>
 Gideon le Grange <gideon@legrange.me>

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -37,6 +37,8 @@ import org.openhab.binding.homematic.internal.model.HmResult;
 import org.openhab.binding.homematic.internal.model.TclScript;
 import org.openhab.binding.homematic.internal.model.TclScriptDataList;
 import org.openhab.binding.homematic.internal.model.TclScriptList;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,8 +235,8 @@ public class CcuGateway extends AbstractHomematicGateway {
      * Load predefined scripts from an XML file.
      */
     private Map<String, String> loadTclRegaScripts() throws IOException {
-        InputStream stream = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("homematic/tclrega-scripts.xml");
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        InputStream stream = bundle.getResource("homematic/tclrega-scripts.xml").openStream();
         TclScriptList scriptList = (TclScriptList) xStream.fromXML(stream);
 
         Map<String, String> result = new HashMap<String, String>();


### PR DESCRIPTION
Bugfix: In the CcuGateway class of the Homematic Binding, an XML resource was
loaded using the class loader provided by the thread. Now, the resource
is directly loaded via the bundle to avoid using the wrong class loader.

Closes #3195
