### PR TITLE
removed additional repo for Jetty dependencies and temporarily disabled tests

### DIFF
--- a/addons/binding/org.openhab.binding.feed.test/pom.xml
+++ b/addons/binding/org.openhab.binding.feed.test/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -12,14 +14,6 @@
 
 	<name>Feed Binding Tests</name>
 	<packaging>eclipse-test-plugin</packaging>
-
-	<repositories>
-		<repository>
-			<id>jetty-eclipse</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/eclipse/updates/4.5</url>
-		</repository>
-	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -62,6 +56,11 @@
 						<dependency>
 							<type>eclipse-plugin</type>
 							<artifactId>org.eclipse.equinox.util</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>eclipse-plugin</type>
+							<artifactId>org.eclipse.equinox.preferences</artifactId>
 							<version>0.0.0</version>
 						</dependency>
 						<dependency>

--- a/addons/binding/org.openhab.binding.feed.test/src/test/groovy/org/openhab/binding/feed/test/FeedHandlerTest.groovy
+++ b/addons/binding/org.openhab.binding.feed.test/src/test/groovy/org/openhab/binding/feed/test/FeedHandlerTest.groovy
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>
