### PR TITLE
[yamaha] add dialogue level item

### DIFF
--- a/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.yamahareceiver/ESH-INF/thing/thing-types.xml
@@ -77,6 +77,7 @@
 			<channel id="surroundProgram" typeId="surroundProgram" />
 			<channel id="volume" typeId="volume" />
 			<channel id="volumeDB" typeId="volumeDB" />
+			<channel id="dialogueLevel" typeId="dialogueLevel" />
 			<channel id="mute" typeId="mute" />
 		</channels>
 	</channel-group-type>
@@ -146,6 +147,14 @@
 		<label>Mute</label>
 		<description>Enable/Disable Mute on the AVR</description>
 		<category>SoundVolume</category>
+	</channel-type>
+
+	<channel-type id="dialogueLevel">
+		<item-type>Number</item-type>
+		<label>Dialogue level</label>
+		<description>Set the dialogue level</description>
+		<category>SoundVolume</category>
+		<state min="0" max="2" step="1" pattern="%d" />
 	</channel-type>
 
 	<channel-group-type id="playback_channels">

--- a/addons/binding/org.openhab.binding.yamahareceiver/README.md
+++ b/addons/binding/org.openhab.binding.yamahareceiver/README.md
@@ -37,6 +37,7 @@ Zone control channels are:
 *   `mute#zone_channels`: openHAB Type `Switch`, Mute or Unmute the receiver.
 *   `volume#zone_channels`: openHAB Type `Dimmer`, Set's the receivers volume as percentage.
 *   `volumeDB#zone_channels`: openHAB Type `Dimmer`, Set's the receivers volume in dB.
+*   `dialogueLevel#zone_channels`: openHAB Type `Number`, Set's the receivers dialogue level.
 *   `input#zone_channels`: openHAB Type `String`, Set's the input selection, depends on your receiver's real inputs. Examples: HDMI1, HDMI2, AV4, TUNER, NET RADIO, etc.
 *   `surroundProgram#zone_channels`: openHAB Type `String`, Set's the surround mode. Examples: 2ch Stereo, 7ch Stereo, Hall in Munic, Straight, Surround Decoder.
 
@@ -79,6 +80,7 @@ Items:
 Switch      Yamaha_Power                "Power [%s]"                <switch>
 Dimmer      Yamaha_Volume               "Volume [%.1f %%]"          <soundvolume>
 Switch      Yamaha_Mute                 "Mute [%s]"                 <soundvolume_mute>
+Number      Yamaha_Dialogue_Level       "Dialogue Level [%d]"       <soundvolume>
 String      Yamaha_Input                "Input [%s]"                <video>
 String      Yamaha_Surround             "Surround [%s]"             <video>
 ```
@@ -94,6 +96,7 @@ Items:
 Switch      Yamaha_Power                "Power [%s]"                <switch>             { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#power" }
 Dimmer      Yamaha_Volume               "Volume [%.1f %%]"          <soundvolume>        { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#volume" }
 Switch      Yamaha_Mute                 "Mute [%s]"                 <soundvolume_mute>   { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#mute" }
+Switch      Yamaha_Dialogue_Level       "Dialogue Level [%d]"      <soundvolume>         { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#dialogueLevel" }
 String      Yamaha_Input                "Input [%s]"                <video>              { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#input" }
 String      Yamaha_Surround             "Surround [%s]"             <video>              { channel="yamahareceiver:zone:9ab0c000_f668_11de_9976_00a0ded41bb7:Main_Zone:zone_channels#surroundProgram" }
 ```
@@ -104,6 +107,7 @@ Sitemap:
 Switch     item=Yamaha_Power
 Switch     item=Yamaha_Mute
 Slider     item=Yamaha_Volume
+Setpoint   item=Yamaha_Dialogue_Level minValue=0 maxValue=2 step=1
 Selection  item=Yamaha_Input       mappings=[HDMI1="Kodi",HDMI2="PC",AUDIO1="TV",TUNER="Tuner",Spotify="Spotify",Bluetooth="Bluetooth","NET RADIO"="NetRadio"]
 Selection  item=Yamaha_Surround    mappings=["2ch Stereo"="2ch Stereo","5ch Stereo"="5ch Stereo","Chamber"="Chamber","Sci-Fi"="Sci-Fi","Adventure"="Adventure"]
 ```

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
@@ -39,6 +39,7 @@ public class YamahaReceiverBindingConstants {
     public static final String CHANNEL_SURROUND = "surroundProgram";
     public static final String CHANNEL_VOLUME = "volume";
     public static final String CHANNEL_VOLUME_DB = "volumeDB";
+    public static final String CHANNEL_DIALOGUE_LEVEL = "dialogueLevel";
     public static final String CHANNEL_MUTE = "mute";
 
     // List of channel IDs for navigation control: Read/Write

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaZoneThingHandler.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/handler/YamahaZoneThingHandler.java
@@ -259,6 +259,9 @@ public class YamahaZoneThingHandler extends BaseThingHandler implements ZoneCont
                 case YamahaReceiverBindingConstants.CHANNEL_MUTE:
                     zoneControl.setMute(((OnOffType) command) == OnOffType.ON);
                     break;
+                case YamahaReceiverBindingConstants.CHANNEL_DIALOGUE_LEVEL:
+                    zoneControl.setDialogueLevel(((DecimalType) command).intValue());
+                    break;
 
                 case YamahaReceiverBindingConstants.CHANNEL_NAVIGATION_MENU:
                     if (inputWithNavigationControl == null) {
@@ -443,6 +446,8 @@ public class YamahaZoneThingHandler extends BaseThingHandler implements ZoneCont
             updateState(channelUID, new PercentType((int) zoneState.volume));
         } else if (id.equals(grpZone(YamahaReceiverBindingConstants.CHANNEL_MUTE))) {
             updateState(channelUID, zoneState.mute ? OnOffType.ON : OnOffType.OFF);
+        } else if (id.equals(grpZone(YamahaReceiverBindingConstants.CHANNEL_DIALOGUE_LEVEL))) {
+            updateState(channelUID, new DecimalType(zoneState.dialogueLevel));
 
         } else if (id.equals(grpPlayback(YamahaReceiverBindingConstants.CHANNEL_PLAYBACK))) {
             updateState(channelUID, new StringType(playInfoState.playbackMode));
@@ -494,6 +499,8 @@ public class YamahaZoneThingHandler extends BaseThingHandler implements ZoneCont
         updateState(grpZone(YamahaReceiverBindingConstants.CHANNEL_VOLUME), new PercentType((int) zoneState.volume));
         updateState(grpZone(YamahaReceiverBindingConstants.CHANNEL_MUTE),
                 zoneState.mute ? OnOffType.ON : OnOffType.OFF);
+        updateState(grpZone(YamahaReceiverBindingConstants.CHANNEL_DIALOGUE_LEVEL),
+                new DecimalType(zoneState.dialogueLevel));
 
         // If the input changed
         if (inputChanged) {

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/ZoneControl.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/ZoneControl.java
@@ -58,4 +58,6 @@ public interface ZoneControl extends IStateUpdatable {
     void setInput(String name) throws IOException, ReceivedMessageParseException;
 
     void setSurroundProgram(String name) throws IOException, ReceivedMessageParseException;
+
+    void setDialogueLevel(int level) throws IOException, ReceivedMessageParseException;
 }

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXML.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXML.java
@@ -151,6 +151,13 @@ public class ZoneControlXML implements ZoneControl {
     }
 
     @Override
+    public void setDialogueLevel(int level) throws IOException, ReceivedMessageParseException {
+        comReference.get().send(XMLUtils.wrZone(zone, "<Sound_Video><Dialogue_Adjust><Dialogue_Lvl>" + level
+                + "</Dialogue_Lvl></Dialogue_Adjust></Sound_Video>"));
+        update();
+    }
+
+    @Override
     public void update() throws IOException, ReceivedMessageParseException {
         if (observer == null) {
             return;
@@ -199,8 +206,11 @@ public class ZoneControlXML implements ZoneControl {
         value = XMLUtils.getNodeContentOrDefault(basicStatus, "Volume/Mute", "");
         state.mute = "On".equalsIgnoreCase(value);
 
-        logger.trace("Zone {} state - power: {}, input: {}, mute: {}, surroundProgram: {}, volume: {}",
-                zone, state.power, state.inputID, state.mute, state.surroundProgram, state.volume);
+        value = XMLUtils.getNodeContentOrDefault(basicStatus, "Sound_Video/Dialogue_Adjust/Dialogue_Lvl", "0");
+        state.dialogueLevel = Integer.parseInt(value);
+
+        logger.trace("Zone {} state - power: {}, input: {}, mute: {}, surroundProgram: {}, volume: {}", zone,
+                state.power, state.inputID, state.mute, state.surroundProgram, state.volume);
 
         observer.zoneStateChanged(state);
     }

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/state/ZoneControlState.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/state/ZoneControlState.java
@@ -26,4 +26,5 @@ public class ZoneControlState {
     public String surroundProgram = VALUE_EMPTY;
     public float volume = 0.0f; // volume in percent
     public boolean mute = false;
+    public int dialogueLevel = 0;
 }


### PR DESCRIPTION
Adds item `dialogueLevel` to the Yamaha AVR binding.
It allows to adjust the volume of voice independent of master volume.