### PR TITLE
[lgwebos] Correction in Readme file

### DIFF
--- a/addons/binding/org.openhab.binding.lgwebos/README.md
+++ b/addons/binding/org.openhab.binding.lgwebos/README.md
@@ -53,24 +53,25 @@ Please note that at least one channel must be bound to an item before the bindin
 
 ## Example
 
-This example assumes the IP of your smart TV is 192.168.2.119.
+This example assumes your TV has ThingID lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46. 
+You can find it in the discovery results in Paper UI.
 
 demo.items:
 
 ```
-Switch LG_TV0_Power "TV Power" <television>  { autoupdate="false", channel="lgwebos:WebOSTV:192_168_2_119:power" }
-Switch LG_TV0_Mute  "TV Mute"                { channel="lgwebos:WebOSTV:192_168_2_119:mute"}
-Dimmer LG_TV0_Volume "Volume [%S]"           { channel="lgwebos:WebOSTV:192_168_2_119:volume" }
+Switch LG_TV0_Power "TV Power" <television>  { autoupdate="false", channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:power" }
+Switch LG_TV0_Mute  "TV Mute"                { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:mute"}
+Dimmer LG_TV0_Volume "Volume [%S]"           { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:volume" }
 Number LG_TV0_VolDummy "VolumeUpDown"
-Number LG_TV0_ChannelNo "Channel [%d]"       { channel="lgwebos:WebOSTV:192_168_2_119:channel" }
+Number LG_TV0_ChannelNo "Channel [%d]"       { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:channel" }
 Number LG_TV0_ChannelDummy "ChannelUpDown"
-String LG_TV0_Channel "Channel [%S]"         { channel="lgwebos:WebOSTV:192_168_2_119:channelName"}
-String LG_TV0_Toast                          { channel="lgwebos:WebOSTV:192_168_2_119:toast"}
-Switch LG_TV0_Stop "Stop"                    { autoupdate="false", channel="lgwebos:WebOSTV:192_168_2_119:mediaStop" }
-String LG_TV0_Application "Application [%s]" { channel="lgwebos:WebOSTV:192_168_2_119:appLauncher"}
-Player LG_TV0_Player                         { channel="lgwebos:WebOSTV:192_168_2_119:mediaPlayer"}
+String LG_TV0_Channel "Channel [%S]"         { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:channelName"}
+String LG_TV0_Toast                          { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:toast"}
+Switch LG_TV0_Stop "Stop"                    { autoupdate="false", channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:mediaStop" }
+String LG_TV0_Application "Application [%s]" { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:appLauncher"}
+Player LG_TV0_Player                         { channel="lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46:mediaPlayer"}
 
-// this assumes you also have the wake on lan binding configured & You need to update your broadcast and mac address
+// this assumes you also have the wake on lan binding configured and your TV's IP address is on this network - You would need to update your broadcast and mac address accordingly
 Switch LG_TV0_WOL                            { wol="192.168.2.255#3c:cd:93:c2:20:e0" }
 ```
 


### PR DESCRIPTION
ThingID is no longer made up by IP address. It uses a Unique ID provided by the TV, which remains constant. This was incorrectly described in the Readme file.

Signed-off-by: Sebastian Prehn <sebastian.prehn@gmx.de> (github: sprehn)