### PR TITLE
[homematic] Add properties to a homematic bridge during initialization

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -8,8 +8,13 @@
  */
 package org.openhab.binding.homematic.handler;
 
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_MODEL_ID;
+
 import java.io.IOException;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -32,6 +37,7 @@ import org.openhab.binding.homematic.internal.misc.HomematicClientException;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmDatapointConfig;
 import org.openhab.binding.homematic.internal.model.HmDevice;
+import org.openhab.binding.homematic.internal.model.HmGatewayInfo;
 import org.openhab.binding.homematic.internal.type.HomematicTypeGenerator;
 import org.openhab.binding.homematic.internal.type.UidUtils;
 import org.osgi.framework.ServiceRegistration;
@@ -72,6 +78,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
             try {
                 String id = getThing().getUID().getId();
                 gateway = HomematicGatewayFactory.createGateway(id, config, instance);
+                configureThingProperties();
                 gateway.initialize();
 
                 discoveryService.startScan(null);
@@ -92,6 +99,21 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 scheduleReinitialize();
             }
         });
+    }
+
+    private void configureThingProperties() {
+        final HmGatewayInfo info = config.getGatewayInfo();
+        final Map<String, String> properties = getThing().getProperties();
+
+        if (!properties.containsKey(PROPERTY_FIRMWARE_VERSION)) {
+            getThing().setProperty(PROPERTY_FIRMWARE_VERSION, info.getFirmware());
+        }
+        if (!properties.containsKey(PROPERTY_SERIAL_NUMBER)) {
+            getThing().setProperty(PROPERTY_SERIAL_NUMBER, info.getAddress());
+        }
+        if (!properties.containsKey(PROPERTY_MODEL_ID)) {
+            getThing().setProperty(PROPERTY_MODEL_ID, info.getType());
+        }
     }
 
     /**


### PR DESCRIPTION
Improvement:
The `HomematicBridgeHandler` retrieves information about a bridge's firmware, model and serial number during initialization. Currently, these properties are stored in a private field of the handler of type `HomematicConfig`. These properties, however, could also be provided as `thingProperties` in the bridge thing.

Users will now be able to access the firmware, model and serial number of a homematic bridge from the bridge thing after initialization. Moreover, if the bridge thing has already configured values for any of these properties, they will **not** be overwritten. This should prevent any undesired changes in existing systems that already make use of these specific properties.

The decision to map `PROPERTY_SERIAL_NUMBER` to `info.getAddress()` comes from the documentation of the XML-RPC API of homematic, which states that the `ADDRESS` returned by the homematic bridge is its serial number (http://www.eq-3.de/Downloads/eq3/download%20bereich/hm_web_ui_doku/HM_XmlRpc_API.pdf, see method `listBidcosInterfaces`, in German).

The decision to map `PROPERTY_MODEL_ID` to `info.getType()` instead of `info.getId()` was made because, while both properties hold similar information, the type is more informative than the id. For instance, according to the implementation of `HmGatewayInfo`, all CCUs have the ID "CCU". Thus, a CCU1 and a CCU2 can only be distinguished through their type, not through their id.

Signed-off-by: Florian Stolte <fstolte@gmx.de> (github: FStolte)
