### PR TITLE
Add @NonNullByDefault to constants classes

### DIFF
--- a/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/AirQualityBindingConstants.java
+++ b/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/AirQualityBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.airquality;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -21,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Kuba Wolanin - Initial contribution
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public class AirQualityBindingConstants {
 
     public static final String BINDING_ID = "airquality";

--- a/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/AllPlayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/AllPlayBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.allplay;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Dominic Lerbs - Initial contribution
  */
+@NonNullByDefault
 public class AllPlayBindingConstants {
 
     public static final String BINDING_ID = "allplay";

--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/AmazonDashButtonBindingConstants.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/AmazonDashButtonBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.amazondashbutton;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Oliver Libutzki - Initial contribution
  */
+@NonNullByDefault
 public class AmazonDashButtonBindingConstants {
 
     public static final String BINDING_ID = "amazondashbutton";

--- a/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/AtlonaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/AtlonaBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.atlona;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -15,6 +16,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Tim Roberts
  */
+@NonNullByDefault
 public class AtlonaBindingConstants {
 
     /**

--- a/addons/binding/org.openhab.binding.autelis/src/main/java/org/openhab/binding/autelis/AutelisBindingConstants.java
+++ b/addons/binding/org.openhab.binding.autelis/src/main/java/org/openhab/binding/autelis/AutelisBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.autelis;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Dan Cunningham - Initial contribution
  */
+@NonNullByDefault
 public class AutelisBindingConstants {
 
     public static final String BINDING_ID = "autelis";

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/BindingConstants.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -22,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *         DECT
  *
  */
+@NonNullByDefault
 public class BindingConstants {
 
     public static final String BINDING_ID = "avmfritz";

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/BigAssFanBindingConstants.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/BigAssFanBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.bigassfan;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Mark Hilbush - Initial contribution
  */
+@NonNullByDefault
 public class BigAssFanBindingConstants {
 
     public static final String BINDING_ID = "bigassfan";

--- a/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/BoschIndegoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/BoschIndegoBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.boschindego;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Jonas Fleck - Initial contribution
  */
+@NonNullByDefault
 public class BoschIndegoBindingConstants {
 
     public static final String BINDING_ID = "boschindego";

--- a/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoStateConstants.java
+++ b/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoStateConstants.java
@@ -8,10 +8,13 @@
  */
 package org.openhab.binding.boschindego.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  *
  * @author Jonas Fleck - Initial contribution
  */
+@NonNullByDefault
 public class IndegoStateConstants {
 
     public static final int STATE_DOCKED_1 = 258;

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/ChromecastBindingConstants.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/ChromecastBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.chromecast;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Kai Kreuzer - Initial contribution
  * @author Jason Holmes - Additional channels
  */
+@NonNullByDefault
 public class ChromecastBindingConstants {
     public static final String BINDING_ID = "chromecast";
     public static final String MEDIA_PLAYER = "CC1AD845";
@@ -80,24 +82,10 @@ public class ChromecastBindingConstants {
      * These are channels that map directly. Images and location are unique channels that
      * don't fit this description.
      */
-    public static final String[] METADATA_SIMPLE_CHANNELS = {
-            CHANNEL_ALBUM_ARTIST,
-            CHANNEL_ALBUM_NAME,
-            CHANNEL_ARTIST,
-            CHANNEL_BROADCAST_DATE,
-            CHANNEL_COMPOSER,
-            CHANNEL_CREATION_DATE,
-            CHANNEL_DISC_NUMBER,
-            CHANNEL_EPISODE_NUMBER,
-            CHANNEL_LOCATION_NAME,
-            CHANNEL_RELEASE_DATE,
-            CHANNEL_SEASON_NUMBER,
-            CHANNEL_SERIES_TITLE,
-            CHANNEL_STUDIO,
-            CHANNEL_SUBTITLE,
-            CHANNEL_TITLE,
-            CHANNEL_TRACK_NUMBER,
-    };
+    public static final String[] METADATA_SIMPLE_CHANNELS = { CHANNEL_ALBUM_ARTIST, CHANNEL_ALBUM_NAME, CHANNEL_ARTIST,
+            CHANNEL_BROADCAST_DATE, CHANNEL_COMPOSER, CHANNEL_CREATION_DATE, CHANNEL_DISC_NUMBER,
+            CHANNEL_EPISODE_NUMBER, CHANNEL_LOCATION_NAME, CHANNEL_RELEASE_DATE, CHANNEL_SEASON_NUMBER,
+            CHANNEL_SERIES_TITLE, CHANNEL_STUDIO, CHANNEL_SUBTITLE, CHANNEL_TITLE, CHANNEL_TRACK_NUMBER, };
 
     // We don't key these metadata keys directly to a channel, they get linked together
     // into a Location channel.

--- a/addons/binding/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/CM11ABindingConstants.java
+++ b/addons/binding/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/CM11ABindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.cm11a;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,7 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Bob Raker - Initial contribution
  */
-
+@NonNullByDefault
 public class CM11ABindingConstants {
 
     public static final String BINDING_ID = "cm11a";

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/CoolMasterNetBindingConstants.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/CoolMasterNetBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.coolmasternet;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Angus Gratton
  */
+@NonNullByDefault
 public class CoolMasterNetBindingConstants {
 
     public static final String BINDING_ID = "coolmasternet";

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/DLinkSmartHomeBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/DLinkSmartHomeBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.dlinksmarthome;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Mike Major - Initial contribution
  */
+@NonNullByDefault
 public class DLinkSmartHomeBindingConstants {
 
     public static final String BINDING_ID = "dlinksmarthome";

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.dscalarm;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -19,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Russell Stephens - Initial contribution
  */
+@NonNullByDefault
 public class DSCAlarmBindingConstants {
 
     // Binding ID

--- a/addons/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/ExecBindingConstants.java
+++ b/addons/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/ExecBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.exec;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class ExecBindingConstants {
 
     public static final String BINDING_ID = "exec";

--- a/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/FeedBindingConstants.java
+++ b/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/FeedBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.feed;
 
 import java.math.BigDecimal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -18,6 +19,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Svilen Valkanov - Initial contribution
  */
+@NonNullByDefault
 public class FeedBindingConstants {
 
     public static final String BINDING_ID = "feed";

--- a/addons/binding/org.openhab.binding.folding/src/main/java/org/openhab/binding/folding/FoldingBindingConstants.java
+++ b/addons/binding/org.openhab.binding.folding/src/main/java/org/openhab/binding/folding/FoldingBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.folding;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Marius Bjoernstad - Initial contribution
  */
+@NonNullByDefault
 public class FoldingBindingConstants {
 
     public static final String BINDING_ID = "folding";

--- a/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/FreeboxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/FreeboxBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.freebox;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Gaël L'hopital - Initial contribution
  */
+@NonNullByDefault
 public class FreeboxBindingConstants {
 
     public static final String BINDING_ID = "freebox";

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/FroniusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/FroniusBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.fronius;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Thomas Rokohl - Initial contribution
  */
+@NonNullByDefault
 public class FroniusBindingConstants {
 
     private static final String BINDING_ID = "fronius";

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/GardenaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/GardenaBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.gardena;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -15,6 +16,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GardenaBindingConstants {
 
     public static final String BINDING_ID = "gardena";

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/GlobalCacheBindingConstants.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/GlobalCacheBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.globalcache;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Mark Hilbush - Initial contribution
  */
+@NonNullByDefault
 public class GlobalCacheBindingConstants {
 
     public static final String BINDING_ID = "globalcache";

--- a/addons/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/HDanywhereBindingConstants.java
+++ b/addons/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/HDanywhereBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.hdanywhere;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class HDanywhereBindingConstants {
 
     public static final String BINDING_ID = "hdanywhere";

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/HDPowerViewBindingConstants.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/HDPowerViewBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.hdpowerview;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Andy Lintner - Initial contribution
  */
+@NonNullByDefault
 public class HDPowerViewBindingConstants {
 
     public static final String BINDING_ID = "hdpowerview";

--- a/addons/binding/org.openhab.binding.helios/src/main/java/org/openhab/binding/helios/HeliosBindingConstants.java
+++ b/addons/binding/org.openhab.binding.helios/src/main/java/org/openhab/binding/helios/HeliosBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.helios;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class HeliosBindingConstants {
 
     public static final String BINDING_ID = "helios";

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.homematic;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -15,6 +16,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicBindingConstants {
 
     public static final String BINDING_ID = "homematic";

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicConstants.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicConstants.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.homematic.internal.misc;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Defines common constants, which are used across the Homematic implementation.
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicConstants {
     public static final String DEVICE_TYPE_VIRTUAL = "HM-RCV-50";
     public static final String DEVICE_TYPE_VIRTUAL_WIRED = "HMW-RCV-50";

--- a/addons/binding/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/BindingConstants.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Patrik Gfeller - Initial contribution
  */
+@NonNullByDefault
 public class BindingConstants {
 
     private static final String BINDING_ID = "icloud";

--- a/addons/binding/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/IppBindingConstants.java
+++ b/addons/binding/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/IppBindingConstants.java
@@ -10,21 +10,22 @@ package org.openhab.binding.ipp;
 
 import java.util.Collection;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Lists;
 
-
 /**
- * The {@link IppBindingConstants} class defines common constants, which are 
+ * The {@link IppBindingConstants} class defines common constants, which are
  * used across the whole binding.
- * 
+ *
  * @author Tobias Braeutigam - Initial contribution
  */
+@NonNullByDefault
 public class IppBindingConstants {
 
     public static final String BINDING_ID = "ipp";
-    
+
     // List of all Thing Type UIDs
     public static final ThingTypeUID PRINTER_THING_TYPE = new ThingTypeUID(BINDING_ID, "printer");
 
@@ -36,6 +37,7 @@ public class IppBindingConstants {
     public static final String PRINTER_PARAMETER_URL = "url";
     public static final String PRINTER_PARAMETER_NAME = "name";
     public static final String PRINTER_PARAMETER_REFRESH_INTERVAL = "refresh";
-    
-    public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(IppBindingConstants.PRINTER_THING_TYPE);
+
+    public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists
+            .newArrayList(IppBindingConstants.PRINTER_THING_TYPE);
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.jeelink;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.jeelink.internal.SensorDefinition;
 
@@ -19,6 +20,7 @@ import org.openhab.binding.jeelink.internal.SensorDefinition;
  *
  * @author Volker Bier - Initial contribution
  */
+@NonNullByDefault
 public class JeeLinkBindingConstants {
 
     private JeeLinkBindingConstants() {

--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/KebaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/KebaBindingConstants.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class KebaBindingConstants {
 
     public static final String BINDING_ID = "keba";

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/KodiBindingConstants.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/KodiBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.kodi;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -22,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Andreas Reinhardt & Christoph Weitkamp - Added channels for thumbnail and fanart
  *
  */
+@NonNullByDefault
 public class KodiBindingConstants {
 
     public static final String BINDING_ID = "kodi";

--- a/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/LaMetricTimeBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/LaMetricTimeBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lametrictime;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Gregory Moyer - Initial contribution
  */
+@NonNullByDefault
 public class LaMetricTimeBindingConstants {
 
     public static final String BINDING_ID = "lametrictime";

--- a/addons/binding/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/LgTvSerialBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/LgTvSerialBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lgtvserial;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Marius Bjoernstad - Initial contribution
  */
+@NonNullByDefault
 public class LgTvSerialBindingConstants {
 
     public static final String BINDING_ID = "lgtvserial";

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
@@ -11,7 +11,7 @@ package org.openhab.binding.lgwebos;
 import java.util.Collections;
 import java.util.Set;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,9 +19,10 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Sebastian Prehn - initial contribution
  */
+@NonNullByDefault
 public class LGWebOSBindingConstants {
 
-    public static final @NonNull String BINDING_ID = "lgwebos";
+    public static final String BINDING_ID = "lgwebos";
 
     public static final ThingTypeUID THING_TYPE_WEBOSTV = new ThingTypeUID(BINDING_ID, "WebOSTV");
 

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/LoxoneBindingConstants.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/LoxoneBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.loxone;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -15,6 +16,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Pawel Pieczul - Initial contribution
  */
+@NonNullByDefault
 public class LoxoneBindingConstants {
 
     public static final String BINDING_ID = "loxone";

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lutron;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Allan Tong - Initial contribution
  */
+@NonNullByDefault
 public class LutronBindingConstants {
 
     public static final String BINDING_ID = "lutron";

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lutron.internal.grxprg;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.lutron.LutronBindingConstants;
 
@@ -16,6 +17,7 @@ import org.openhab.binding.lutron.LutronBindingConstants;
  *
  * @author Tim Roberts
  */
+@NonNullByDefault
 public class PrgConstants {
 
     public static final ThingTypeUID THING_TYPE_PRGBRIDGE = new ThingTypeUID(LutronBindingConstants.BINDING_ID,

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RadioRAConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RadioRAConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lutron.internal.radiora;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.lutron.LutronBindingConstants;
 
@@ -16,6 +17,7 @@ import org.openhab.binding.lutron.LutronBindingConstants;
  *
  * @author Jeff Lauterbach - Initial contribution
  */
+@NonNullByDefault
 public class RadioRAConstants {
 
     // List of all Thing Type UIDs

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/MaxBinding.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/MaxBinding.java
@@ -11,6 +11,7 @@ package org.openhab.binding.max;
 import java.util.Collection;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -22,6 +23,7 @@ import com.google.common.collect.Lists;
  *
  * @author Marcel Verpaalen - Initial contribution
  */
+@NonNullByDefault
 public class MaxBinding {
 
     public static final String BINDING_ID = "max";

--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/Mcp23017BindingConstants.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/Mcp23017BindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.mcp23017;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Lists;
@@ -20,6 +21,7 @@ import com.google.common.collect.Lists;
  *
  * @author Anatol Ogorek
  */
+@NonNullByDefault
 public class Mcp23017BindingConstants {
 
     public static final String BINDING_ID = "mcp23017";

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.meteostick;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Chris Jackson - Initial contribution
  */
+@NonNullByDefault
 public class MeteostickBindingConstants {
 
     public static final String BINDING_ID = "meteostick";

--- a/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/MieleBindingConstants.java
+++ b/addons/binding/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/MieleBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.miele;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class MieleBindingConstants {
 
     public static final String BINDING_ID = "miele";

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/XiaomiGatewayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/XiaomiGatewayBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.mihome;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Daniel Walters - Added Aqara Door/Window sensor and Aqara temperature, humidity and pressure sensor
  * @author Kuba Wolanin - Added Water Leak sensor
  */
+@NonNullByDefault
 public class XiaomiGatewayBindingConstants {
 
     public static final String BINDING_ID = "mihome";

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/MilightBindingConstants.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/MilightBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.milight;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -20,6 +21,7 @@ import com.google.common.collect.Sets;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class MilightBindingConstants {
 
     public static final String BINDING_ID = "milight";

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/MinecraftBindingConstants.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/MinecraftBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.minecraft;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Mattias Markehed
  */
+@NonNullByDefault
 public class MinecraftBindingConstants {
 
     public static final String BINDING_ID = "minecraft";

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/NetatmoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/NetatmoBindingConstants.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import io.swagger.client.model.NAWebhookCameraEvent.EventTypeEnum;
@@ -23,9 +23,9 @@ import io.swagger.client.model.NAWebhookCameraEvent.EventTypeEnum;
  *
  * @author Gaël L'hopital - Initial contribution
  */
+@NonNullByDefault
 public class NetatmoBindingConstants {
 
-    @NonNull
     private static final String BINDING_ID = "netatmo";
 
     // Configuration keys

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/NetworkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/NetworkBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.network;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Marc Mettke - Initial contribution
  * @author David Gräff - 2016, Add dhcp listen
  */
+@NonNullByDefault
 public class NetworkBindingConstants {
 
     public static final String BINDING_ID = "network";

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.nikohomecontrol;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -21,6 +22,7 @@ import com.google.common.collect.Sets;
  *
  * @author Mark Herwege
  */
+@NonNullByDefault
 public class NikoHomeControlBindingConstants {
 
     public static final String BINDING_ID = "nikohomecontrol";

--- a/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/OceanicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/OceanicBindingConstants.java
@@ -13,14 +13,13 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link OceanicBinding} class defines common constants, which are used
@@ -28,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class OceanicBindingConstants {
 
     public static final String BINDING_ID = "oceanic";

--- a/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/OneBusAwayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/OneBusAwayBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.onebusaway;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Shawn Wilsher - Initial contribution
  */
+@NonNullByDefault
 public class OneBusAwayBindingConstants {
 
     public static final String BINDING_ID = "onebusaway";

--- a/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/OneWireGPIOBindingConstants.java
+++ b/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/OneWireGPIOBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.onewiregpio;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Anatol Ogorek - Initial contribution
  */
+@NonNullByDefault
 public class OneWireGPIOBindingConstants {
 
     public static final String BINDING_ID = "onewiregpio";

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -21,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Paul Frank - Initial contribution
  * @author Pauli Anttila
  */
+@NonNullByDefault
 public class OnkyoBindingConstants {
 
     public static final String BINDING_ID = "onkyo";

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/OpenSprinklerBindingConstants.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/OpenSprinklerBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.opensprinkler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Chris Graham - Initial contribution
  */
+@NonNullByDefault
 public class OpenSprinklerBindingConstants {
     public static final String BINDING_ID = "opensprinkler";
 

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApiConstants.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApiConstants.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.opensprinkler.internal.api;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import com.pi4j.io.gpio.Pin;
 import com.pi4j.io.gpio.RaspiPin;
 
@@ -17,6 +19,7 @@ import com.pi4j.io.gpio.RaspiPin;
  *
  * @author Chris Graham - Initial contribution
  */
+@NonNullByDefault
 public class OpenSprinklerApiConstants {
     public static final String HTTP_REQUEST_URL_PREFIX = "http://";
     public static final String HTTPS_REQUEST_URL_PREFIX = "https://";

--- a/addons/binding/org.openhab.binding.orvibo/src/main/java/org/openhab/binding/orvibo/OrviboBindingConstants.java
+++ b/addons/binding/org.openhab.binding.orvibo/src/main/java/org/openhab/binding/orvibo/OrviboBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.orvibo;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Daniel Walters - Initial contribution
  */
+@NonNullByDefault
 public class OrviboBindingConstants {
 
     public static final String BINDING_ID = "orvibo";

--- a/addons/binding/org.openhab.binding.pentair/src/main/java/org/openhab/binding/pentair/PentairBindingConstants.java
+++ b/addons/binding/org.openhab.binding.pentair/src/main/java/org/openhab/binding/pentair/PentairBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.pentair;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Jeff James - Initial contribution
  */
+@NonNullByDefault
 public class PentairBindingConstants {
 
     public static final String BINDING_ID = "pentair";
@@ -89,4 +91,3 @@ public class PentairBindingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(IP_BRIDGE_THING_TYPE,
             SERIAL_BRIDGE_THING_TYPE, EASYTOUCH_THING_TYPE, INTELLIFLO_THING_TYPE, INTELLICHLOR_THING_TYPE);
 }
-

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/PioneerAvrBindingConstants.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/PioneerAvrBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.pioneeravr;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Antoine Besnard - Initial contribution
  */
+@NonNullByDefault
 public class PioneerAvrBindingConstants {
 
     public static final String BINDING_ID = "pioneeravr";

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/PlugwiseBindingConstants.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/PlugwiseBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.plugwise;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -19,6 +20,7 @@ import com.google.common.collect.Sets;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseBindingConstants {
 
     public static final String BINDING_ID = "plugwise";

--- a/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/RegoHeatPumpBindingConstants.java
+++ b/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/RegoHeatPumpBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.regoheatpump;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class RegoHeatPumpBindingConstants {
 
     public static final String BINDING_ID = "regoheatpump";

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.rfxcom;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -23,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Pauli Anttila - Initial contribution
  */
+@NonNullByDefault
 public class RFXComBindingConstants {
 
     public static final String BINDING_ID = "rfxcom";

--- a/addons/binding/org.openhab.binding.rme/src/main/java/org/openhab/binding/rme/RMEBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rme/src/main/java/org/openhab/binding/rme/RMEBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.rme;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class RMEBindingConstants {
 
     public static final String BINDING_ID = "rme";

--- a/addons/binding/org.openhab.binding.rotelra1x/src/main/java/org/openhab/binding/rotelra1x/RotelRa1xBindingConstants.java
+++ b/addons/binding/org.openhab.binding.rotelra1x/src/main/java/org/openhab/binding/rotelra1x/RotelRa1xBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.rotelra1x;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Marius Bjørnstad - Initial contribution
  */
+@NonNullByDefault
 public class RotelRa1xBindingConstants {
 
     public static final String BINDING_ID = "rotelra1x";

--- a/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/RussoundBindingConstants.java
+++ b/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/RussoundBindingConstants.java
@@ -8,12 +8,15 @@
  */
 package org.openhab.binding.russound;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link RussoundBinding} class defines common constants, which are
  * used across the whole binding.
  *
  * @author Tim Roberts
  */
+@NonNullByDefault
 public class RussoundBindingConstants {
 
     public static final String BINDING_ID = "russound";

--- a/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/RioConstants.java
+++ b/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/RioConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.russound.internal.rio;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.russound.RussoundBindingConstants;
 
@@ -16,6 +17,7 @@ import org.openhab.binding.russound.RussoundBindingConstants;
  *
  * @author Tim Roberts
  */
+@NonNullByDefault
 public class RioConstants {
 
     // BRIDGE TYPE IDS

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/SamsungTvBindingConstants.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/SamsungTvBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.samsungtv;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Pauli Anttila - Initial contribution
  */
+@NonNullByDefault
 public class SamsungTvBindingConstants {
 
     public static final String BINDING_ID = "samsungtv";

--- a/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/SeneyeBindingConstants.java
+++ b/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/SeneyeBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.seneye;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Niko Tanghe - Initial contribution
  */
+@NonNullByDefault
 public class SeneyeBindingConstants {
 
     public static final String BINDING_ID = "seneye";

--- a/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/SenseBoxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/SenseBoxBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.sensebox;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Hakan Tandogan - Initial contribution
  */
+@NonNullByDefault
 public class SenseBoxBindingConstants {
 
     public static final String BINDING_ID = "sensebox";

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/SilvercrestWifiSocketBindingConstants.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/SilvercrestWifiSocketBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.silvercrestwifisocket;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.silvercrestwifisocket.internal.enums.SilvercrestWifiSocketVendor;
 
@@ -22,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Jaime Vaz - Initial contribution
  * @author Christian Heimerl - for integration of EasyHome
  */
+@NonNullByDefault
 public class SilvercrestWifiSocketBindingConstants {
 
     /**

--- a/addons/binding/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/SleepIQBindingConstants.java
+++ b/addons/binding/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/SleepIQBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.sleepiq;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Gregory Moyer - Initial contribution
  */
+@NonNullByDefault
 public class SleepIQBindingConstants {
     public static final String BINDING_ID = "sleepiq";
 

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/SMAEnergyMeterBindingConstants.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/SMAEnergyMeterBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.smaenergymeter;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Osman Basha - Initial contribution
  */
+@NonNullByDefault
 public class SMAEnergyMeterBindingConstants {
 
     public static final String BINDING_ID = "smaenergymeter";

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/SqueezeBoxBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.squeezebox;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -17,6 +18,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Dan Cunningham - Initial contribution
  * @author Mark Hilbush - Added duration channel
  */
+@NonNullByDefault
 public class SqueezeBoxBindingConstants {
 
     public static final String BINDING_ID = "squeezebox";

--- a/addons/binding/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/SynopAnalyzerBindingConstants.java
+++ b/addons/binding/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/SynopAnalyzerBindingConstants.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.synopanalyzer;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -17,9 +17,9 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Gaël L'hopital - Initial contribution
  */
+@NonNullByDefault
 public class SynopAnalyzerBindingConstants {
 
-    @NonNull
     public static final String BINDING_ID = "synopanalyzer";
 
     // List of all Thing Type UIDs

--- a/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/SysteminfoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/SysteminfoBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.systeminfo;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Svilen Valkanov - Initial contribution
  */
+@NonNullByDefault
 public class SysteminfoBindingConstants {
 
     public static final String BINDING_ID = "systeminfo";

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/TankerkoenigBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.tankerkoenig;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -21,6 +22,7 @@ import com.google.common.collect.Sets;
  *
  * @author Dennis Dollinger
  */
+@NonNullByDefault
 public class TankerkoenigBindingConstants {
 
     public static final String BINDING_ID = "tankerkoenig";

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/TellstickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/TellstickBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.tellstick;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -20,6 +21,7 @@ import com.google.common.collect.Sets;
  *
  * @author jarlebh - Initial contribution
  */
+@NonNullByDefault
 public class TellstickBindingConstants {
 
     public static final String BINDING_ID = "tellstick";

--- a/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/TeslaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/TeslaBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.tesla;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class TeslaBindingConstants {
 
     // REST URI constants

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/ToonBindingConstants.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/ToonBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.toon;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Jorg de Jong - Initial contribution
  */
+@NonNullByDefault
 public class ToonBindingConstants {
 
     public static final String BINDING_ID = "toon";

--- a/addons/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/UrtsiBindingConstants.java
+++ b/addons/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/UrtsiBindingConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.urtsi;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Oliver Libutzki - Initial contribution
  */
+@NonNullByDefault
 public class UrtsiBindingConstants {
 
     public static final String BINDING_ID = "urtsi";

--- a/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/VitotronicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.vitotronic/src/main/java/org/openhab/binding/vitotronic/VitotronicBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.vitotronic;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Stefan Andres - Initial contribution
  */
+@NonNullByDefault
 public class VitotronicBindingConstants {
 
     public static final String BROADCAST_MESSAGE = "@@@@VITOTRONIC@@@@/";

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/WiFiLEDBindingConstants.java
@@ -8,10 +8,11 @@
  */
 package org.openhab.binding.wifiled;
 
-import org.eclipse.smarthome.core.thing.ThingTypeUID;
-
 import java.util.Collections;
 import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
  * The {@link WiFiLEDBindingConstants} class defines common constants, which are
@@ -19,6 +20,7 @@ import java.util.Set;
  *
  * @author Osman Basha - Initial contribution
  */
+@NonNullByDefault
 public class WiFiLEDBindingConstants {
 
     public static final String BINDING_ID = "wifiled";

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/YamahaReceiverBindingConstants.java
@@ -11,6 +11,7 @@ package org.openhab.binding.yamahareceiver;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.Sets;
@@ -22,6 +23,7 @@ import com.google.common.collect.Sets;
  * @author David Graeff <david.graeff@web.de>
  * @author Tomasz Maruszak - DAB support, Spotify support, refactoring
  */
+@NonNullByDefault
 public class YamahaReceiverBindingConstants {
     public static final String BINDING_ID = "yamahareceiver";
 

--- a/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/ZoneMinderConstants.java
+++ b/addons/binding/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/ZoneMinderConstants.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.zoneminder;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -16,6 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Martin S. Eskildsen - Initial contribution
  */
+@NonNullByDefault
 public class ZoneMinderConstants {
 
     public static final String BINDING_ID = "zoneminder";

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
@@ -10,6 +10,7 @@ package org.openhab.binding.zway;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 import com.google.common.collect.ImmutableSet;
@@ -20,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Patrick Hecker - Initial contribution
  */
+@NonNullByDefault
 public class ZWayBindingConstants {
 
     public static final String BINDING_ID = "zway";


### PR DESCRIPTION
This should fix lot of null type safety warnings.

Nowadays `@NonNullByDefault` is also added to the generated binding constants by the binding archetype.