### PR TITLE
[squeezebox] Remove notification volume channel and replace with config property

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
@@ -78,7 +78,6 @@
 			<channel id="coverartdata" typeId="coverartdata" />
 			<channel id="ircode" typeId="ircode" />
 			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks" />
-			<channel id="notificationSoundVolume" typeId="notificationVolume" />
 			<channel id="playFavorite" typeId="playFavorite" />
 		</channels>
 
@@ -94,6 +93,15 @@
 			<parameter name="mac" type="text" required="true">
 				<label>MAC Address</label>
 				<description>SqueezeBox Players are identified by their MAC address</description>
+			</parameter>
+			<parameter name="notificationTimeout" type="integer" unit="s" required="true">
+				<label>Notification Timeout</label>
+				<description>Maximum amount of time in seconds for which the notification will be played</description>
+				<default>90</default>
+			</parameter>
+			<parameter name="notificationVolume" type="integer" min="0" max="100" step="1" unit="%">
+				<label>Notification Sound Volume</label>
+				<description>Volume used for notifications. Leaving blank uses current player volume.</description>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -277,12 +285,5 @@
 		<label>Number of Playlist Tracks</label>
 		<description>Number of playlist tracks</description>
 		<state readOnly="true" pattern="%d"></state>
-	</channel-type>
-	<channel-type id="notificationVolume">
-		<item-type>Dimmer</item-type>
-		<label>Notification Volume</label>
-		<description>Volume of notifications</description>
-		<state min="0" max="100" step="1" pattern="%d %%">
-		</state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
@@ -14,8 +14,7 @@
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<label>IP or Host Name</label>
-				<description>The IP or host name of the SqueezeServer
-                </description>
+				<description>The IP or host name of the SqueezeServer</description>
 			</parameter>
 			<parameter name="webport" type="integer" required="true" min="1" max="65335">
 				<label>SqueezeServer Web Port</label>
@@ -94,10 +93,10 @@
 				<label>MAC Address</label>
 				<description>SqueezeBox Players are identified by their MAC address</description>
 			</parameter>
-			<parameter name="notificationTimeout" type="integer" unit="s" required="true">
+			<parameter name="notificationTimeout" type="integer" unit="s">
 				<label>Notification Timeout</label>
 				<description>Maximum amount of time in seconds for which the notification will be played</description>
-				<default>90</default>
+				<default>20</default>
 			</parameter>
 			<parameter name="notificationVolume" type="integer" min="0" max="100" step="1" unit="%">
 				<label>Notification Sound Volume</label>

--- a/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.squeezebox/ESH-INF/thing/thing-types.xml
@@ -14,7 +14,8 @@
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<label>IP or Host Name</label>
-				<description>The IP or host name of the SqueezeServer</description>
+				<description>The IP or host name of the SqueezeServer
+                </description>
 			</parameter>
 			<parameter name="webport" type="integer" required="true" min="1" max="65335">
 				<label>SqueezeServer Web Port</label>

--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -182,4 +182,4 @@ This bug has been fixed in squeezelite version 1.8.6-985, which is included in p
 Therefore, it is recommended that the LMS be on a more current version than 7.7.5.
 
 -   There have been reports that the LMS does not play some WAV files reliably.
-If you're using a TTS service that produces WAV files, and the notifications are not playing, try using an MP#-formatted TTS notification.
+If you're using a TTS service that produces WAV files, and the notifications are not playing, try using an MP3-formatted TTS notification.

--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -139,7 +139,7 @@ Please follow the [openHAB multimedia documentation](http://docs.openhab.org/con
 
 You can set the default notification volume in the player thing configuration.
 
-You can override the default notification volume by supplying it as a parameter to *say* and *playSound*
+You can override the default notification volume by supplying it as a parameter to `say` and `playSound`.
 
 You can play notifications from within rules.
 
@@ -155,7 +155,7 @@ then
 end
 ```
 
-And, you can play sounds from the conf/sounds directory.
+And, you can play sounds from the `conf/sounds` directory.
 
 ```
 rule "Play Sounds"
@@ -163,9 +163,9 @@ when
     Item PlaySounds received command ON
 then
     // Play the sound on the default sink
-    playsound("doorbell.mp3")
+    playSound("doorbell.mp3")
     // Play the sound on a specific sink at a specified volume level
-    playsound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3", 45)
+    playSound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3", 45)
 end
 ```
 

--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -50,7 +50,7 @@ Or, if Squeeze Server authentication is enabled:
 ```
 Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090, userId="yourid", password="yourpassword" ]
 {
-    Thing squeezeboxplayer myplayer[ mac="00:f1:bb:00:00:f1" ]
+    Thing squeezeboxplayer myplayer[ mac="00:f1:bb:00:00:f1", notificationTimeout=30, notificationVolume=35 ]
 }
 ```
 
@@ -88,7 +88,6 @@ All devices support some of the following channels:
 | coverartdata            | Image     | Image data of cover art of the current song                                            |
 | ircode                  | String    | Received IR code                                                                       |
 | numberPlaylistTracks    | Number    | Number of playlist tracks                                                              |
-| notificationSoundVolume | Dimmer    | Volume for playing notifications                                                       |
 | playFavorite            | String    | ID of Favorite to play (channel's state options contains available favorites)          |
 
 ## Playing Favorites
@@ -99,6 +98,38 @@ The Selection widget in HABpanel can be used to present the favorites as a choic
 Selecting from that choice list will play the favorite on the SqueezeBox player.
 Currently, only favorites from the root level of the LMS favorites list are exposed on the **playFavorite** channel.
 
+### How to Set Up Favorites
+
+-   Add some favorites to your favorites list in LMS (local music playlists, Pandora, Slacker, Internet radio, etc.).
+Keep all favorites at the root level (i.e. favorites in sub-folders will be ignored).
+
+-   If you're on an older openHAB build, you may need to delete and readd your squeezebox server and player things to pick up the new channels.
+
+-   Create a new item on each player
+
+```
+String YourPlayer_PlayFavorite "Play Favorite [%s]" { channel="squeezebox:squeezeboxplayer:736549a3:00042016e7a0:playFavorite" }
+```
+
+#### For HABpanel (do this for each player)
+
+-   Add a Selection widget to your dashboard
+
+-   In the Selection widget settings
+
+    -  Enter the **YourPlayer_PlayFavorite** item
+
+    -  Select *Choices source* of *Server-provided item options*
+
+    -  Modify other settings to suite your taste
+
+-   When you load the dashboard and click on the selection widget, you should see the favorites.
+Selecting a favorite from the list will play it.
+
+#### For Sitemap
+
+-   Currently, the Selection widget in Basic UI doesn’t use the state options.
+
 ## Notifications
 
 ### How To Set Up
@@ -106,20 +137,9 @@ Currently, only favorites from the root level of the LMS favorites list are expo
 Squeeze Players can be set up as audio sinks in openHAB.
 Please follow the [openHAB multimedia documentation](http://docs.openhab.org/configuration/multimedia.html) for setup guidance.
 
-You can create an item and sitemap entry in order to set the notification volume independently from the Squeeze Player's current volume setting.
-If the notification volume is not specified, it will use the Player's current volume setting.
+You can set the default notification volume in the player thing configuration.
 
-Item for setting notification volume.
-
-```
-Dimmer NotificationVolume "Notification Volume [%d %%]" {channel="squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510:notificationSoundVolume"}
-```
-
-Sitemap entry for setting notification volume.
-
-```
-Slider item=NotificationVolume label="Notification Volume"
-```
+You can override the default notification volume by supplying it as a parameter to *say* and *playSound*
 
 You can play notifications from within rules.
 
@@ -128,8 +148,8 @@ rule "Garage Door Open Notification"
 when
     Item GarageDoorOpenNotification received command ON
 then
-    // Play the notification on the default sink
-    say("The garage door is open!", "voicerss:enUS")
+    // Play the notification on the default sink at a specified volume level
+    say("The garage door is open!", "voicerss:enUS", 35)
     // Play the notification on a specific sink
     say("The garage door is open!", "voicerss:enUS", "squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510")
 end
@@ -144,15 +164,22 @@ when
 then
     // Play the sound on the default sink
     playsound("doorbell.mp3")
-    // Play the sound on a specific sink
-    playsound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3")
+    // Play the sound on a specific sink at a specified volume level
+    playsound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3", 45)
 end
 ```
 
 ### Known Issues
 
--   There are some versions of squeezelite that will not correctly play very short duration mp3 files.  Versions of squeezelite after v1.7 and before v1.8.6 will not play very short duration mp3 files reliably.  For example, if you're using piCorePlayer (which uses squeezelite), please check your version of squeezelite if you're having trouble playing notifications. This bug has been fixed in squeezelite version 1.8.6-985, which is included in piCorePlayer version 3.20.
+-   There are some versions of squeezelite that will not correctly play very short duration mp3 files.
+Versions of squeezelite after v1.7 and before v1.8.6 will not play very short duration mp3 files reliably.
+For example, if you're using piCorePlayer (which uses squeezelite), please check your version of squeezelite if you're having trouble playing notifications.
+This bug has been fixed in squeezelite version 1.8.6-985, which is included in piCorePlayer version 3.20.
 
 -   When streaming from a remote service (such as Pandora or Spotify), after the notification plays, the Squeezebox Server starts playing a new track, instead of picking up from where it left off on the currently playing track.
 
--   There have been reports that notifications do not play reliably, or do not play at all, when using Logitech Media Server (LMS) version 7.7.5. Therefore, it is recommended that the LMS be on a more current version than 7.7.5.
+-   There have been reports that notifications do not play reliably, or do not play at all, when using Logitech Media Server (LMS) version 7.7.5.
+Therefore, it is recommended that the LMS be on a more current version than 7.7.5.
+
+-   There have been reports that the LMS does not play some WAV files reliably.
+If you're using a TTS service that produces WAV files, and the notifications are not playing, try using an MP#-formatted TTS notification.

--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -35,8 +35,13 @@ The binding requires no special configuration
 
 The Squeeze Server bridge requires the ip address, web port, and cli port to access it on.
 If Squeeze Server authentication is enabled, the userId and password also are required.
-Squeeze Players are identified by their MAC address.
-In the thing file, this looks e.g. like
+
+Squeeze Players are identified by their MAC address, which is required.
+In addition, the notification timeout can be specified.
+If omitted, the default timeout value will be used.
+A notification volume can be optionally specified, which, if provided, will override the player's current volume level when playing notifications.
+
+Here are some examples of how to define the Squeeze Server and Player things in a things file.
 
 ```
 Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090 ]
@@ -45,10 +50,19 @@ Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=
 }
 ```
 
-Or, if Squeeze Server authentication is enabled:
+If Squeeze Server authentication is enabled, the user ID and password can be specified for the Squeeze Server:
 
 ```
 Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090, userId="yourid", password="yourpassword" ]
+{
+    Thing squeezeboxplayer myplayer[ mac="00:f1:bb:00:00:f1" ]
+}
+```
+
+The notification timeout and/or notification volume can be specified for the Squeeze Player:
+
+```
+Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090 ]
 {
     Thing squeezeboxplayer myplayer[ mac="00:f1:bb:00:00:f1", notificationTimeout=30, notificationVolume=35 ]
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
@@ -59,6 +59,5 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_TYPEID = "typeId";
     public static final String CHANNEL_NAME = "name";
     public static final String CHANNEL_MODEL = "model";
-    public static final String CHANNEL_NOTIFICATION_SOUND_VOLUME = "notificationSoundVolume";
     public static final String CHANNEL_FAVORITES_PLAY = "playFavorite";
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -242,7 +242,7 @@ class SqueezeBoxNotificationPlayer implements Closeable {
                  * If the player was paused, stop it. We stop it because the LMS
                  * doesn't respond to a pause command while it's processing the
                  * above 'playPlaylist item' command. The consequence of this is
-                 * we lose the ability to resume local music from saved state.
+                 * we lose the ability to resume local music from saved playing time.
                  */
                 logger.debug("Stopping the player");
                 squeezeBoxServerHandler.stop(mac);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -87,12 +87,7 @@ class SqueezeBoxNotificationPlayer implements Closeable {
         if (playerState.isPlaying()) {
             squeezeBoxServerHandler.stop(mac);
         }
-
-        int notificationVolume = squeezeBoxPlayerHandler.getNotificationSoundVolume().intValue();
-        if (notificationVolume == 0) {
-            logger.info("Player notification volume is 0.");
-        }
-        setVolume(notificationVolume);
+        setVolume(squeezeBoxPlayerHandler.getNotificationSoundVolume().intValue());
     }
 
     /**

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -182,6 +182,7 @@ class SqueezeBoxNotificationPlayer implements Closeable {
                 throw new SqueezeBoxTimeoutException("Unable to update playlist.");
             }
         }
+        logger.debug("Playlist updated");
     }
 
     private void playNotification() throws InterruptedException, SqueezeBoxTimeoutException {
@@ -237,8 +238,14 @@ class SqueezeBoxNotificationPlayer implements Closeable {
                 logger.debug("Resuming last item playing");
                 break;
             case PAUSE:
-                logger.debug("Pausing the player");
-                squeezeBoxServerHandler.pause(mac);
+                /*
+                 * If the player was paused, stop it. We stop it because the LMS
+                 * doesn't respond to a pause command while it's processing the
+                 * above 'playPlaylist item' command. The consequence of this is
+                 * we lose the ability to resume local music from saved state.
+                 */
+                logger.debug("Stopping the player");
+                squeezeBoxServerHandler.stop(mac);
                 break;
             case STOP:
                 logger.debug("Stopping the player");

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxNotificationPlayer.java
@@ -191,7 +191,7 @@ class SqueezeBoxNotificationPlayer implements Closeable {
         squeezeBoxServerHandler.playPlaylistItem(mac, notificationMessagePlaylistsIndex);
 
         try {
-            int notificationTimeout = squeezeBoxPlayerHandler.getNotificationTimeout().intValue();
+            int notificationTimeout = squeezeBoxPlayerHandler.getNotificationTimeout();
             int timeoutCount = 0;
 
             logger.trace("Waiting up to {} s for stop...", notificationTimeout);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -623,7 +623,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     /*
      * Give the notification player access to the notification timeout
      */
-    public Integer getNotificationTimeout() {
+    public int getNotificationTimeout() {
         return getConfigAs(SqueezeBoxPlayerConfig.class).notificationTimeout;
     }
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -310,7 +310,8 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     @Override
     public synchronized void modeChangeEvent(String mac, String mode) {
         updateChannel(mac, CHANNEL_CONTROL, "play".equals(mode) ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
-        updateChannel(mac, CHANNEL_STOP, mode.equals("stop") ? OnOffType.ON : OnOffType.OFF);
+        updateChannel(mac, CHANNEL_PLAY_PAUSE, "play".equals(mode) ? OnOffType.ON : OnOffType.OFF);
+        updateChannel(mac, CHANNEL_STOP, "stop".equals(mode) ? OnOffType.ON : OnOffType.OFF);
         if (isMe(mac)) {
             playing = "play".equalsIgnoreCase(mode);
         }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -591,13 +591,11 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
      * Ticks away when in a play state to keep current track time
      */
     private void timeCounter() {
-        Runnable runnable = () -> {
+        timeCounterJob = scheduler.scheduleWithFixedDelay(() -> {
             if (playing) {
                 updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new DecimalType(currentTime++));
             }
-        };
-
-        timeCounterJob = scheduler.scheduleWithFixedDelay(runnable, 0, 1, TimeUnit.SECONDS);
+        }, 0, 1, TimeUnit.SECONDS);
     }
 
     private boolean isMe(String mac) {

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxPlayerHandler.java
@@ -591,12 +591,9 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
      * Ticks away when in a play state to keep current track time
      */
     private void timeCounter() {
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                if (playing) {
-                    updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new DecimalType(currentTime++));
-                }
+        Runnable runnable = () -> {
+            if (playing) {
+                updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new DecimalType(currentTime++));
             }
         };
 

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -212,7 +212,16 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     }
 
     public void addPlaylistItem(String mac, String url) {
-        sendCommand(mac + " playlist add " + url);
+        addPlaylistItem(mac, url, null);
+    }
+
+    public void addPlaylistItem(String mac, String url, String title) {
+        StringBuilder playlistCommand = new StringBuilder();
+        playlistCommand.append(mac).append(" playlist add ").append(url);
+        if (title != null) {
+            playlistCommand.append(" ").append(title);
+        }
+        sendCommand(playlistCommand.toString());
     }
 
     public void setPlayingTime(String mac, int time) {

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -111,7 +111,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("initializing server handler for thing {}", getThing().getUID());
 
-        scheduler.schedule(this::connect, 0, TimeUnit.SECONDS);
+        scheduler.submit(this::connect, TimeUnit.SECONDS);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -27,8 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Future;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -91,7 +90,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     // client socket and listener thread
     private Socket clientSocket;
     private SqueezeServerListener listener;
-    private ScheduledFuture<?> reconnectFuture;
+    private Future<?> reconnectFuture;
 
     private String host;
 
@@ -110,8 +109,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     @Override
     public void initialize() {
         logger.debug("initializing server handler for thing {}", getThing().getUID());
-
-        scheduler.submit(this::connect, TimeUnit.SECONDS);
+        scheduler.submit(this::connect);
     }
 
     @Override
@@ -984,10 +982,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         // update our children
         Bridge bridge = getThing();
 
-        if (bridge == null) {
-            return;
-        }
-
         List<Thing> things = bridge.getThings();
         for (Thing thing : things) {
             ThingHandler handler = thing.getHandler();
@@ -1035,7 +1029,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private void scheduleReconnect() {
         logger.debug("scheduling squeeze server reconnect in {} seconds", RECONNECT_TIME);
         cancelReconnect();
-        reconnectFuture = scheduler.schedule(this::connect, RECONNECT_TIME, TimeUnit.SECONDS);
+        reconnectFuture = scheduler.submit(this::connect);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/handler/SqueezeBoxServerHandler.java
@@ -111,13 +111,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("initializing server handler for thing {}", getThing().getUID());
 
-        scheduler.schedule(new Runnable() {
-
-            @Override
-            public void run() {
-                connect();
-            }
-        }, 0, TimeUnit.SECONDS);
+        scheduler.schedule(this::connect, 0, TimeUnit.SECONDS);
     }
 
     @Override
@@ -1041,12 +1035,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private void scheduleReconnect() {
         logger.debug("scheduling squeeze server reconnect in {} seconds", RECONNECT_TIME);
         cancelReconnect();
-        reconnectFuture = scheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                connect();
-            }
-        }, RECONNECT_TIME, TimeUnit.SECONDS);
+        reconnectFuture = scheduler.schedule(this::connect, RECONNECT_TIME, TimeUnit.SECONDS);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
@@ -24,7 +24,7 @@ public class SqueezeBoxPlayerConfig {
     /**
      * Number of seconds to wait to time out a notification
      */
-    public Integer notificationTimeout;
+    public int notificationTimeout;
 
     /**
      * Volume used for playing notifications

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/config/SqueezeBoxPlayerConfig.java
@@ -12,8 +12,22 @@ package org.openhab.binding.squeezebox.internal.config;
  * Configuration for a player
  *
  * @author Dan Cunningham
+ * @author Mark Hilbush - Convert sound notification volume from channel to config parameter
  *
  */
 public class SqueezeBoxPlayerConfig {
+    /**
+     * MAC address of player
+     */
     public String mac;
+
+    /**
+     * Number of seconds to wait to time out a notification
+     */
+    public Integer notificationTimeout;
+
+    /**
+     * Volume used for playing notifications
+     */
+    public Integer notificationVolume;
 }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -110,11 +110,8 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
      * Tells the bridge to request a list of players
      */
     private void setupRequestPlayerJob() {
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                squeezeBoxServerHandler.requestPlayers();
-            }
+        Runnable runnable = () -> {
+            squeezeBoxServerHandler.requestPlayers();
         };
 
         logger.debug("request player job scheduled to run every {} seconds", TTL);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -110,12 +110,10 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
      * Tells the bridge to request a list of players
      */
     private void setupRequestPlayerJob() {
-        Runnable runnable = () -> {
+        logger.debug("Request player job scheduled to run every {} seconds", TTL);
+        requestPlayerJob = scheduler.scheduleWithFixedDelay(() -> {
             squeezeBoxServerHandler.requestPlayers();
-        };
-
-        logger.debug("request player job scheduled to run every {} seconds", TTL);
-        requestPlayerJob = scheduler.scheduleWithFixedDelay(runnable, 10, TTL, TimeUnit.SECONDS);
+        }, 10, TTL, TimeUnit.SECONDS);
     }
 
     // we can ignore the other events

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/HttpUtils.java
@@ -8,7 +8,9 @@
  */
 package org.openhab.binding.squeezebox.internal.utils;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -27,6 +29,7 @@ import com.google.gson.JsonParser;
  * @author Dan Cunningham
  * @author Svilen Valkanov - replaced Apache HttpClient with Jetty
  * @author Mark Hilbush - Add support for LMS authentication
+ * @author Mark Hilbush - Rework exception handling
  */
 public class HttpUtils {
     private static Logger logger = LoggerFactory.getLogger(HttpUtils.class);
@@ -41,21 +44,29 @@ public class HttpUtils {
     /**
      * Simple logic to perform a post request
      *
-     * @param url
-     * @param timeout
-     * @return
+     * @param url URL to be sent to LMS server
+     * @param postData Data to be sent to LMS server
+     * @return Content received from LMS
+     * @throws SqueezeBoxCommunicationException
+     * @throws SqueezeBoxNotAuthorizedException
      */
-    public static String post(String url, String postData) throws Exception, SqueezeBoxNotAuthorizedException {
+    public static String post(String url, String postData)
+            throws SqueezeBoxNotAuthorizedException, SqueezeBoxCommunicationException {
         if (!client.isStarted()) {
-            client.start();
+            try {
+                client.start();
+            } catch (Exception e) {
+                throw new SqueezeBoxCommunicationException("Jetty http client exception: " + e.getMessage());
+            }
         }
 
-        // @formatter:off
-        ContentResponse response = client.newRequest(url)
-                .method(HttpMethod.POST)
-                .content(new StringContentProvider(postData))
-                .timeout(TIMEOUT, TimeUnit.MILLISECONDS)
-                .send();
+        ContentResponse response;
+        try {
+            response = client.newRequest(url).method(HttpMethod.POST).content(new StringContentProvider(postData))
+                    .timeout(TIMEOUT, TimeUnit.MILLISECONDS).send();
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            throw new SqueezeBoxCommunicationException("Jetty http client exception: " + e.getMessage());
+        }
 
         int statusCode = response.getStatus();
 
@@ -68,7 +79,7 @@ public class HttpUtils {
         if (statusCode != HttpStatus.OK_200) {
             String statusLine = response.getStatus() + " " + response.getReason();
             logger.error("HTTP POST method failed: {}", statusLine);
-            throw new Exception("Method failed: " + statusLine);
+            throw new SqueezeBoxCommunicationException("Http post to server failed: " + statusLine);
         }
 
         return response.getContentAsString();
@@ -79,10 +90,13 @@ public class HttpUtils {
      *
      * @param ip
      * @param webPort
-     * @return
-     * @throws Exception
+     * @return Command Line Interpreter (CLI) port number
+     * @throws SqueezeBoxNotAuthorizedException
+     * @throws SqueezeBoxCommunicationException
+     * @throws NumberFormatException
      */
-    public static int getCliPort(String ip, int webPort) throws Exception {
+    public static int getCliPort(String ip, int webPort)
+            throws SqueezeBoxNotAuthorizedException, SqueezeBoxCommunicationException {
         String url = "http://" + ip + ":" + webPort + "/jsonrpc.js";
         String json = HttpUtils.post(url, JSON_REQ);
         logger.trace("Recieved json from server {}", json);

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxCommunicationException.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/utils/SqueezeBoxCommunicationException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.squeezebox.internal.utils;
+
+/**
+ * Exception thrown when unable to communicate with LMS server.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class SqueezeBoxCommunicationException extends Exception {
+    private static final long serialVersionUID = 1540489268747099161L;
+
+    public SqueezeBoxCommunicationException(String message) {
+        super(message);
+    }
+
+    public SqueezeBoxCommunicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

Removes `notificationSoundVolume` channel and replaces it with a configuration parameter on the Player thing. This maintains consistency with pending changes to Sonos, as well as supports the modifications to audio actions where the volume can be specified as part of the audio and voice APIs.

Also adds a `notificationTimeout` config parameter on the Player thing to provide greater user control over notification duration, as well as to maintain consistency with Sonos notification functionality.

Depends on next stable ESH containing this PR .
https://github.com/eclipse/smarthome/pull/4963

Also
- Rework HttpUtils to not throw Exception in order to resolve build failure due to code analysis error
- Rework Notification Player to consolidate code for player state restoration (see https://github.com/openhab/openhab2-addons/pull/3231#discussion_r168277844)
- Fixed play/pause channel not updating when mode changes
- Fix player not pausing after notification completes
- Replace Runnables with lambdas
