### PR TITLE
[bigassfan] Add support for standalone lights

### DIFF
--- a/addons/binding/org.openhab.binding.bigassfan/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.bigassfan/ESH-INF/config/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:bigassfan:device">
+		<parameter name="label" type="text" required="true">
+			<label>Name of Device</label>
+			<description>Enter the name you've given to the device</description>
+		</parameter>
+		<parameter name="ipAddress" type="text" required="true">
+			<label>Network Address</label>
+			<description>Enter the IP address of the device</description>
+			<context>network-address</context>
+		</parameter>
+		<parameter name="macAddress" type="text" required="true">
+			<label>MAC Address</label>
+			<description>Enter the MAC address of the device</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.bigassfan/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.bigassfan/ESH-INF/thing/thing-types.xml
@@ -38,21 +38,30 @@
 			<channel id="time" typeId="time" />
 		</channels>
 
-		<config-description>
-			<parameter name="label" type="text" required="true">
-				<label>Name of Device</label>
-				<description>Enter the name you've given to the device</description>
-			</parameter>
-			<parameter name="ipAddress" type="text" required="true">
-				<label>Network Address</label>
-				<description>Enter the IP address of the fan</description>
-				<context>network-address</context>
-			</parameter>
-			<parameter name="macAddress" type="text" required="true">
-				<label>MAC Address</label>
-				<description>Enter the MAC address of the fan</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:bigassfan:device" />
+	</thing-type>
+
+	<!-- Thing Type for BigAssFan light -->
+	<thing-type id="light">
+		<label>Light</label>
+		<description>Light</description>
+
+		<channels>
+			<!-- Channels related to light functions -->
+			<channel id="light-power" typeId="light-power" />
+			<channel id="light-level" typeId="light-level" />
+			<channel id="light-hue" typeId="light-hue" />
+			<channel id="light-present" typeId="light-present" />
+			<channel id="light-color" typeId="light-color" />
+
+			<!-- Channels related to motion sensor -->
+			<channel id="motion" typeId="motion" />
+
+			<!-- Miscellaneous channels -->
+			<channel id="time" typeId="time" />
+		</channels>
+
+		<config-description-ref uri="thing-type:bigassfan:device" />
 	</thing-type>
 
 	<!-- Thing Type for BigAssFan controller -->
@@ -65,21 +74,7 @@
 			<channel id="time" typeId="time" />
 		</channels>
 
-		<config-description>
-			<parameter name="label" type="text" required="true">
-				<label>Name of Device</label>
-				<description>Enter the name you've given to the device</description>
-			</parameter>
-			<parameter name="ipAddress" type="text" required="true">
-				<label>Network Address</label>
-				<description>Enter the IP address of the fan</description>
-				<context>network-address</context>
-			</parameter>
-			<parameter name="macAddress" type="text" required="true">
-				<label>MAC Address</label>
-				<description>Enter the MAC address of the fan</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:bigassfan:device" />
 	</thing-type>
 
 	<!-- Channel types -->
@@ -189,6 +184,11 @@
 		<label>Maximum Brightness</label>
 		<description>Set the maximum brightness level when using Smarter Lighting</description>
 	</channel-type>
+	<channel-type id="light-hue">
+		<item-type>Dimmer</item-type>
+		<label>Hue</label>
+		<description>Set the hue of the light</description>
+	</channel-type>
 	<channel-type id="light-present">
 		<item-type>String</item-type>
 		<label>Light Present</label>
@@ -197,6 +197,17 @@
 			<options>
 				<option value="PRESENT">Present</option>
 				<option value="NOTPRESENT">Not Present</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="light-color">
+		<item-type>String</item-type>
+		<label>Light Color</label>
+		<description>Light allows hue to be adjusted</description>
+		<state readOnly="true">
+			<options>
+				<option value="COLOR">Color</option>
+				<option value="NOCOLOR">No Color</option>
 			</options>
 		</state>
 	</channel-type>

--- a/addons/binding/org.openhab.binding.bigassfan/README.md
+++ b/addons/binding/org.openhab.binding.bigassfan/README.md
@@ -1,20 +1,20 @@
 # BigAssFan Binding
 
-The [BigAssFan](http://www.bigassfans.com/) binding is used to enable communication between openHAB and Big Ass Fans'  Haiku family of residential fans that implement the SenseME technology.
+The [BigAssFan](http://www.bigassfans.com/) binding is used to enable communication between openHAB and Big Ass Fans'  Haiku family of residential fans and lights that implement the SenseME technology.
 
 ## Overview
 
-Fans are discovered dynamically.
-There is a single thing created for each fan connected to the network.
-Each thing has channels that allow control of the fan and the optional LED light, as well as to monitor the status of the fan.
-When the fan is controlled from the remote control, Wall Controller, or smartphone app, the openHAB items linked to the fan's channels will be updated to reflect the fan's status.
+Fans and lights are discovered dynamically.
+There is a single thing created for each fan and/or connected to the network.
+Each thing has channels that allow control of the fan and light, as well as to monitor the status.
+When a fan or light is controlled from the remote control, Wall Controller, or smartphone app, the openHAB items linked to the device's channels will be updated to reflect the status.
 
 ## Device Discovery
 
-The BigAssFan binding discovers Haiku fans on the network, and creates an inbox entry for each discovered device.
-Once added as a thing, the user can control the fan and optional LED light kit, similarly to how the fan is controlled using the remote, Wall Controller, or smartphone app.
+The BigAssFan binding discovers Haiku fans and lights on the network, and creates an inbox entry for each discovered device.
+Once added as a thing, the user can control the fan and light, similarly to how the device is controlled using the remote, Wall Controller, or smartphone app.
 
-Background discovery polls the network every few minutes for fans.
+Background discovery polls the network every few minutes for devices.
 Background discovery is **enabled** by default.
 To **disable** background discovery, add the following line to the *conf/services/runtime.cfg* file:
 
@@ -24,12 +24,12 @@ discovery.bigassfan:background=false
 
 ## Thing Configuration
 
-The fan's IP address, MAC address, and name is set at time of discovery.
-However, in the event that any of this information changes, the fan's configuration must be updated.
+The device's IP address, MAC address, and name is set at time of discovery.
+However, in the event that any of this information changes, the configuration must be updated.
 
 ### Manual Thing Creation
 
-Fans can be manually created in the *PaperUI* or *HABmin*, or by placing a *.things* file in the *conf/things* directory.
+Fans and lights can be manually created in the *PaperUI* or *HABmin*, or by placing a *.things* file in the *conf/things* directory.
 See example below.
 
 ## Channels
@@ -49,8 +49,8 @@ The following channels are supported for fans:
 | fan-wintermode          | Switch       | Enable/disable fan winter mode                        |
 | fan-speed-min           | Dimmer       | Set minimum fan speed                                 |
 | fan-speed-max           | Dimmer       | Set maximum fan speed                                 |
-| light-power             | Switch       | Power on/off the fan                                  |
-| light-level             | Dimmer       | Adjust the brightness of the light from               |
+| light-power             | Switch       | Power on/off the light                                |
+| light-level             | Dimmer       | Adjust the brightness of the light                    |
 | light-auto              | Switch       | Enable/disable light auto mode                        |
 | light-smarter           | String       | Enable/disable Smarter Lighting                       |
 | light-level-min         | Dimmer       | Set minimum light level for Smarter Lighting          |
@@ -58,6 +58,18 @@ The following channels are supported for fans:
 | light-present           | String       | Indicates is a light is installed in the fan          |
 | motion                  | Switch       | Motion was detected                                   |
 | time                    | DateTime     | Fan's date and time                                   |
+
+The following channels are supported for lights:
+
+| Channel Name            | Item Type    | Description                                           |
+|-------------------------|--------------|-------------------------------------------------------|
+| light-power             | Switch       | Power on/off the light                                |
+| light-level             | Dimmer       | Adjust the brightness of the light                    |
+| light-hue               | Dimmer       | Adjust the color temperature of the light             |
+| light-present           | String       | Indicates if a light is installed                     |
+| light-color             | String       | Indicates if the light supports hue adjustment        |
+| motion                  | Switch       | Motion was detected                                   |
+| time                    | DateTime     | Light's date and time                                 |
 
 The following channels are supported for wall controllers:
 
@@ -89,17 +101,36 @@ Switch PorchFanLightAuto            { channel="bigassfan:fan:20F85EDAA56A:light-
 Switch PorchFanLightSmarter         { channel="bigassfan:fan:20F85EDAA56A:light-smarter" }
 Dimmer PorchFanLightLevelMin        { channel="bigassfan:fan:20F85EDAA56A:light-level-min" }
 Dimmer PorchFanLightLevelMax        { channel="bigassfan:fan:20F85EDAA56A:light-level-max" }
-String PorchFanLightPresent         { channel="bigassfan:fan:20F85EDAA56A:light-present" }
 ```
 
-The following readonly items are provided by the fan.
+The following read-only items are provided by the fan.
 
 ```java
+String PorchFanLightPresent         { channel="bigassfan:fan:20F85EDAA56A:light-present" }
 Switch PorchFanMotionSensor         { channel="bigassfan:fan:20F85EDAA56A:motion" }
 DateTime PorchFanTime               { channel="bigassfan:fan:20F85EDAA56A:time" }
 ```
 
+## Light Items
+
+```java
+Switch KitchenLightPower            { channel="bigassfan:light:20F85EDA87A0:light-power" }
+Dimmer KitchenLightLevel            { channel="bigassfan:light:20F85EDA87A0:light-level" }
+Switch KitchenLightHue              { channel="bigassfan:light:20F85EDA87A0:light-hue" }
+```
+
+The following read-only items are provided by the light.
+
+```java
+String KitchenLightPresent          { channel="bigassfan:light:20F85EDA87A0:light-present" }
+String KitchenLightColor            { channel="bigassfan:light:20F85EDA87A0:light-color" }
+Switch KitchenLightMotionSensor     { channel="bigassfan:light:20F85EDA87A0:motion" }
+DateTime KitchenLightTime           { channel="bigassfan:light:20F85EDA87A0:time" }
+```
+
 ## Wall Controller Items
+
+The following read-only items are provided by the wall controller.
 
 ```java
 Switch PorchControllerMotionSensor  { channel="bigassfan:controller:20F85ED87F01:motion" }
@@ -116,6 +147,11 @@ Frame label="Control My BigAssFan" {
     Slider item=PorchFanSpeed label="Fan Speed [%s %%]"
     Switch item=PorchFanLightPower label="Light Power [%s]"
     Slider item=PorchFanLightLevel label="Light Brightness [%s %%]"
+}
+Frame label="Control My Light" {
+    Switch item=KitchenLightPower label="Light Power [%s]"
+    Slider item=KitchenLightLevel label="Light Level [%s %%]"
+    Slider item=KitchenLightHue label="Light Hue [%s]"
 }
 ```
 

--- a/addons/binding/org.openhab.binding.bigassfan/pom.xml
+++ b/addons/binding/org.openhab.binding.bigassfan/pom.xml
@@ -1,23 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.openhab.binding</groupId>
-    <artifactId>pom</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
-  </parent>
+	<parent>
+		<groupId>org.openhab.binding</groupId>
+		<artifactId>pom</artifactId>
+		<version>2.3.0-SNAPSHOT</version>
+	</parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.binding.bigassfan</bundle.symbolicName>
-    <bundle.namespace>org.openhab.binding.bigassfan</bundle.namespace>
-  </properties>
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.bigassfan</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.bigassfan</bundle.namespace>
+	</properties>
 
-  <groupId>org.openhab.binding</groupId>
-  <artifactId>org.openhab.binding.bigassfan</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.bigassfan</artifactId>
+	<version>2.3.0-SNAPSHOT</version>
 
-  <name>BigAssFan Binding</name>
-  <packaging>eclipse-plugin</packaging>
+	<name>BigAssFan Binding</name>
+	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/BigAssFanBindingConstants.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/BigAssFanBindingConstants.java
@@ -32,8 +32,9 @@ public class BigAssFanBindingConstants {
 
     // BigAssFan Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_FAN = new ThingTypeUID(BINDING_ID, "fan");
+    public static final ThingTypeUID THING_TYPE_LIGHT = new ThingTypeUID(BINDING_ID, "light");
     public static final ThingTypeUID THING_TYPE_CONTROLLER = new ThingTypeUID(BINDING_ID, "controller");
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_FAN,
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_FAN, THING_TYPE_LIGHT,
             THING_TYPE_CONTROLLER);
 
     /*
@@ -60,6 +61,10 @@ public class BigAssFanBindingConstants {
     public static final String CHANNEL_LIGHT_LEVEL_MIN = "light-level-min";
     public static final String CHANNEL_LIGHT_LEVEL_MAX = "light-level-max";
     public static final String CHANNEL_LIGHT_PRESENT = "light-present";
+
+    // Standalone light channels
+    public static final String CHANNEL_LIGHT_HUE = "light-hue";
+    public static final String CHANNEL_LIGHT_COLOR = "light-color";
 
     // Miscellaneous channels
     public static final String CHANNEL_MOTION = "motion";

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
@@ -53,6 +53,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.bigassfan.internal.BigAssFanConfig;
+import org.openhab.binding.bigassfan.internal.utils.BigAssFanConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,52 +122,38 @@ public class BigAssFanHandler extends BaseThingHandler {
         logger.debug("Handle command for {} on channel {}: {}", thing.getUID(), channelUID, command);
         if (channelUID.getId().equals(CHANNEL_FAN_POWER)) {
             handleFanPower(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_SPEED)) {
             handleFanSpeed(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_AUTO)) {
             handleFanAuto(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_WHOOSH)) {
             handleFanWhoosh(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_SMARTMODE)) {
             handleFanSmartmode(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_LEARN_MINSPEED)) {
             handleFanLearnSpeedMin(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_LEARN_MAXSPEED)) {
             handleFanLearnSpeedMax(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_SPEED_MIN)) {
             handleFanSpeedMin(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_SPEED_MAX)) {
             handleFanSpeedMax(command);
-
         } else if (channelUID.getId().equals(CHANNEL_FAN_WINTERMODE)) {
             handleFanWintermode(command);
-
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_POWER)) {
             handleLightPower(command);
-
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_LEVEL)) {
             handleLightLevel(command);
-
+        } else if (channelUID.getId().equals(CHANNEL_LIGHT_HUE)) {
+            handleLightHue(command);
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_AUTO)) {
             handleLightAuto(command);
-
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_SMARTER)) {
             handleLightSmarter(command);
-
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_LEVEL_MIN)) {
             handleLightLevelMin(command);
-
         } else if (channelUID.getId().equals(CHANNEL_LIGHT_LEVEL_MAX)) {
             handleLightLevelMax(command);
-
         } else {
             logger.debug("Received command for {} on unknown channel {}", thing.getUID(), channelUID.getId());
         }
@@ -190,7 +177,7 @@ public class BigAssFanHandler extends BaseThingHandler {
 
         // <mac;FAN;SPD;SET;0..7>
         if (command instanceof PercentType) {
-            sendCommand(macAddress, ";FAN;SPD;SET;".concat(convertPercentToSpeed((PercentType) command)));
+            sendCommand(macAddress, ";FAN;SPD;SET;".concat(BigAssFanConverter.percentToSpeed((PercentType) command)));
         }
     }
 
@@ -242,7 +229,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;FAN;SPD;SET;MIN;0..7>
         if (command instanceof PercentType) {
             // Send min speed set command
-            sendCommand(macAddress, ";LEARN;MINSPEED;SET;".concat(convertPercentToSpeed((PercentType) command)));
+            sendCommand(macAddress,
+                    ";LEARN;MINSPEED;SET;".concat(BigAssFanConverter.percentToSpeed((PercentType) command)));
             fanStateMap.put(CHANNEL_FAN_LEARN_MINSPEED, (PercentType) command);
             // Don't let max be less than min
             adjustMaxSpeed((PercentType) command, CHANNEL_FAN_LEARN_MAXSPEED, ";LEARN;MAXSPEED;");
@@ -254,7 +242,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;FAN;SPD;SET;MAX;0..7>
         if (command instanceof PercentType) {
             // Send max speed set command
-            sendCommand(macAddress, ";LEARN;MAXSPEED;SET;;".concat(convertPercentToSpeed((PercentType) command)));
+            sendCommand(macAddress,
+                    ";LEARN;MAXSPEED;SET;;".concat(BigAssFanConverter.percentToSpeed((PercentType) command)));
             fanStateMap.put(CHANNEL_FAN_LEARN_MAXSPEED, (PercentType) command);
             // Don't let min be greater than max
             adjustMinSpeed((PercentType) command, CHANNEL_FAN_LEARN_MINSPEED, ";LEARN;MINSPEED;");
@@ -266,7 +255,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;FAN;SPD;SET;MIN;0..7>
         if (command instanceof PercentType) {
             // Send min speed set command
-            sendCommand(macAddress, ";FAN;SPD;SET;MIN;".concat(convertPercentToSpeed((PercentType) command)));
+            sendCommand(macAddress,
+                    ";FAN;SPD;SET;MIN;".concat(BigAssFanConverter.percentToSpeed((PercentType) command)));
             fanStateMap.put(CHANNEL_FAN_SPEED_MIN, (PercentType) command);
             // Don't let max be less than min
             adjustMaxSpeed((PercentType) command, CHANNEL_FAN_SPEED_MAX, ";FAN;SPD;SET;MAX;");
@@ -278,7 +268,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;FAN;SPD;SET;MAX;0..7>
         if (command instanceof PercentType) {
             // Send max speed set command
-            sendCommand(macAddress, ";FAN;SPD;SET;MAX;".concat(convertPercentToSpeed((PercentType) command)));
+            sendCommand(macAddress,
+                    ";FAN;SPD;SET;MAX;".concat(BigAssFanConverter.percentToSpeed((PercentType) command)));
             fanStateMap.put(CHANNEL_FAN_SPEED_MAX, (PercentType) command);
             // Don't let min be greater than max
             adjustMinSpeed((PercentType) command, CHANNEL_FAN_SPEED_MIN, ";FAN;SPD;SET;MIN;");
@@ -306,7 +297,7 @@ public class BigAssFanHandler extends BaseThingHandler {
         }
         if (newMin > currentMax) {
             updateState(CHANNEL_FAN_SPEED_MAX, command);
-            sendCommand(macAddress, commandFragment.concat(convertPercentToSpeed(command)));
+            sendCommand(macAddress, commandFragment.concat(BigAssFanConverter.percentToSpeed(command)));
         }
     }
 
@@ -318,7 +309,7 @@ public class BigAssFanHandler extends BaseThingHandler {
         }
         if (newMax < currentMin) {
             updateState(channelId, command);
-            sendCommand(macAddress, commandFragment.concat(convertPercentToSpeed(command)));
+            sendCommand(macAddress, commandFragment.concat(BigAssFanConverter.percentToSpeed(command)));
         }
     }
 
@@ -348,7 +339,22 @@ public class BigAssFanHandler extends BaseThingHandler {
         logger.debug("Handling light level command {}", command);
         // <mac;LIGHT;LEVEL;SET;0..16>
         if (command instanceof PercentType) {
-            sendCommand(macAddress, ";LIGHT;LEVEL;SET;".concat(convertPercentToLevel((PercentType) command)));
+            sendCommand(macAddress,
+                    ";LIGHT;LEVEL;SET;".concat(BigAssFanConverter.percentToLevel((PercentType) command)));
+        }
+    }
+
+    private void handleLightHue(Command command) {
+        if (!isLightPresent() || !isLightColor()) {
+            logger.debug("Fan does not have light installed or does not support hue for command {}", command);
+            return;
+        }
+
+        logger.debug("Handling light hue command {}", command);
+        // <mac;LIGHT;COLOR;TEMP;SET;2200..5000>
+        if (command instanceof PercentType) {
+            sendCommand(macAddress,
+                    ";LIGHT;COLOR;TEMP;VALUE;SET;".concat(BigAssFanConverter.percentToHue((PercentType) command)));
         }
     }
 
@@ -396,7 +402,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;LIGHT;LEVEL;MIN;0-16>
         if (command instanceof PercentType) {
             // Send min light level set command
-            sendCommand(macAddress, ";LIGHT;LEVEL;MIN;".concat(convertPercentToLevel((PercentType) command)));
+            sendCommand(macAddress,
+                    ";LIGHT;LEVEL;MIN;".concat(BigAssFanConverter.percentToLevel((PercentType) command)));
             // Don't let max be less than min
             adjustMaxLevel((PercentType) command);
         }
@@ -412,7 +419,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         // <mac;LIGHT;LEVEL;MAX;0-16>
         if (command instanceof PercentType) {
             // Send max light level set command
-            sendCommand(macAddress, ";LIGHT;LEVEL;MAX;".concat(convertPercentToLevel((PercentType) command)));
+            sendCommand(macAddress,
+                    ";LIGHT;LEVEL;MAX;".concat(BigAssFanConverter.percentToLevel((PercentType) command)));
             // Don't let min be greater than max
             adjustMinLevel((PercentType) command);
         }
@@ -426,7 +434,7 @@ public class BigAssFanHandler extends BaseThingHandler {
         }
         if (newMin > currentMax) {
             updateState(CHANNEL_LIGHT_LEVEL_MAX, command);
-            sendCommand(macAddress, ";LIGHT;LEVEL;MAX;".concat(convertPercentToLevel(command)));
+            sendCommand(macAddress, ";LIGHT;LEVEL;MAX;".concat(BigAssFanConverter.percentToLevel(command)));
         }
     }
 
@@ -438,38 +446,8 @@ public class BigAssFanHandler extends BaseThingHandler {
         }
         if (newMax < currentMin) {
             updateState(CHANNEL_LIGHT_LEVEL_MIN, command);
-            sendCommand(macAddress, ";LIGHT;LEVEL;MIN;".concat(convertPercentToLevel(command)));
+            sendCommand(macAddress, ";LIGHT;LEVEL;MIN;".concat(BigAssFanConverter.percentToLevel(command)));
         }
-    }
-
-    /*
-     * Convert from fan range (0-7) and light range (0-16) to dimmer range (0-100).
-     */
-    private static final double SPEED_CONVERSION_FACTOR = 14.2857;
-    private static final double BRIGHTNESS_CONVERSION_FACTOR = 6.25;
-
-    private String convertPercentToSpeed(PercentType command) {
-        // Dimmer item will produce PercentType value, which is 0-100
-        // Convert that value to what the fan expects, which is 0-7
-        return String.valueOf((int) Math.round(command.doubleValue() / SPEED_CONVERSION_FACTOR));
-    }
-
-    private PercentType convertSpeedToPercent(String speed) {
-        // Fan will supply fan speed value in range of 0-7
-        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
-        return new PercentType((int) Math.round(Integer.parseInt(speed) * SPEED_CONVERSION_FACTOR));
-    }
-
-    private String convertPercentToLevel(PercentType command) {
-        // Dimmer item will produce PercentType value, which is 0-100
-        // Convert that value to what the light expects, which is 0-16
-        return String.valueOf((int) Math.round(command.doubleValue() / BRIGHTNESS_CONVERSION_FACTOR));
-    }
-
-    private PercentType convertLevelToPercent(String level) {
-        // Light will supply brightness value in range of 0-16
-        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
-        return new PercentType((int) Math.round(Integer.parseInt(level) * BRIGHTNESS_CONVERSION_FACTOR));
     }
 
     private static final StringType LIGHT_PRESENT = new StringType("PRESENT");
@@ -477,6 +455,17 @@ public class BigAssFanHandler extends BaseThingHandler {
     private boolean isLightPresent() {
         if (fanStateMap.containsKey(CHANNEL_LIGHT_PRESENT)) {
             if (fanStateMap.get(CHANNEL_LIGHT_PRESENT).equals(LIGHT_PRESENT)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final StringType LIGHT_COLOR = new StringType("COLOR");
+
+    private boolean isLightColor() {
+        if (fanStateMap.containsKey(CHANNEL_LIGHT_COLOR)) {
+            if (fanStateMap.get(CHANNEL_LIGHT_COLOR).equals(LIGHT_COLOR)) {
                 return true;
             }
         }
@@ -564,6 +553,8 @@ public class BigAssFanHandler extends BaseThingHandler {
 
         private final long FAN_LISTENER_DELAY = 2L;
         private boolean terminate;
+
+        private final Pattern messagePattern = Pattern.compile("[(](.*)");
 
         private ConnectionManager conn;
 
@@ -677,10 +668,9 @@ public class BigAssFanHandler extends BaseThingHandler {
             }
 
             // Match on (msg)
-            logger.debug("FanListener for {} processing received message from {}: {}", thing.getUID(), macAddress,
+            logger.debug("FanListener for {} received message from {}: {}", thing.getUID(), macAddress,
                     incomingMessage);
-            Pattern pattern = Pattern.compile("[(](.*)");
-            Matcher matcher = pattern.matcher(incomingMessage);
+            Matcher matcher = messagePattern.matcher(incomingMessage);
             if (!matcher.find()) {
                 logger.debug("Unable to process message from {}, not in expected format: {}", thing.getUID(),
                         incomingMessage);
@@ -700,61 +690,44 @@ public class BigAssFanHandler extends BaseThingHandler {
             String messageUpperCase = message.toUpperCase();
             if (messageUpperCase.contains(";FAN;PWR;")) {
                 updateFanPower(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;SPD;ACTUAL;")) {
                 updateFanSpeed(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;DIR;")) {
                 updateFanDirection(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;AUTO;")) {
                 updateFanAuto(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;WHOOSH;STATUS;")) {
                 updateFanWhoosh(messageParts);
-
             } else if (messageUpperCase.contains(";WINTERMODE;STATE;")) {
                 updateFanWintermode(messageParts);
-
             } else if (messageUpperCase.contains(";SMARTMODE;STATE;")) {
                 updateFanSmartmode(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;SPD;MIN;")) {
                 updateFanSpeedMin(messageParts);
-
             } else if (messageUpperCase.contains(";FAN;SPD;MAX;")) {
                 updateFanSpeedMax(messageParts);
-
             } else if (messageUpperCase.contains(";LEARN;MINSPEED;")) {
                 updateFanLearnMinSpeed(messageParts);
-
             } else if (messageUpperCase.contains(";LEARN;MAXSPEED;")) {
                 updateFanLearnMaxSpeed(messageParts);
-
             } else if (messageUpperCase.contains(";LIGHT;PWR;")) {
                 updateLightPower(messageParts);
-
             } else if (messageUpperCase.contains(";LIGHT;LEVEL;ACTUAL;")) {
                 updateLightLevel(messageParts);
-
+            } else if (messageUpperCase.contains(";LIGHT;COLOR;TEMP;VALUE;")) {
+                updateLightHue(messageParts);
             } else if (messageUpperCase.contains(";LIGHT;AUTO;")) {
                 updateLightAuto(messageParts);
-
             } else if (messageUpperCase.contains(";LIGHT;LEVEL;MIN;")) {
                 updateLightLevelMin(messageParts);
-
             } else if (messageUpperCase.contains(";LIGHT;LEVEL;MAX;")) {
                 updateLightLevelMax(messageParts);
-
             } else if (messageUpperCase.contains(";DEVICE;LIGHT;")) {
                 updateLightPresent(messageParts);
-
             } else if (messageUpperCase.contains(";SNSROCC;STATUS;")) {
                 updateMotion(messageParts);
-
             } else if (messageUpperCase.contains(";TIME;VALUE;")) {
                 updateTime(messageParts);
-
             } else {
                 logger.trace("Received unsupported message from {}: {}", thing.getUID(), message);
             }
@@ -791,7 +764,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process fan speed update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertSpeedToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.speedToPercent(messageParts[4]);
             updateChannel(CHANNEL_FAN_SPEED, state);
             fanStateMap.put(CHANNEL_FAN_SPEED, state);
         }
@@ -857,7 +830,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process fan min speed update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertSpeedToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.speedToPercent(messageParts[4]);
             updateChannel(CHANNEL_FAN_SPEED_MIN, state);
             fanStateMap.put(CHANNEL_FAN_SPEED_MIN, state);
         }
@@ -868,7 +841,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process fan speed max update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertSpeedToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.speedToPercent(messageParts[4]);
             updateChannel(CHANNEL_FAN_SPEED_MAX, state);
             fanStateMap.put(CHANNEL_FAN_SPEED_MAX, state);
         }
@@ -879,7 +852,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process fan learn min speed update for {}: {}", thing.getUID(), messageParts[3]);
-            PercentType state = convertSpeedToPercent(messageParts[3]);
+            PercentType state = BigAssFanConverter.speedToPercent(messageParts[3]);
             updateChannel(CHANNEL_FAN_LEARN_MINSPEED, state);
             fanStateMap.put(CHANNEL_FAN_LEARN_MINSPEED, state);
         }
@@ -890,7 +863,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process fan learn max speed update for {}: {}", thing.getUID(), messageParts[3]);
-            PercentType state = convertSpeedToPercent(messageParts[3]);
+            PercentType state = BigAssFanConverter.speedToPercent(messageParts[3]);
             updateChannel(CHANNEL_FAN_LEARN_MAXSPEED, state);
             fanStateMap.put(CHANNEL_FAN_LEARN_MAXSPEED, state);
         }
@@ -912,9 +885,21 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process light level update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertLevelToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.levelToPercent(messageParts[4]);
             updateChannel(CHANNEL_LIGHT_LEVEL, state);
             fanStateMap.put(CHANNEL_LIGHT_LEVEL, state);
+        }
+
+        private void updateLightHue(String[] messageParts) {
+            if (messageParts.length != 6) {
+                logger.debug("LIGHT;COLOR;TEMP;VALUE has unexpected number of parameters: {}",
+                        Arrays.toString(messageParts));
+                return;
+            }
+            logger.debug("Process light hue update for {}: {}", thing.getUID(), messageParts[4]);
+            PercentType state = BigAssFanConverter.hueToPercent(messageParts[5]);
+            updateChannel(CHANNEL_LIGHT_HUE, state);
+            fanStateMap.put(CHANNEL_LIGHT_HUE, state);
         }
 
         private void updateLightAuto(String[] messageParts) {
@@ -934,7 +919,7 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process light level min update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertLevelToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.levelToPercent(messageParts[4]);
             updateChannel(CHANNEL_LIGHT_LEVEL_MIN, state);
             fanStateMap.put(CHANNEL_LIGHT_LEVEL_MIN, state);
         }
@@ -945,13 +930,13 @@ public class BigAssFanHandler extends BaseThingHandler {
                 return;
             }
             logger.debug("Process light level max update for {}: {}", thing.getUID(), messageParts[4]);
-            PercentType state = convertLevelToPercent(messageParts[4]);
+            PercentType state = BigAssFanConverter.levelToPercent(messageParts[4]);
             updateChannel(CHANNEL_LIGHT_LEVEL_MAX, state);
             fanStateMap.put(CHANNEL_LIGHT_LEVEL_MAX, state);
         }
 
         private void updateLightPresent(String[] messageParts) {
-            if (messageParts.length != 4) {
+            if (messageParts.length < 4) {
                 logger.debug("LightPresent has unexpected number of parameters: {}", Arrays.toString(messageParts));
                 return;
             }
@@ -959,6 +944,12 @@ public class BigAssFanHandler extends BaseThingHandler {
             StringType lightPresent = new StringType(messageParts[3]);
             updateChannel(CHANNEL_LIGHT_PRESENT, lightPresent);
             fanStateMap.put(CHANNEL_LIGHT_PRESENT, lightPresent);
+            if (messageParts.length == 5) {
+                logger.debug("Light supports hue adjustment");
+                StringType lightColor = new StringType(messageParts[4]);
+                updateChannel(CHANNEL_LIGHT_COLOR, lightColor);
+                fanStateMap.put(CHANNEL_LIGHT_COLOR, lightColor);
+            }
         }
 
         private void updateMotion(String[] messageParts) {

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/handler/BigAssFanHandler.java
@@ -66,6 +66,13 @@ import org.slf4j.LoggerFactory;
 public class BigAssFanHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(BigAssFanHandler.class);
 
+    private static final StringType LIGHT_COLOR = new StringType("COLOR");
+    private static final StringType LIGHT_PRESENT = new StringType("PRESENT");
+
+    private static final StringType OFF = new StringType("OFF");
+    private static final StringType COOLING = new StringType("COOLING");
+    private static final StringType HEATING = new StringType("HEATING");
+
     private BigAssFanConfig config;
     private String label = null;
     private String ipAddress = null;
@@ -74,10 +81,6 @@ public class BigAssFanHandler extends BaseThingHandler {
     private FanListener fanListener;
 
     protected Map<String, State> fanStateMap = Collections.synchronizedMap(new HashMap<String, State>());
-
-    private final StringType OFF = new StringType("OFF");
-    private final StringType COOLING = new StringType("COOLING");
-    private final StringType HEATING = new StringType("HEATING");
 
     public BigAssFanHandler(@NonNull Thing thing, String ipv4Address) {
         super(thing);
@@ -450,26 +453,13 @@ public class BigAssFanHandler extends BaseThingHandler {
         }
     }
 
-    private static final StringType LIGHT_PRESENT = new StringType("PRESENT");
-
     private boolean isLightPresent() {
-        if (fanStateMap.containsKey(CHANNEL_LIGHT_PRESENT)) {
-            if (fanStateMap.get(CHANNEL_LIGHT_PRESENT).equals(LIGHT_PRESENT)) {
-                return true;
-            }
-        }
-        return false;
+        return fanStateMap.containsKey(CHANNEL_LIGHT_PRESENT)
+                && LIGHT_PRESENT.equals(fanStateMap.get(CHANNEL_LIGHT_PRESENT));
     }
 
-    private static final StringType LIGHT_COLOR = new StringType("COLOR");
-
     private boolean isLightColor() {
-        if (fanStateMap.containsKey(CHANNEL_LIGHT_COLOR)) {
-            if (fanStateMap.get(CHANNEL_LIGHT_COLOR).equals(LIGHT_COLOR)) {
-                return true;
-            }
-        }
-        return false;
+        return fanStateMap.containsKey(CHANNEL_LIGHT_COLOR) && LIGHT_COLOR.equals(fanStateMap.get(CHANNEL_LIGHT_COLOR));
     }
 
     /*

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/BigAssFanConfig.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/BigAssFanConfig.java
@@ -16,8 +16,19 @@ import org.apache.commons.lang.StringUtils;
  * @author Mark Hilbush - Initial contribution
  */
 public class BigAssFanConfig {
+    /**
+     * Name of the device
+     */
     private String label;
+
+    /**
+     * IP address of the device
+     */
     private String ipAddress;
+
+    /**
+     * MAC address of the device
+     */
     private String macAddress;
 
     public String getLabel() {

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/discovery/BigAssFanDevice.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/discovery/BigAssFanDevice.java
@@ -14,22 +14,34 @@ package org.openhab.binding.bigassfan.internal.discovery;
  * @author Mark Hilbush - Initial contribution
  */
 public class BigAssFanDevice {
-    // Name of device (e.g. Master Bedroom Fan)
+    /**
+     * Name of device (e.g. Master Bedroom Fan)
+     */
     private String label;
 
-    // IP address of the device extracted from UDP packet
+    /**
+     * IP address of the device extracted from UDP packet
+     */
     private String ipAddress;
 
-    // MAC address of the device extracted from discovery message
+    /**
+     * MAC address of the device extracted from discovery message
+     */
     private String macAddress;
 
-    // Type of device extracted from discovery message (e.g. FAN or SWITCH)
+    /**
+     * Type of device extracted from discovery message (e.g. FAN or SWITCH)
+     */
     private String type;
 
-    // Model of device extracted from discovery message (e.g. HSERIES)
+    /**
+     * Model of device extracted from discovery message (e.g. HSERIES)
+     */
     private String model;
 
-    // The raw discovery message
+    /**
+     * The raw discovery message
+     */
     private String discoveryMessage;
 
     public String getLabel() {
@@ -86,6 +98,10 @@ public class BigAssFanDevice {
 
     public boolean isSwitch() {
         return type.toUpperCase().contains("SWITCH") ? true : false;
+    }
+
+    public boolean isLight() {
+        return type.toUpperCase().contains("LIGHT") ? true : false;
     }
 
     public void reset() {

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/utils/BigAssFanConverter.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/utils/BigAssFanConverter.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.bigassfan.internal.utils;
+
+import org.eclipse.smarthome.core.library.types.PercentType;
+
+/**
+ * The {@link BigAssFanConverter} is responsible for converting between
+ * Dimmer values and values used for fan speed, light brightness, and
+ * light color temperature.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class BigAssFanConverter {
+    /*
+     * Convert from fan range (0-7) to dimmer range (0-100).
+     */
+    private static final double SPEED_CONVERSION_FACTOR = 14.2857;
+
+    public static String percentToSpeed(PercentType command) {
+        // Dimmer item will produce PercentType value, which is 0-100
+        // Convert that value to what the fan expects, which is 0-7
+        return String.valueOf((int) Math.round(command.doubleValue() / SPEED_CONVERSION_FACTOR));
+    }
+
+    public static PercentType speedToPercent(String speed) {
+        // Fan will supply fan speed value in range of 0-7
+        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+        return new PercentType((int) Math.round(Integer.parseInt(speed) * SPEED_CONVERSION_FACTOR));
+    }
+
+    /*
+     * Convert from light range (0-16) to dimmer range (0-100).
+     */
+    private static final double BRIGHTNESS_CONVERSION_FACTOR = 6.25;
+
+    public static String percentToLevel(PercentType command) {
+        // Dimmer item will produce PercentType value, which is 0-100
+        // Convert that value to what the light expects, which is 0-16
+        return String.valueOf((int) Math.round(command.doubleValue() / BRIGHTNESS_CONVERSION_FACTOR));
+    }
+
+    public static PercentType levelToPercent(String level) {
+        // Light will supply brightness value in range of 0-16
+        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+        return new PercentType((int) Math.round(Integer.parseInt(level) * BRIGHTNESS_CONVERSION_FACTOR));
+    }
+
+    /*
+     * Convert from hue range (2200-5000) to dimmer range (0-100).
+     */
+    private static final double HUE_CONVERSION_FACTOR = 28.0;
+
+    public static String percentToHue(PercentType command) {
+        // Dimmer item will produce PercentType value, which is 0-100
+        // Convert that value to what the light expects, which is 2200-5000
+        return String.valueOf(2200 + (int) Math.round(command.doubleValue() * HUE_CONVERSION_FACTOR));
+    }
+
+    public static PercentType hueToPercent(String hue) {
+        // Light will supply hue value in range of 2200-5000
+        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+        return new PercentType((int) Math.round((Integer.parseInt(hue) - 2200) / HUE_CONVERSION_FACTOR));
+    }
+}

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/utils/BigAssFanConverter.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/utils/BigAssFanConverter.java
@@ -19,53 +19,65 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  */
 public class BigAssFanConverter {
     /*
-     * Convert from fan range (0-7) to dimmer range (0-100).
+     * Conversion factor for fan range (0-7) to dimmer range (0-100).
      */
     private static final double SPEED_CONVERSION_FACTOR = 14.2857;
 
+    /*
+     * Conversion factor for light range (0-16) to dimmer range (0-100).
+     */
+    private static final double BRIGHTNESS_CONVERSION_FACTOR = 6.25;
+
+    /*
+     * Conversion factor for hue range (2200-5000) to dimmer range (0-100).
+     */
+    private static final double HUE_CONVERSION_FACTOR = 28.0;
+
+    /*
+     * Dimmer item will produce PercentType value, which is 0-100
+     * Convert that value to what the fan expects, which is 0-7
+     */
     public static String percentToSpeed(PercentType command) {
-        // Dimmer item will produce PercentType value, which is 0-100
-        // Convert that value to what the fan expects, which is 0-7
         return String.valueOf((int) Math.round(command.doubleValue() / SPEED_CONVERSION_FACTOR));
     }
 
+    /*
+     * Fan will supply fan speed value in range of 0-7
+     * Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+     */
     public static PercentType speedToPercent(String speed) {
-        // Fan will supply fan speed value in range of 0-7
-        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
         return new PercentType((int) Math.round(Integer.parseInt(speed) * SPEED_CONVERSION_FACTOR));
     }
 
     /*
-     * Convert from light range (0-16) to dimmer range (0-100).
+     * Dimmer item will produce PercentType value, which is 0-100
+     * Convert that value to what the light expects, which is 0-16
      */
-    private static final double BRIGHTNESS_CONVERSION_FACTOR = 6.25;
-
     public static String percentToLevel(PercentType command) {
-        // Dimmer item will produce PercentType value, which is 0-100
-        // Convert that value to what the light expects, which is 0-16
         return String.valueOf((int) Math.round(command.doubleValue() / BRIGHTNESS_CONVERSION_FACTOR));
     }
 
+    /*
+     * Light will supply brightness value in range of 0-16
+     * Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+     */
     public static PercentType levelToPercent(String level) {
-        // Light will supply brightness value in range of 0-16
-        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
         return new PercentType((int) Math.round(Integer.parseInt(level) * BRIGHTNESS_CONVERSION_FACTOR));
     }
 
     /*
-     * Convert from hue range (2200-5000) to dimmer range (0-100).
+     * Dimmer item will produce PercentType value, which is 0-100
+     * Convert that value to what the light expects, which is 2200-5000
      */
-    private static final double HUE_CONVERSION_FACTOR = 28.0;
-
     public static String percentToHue(PercentType command) {
-        // Dimmer item will produce PercentType value, which is 0-100
-        // Convert that value to what the light expects, which is 2200-5000
         return String.valueOf(2200 + (int) Math.round(command.doubleValue() * HUE_CONVERSION_FACTOR));
     }
 
+    /*
+     * Light will supply hue value in range of 2200-5000
+     * Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
+     */
     public static PercentType hueToPercent(String hue) {
-        // Light will supply hue value in range of 2200-5000
-        // Convert that value to a PercentType in range 0-100, which is what Dimmer item expects
         return new PercentType((int) Math.round((Integer.parseInt(hue) - 2200) / HUE_CONVERSION_FACTOR));
     }
 }


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

- Add support for standalone lights, including ON/OFF, brightness level, and color temperature. See community discussion [here](https://community.openhab.org/t/haiku-light-with-bigassfan-binding/41226/3).

- Refactor config parameters into separate config.xml.

- Fix issues from code analysis
