### PR TITLE
[homekit] Make bridge name configurable

### DIFF
--- a/addons/io/org.openhab.io.homekit/README.md
+++ b/addons/io/org.openhab.io.homekit/README.md
@@ -16,7 +16,7 @@ Requirements beyond this are not clear, and Apple enforces limitations on eligib
 At the very least, you cannot use repeating (111-11-111) or sequential (123-45-678) pin codes.
 If your home network is secure, a good starting point is the pin code used in most sample applications: 031-45-154.
 
-Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the Homekit bridge, which can be edited in PaperUI in standard mode, on are also illustrated in the following sample:
+Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the Homekit bridge (which can be edited in PaperUI standard mode) are also illustrated in the following sample:
 
 ```
 org.openhab.homekit:port=9124
@@ -48,10 +48,10 @@ org.openhab.homekit:maximumTemperature=100
 | thermostatCoolMode        | Word used for activating the cooling mode of the device (if applicable).                                                                                                                                                                  | CoolOn            |
 | thermostatHeatMode        | Word used for activating the heating mode of the device (if applicable).                                                                                                                                                                  | HeatOn            |
 | thermostatAutoMode        | Word used for activating the automatic mode of the device (if applicable).                                                                                                                                                                | Auto              |
-| thermostatOffMode         | Word used for turning thermostat mode of the device to off (if applicable).                                                                                                                                                               | Off               |
+| thermostatOffMode         | Word used to set the thermostat mode of the device to off (if applicable).                                                                                                                                                               | Off               |
 | minimumTemperature        | Lower bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                    | -100              |
 | maximumTemperature        | Upper bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                    | 100               |
-| name                      | Name under which this HomeKit bridge is announced in the network and which is displayed on the iOS device when searching for available bridges.                                                                                           | openHAB           |
+| name                      | Name under which this HomeKit bridge is announced on the network. This is also the name displayed on the iOS device when searching for available bridges.                                                                                           | openHAB           |
 
 ## Item Configuration
 

--- a/addons/io/org.openhab.io.homekit/README.md
+++ b/addons/io/org.openhab.io.homekit/README.md
@@ -39,68 +39,19 @@ org.openhab.homekit:maximumTemperature=100
 
 ### Overview of all settings
 
-<table>
- <tr>
-  <th>Setting</th>
-  <th>Description</th>
-  <th>Default value</th>
- </tr>
- <tr>
-  <td>networkInterface</td>
-  <td>IP address or domain name under which the HomeKit bridge can be reached. If no value is configured, the addon tries to determine the IP address from the local hostname. </td>
-  <td>(none)</td>  
- </tr>
- <tr>
-  <td>port</td>
-  <td>Port under which the HomeKit bridge can be reached. </td>
-  <td>9123</td>  
- </tr>
- <tr>
-  <td>pin</td>
-  <td>Pin code used for pairing with iOS devices. Apparently, pin codes are provided by Apple and represent specific device types, so they cannot be chosen freely. The pin code <em>031-45-154</em> is used in sample applications and known to work.</td>
-  <td>031-45-154</td>  
- </tr>
- <tr>
-  <td>useFahrenheitTemperature</td>
-  <td>Set to <em>true</em> to use Fahrenheit degrees, or <em>false</em> to use Celsius degrees.</td>
-  <td>false</td>  
- </tr>
- <tr>
-  <td>thermostatCoolMode</td>
-  <td>Word used for activating the cooling mode of the device (if applicable).</td>
-  <td>CoolOn</td>  
- </tr>
- <tr>
-  <td>thermostatHeatMode</td>
-  <td>Word used for activating the heating mode of the device (if applicable).</td>
-  <td>HeatOn</td>  
- </tr>
- <tr>
-  <td>thermostatAutoMode</td>
-  <td>Word used for activating the automatic mode of the device (if applicable).</td>
-  <td>Auto</td>  
- </tr>
- <tr>
-  <td>thermostatOffMode</td>
-  <td>Word used for turning thermostat mode of the device to off (if applicable).</td>
-  <td>Off</td>  
- </tr>
- <tr>
-  <td>minimumTemperature</td>
-  <td>Lower bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit. </td>
-  <td>-100</td>  
- </tr>
- <tr>
-  <td>maximumTemperature</td>
-  <td>Upper bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit. </td>
-  <td>100</td>  
- </tr>
- <tr>
-  <td>name</td>
-  <td>Name under which this HomeKit bridge is announced in the network and which is displayed on the iOS device when searching for available bridges. </td>
-  <td>openHAB</td>  
- </tr>
-</table> 
+| Setting                   | Description                                                                                                                                                                                                                               | Default value     |
+|-------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |---------------    |
+| networkInterface          | IP address or domain name under which the HomeKit bridge can be reached. If no value is configured, the addon tries to determine the IP address from the local hostname.                                                                  | (none)            |
+| port                      | Port under which the HomeKit bridge can be reached.                                                                                                                                                                                       | 9123              |
+| pin                       | Pin code used for pairing with iOS devices. Apparently, pin codes are provided by Apple and represent specific device types, so they cannot be chosen freely. The pin code 031-45-154 is used in sample applications and known to work.   | 031-45-154        |
+| useFahrenheitTemperature  | Set to true to use Fahrenheit degrees, or false to use Celsius degrees.                                                                                                                                                                   | false             |
+| thermostatCoolMode        | Word used for activating the cooling mode of the device (if applicable).                                                                                                                                                                  | CoolOn            |
+| thermostatHeatMode        | Word used for activating the heating mode of the device (if applicable).                                                                                                                                                                  | HeatOn            |
+| thermostatAutoMode        | Word used for activating the automatic mode of the device (if applicable).                                                                                                                                                                | Auto              |
+| thermostatOffMode         | Word used for turning thermostat mode of the device to off (if applicable).                                                                                                                                                               | Off               |
+| minimumTemperature        | Lower bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                    | -100              |
+| maximumTemperature        | Upper bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                    | 100               |
+| name                      | Name under which this HomeKit bridge is announced in the network and which is displayed on the iOS device when searching for available bridges.                                                                                           | openHAB           |
 
 ## Item Configuration
 
@@ -113,62 +64,16 @@ Complex accessories require a tag on a Group indicating the accessory type, as w
 
 A full list of supported accessory types can be found in the table below.
 
-<table>
- <tr>
-  <td><b>tag</b></td>
-  <td><b>child tag</b></td>
-  <td><b>supported items</b></td>
-  <td><b>description</b></td>
- </tr>
- <tr>
-  <td>Lighting</td>
-  <td>&nbsp;</td>
-  <td>Switch, Dimmer, Color</td>
-  <td>A lightbulb, switchable, dimmable or rgb</td>
- </tr>
- <tr>
-  <td>Switchable</td>
-  <td>&nbsp;</td>
-  <td>Switch, Dimmer, Color</td>
-  <td>An accessory that can be turned off and on. While similar to a lightbulb, this will be presented differently in the Siri grammar and iOS apps</td>
- </tr>
- <tr>
-  <td>CurrentTemperature</td>
-  <td>&nbsp;</td>
-  <td>Number</td>
-  <td>An accessory that provides a single read-only temperature value. The units default to celsius but can be overridden globally using the useFahrenheitTemperature global property</td>
- </tr>
- <tr>
-  <td>CurrentHumidity</td>
-  <td>&nbsp;</td>
-  <td>Number</td>
-  <td>An accessory that provides a single read-only value indicating the relative humidity.</td>
- </tr>
- <tr>
-  <td>Thermostat</td>
-  <td>&nbsp;</td>
-  <td>Group</td>
-  <td>A thermostat requires all child tags defined below</td>
- </tr>
- <tr>
-  <td>&nbsp;</td>
-  <td>CurrentTemperature</td>
-  <td>Number</td>
-  <td>The current temperature, same as above</td>
- </tr>
- <tr>
-  <td>&nbsp;</td>
-  <td>homekit:HeatingCoolingMode</td>
-  <td>String</td>
-  <td>Indicates the current mode of the device: OFF, AUTO, HEAT, COOL. The string's value must match those defined in the thermostat*Mode properties. This is a homekit-specific term and therefore the tags needs to be prefixed with "homekit:"</td>
- </tr>
- <tr>
-  <td>&nbsp;</td>
-  <td>TargetTemperature</td>
-  <td>Number</td>
-  <td>A target temperature that will engage the thermostat's heating and cooling actions as necessary, depending on the heatingCoolingMode</td>
- </tr>
-</table>
+| Tag                   | Child tag                     | Supported items           | Description                                                                                                                                                                                                                                   |
+|--------------------   |----------------------------   |-----------------------    |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
+| Lighting              |                               | Switch, Dimmer, Color     | A lightbulb, switchable, dimmable or rgb                                                                                                                                                                                                      |
+| Switchable            |                               | Switch, Dimmer, Color     | An accessory that can be turned off and on. While similar to a lightbulb, this will be presented differently in the Siri grammar and iOS apps                                                                                                 |
+| CurrentTemperature    |                               | Number                    | An accessory that provides a single read-only temperature value. The units default to celsius but can be overridden globally using the useFahrenheitTemperature global property                                                               |
+| CurrentHumidity       |                               | Number                    | An accessory that provides a single read-only value indicating the relative humidity.                                                                                                                                                         |
+| Thermostat            |                               | Group                     | A thermostat requires all child tags defined below                                                                                                                                                                                            |
+|                       | CurrentTemperature            | Number                    | The current temperature, same as above                                                                                                                                                                                                        |
+|                       | homekit:HeatingCoolingMode    | String                    | Indicates the current mode of the device: OFF, AUTO, HEAT, COOL. The string's value must match those defined in the thermostat*Mode properties. This is a homekit-specific term and therefore the tags needs to be prefixed with "homekit:"   |
+|                       | TargetTemperature             | Number                    | A target temperature that will engage the thermostat's heating and cooling actions as necessary, depending on the heatingCoolingMode                                                                                                          |
 
 See the sample below for example items:
 

--- a/addons/io/org.openhab.io.homekit/README.md
+++ b/addons/io/org.openhab.io.homekit/README.md
@@ -16,7 +16,7 @@ Requirements beyond this are not clear, and Apple enforces limitations on eligib
 At the very least, you cannot use repeating (111-11-111) or sequential (123-45-678) pin codes.
 If your home network is secure, a good starting point is the pin code used in most sample applications: 031-45-154.
 
-Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the Homekit bridge on are also illustrated in the following sample:
+Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the Homekit bridge, which can be edited in PaperUI in standard mode, on are also illustrated in the following sample:
 
 ```
 org.openhab.homekit:port=9124
@@ -27,8 +27,80 @@ org.openhab.homekit:thermostatHeatMode=HeatOn
 org.openhab.homekit:thermostatAutoMode=Auto
 org.openhab.homekit:thermostatOffMode=Off
 org.openhab.homekit:networkInterface=192.168.0.6
+```
+
+The following additional settings can be added or edited in PaperUI after switching to expert mode:
 
 ```
+org.openhab.homekit:name=openHAB
+org.openhab.homekit:minimumTemperature=-100
+org.openhab.homekit:maximumTemperature=100
+```
+
+### Overview of all settings
+
+<table>
+ <tr>
+  <th>Setting</th>
+  <th>Description</th>
+  <th>Default value</th>
+ </tr>
+ <tr>
+  <td>networkInterface</td>
+  <td>IP address or domain name under which the HomeKit bridge can be reached. If no value is configured, the addon tries to determine the IP address from the local hostname. </td>
+  <td>(none)</td>  
+ </tr>
+ <tr>
+  <td>port</td>
+  <td>Port under which the HomeKit bridge can be reached. </td>
+  <td>9123</td>  
+ </tr>
+ <tr>
+  <td>pin</td>
+  <td>Pin code used for pairing with iOS devices. Apparently, pin codes are provided by Apple and represent specific device types, so they cannot be chosen freely. The pin code <em>031-45-154</em> is used in sample applications and known to work.</td>
+  <td>031-45-154</td>  
+ </tr>
+ <tr>
+  <td>useFahrenheitTemperature</td>
+  <td>Set to <em>true</em> to use Fahrenheit degrees, or <em>false</em> to use Celsius degrees.</td>
+  <td>false</td>  
+ </tr>
+ <tr>
+  <td>thermostatCoolMode</td>
+  <td>Word used for activating the cooling mode of the device (if applicable).</td>
+  <td>CoolOn</td>  
+ </tr>
+ <tr>
+  <td>thermostatHeatMode</td>
+  <td>Word used for activating the heating mode of the device (if applicable).</td>
+  <td>HeatOn</td>  
+ </tr>
+ <tr>
+  <td>thermostatAutoMode</td>
+  <td>Word used for activating the automatic mode of the device (if applicable).</td>
+  <td>Auto</td>  
+ </tr>
+ <tr>
+  <td>thermostatOffMode</td>
+  <td>Word used for turning thermostat mode of the device to off (if applicable).</td>
+  <td>Off</td>  
+ </tr>
+ <tr>
+  <td>minimumTemperature</td>
+  <td>Lower bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit. </td>
+  <td>-100</td>  
+ </tr>
+ <tr>
+  <td>maximumTemperature</td>
+  <td>Upper bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit. </td>
+  <td>100</td>  
+ </tr>
+ <tr>
+  <td>name</td>
+  <td>Name under which this HomeKit bridge is announced in the network and which is displayed on the iOS device when searching for available bridges. </td>
+  <td>openHAB</td>  
+ </tr>
+</table> 
 
 ## Item Configuration
 
@@ -125,3 +197,4 @@ If you encounter any issues with the add-on and need support, it may be importan
 In order to get logs from the underlying library used to implement the HomeKit protocol, enable trace logging using the following command:
 
 ```openhab> log:set TRACE com.beowulfe.hap```
+

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -92,7 +92,7 @@ public class HomekitSettings {
     }
 
     public String getName() {
-        logger.debug("Using homekit name '" + name + "'");
+        logger.debug("Using homekit name '{}'", name);
         return name;
     }
 

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -13,6 +13,8 @@ import java.net.UnknownHostException;
 import java.util.Dictionary;
 
 import org.osgi.framework.FrameworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides the configured and static settings for the Homekit addon
@@ -25,6 +27,8 @@ public class HomekitSettings {
     private static final String MANUFACTURER = "openHAB";
     private static final String SERIAL_NUMBER = "none";
 
+    /* Name under which openHAB announces itself as HomeKit bridge (#1946) */
+    private String name = NAME;
     private int port = 9123;
     private String pin = "031-45-154";
     private boolean useFahrenheitTemperature = false;
@@ -36,7 +40,13 @@ public class HomekitSettings {
     private String thermostatOffMode = "Off";
     private InetAddress networkInterface;
 
+    private final Logger logger = LoggerFactory.getLogger(HomekitSettings.class);
+
     public void fill(Dictionary<String, ?> properties) throws UnknownHostException {
+        Object name = properties.get("name");
+        if (name instanceof String && ((String) name).length() > 0) {
+            this.name = (String) name;
+        }
         Object port = properties.get("port");
         if (port instanceof Integer) {
             this.port = (Integer) port;
@@ -82,7 +92,8 @@ public class HomekitSettings {
     }
 
     public String getName() {
-        return NAME;
+        logger.debug("Using homekit name '" + name + "'");
+        return name;
     }
 
     public String getManufacturer() {


### PR DESCRIPTION
Name of the homekit bridge as announced in the network can be changed
from default "openHAB" to any valid name by setting the parameter "name"

Signed-off-by: Metin Savignano <ms@savignano.net> (github: cubistico)


[homekit] MAKE BRIDGE NAME CONFIGURABLE

Make name of the homekit bridge as announced in the network configurable
from default "openHAB" to any valid name by setting the parameter "name", 
as requested in issue #1946 

This is helpful, if you have more than one openHAB running.

