### PR TITLE
[Netatmo] Handle errors more gracefully

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoBridgeHandler.java
@@ -140,7 +140,12 @@ public class NetatmoBridgeHandler extends BaseBridgeHandler {
                                             + " seconds.");
                             break;
                         default:
-                            logger.error("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                            if (logger.isDebugEnabled()) {
+                                // we also attach the stack trace
+                                logger.error("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                            } else {
+                                logger.error("Unable to connect Netatmo API : {}", e.getMessage());
+                            }
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                                     "Unable to connect Netatmo API : " + e.getLocalizedMessage());
                             return;

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoDeviceHandler.java
@@ -117,7 +117,12 @@ public abstract class NetatmoDeviceHandler<DEVICE> extends AbstractNetatmoThingH
                 try {
                     newDeviceReading = updateReadings();
                 } catch (RetrofitError e) {
-                    logger.error("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                    if (logger.isDebugEnabled()) {
+                        // we also attach the stack trace
+                        logger.error("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                    } else {
+                        logger.error("Unable to connect Netatmo API : {}", e.getMessage());
+                    }
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "Unable to connect Netatmo API : " + e.getLocalizedMessage());
                 }
@@ -170,7 +175,7 @@ public abstract class NetatmoDeviceHandler<DEVICE> extends AbstractNetatmoThingH
                     return new DecimalType(userAdministrative.getUnit());
             }
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            logger.error("The device has no method to access {} property ", channelId);
+            logger.debug("The device has no method to access {} property ", channelId);
             return UnDefType.NULL;
         }
 

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/NetatmoModuleHandler.java
@@ -65,7 +65,7 @@ public class NetatmoModuleHandler<MODULE> extends AbstractNetatmoThingHandler {
             }
         } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
                 | InvocationTargetException e) {
-            logger.error("The module has no method to access {} property ", channelId);
+            logger.debug("The module has no method to access {} property ", channelId);
             return UnDefType.NULL;
         }
 

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/TrustingOkHttpClient.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/handler/TrustingOkHttpClient.java
@@ -10,12 +10,9 @@ package org.openhab.binding.netatmo.handler;
 
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 


### PR DESCRIPTION
We currently see the complete stack trace in case of an error.
```
2018-02-28 09:42:02.964 [ERROR] [netatmo.handler.NetatmoDeviceHandler] - Unable to connect Netatmo API : 502 Bad Gateway
retrofit.RetrofitError: 502 Bad Gateway
        at retrofit.RetrofitError.httpError(RetrofitError.java:40) ~[?:?]
        at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:388) ~[?:?]
        at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:240) ~[?:?]
        at com.sun.proxy.$Proxy182.getstationsdata(Unknown Source) ~[?:?]
        at org.openhab.binding.netatmo.handler.NetatmoBridgeHandler.getStationsDataBody(NetatmoBridgeHandler.java:231) ~[?:?]
        at org.openhab.binding.netatmo.internal.station.NAMainHandler.updateReadings(NAMainHandler.java:42) ~[?:?]
        at org.openhab.binding.netatmo.internal.station.NAMainHandler.updateReadings(NAMainHandler.java:1) ~[?:?]
        at org.openhab.binding.netatmo.handler.NetatmoDeviceHandler.updateChannels(NetatmoDeviceHandler.java:118) ~[?:?]
        at org.openhab.binding.netatmo.handler.NetatmoDeviceHandler.lambda$0(NetatmoDeviceHandler.java:86) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
```

Handle this more gracefully (while still writing a single ERROR line to your log as it is a bug that we come across here).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>