### PR TITLE
[LGWebOS] LocalIP Binding Property

### DIFF
--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
@@ -12,6 +12,7 @@
             <description>Local IP of server network interface to bind to. This is optional. If not set, the binding will use openHAB's primary IP address, which may be configured under network settings.
             </description>
             <required>false</required>
+            <context>network-address</context>
         </parameter>
     </config-description>
 

--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
@@ -5,5 +5,14 @@
 	<name>LG webOS Binding</name>
 	<description>Binding to connect LG's WebOS based smart TVs based on Connect SDK</description>
 	<author>Sebastian Prehn</author>
+	
+	<config-description>
+        <parameter name="localIP" type="text">
+            <label>Local IP</label>
+            <description>Local IP of server network interface to bind to. This is optional. If not set, the binding will use openHAB's primary IP address, which may be configured under network settings.
+            </description>
+            <required>false</required>
+        </parameter>
+    </config-description>
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.lgwebos/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.lgwebos/META-INF/MANIFEST.MF
@@ -30,7 +30,6 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
- org.eclipse.smarthome.model.script.engine.action,
  org.openhab.binding.lgwebos,
  org.openhab.binding.lgwebos.handler,
  org.slf4j

--- a/addons/binding/org.openhab.binding.lgwebos/README.md
+++ b/addons/binding/org.openhab.binding.lgwebos/README.md
@@ -17,6 +17,16 @@ Under network settings allow "LG CONNECT APPS" to connect.
 Note: Under general settings allow mobile applications to turn on the TV, if this option is available.
 In combination with the wake on LAN binding this will allow you to start the TV via openHAB.
 
+## Binding Configuration
+
+The binding has only one configuration parameter, which is only required if the binding cannot automatically detect openHAB's local IP address: 
+
+| Name    | Description                                                          |
+|---------|----------------------------------------------------------------------|
+| LocalIP | This is the local IP of your openHAB host on the network. (Optional) |
+
+If LocalIP is not set, the binding will use openHAB's primary IP address, which may be configured under network settings.
+
 ## Discovery
 
 TVs are auto discovered through SSDP in the local network.

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -14,7 +14,9 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -50,6 +52,7 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
     private DiscoveryManager discoveryManager;
 
     private NetworkAddressService networkAddressService;
+    private Optional<InetAddress> localInetAddressesOverride;
 
     public LGWebOSDiscovery() {
         super(LGWebOSBindingConstants.SUPPORTED_THING_TYPES_UIDS, DISCOVERY_TIMEOUT_SECONDS, true);
@@ -68,6 +71,7 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
     @Override
     protected void activate(Map<String, Object> configProperties) {
         logger.debug("Config Parameters: {}", configProperties);
+        localInetAddressesOverride = evaluateConfigPropertyLocalIP((String) configProperties.get("localIP"));
         Util.init(AbstractDiscoveryService.scheduler);
         discoveryManager = DiscoveryManager.getInstance();
         discoveryManager.setPairingLevel(DiscoveryManager.PairingLevel.ON);
@@ -161,16 +165,55 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
 
     @Override
     public InetAddress getIpAddress() {
+        if (localInetAddressesOverride.isPresent()) {
+            return localInetAddressesOverride.get();
+        }
+
+        Optional<InetAddress> inetAddressFromNetworkAddressService = getInetAddressFromNetworkAddressService();
+        if (inetAddressFromNetworkAddressService.isPresent()) {
+            return inetAddressFromNetworkAddressService.get();
+        }
+
+        return null;
+    }
+
+    /**
+     * Evaluate local IP optional configuration property.
+     *
+     * @param localIP optional configuration string
+     * @return local ip or <code>empty</code> if property is not set or unparseable.
+     */
+    private Optional<InetAddress> evaluateConfigPropertyLocalIP(String localIP) {
+        if (StringUtils.isNotBlank(localIP)) {
+            try {
+                logger.debug("localIP property was explicitly set to: {}", localIP);
+                return Optional.ofNullable(InetAddress.getByName(localIP.trim()));
+            } catch (UnknownHostException e) {
+                logger.warn("localIP property could not be parsed: {} Details: {}", localIP, e.getMessage());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Uses OpenHAB's NetworkAddressService to determine the local primary network interface.
+     *
+     * @return local ip or <code>empty</code> if configured primary IP is not set or could not be parsed.
+     */
+    private Optional<InetAddress> getInetAddressFromNetworkAddressService() {
         String ipAddress = networkAddressService.getPrimaryIpv4HostAddress();
         if (ipAddress == null) {
             logger.warn("No network interface could be found.");
-            return null;
+            return Optional.empty();
         }
         try {
-            return InetAddress.getByName(ipAddress);
+            return Optional.of(InetAddress.getByName(ipAddress));
         } catch (UnknownHostException e) {
             logger.warn("Configured primary IP cannot be parsed: {} Details: {}", ipAddress, e.getMessage());
-            return null;
+            return Optional.empty();
         }
+
     }
+
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -165,7 +165,7 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
 
     @Override
     public InetAddress getIpAddress() {
-        return localInetAddressesOverride.orElse(getIpFromNetworkAddressService().orElse(null));
+        return localInetAddressesOverride.orElseGet(() -> getIpFromNetworkAddressService().orElse(null));
     }
 
     /**

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -165,16 +165,7 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
 
     @Override
     public InetAddress getIpAddress() {
-        if (localInetAddressesOverride.isPresent()) {
-            return localInetAddressesOverride.get();
-        }
-
-        Optional<InetAddress> inetAddressFromNetworkAddressService = getInetAddressFromNetworkAddressService();
-        if (inetAddressFromNetworkAddressService.isPresent()) {
-            return inetAddressFromNetworkAddressService.get();
-        }
-
-        return null;
+        return localInetAddressesOverride.orElse(getIpFromNetworkAddressService().orElse(null));
     }
 
     /**
@@ -201,7 +192,7 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
      *
      * @return local ip or <code>empty</code> if configured primary IP is not set or could not be parsed.
      */
-    private Optional<InetAddress> getInetAddressFromNetworkAddressService() {
+    private Optional<InetAddress> getIpFromNetworkAddressService() {
         String ipAddress = networkAddressService.getPrimaryIpv4HostAddress();
         if (ipAddress == null) {
             logger.warn("No network interface could be found.");


### PR DESCRIPTION
Adding back LocalIP Binding Property

Reintroducing the ability to set the IP address to bind to. It used to exist in the binding until we switched to using NetworkAddressService. Multiple users have found that it would be advantageous to bring this feature back. It allows to override what is configured as primary network interface. This is required in situations when users segregate networks into multiple zones.