### PR TITLE
Improve safety of refactored operation from #3194

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
@@ -82,7 +82,17 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
         }
         int datasize = (new BigInteger(ArrayUtils.subarray(sig, 4, 8))).intValue();
         byte payload[] = new byte[datasize];
-        is.read(payload, 0, datasize);
+        int offset = 0;
+        int currentLength;
+
+        while (offset < datasize && (currentLength = is.read(payload, offset, datasize - offset)) != -1) {
+            offset += currentLength;
+        }
+        if (offset != datasize) {
+            throw new EOFException(
+                    "Only " + offset + " bytes received while reading message payload, expected " + datasize
+                            + " bytes");
+        }
         byte[] message = ArrayUtils.addAll(sig, payload);
         decodeMessage(message, methodHeader);
     }


### PR DESCRIPTION
In the class BinRpcMessage, while reading the message content from the InputStream, `read()` was only called once. This call might not acquire the whole message.
Now, it is called repeatedly until no more content is available. If the amount read from the stream is smaller than expected, an EOFException is thrown.

This behavior is also much closer to the implementation of `toByteArray()`, which was used to read the stream into an array before the refactoring.

Improves on #3194
