### PR TITLE
[homematic] Provide config-descriptions for every config-description-URI

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -338,9 +338,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 }
             }
         }
-        if (!parms.isEmpty()) {
-            configDescriptionProvider.addConfigDescription(new ConfigDescription(configDescriptionURI, parms, groups));
-        }
+        
+        configDescriptionProvider.addConfigDescription(new ConfigDescription(configDescriptionURI, parms, groups));
 
     }
 


### PR DESCRIPTION
Our application evaluates any thing's ConfigDescriptions to decorate the thing with application-specific functionality. Therefore I suggest that the binding creates ConfigDescrition for each created
ThingType, even if it does not contain any parameter.

Closes #3277 

Signed-off-by: Michael Reitler <github@madpage.de>
