### PR TITLE
[nikohomecontrol] Improvement of rollershutter PercentType implementation.

### DIFF
--- a/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
@@ -87,12 +87,6 @@
 				<description>Niko Home Control IP Interface Object ID</description>
 				<advanced>false</advanced>
 			</parameter>
-			<parameter name="invert" type="boolean" required="false">
-				<label>Invert</label>
-				<description>Invert open/close behavior</description>
-				<default>false</default>
-				<advanced>false</advanced>
-			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
@@ -87,6 +87,12 @@
 				<description>Niko Home Control IP Interface Object ID</description>
 				<advanced>false</advanced>
 			</parameter>
+			<parameter name="invert" type="boolean" required="false">
+				<label>Invert</label>
+				<description>Invert open/close behavior</description>
+				<default>false</default>
+				<advanced>false</advanced>
+			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Niko Home Control Binding

--- a/addons/binding/org.openhab.binding.nikohomecontrol/README.md
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/README.md
@@ -2,11 +2,10 @@
 
 The Niko Home Control binding integrates with a [Niko Home Control](http://www.nikohomecontrol.be/) system through a Niko Home Control IP-interface.
 
-The binding has been tested with a Niko Home Control IP-interface (550-00508).
-This IP-interface provides access on the LAN.
-The binding does not require a Niko Home Control Gateway (550-00580), but does work with it in the LAN.
-It will not make a remote connection.
+The binding has been tested with a Niko Home Control IP-interface (550-00508). This IP-interface provides access on the LAN.
+The binding does not require a Niko Home Control Gateway (550-00580), but does work with it in the LAN. It will not make a remote connection.
 It has also been confirmed to work with the Niko Home Control Connected Controller (550-00003).
+The binding does not work for Niko Home Control II.
 
 The binding exposes all actions from the Niko Home Control System that can be triggered from the smartphone/tablet interface, as defined in the Niko Home Control programming software.
 
@@ -22,12 +21,11 @@ Connected to a bridge, the Niko Home Control Binding supports on/off actions (e.
 
 The bridge representing the Niko Home Control IP-interface needs to be added first in the things file or through Paper UI.
 A bridge can be auto-discovered or created manually.
-No bridge configuration is required when using auto-discovery.
+No bridge configuration is required when using auto-discovery. An auto-discovered bridge will have an IP-address parameter automatically filled with the current IP-address of the IP-interface.
 
 The IP-address and port can be set when manually creating the bridge.
 
-If the IP-address is set, no attempt will be made to discover the correct IP-address.
-ou are responsible to force a fixed IP address on the Niko Home Control IP-interface through settings in your DHCP server.
+If the IP-address is set on a manually created bridge, no attempt will be made to discover the correct IP-address. You are responsible to force a fixed IP address on the Niko Home Control IP-interface through settings in your DHCP server.
 
 The port is set to 8000 by default and should match the port used by the Niko Home Control IP-interface.
 
@@ -100,6 +98,9 @@ Open the file with an unzip tool to read it's content.
 The `step` parameter is only available for dimmers.
 It sets a step value for dimmer increase/decrease actions. The parameter is optional and set to 10 by default.
 
+The `invert` parameter is only available for rollershutters.
+It will invert the up/down direction of the rollerhutter and remap the position to the opposite position. The parameter is optional and false by default.
+
 ## Channels
 
 For thing type `onOff` the supported channel is `switch`.
@@ -119,11 +120,13 @@ It can be used as a trigger to rules. The event message is the alarm or notice t
 
 The binding has been tested with a Niko Home Control IP-interface (550-00508) and the Niko Home Control Connected Controller (550-00003).
 
+The binding has been developed for and tested with Niko Home Control I. It is not expected to work with Niko Home Control II, or with Niko Home Control I installations upgraded to Niko Home Control II.
+
 The action events implemented are limited to onOff, dimmer and rollershutter or blinds.
 Other actions have not been implemented.
 It is not possible to tilt the slats of venetian blinds.
 
-Beyond action events, the Niko Home Control communication also supports thermostats, electricity usage data and alarms.
+Beyond action events, the Niko Home Control communication also supports thermostats and electricity usage data.
 This has not been implemented.
 
 ## Example
@@ -140,7 +143,7 @@ Bridge nikohomecontrol:bridge:nhc1 [ addr="192.168.0.70", port=8000, refresh=300
 Bridge nikohomecontrol:bridge:nhc2 [ addr="192.168.0.110" ] {
     onOff 11 @ "Upstairs"[ actionId=11 ]
     dimmer 12 [ actionId=12, step=5 ]
-    blind 13 [ actionId=13 ]
+    blind 13 [ actionId=13, invert=true ]
 }
 ```
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/README.md
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/README.md
@@ -99,7 +99,7 @@ The `step` parameter is only available for dimmers.
 It sets a step value for dimmer increase/decrease actions. The parameter is optional and set to 10 by default.
 
 The `invert` parameter is only available for rollershutters.
-It will invert the up/down direction of the rollerhutter and remap the position to the opposite position. The parameter is optional and false by default.
+It will invert the up/down direction of the rollerhutter and remap the position to the opposite position. This can be used if Niko Home Control does not map correctly to openHAB 0% UP and 100% DOWN. The parameter is optional and false by default.
 
 ## Channels
 
@@ -143,7 +143,7 @@ Bridge nikohomecontrol:bridge:nhc1 [ addr="192.168.0.70", port=8000, refresh=300
 Bridge nikohomecontrol:bridge:nhc2 [ addr="192.168.0.110" ] {
     onOff 11 @ "Upstairs"[ actionId=11 ]
     dimmer 12 [ actionId=12, step=5 ]
-    blind 13 [ actionId=13, invert=true ]
+    blind 13 [ actionId=13 ]
 }
 ```
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/README.md
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/README.md
@@ -9,7 +9,7 @@ The binding does not work for Niko Home Control II.
 
 The binding exposes all actions from the Niko Home Control System that can be triggered from the smartphone/tablet interface, as defined in the Niko Home Control programming software.
 
-Supported actions are types are switches, dimmers and rollershutters.
+Supported action types are switches, dimmers and rollershutters or blinds.
 Niko Home Control alarm and notice messages are retrieved and made available in the binding.
 
 ## Supported Things
@@ -21,7 +21,7 @@ Connected to a bridge, the Niko Home Control Binding supports on/off actions (e.
 
 The bridge representing the Niko Home Control IP-interface needs to be added first in the things file or through Paper UI.
 A bridge can be auto-discovered or created manually.
-No bridge configuration is required when using auto-discovery. An auto-discovered bridge will have an IP-address parameter automatically filled with the current IP-address of the IP-interface.
+No bridge configuration is required when using auto-discovery. An auto-discovered bridge will have an IP-address parameter automatically filled with the current IP-address of the IP-interface. This IP-address for the discovered bridge will automatically update when the IP-address of the IP-interface changes.
 
 The IP-address and port can be set when manually creating the bridge.
 
@@ -36,7 +36,7 @@ Restarting the bridge at regular times improves the connection stability and avo
 
 A discovery scan will first discover the Niko Home Control IP-interface in the network as a bridge.
 Default parameters will be used.
-Note that this may fail to find the correct Niko Home Control IP-interface when there are multiple IP-interfaces in the network.
+Note that this may fail to find the correct Niko Home Control IP-interface when there are multiple IP-interfaces in the network, or when traffic to port 10000 on the openHAB server is blocked.
 
 When the Niko Home Control bridge is added as a thing, from the discovery inbox or manually, system information will be read from the Niko Home Control Controller and will be put in the bridge properties, visible through Paper UI.
 
@@ -44,7 +44,7 @@ Subsequently, all defined actions that can be triggered from a smartphone/tablet
 It is possible to trigger a manual scan for things on the Niko Home Control bridge.
 
 If the Niko Home Control system has locations configured, these will be copied to thing locations and grouped as such in PaperUI.
-Locations can subsequently be changed through the thing location paramter in PaperUI.
+Locations can subsequently be changed through the thing location parameter in PaperUI.
 
 ## Thing Configuration
 
@@ -86,7 +86,7 @@ onOff, dimmer, blind
 
 `thingId` can have any value, but will be set to the same value as the actionId parameter if discovery is used.
 
-`"Label"` is een optional label for the thing.
+`"Label"` is an optional label for the thing.
 
 `@ "Location"` is optional, and represents the location of the thing. Auto-discovery would have assigned a value automatically.
 
@@ -97,9 +97,6 @@ Open the file with an unzip tool to read it's content.
 
 The `step` parameter is only available for dimmers.
 It sets a step value for dimmer increase/decrease actions. The parameter is optional and set to 10 by default.
-
-The `invert` parameter is only available for rollershutters.
-It will invert the up/down direction of the rollerhutter and remap the position to the opposite position. This can be used if Niko Home Control does not map correctly to openHAB 0% UP and 100% DOWN. The parameter is optional and false by default.
 
 ## Channels
 
@@ -120,7 +117,7 @@ It can be used as a trigger to rules. The event message is the alarm or notice t
 
 The binding has been tested with a Niko Home Control IP-interface (550-00508) and the Niko Home Control Connected Controller (550-00003).
 
-The binding has been developed for and tested with Niko Home Control I. It is not expected to work with Niko Home Control II, or with Niko Home Control I installations upgraded to Niko Home Control II.
+The binding has been developed for and tested with Niko Home Control I. It does not work with Niko Home Control II, or with Niko Home Control I installations upgraded to Niko Home Control II.
 
 The action events implemented are limited to onOff, dimmer and rollershutter or blinds.
 Other actions have not been implemented.

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
@@ -58,5 +58,6 @@ public class NikoHomeControlBindingConstants {
     // Thing config properties
     public static final String CONFIG_ACTION_ID = "actionId";
     public static final String CONFIG_STEP_VALUE = "step";
-    public static final String CONFIG_INVERT = "invert";
+    public static final String CONFIG_INVERT = "invert"; // parameter for rollershutters if NHC does not correctly map
+                                                         // to openHAB 0% UP and 100% DOWN
 }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
@@ -58,4 +58,5 @@ public class NikoHomeControlBindingConstants {
     // Thing config properties
     public static final String CONFIG_ACTION_ID = "actionId";
     public static final String CONFIG_STEP_VALUE = "step";
+    public static final String CONFIG_INVERT = "invert";
 }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/NikoHomeControlBindingConstants.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Sets;
  * The {@link NikoHomeControlBindingConstants} class defines common constants, which are
  * used across the whole binding.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 @NonNullByDefault
 public class NikoHomeControlBindingConstants {
@@ -58,6 +58,4 @@ public class NikoHomeControlBindingConstants {
     // Thing config properties
     public static final String CONFIG_ACTION_ID = "actionId";
     public static final String CONFIG_STEP_VALUE = "step";
-    public static final String CONFIG_INVERT = "invert"; // parameter for rollershutters if NHC does not correctly map
-                                                         // to openHAB 0% UP and 100% DOWN
 }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlBridgeHandler.java
@@ -71,7 +71,6 @@ public class NikoHomeControlBridgeHandler extends BaseBridgeHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
                     "Niko Home Control: cannot resolve bridge IP with hostname " + config.get(CONFIG_HOST_NAME));
         }
-
     }
 
     /**
@@ -148,7 +147,6 @@ public class NikoHomeControlBridgeHandler extends BaseBridgeHandler {
 
             updateStatus(ThingStatus.ONLINE);
         }, refreshInterval, refreshInterval, TimeUnit.MINUTES);
-
     }
 
     /**
@@ -166,7 +164,6 @@ public class NikoHomeControlBridgeHandler extends BaseBridgeHandler {
     public void bridgeOnline() {
         updateProperties();
         updateStatus(ThingStatus.ONLINE);
-
     }
 
     /**
@@ -188,7 +185,6 @@ public class NikoHomeControlBridgeHandler extends BaseBridgeHandler {
         properties.put("connectionStartDate", this.nhcComm.getSystemInfo().getTime());
 
         thing.setProperties(properties);
-
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlBridgeHandler.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * {@link NikoHomeControlBridgeHandler} is the handler for a Niko Home Control IP-interface and connects it to
  * the framework.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public class NikoHomeControlBridgeHandler extends BaseBridgeHandler {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
@@ -10,12 +10,20 @@ package org.openhab.binding.nikohomecontrol.handler;
 
 import static org.openhab.binding.nikohomecontrol.NikoHomeControlBindingConstants.*;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -33,9 +41,34 @@ import org.slf4j.LoggerFactory;
  *
  * @author Mark Herwege
  */
+@NonNullByDefault
 public class NikoHomeControlHandler extends BaseThingHandler {
 
     private Logger logger = LoggerFactory.getLogger(NikoHomeControlHandler.class);
+
+    // dimmer constants
+    static final int NHCON = 254;
+    static final int NHCOFF = 255;
+
+    // rollershutter constants
+    static final int NHCUP = 254;
+    static final int NHCDOWN = 255;
+    static final int NHCSTOP = 253;
+
+    @Nullable
+    private volatile Runnable rollershutterTask;
+    @Nullable
+    private volatile ScheduledFuture<?> rollershutterStopTask;
+    @Nullable
+    private volatile ScheduledFuture<?> rollershutterMovingFlagTask;
+
+    private volatile boolean filterEvent; // flag to filter first event from rollershutter on percent move to
+                                          // avoid wrong position update
+    private volatile boolean rollershutterMoving; // flag to indicate if rollershutter is currently moving
+    private volatile boolean waitForEvent; // flag to wait for position update rollershutter before doing next
+                                           // move
+
+    private int prevActionState;
 
     public NikoHomeControlHandler(Thing thing) {
         super(thing);
@@ -45,7 +78,18 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         Integer actionId = ((Number) this.getConfig().get(CONFIG_ACTION_ID)).intValue();
 
-        NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) getBridge().getHandler();
+        Bridge nhcBridge = getBridge();
+        if (nhcBridge == null) {
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Niko Home Control: no bridge initialized when trying to execute action " + actionId);
+            return;
+        }
+        NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();
+        if (nhcBridgeHandler == null) {
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Niko Home Control: no bridge initialized when trying to execute action " + actionId);
+            return;
+        }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
 
         if (nhcComm == null) {
@@ -125,9 +169,9 @@ public class NikoHomeControlHandler extends BaseThingHandler {
         if (command instanceof OnOffType) {
             OnOffType s = (OnOffType) command;
             if (s == OnOffType.OFF) {
-                nhcAction.execute(255);
+                nhcAction.execute(NHCOFF);
             } else {
-                nhcAction.execute(254);
+                nhcAction.execute(NHCON);
             }
         } else if (command instanceof IncreaseDecreaseType) {
             IncreaseDecreaseType s = (IncreaseDecreaseType) command;
@@ -147,32 +191,165 @@ public class NikoHomeControlHandler extends BaseThingHandler {
             }
         } else if (command instanceof PercentType) {
             PercentType p = (PercentType) command;
-            nhcAction.execute(p.intValue());
+            if (p == PercentType.ZERO) {
+                nhcAction.execute(NHCOFF);
+            } else {
+                nhcAction.execute(p.intValue());
+            }
         }
     }
 
     private void handleRollershutterCommand(NhcAction nhcAction, Command command) {
-        if (command instanceof UpDownType) {
-            UpDownType s = (UpDownType) command;
-            if (s == UpDownType.UP) {
-                nhcAction.execute(255);
-            } else {
-                nhcAction.execute(254);
-            }
-        } else if (command instanceof StopMoveType) {
-            StopMoveType s = (StopMoveType) command;
-            if (s == StopMoveType.STOP) {
-                nhcAction.execute(253);
-            }
-        } else if (command instanceof PercentType) {
-            PercentType p = (PercentType) command;
-            int currentState = nhcAction.getState();
-            if (currentState < p.intValue()) {
-                nhcAction.execute(255);
-            } else if (currentState > p.intValue()) {
-                nhcAction.execute(254);
-            }
+        Configuration config = this.getConfig();
+        boolean invert = (boolean) config.get(CONFIG_INVERT);
+        logger.trace("handleRollerShutterCommand: rollershutter {} command {}", config.get(CONFIG_ACTION_ID), command);
+        logger.trace("handleRollerShutterCommand: rollershutter {} invert flag {}", config.get(CONFIG_ACTION_ID),
+                invert);
+        logger.trace("handleRollerShutterCommand: rollershutter {}, current position {}", config.get(CONFIG_ACTION_ID),
+                nhcAction.getState());
+
+        // first stop all current movement of rollershutter and wait until exact position is known
+        if (this.rollershutterMoving) {
+            logger.trace("handleRollerShutterCommand: rollershutter {} moving, therefore stop",
+                    config.get(CONFIG_ACTION_ID));
+            rollershutterPositionStop(nhcAction);
         }
+
+        // task to be executed once exact position received from Niko Home Control
+        this.rollershutterTask = () -> {
+            logger.trace("handleRollerShutterCommand: rollershutter {} task running",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+
+            int currentValue = nhcAction.getState();
+
+            if (command instanceof UpDownType) {
+                UpDownType s = (UpDownType) command;
+                if (s == UpDownType.UP) {
+                    nhcAction.execute(invert ? invertRollershutter(NHCUP) : NHCUP);
+                } else {
+                    nhcAction.execute(invert ? invertRollershutter(NHCDOWN) : NHCDOWN);
+                }
+            } else if (command instanceof StopMoveType) {
+                nhcAction.execute(NHCSTOP);
+            } else if (command instanceof PercentType) {
+                int commandValue = ((PercentType) command).intValue();
+                int newValue = invert ? invertRollershutter(commandValue) : commandValue;
+                logger.trace(
+                        "handleRollerShutterCommand: rollershutter {} percent command, current {}, command {}, invert {}, new {}",
+                        config.get(CONFIG_ACTION_ID), currentValue, commandValue, invert, newValue);
+                if (currentValue == newValue) {
+                    return;
+                }
+                if ((newValue > 0) && (newValue < 100)) {
+                    scheduleRollershutterStop(nhcAction, currentValue, newValue);
+                }
+                if (newValue < currentValue) {
+                    nhcAction.execute(NHCUP);
+                } else if (newValue > currentValue) {
+                    nhcAction.execute(NHCDOWN);
+                }
+            }
+        };
+
+        // execute immediately if not waiting for exact position
+        if (!this.waitForEvent) {
+            logger.trace("handleRollerShutterCommand: rollershutter {} task executing immediately",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+            executeRollershutterTask();
+        }
+    }
+
+    /**
+     * Method used to stop rollershutter when moving. This will then result in an exact position to be received, so next
+     * percentage movements could be done accurately.
+     *
+     * @param nhcAction Niko Home Control action
+     *
+     */
+    private void rollershutterPositionStop(NhcAction nhcAction) {
+        logger.trace("rollershutterPositionStop: rollershutter {} executing", this.getConfig().get(CONFIG_ACTION_ID));
+        cancelRollershutterStop();
+        this.rollershutterTask = null;
+        this.filterEvent = false;
+        this.waitForEvent = true;
+        nhcAction.execute(NHCSTOP);
+    }
+
+    private void executeRollershutterTask() {
+        logger.trace("executeRollershutterTask: rollershutter {} task triggered",
+                this.getConfig().get(CONFIG_ACTION_ID));
+        this.waitForEvent = false;
+
+        if (this.rollershutterTask != null) {
+            this.rollershutterTask.run();
+            this.rollershutterTask = null;
+        }
+    }
+
+    /**
+     * Method used to schedule a rollershutter stop when moving. This allows stopping the rollershutter at a percent
+     * position.
+     *
+     * @param nhcAction Niko Home Control action
+     * @param currentValue current percent position
+     * @param newValue new percent position
+     *
+     */
+    private void scheduleRollershutterStop(NhcAction nhcAction, int currentValue, int newValue) {
+        // filter first event for a rollershutter coming from Niko Home Control if moving to an intermediate
+        // position to avoid updating state to full open or full close
+        this.filterEvent = true;
+
+        int duration = rollershutterMoveTime(nhcAction, currentValue, newValue);
+        setRollershutterMovingTrue(nhcAction, duration);
+
+        logger.trace("scheduleRollershutterStop: schedule rollershutter {} stop in {}s",
+                this.getConfig().get(CONFIG_ACTION_ID), duration);
+        this.rollershutterStopTask = scheduler.schedule(() -> {
+            logger.trace("scheduleRollershutterStop: run rollershutter {} stop",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+            nhcAction.execute(NHCSTOP);
+        }, duration, TimeUnit.SECONDS);
+    }
+
+    private void cancelRollershutterStop() {
+        ScheduledFuture<?> stopTask = this.rollershutterStopTask;
+        if (stopTask != null) {
+            logger.trace("cancelRollershutterStop: cancel rollershutter {} stop",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+            stopTask.cancel(true);
+        }
+        this.rollershutterStopTask = null;
+
+        this.filterEvent = false;
+    }
+
+    private void setRollershutterMovingTrue(NhcAction nhcAction, int duration) {
+        logger.trace("setRollershutterMovingTrue: rollershutter {} moving", this.getConfig().get(CONFIG_ACTION_ID));
+        this.rollershutterMoving = true;
+        this.rollershutterMovingFlagTask = scheduler.schedule(() -> {
+            logger.trace("setRollershutterMovingTrue: rollershutter {} stopped moving",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+            this.rollershutterMoving = false;
+        }, duration, TimeUnit.SECONDS);
+    }
+
+    private void setRollershutterMovingFalse() {
+        logger.trace("setRollershutterMovingFalse: rollershutter {} not moving",
+                this.getConfig().get(CONFIG_ACTION_ID));
+        this.rollershutterMoving = false;
+        if (this.rollershutterMovingFlagTask != null) {
+            this.rollershutterMovingFlagTask.cancel(true);
+            this.rollershutterMovingFlagTask = null;
+        }
+    }
+
+    private int rollershutterMoveTime(NhcAction nhcAction, int currentValue, int newValue) {
+        int totalTime = (newValue > currentValue) ? nhcAction.getCloseTime() : nhcAction.getOpenTime();
+        int duration = (int) Math.round(Math.abs(newValue - currentValue) * totalTime / 100.0);
+        logger.trace("rollershutterMoveTime: rollershutter {} move time {}", this.getConfig().get(CONFIG_ACTION_ID),
+                duration);
+        return duration;
     }
 
     @Override
@@ -181,7 +358,18 @@ public class NikoHomeControlHandler extends BaseThingHandler {
 
         Integer actionId = ((Number) config.get(CONFIG_ACTION_ID)).intValue();
 
-        NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) getBridge().getHandler();
+        Bridge nhcBridge = getBridge();
+        if (nhcBridge == null) {
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Niko Home Control: no bridge initialized for action " + actionId);
+            return;
+        }
+        NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();
+        if (nhcBridgeHandler == null) {
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Niko Home Control: no bridge initialized for action " + actionId);
+            return;
+        }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
         if (nhcComm == null || !nhcComm.communicationActive()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
@@ -200,17 +388,55 @@ public class NikoHomeControlHandler extends BaseThingHandler {
         int actionType = nhcAction.getType();
         String actionLocation = nhcAction.getLocation();
 
+        this.prevActionState = actionState;
         nhcAction.setThingHandler(this);
 
-        handleStateUpdate(actionType, actionState);
-        logger.debug("Niko Home Control: action intialized {}", actionId);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", String.valueOf(actionType));
+        if (this.getThing().getThingTypeUID() == THING_TYPE_BLIND) {
+            cancelRollershutterStop();
+            this.waitForEvent = false;
+            setRollershutterMovingFalse();
+
+            if ((boolean) config.get(CONFIG_INVERT)) {
+                properties.put("timeToOpen", String.valueOf(nhcAction.getCloseTime()));
+                properties.put("timeToClose", String.valueOf(nhcAction.getOpenTime()));
+            } else {
+                properties.put("timeToOpen", String.valueOf(nhcAction.getOpenTime()));
+                properties.put("timeToClose", String.valueOf(nhcAction.getCloseTime()));
+            }
+        }
+        thing.setProperties(properties);
 
         if (thing.getLocation() == null) {
             thing.setLocation(actionLocation);
         }
+
+        handleStateUpdate(nhcAction);
+
+        logger.debug("Niko Home Control: action intialized {}", actionId);
     }
 
-    public void handleStateUpdate(int actionType, int actionState) {
+    /**
+     * Method to update state of channel, called from Niko Home Control action.
+     *
+     * @param nhcAction Niko Home Control action
+     *
+     */
+    public void handleStateUpdate(NhcAction nhcAction) {
+        Configuration config = this.getConfig();
+        Integer actionId = ((Number) config.get(CONFIG_ACTION_ID)).intValue();
+
+        int actionType = nhcAction.getType();
+        int actionState = nhcAction.getState();
+
+        if (this.filterEvent) {
+            this.filterEvent = false;
+            logger.debug("Niko Home Control: filtered event {} for {}", actionState, actionId);
+            updateStatus(ThingStatus.ONLINE);
+            return;
+        }
+
         switch (actionType) {
             case 0:
             case 1:
@@ -223,12 +449,43 @@ public class NikoHomeControlHandler extends BaseThingHandler {
                 break;
             case 4:
             case 5:
-                updateState(CHANNEL_ROLLERSHUTTER, new PercentType(actionState));
+                cancelRollershutterStop();
+                if (this.waitForEvent) {
+                    logger.debug("Niko Home Control: received requested rollershutter {} position event {}", actionId,
+                            actionState);
+                    executeRollershutterTask();
+                }
+
+                boolean invert = (boolean) config.get(CONFIG_INVERT);
+                int state = invert ? invertRollershutter(actionState) : actionState;
+                int prevState = invert ? invertRollershutter(this.prevActionState) : this.prevActionState;
+                if (((state == 0) || (state == 100)) && (state != prevState)) {
+                    int duration = rollershutterMoveTime(nhcAction, prevState, state);
+                    setRollershutterMovingTrue(nhcAction, duration);
+                } else {
+                    setRollershutterMovingFalse();
+                }
+                updateState(CHANNEL_ROLLERSHUTTER, new PercentType(state));
                 updateStatus(ThingStatus.ONLINE);
                 break;
             default:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Niko Home Control: unknown action type " + actionType);
+        }
+
+        this.prevActionState = actionState;
+    }
+
+    private int invertRollershutter(int actionState) {
+        switch (actionState) {
+            case NHCUP:
+                return NHCDOWN;
+            case NHCDOWN:
+                return NHCUP;
+            case NHCSTOP:
+                return NHCSTOP;
+            default:
+                return (100 - actionState);
         }
     }
 }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
@@ -202,23 +202,29 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     private void handleRollershutterCommand(NhcAction nhcAction, Command command) {
         Configuration config = this.getConfig();
         boolean invert = (boolean) config.get(CONFIG_INVERT);
-        logger.trace("handleRollerShutterCommand: rollershutter {} command {}", config.get(CONFIG_ACTION_ID), command);
-        logger.trace("handleRollerShutterCommand: rollershutter {} invert flag {}", config.get(CONFIG_ACTION_ID),
-                invert);
-        logger.trace("handleRollerShutterCommand: rollershutter {}, current position {}", config.get(CONFIG_ACTION_ID),
-                nhcAction.getState());
+        if (logger.isTraceEnabled()) {
+            String actionId = (String) config.get(CONFIG_ACTION_ID);
+            logger.trace("handleRollerShutterCommand: rollershutter {} command {}", actionId, command);
+            logger.trace("handleRollerShutterCommand: rollershutter {} invert flag {}", actionId, invert);
+            logger.trace("handleRollerShutterCommand: rollershutter {}, current position {}", actionId,
+                    nhcAction.getState());
+        }
 
         // first stop all current movement of rollershutter and wait until exact position is known
         if (this.rollershutterMoving) {
-            logger.trace("handleRollerShutterCommand: rollershutter {} moving, therefore stop",
-                    config.get(CONFIG_ACTION_ID));
+            if (logger.isTraceEnabled()) {
+                logger.trace("handleRollerShutterCommand: rollershutter {} moving, therefore stop",
+                        config.get(CONFIG_ACTION_ID));
+            }
             rollershutterPositionStop(nhcAction);
         }
 
         // task to be executed once exact position received from Niko Home Control
         this.rollershutterTask = () -> {
-            logger.trace("handleRollerShutterCommand: rollershutter {} task running",
-                    this.getConfig().get(CONFIG_ACTION_ID));
+            if (logger.isTraceEnabled()) {
+                logger.trace("handleRollerShutterCommand: rollershutter {} task running",
+                        this.getConfig().get(CONFIG_ACTION_ID));
+            }
 
             int currentValue = nhcAction.getState();
 
@@ -234,9 +240,11 @@ public class NikoHomeControlHandler extends BaseThingHandler {
             } else if (command instanceof PercentType) {
                 int commandValue = ((PercentType) command).intValue();
                 int newValue = invert ? invertRollershutter(commandValue) : commandValue;
-                logger.trace(
-                        "handleRollerShutterCommand: rollershutter {} percent command, current {}, command {}, invert {}, new {}",
-                        config.get(CONFIG_ACTION_ID), currentValue, commandValue, invert, newValue);
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                            "handleRollerShutterCommand: rollershutter {} percent command, current {}, command {}, invert {}, new {}",
+                            config.get(CONFIG_ACTION_ID), currentValue, commandValue, invert, newValue);
+                }
                 if (currentValue == newValue) {
                     return;
                 }
@@ -253,8 +261,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
 
         // execute immediately if not waiting for exact position
         if (!this.waitForEvent) {
-            logger.trace("handleRollerShutterCommand: rollershutter {} task executing immediately",
-                    this.getConfig().get(CONFIG_ACTION_ID));
+            if (logger.isTraceEnabled()) {
+                logger.trace("handleRollerShutterCommand: rollershutter {} task executing immediately",
+                        this.getConfig().get(CONFIG_ACTION_ID));
+            }
             executeRollershutterTask();
         }
     }
@@ -267,7 +277,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
      *
      */
     private void rollershutterPositionStop(NhcAction nhcAction) {
-        logger.trace("rollershutterPositionStop: rollershutter {} executing", this.getConfig().get(CONFIG_ACTION_ID));
+        if (logger.isTraceEnabled()) {
+            logger.trace("rollershutterPositionStop: rollershutter {} executing",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+        }
         cancelRollershutterStop();
         this.rollershutterTask = null;
         this.filterEvent = false;
@@ -276,8 +289,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     }
 
     private void executeRollershutterTask() {
-        logger.trace("executeRollershutterTask: rollershutter {} task triggered",
-                this.getConfig().get(CONFIG_ACTION_ID));
+        if (logger.isTraceEnabled()) {
+            logger.trace("executeRollershutterTask: rollershutter {} task triggered",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+        }
         this.waitForEvent = false;
 
         if (this.rollershutterTask != null) {
@@ -303,8 +318,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
         long duration = rollershutterMoveTime(nhcAction, currentValue, newValue);
         setRollershutterMovingTrue(nhcAction, duration);
 
-        logger.trace("scheduleRollershutterStop: schedule rollershutter {} stop in {}ms",
-                this.getConfig().get(CONFIG_ACTION_ID), duration);
+        if (logger.isTraceEnabled()) {
+            logger.trace("scheduleRollershutterStop: schedule rollershutter {} stop in {}ms",
+                    this.getConfig().get(CONFIG_ACTION_ID), duration);
+        }
         this.rollershutterStopTask = scheduler.schedule(() -> {
             logger.trace("scheduleRollershutterStop: run rollershutter {} stop",
                     this.getConfig().get(CONFIG_ACTION_ID));
@@ -315,8 +332,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     private void cancelRollershutterStop() {
         ScheduledFuture<?> stopTask = this.rollershutterStopTask;
         if (stopTask != null) {
-            logger.trace("cancelRollershutterStop: cancel rollershutter {} stop",
-                    this.getConfig().get(CONFIG_ACTION_ID));
+            if (logger.isTraceEnabled()) {
+                logger.trace("cancelRollershutterStop: cancel rollershutter {} stop",
+                        this.getConfig().get(CONFIG_ACTION_ID));
+            }
             stopTask.cancel(true);
         }
         this.rollershutterStopTask = null;
@@ -325,18 +344,24 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     }
 
     private void setRollershutterMovingTrue(NhcAction nhcAction, long duration) {
-        logger.trace("setRollershutterMovingTrue: rollershutter {} moving", this.getConfig().get(CONFIG_ACTION_ID));
+        if (logger.isTraceEnabled()) {
+            logger.trace("setRollershutterMovingTrue: rollershutter {} moving", this.getConfig().get(CONFIG_ACTION_ID));
+        }
         this.rollershutterMoving = true;
         this.rollershutterMovingFlagTask = scheduler.schedule(() -> {
-            logger.trace("setRollershutterMovingTrue: rollershutter {} stopped moving",
-                    this.getConfig().get(CONFIG_ACTION_ID));
+            if (logger.isTraceEnabled()) {
+                logger.trace("setRollershutterMovingTrue: rollershutter {} stopped moving",
+                        this.getConfig().get(CONFIG_ACTION_ID));
+            }
             this.rollershutterMoving = false;
         }, duration, TimeUnit.MILLISECONDS);
     }
 
     private void setRollershutterMovingFalse() {
-        logger.trace("setRollershutterMovingFalse: rollershutter {} not moving",
-                this.getConfig().get(CONFIG_ACTION_ID));
+        if (logger.isTraceEnabled()) {
+            logger.trace("setRollershutterMovingFalse: rollershutter {} not moving",
+                    this.getConfig().get(CONFIG_ACTION_ID));
+        }
         this.rollershutterMoving = false;
         if (this.rollershutterMovingFlagTask != null) {
             this.rollershutterMovingFlagTask.cancel(true);
@@ -347,8 +372,10 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     private long rollershutterMoveTime(NhcAction nhcAction, int currentValue, int newValue) {
         int totalTime = (newValue > currentValue) ? nhcAction.getCloseTime() : nhcAction.getOpenTime();
         long duration = Math.abs(newValue - currentValue) * totalTime * 10;
-        logger.trace("rollershutterMoveTime: rollershutter {} move time {}", this.getConfig().get(CONFIG_ACTION_ID),
-                duration);
+        if (logger.isTraceEnabled()) {
+            logger.trace("rollershutterMoveTime: rollershutter {} move time {}", this.getConfig().get(CONFIG_ACTION_ID),
+                    duration);
+        }
         return duration;
     }
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/handler/NikoHomeControlHandler.java
@@ -68,7 +68,7 @@ public class NikoHomeControlHandler extends BaseThingHandler {
     private volatile boolean waitForEvent; // flag to wait for position update rollershutter before doing next
                                            // move
 
-    private int prevActionState;
+    private volatile int prevActionState;
 
     public NikoHomeControlHandler(Thing thing) {
         super(thing);
@@ -201,7 +201,8 @@ public class NikoHomeControlHandler extends BaseThingHandler {
 
     private void handleRollershutterCommand(NhcAction nhcAction, Command command) {
         Configuration config = this.getConfig();
-        boolean invert = (boolean) config.get(CONFIG_INVERT);
+        boolean invert = (boolean) config.get(CONFIG_INVERT); // parameter if NHC does not correctly map to openHAB 0%
+                                                              // UP and 100% DOWN
         if (logger.isTraceEnabled()) {
             String actionId = (String) config.get(CONFIG_ACTION_ID);
             logger.trace("handleRollerShutterCommand: rollershutter {} command {}", actionId, command);

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
  * The {@link NikoHomeControlHandlerFactory} is responsible for creating things and thing
  * handlers.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 
 @Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nikohomecontrol")

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlBridgeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlBridgeDiscoveryService.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * {@link NikoHomeControlBridgeDiscoveryService} is used to discover a Niko Home Control IP-interface in the local
  * network.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.nikohomecontrol")
 public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryService {

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * {@link NikoHomeControlDiscoveryService}
  * is used to return Niko Home Control Actions as things to the framework.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
@@ -30,14 +30,18 @@ public final class NhcAction {
     private Integer type;
     private String location;
     private Integer state;
+    private Integer openTime;
+    private Integer closeTime;
 
     private NikoHomeControlHandler thingHandler;
 
-    NhcAction(int id, String name, Integer type, String location) {
+    NhcAction(int id, String name, Integer type, String location, Integer openTime, Integer closeTime) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.location = location;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
     }
 
     /**
@@ -104,6 +108,28 @@ public final class NhcAction {
     }
 
     /**
+     * Get openTime of action.
+     * <p>
+     * openTime is the time in seconds to fully open a rollershutter.
+     *
+     * @return action openTime
+     */
+    public Integer getOpenTime() {
+        return this.openTime;
+    }
+
+    /**
+     * Get closeTime of action.
+     * <p>
+     * closeTime is the time in seconds to fully close a rollershutter.
+     *
+     * @return action closeTime
+     */
+    public Integer getCloseTime() {
+        return this.closeTime;
+    }
+
+    /**
      * Sets state of action.
      * <p>
      * State is a value between 0 and 100 for a dimmer or rollershutter.
@@ -117,7 +143,7 @@ public final class NhcAction {
         this.state = state;
         if (thingHandler != null) {
             logger.debug("Niko Home Control: update channel state for {} with {}", id, state);
-            thingHandler.handleStateUpdate(this.type, state);
+            thingHandler.handleStateUpdate(this);
         }
     }
 
@@ -127,26 +153,12 @@ public final class NhcAction {
      * @param percent - The allowed values depend on the action type.
      *            switch action: 0 or 100
      *            dimmer action: between 0 and 100, 254 for on, 255 for off
-     *            rollershutter action: between 0 (closed) and 100 (open), 255 to open, 254 to close, 253 to stop
+     *            rollershutter action: 254 to open, 255 to close, 253 to stop
      */
     public void execute(int percent) {
         logger.debug("Niko Home Control: execute action {} of type {} for {}", percent, this.type, this.id);
 
         NhcMessageCmd nhcCmd = new NhcMessageCmd("executeactions", this.id, percent);
-
-        // rollershutters have extra fields in the command
-        if ((this.type == 4) || (this.type == 5)) {
-            switch (percent) {
-                case 255: // open
-                    nhcCmd.setEndValue(100);
-                    break;
-                case 254: // close
-                    nhcCmd.setStartValue(100);
-                    break;
-                case 253: // stop
-                    nhcCmd.setStartValue(getState());
-            }
-        }
 
         nhcComm.sendMessage(nhcCmd);
     }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * representing a Niko Home Control action and has methods to trigger the action in Niko Home Control and receive action
  * updates.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public final class NhcAction {
 
@@ -30,18 +30,18 @@ public final class NhcAction {
     private Integer type;
     private String location;
     private Integer state;
-    private Integer openTime;
     private Integer closeTime;
+    private Integer openTime;
 
     private NikoHomeControlHandler thingHandler;
 
-    NhcAction(int id, String name, Integer type, String location, Integer openTime, Integer closeTime) {
+    NhcAction(int id, String name, Integer type, String location, Integer closeTime, Integer openTime) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.location = location;
-        this.openTime = openTime;
         this.closeTime = closeTime;
+        this.openTime = openTime;
     }
 
     /**
@@ -99,6 +99,7 @@ public final class NhcAction {
      * Get state of action.
      * <p>
      * State is a value between 0 and 100 for a dimmer or rollershutter.
+     * Rollershutter state is 0 for fully closed and 100 for fully open.
      * State is 0 or 100 for a switch.
      *
      * @return action state
@@ -133,6 +134,7 @@ public final class NhcAction {
      * Sets state of action.
      * <p>
      * State is a value between 0 and 100 for a dimmer or rollershutter.
+     * Rollershutter state is 0 for fully closed and 100 for fully open.
      * State is 0 or 100 for a switch.
      * If a thing handler is registered for the action, send a state update through the handler.
      * This method should only be called from inside this package.
@@ -153,7 +155,7 @@ public final class NhcAction {
      * @param percent - The allowed values depend on the action type.
      *            switch action: 0 or 100
      *            dimmer action: between 0 and 100, 254 for on, 255 for off
-     *            rollershutter action: 254 to open, 255 to close, 253 to stop
+     *            rollershutter action: 254 to close, 255 to open, 253 to stop
      */
     public void execute(int percent) {
         logger.debug("Niko Home Control: execute action {} of type {} for {}", percent, this.type, this.id);

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcLocation.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcLocation.java
@@ -12,7 +12,7 @@ package org.openhab.binding.nikohomecontrol.internal.protocol;
  * The {@link NhcLocation} class represents the location Niko Home Control communication object. It contains all fields
  * representing a Niko Home Control location.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 final class NhcLocation {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageBase.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageBase.java
@@ -15,7 +15,7 @@ package org.openhab.binding.nikohomecontrol.internal.protocol;
  * {@link NhcMessageListMap}, {@link NhcMessageCmd}.
  * <p>
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 abstract class NhcMessageBase {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageCmd.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageCmd.java
@@ -23,8 +23,6 @@ class NhcMessageCmd extends NhcMessageBase {
     private Integer value1;
     private Integer value2;
     private Integer value3;
-    private Integer startValue;
-    private Integer endValue;
 
     NhcMessageCmd(String cmd) {
         super.setCmd(cmd);
@@ -40,13 +38,5 @@ class NhcMessageCmd extends NhcMessageBase {
         this(cmd, id, value1);
         this.value2 = value2;
         this.value3 = value3;
-    }
-
-    void setStartValue(Integer startValue) {
-        this.startValue = startValue;
-    }
-
-    void setEndValue(Integer endValue) {
-        this.endValue = endValue;
     }
 }

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageCmd.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageCmd.java
@@ -14,7 +14,7 @@ package org.openhab.binding.nikohomecontrol.internal.protocol;
  * <p>
  * Example: <code>{"cmd":"executeactions","id":1,"value1":0}</code>
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 @SuppressWarnings("unused")
 class NhcMessageCmd extends NhcMessageBase {

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageListMap.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageListMap.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * Example: <code>{"cmd":"listactions","data":[{"id":1,"name":"Garage","type":1,"location":1,"value1":0},
  * {"id":25,"name":"Frontdoor","type":2,"location":2,"value1":0}]}</code>
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 class NhcMessageListMap extends NhcMessageBase {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageMap.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcMessageMap.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * <p>
  * Example: <code>{"cmd":"executeactions", "data":{"error":0}}</code>
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 class NhcMessageMap extends NhcMessageBase {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcSystemInfo.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcSystemInfo.java
@@ -12,7 +12,7 @@ package org.openhab.binding.nikohomecontrol.internal.protocol;
  * The {@link NhcSystemInfo} class represents the systeminfo Niko Home Control communication object. It contains all
  * Niko Home Control system data received from the Niko Home Control controller when initializing the connection.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public final class NhcSystemInfo {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
@@ -40,7 +40,7 @@ import com.google.gson.JsonParseException;
  *
  * A class instance is instantiated from the {@link NikoHomeControlBridgeHandler} class initialization.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public final class NikoHomeControlCommunication {
 
@@ -322,9 +322,9 @@ public final class NikoHomeControlCommunication {
             int id = Integer.parseInt(action.get("id"));
             Integer state = Integer.valueOf(action.get("value1"));
             String value2 = action.get("value2");
-            Integer openTime = (value2 == null ? null : Integer.valueOf(value2));
+            Integer closeTime = (value2 == null ? null : Integer.valueOf(value2));
             String value3 = action.get("value3");
-            Integer closeTime = (value3 == null ? null : Integer.valueOf(value3));
+            Integer openTime = (value3 == null ? null : Integer.valueOf(value3));
 
             if (!this.actions.containsKey(id)) {
                 // Initial instantiation of NhcAction class for action object
@@ -335,7 +335,7 @@ public final class NikoHomeControlCommunication {
                 if (locationId != null) {
                     location = this.locations.get(locationId).getName();
                 }
-                NhcAction nhcAction = new NhcAction(id, name, type, location, openTime, closeTime);
+                NhcAction nhcAction = new NhcAction(id, name, type, location, closeTime, openTime);
                 nhcAction.setState(state);
                 nhcAction.setNhcComm(this);
                 this.actions.put(id, nhcAction);

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
@@ -321,6 +321,10 @@ public final class NikoHomeControlCommunication {
 
             int id = Integer.parseInt(action.get("id"));
             Integer state = Integer.valueOf(action.get("value1"));
+            String value2 = action.get("value2");
+            Integer openTime = (value2 == null ? null : Integer.valueOf(value2));
+            String value3 = action.get("value3");
+            Integer closeTime = (value3 == null ? null : Integer.valueOf(value3));
 
             if (!this.actions.containsKey(id)) {
                 // Initial instantiation of NhcAction class for action object
@@ -331,7 +335,7 @@ public final class NikoHomeControlCommunication {
                 if (locationId != null) {
                     location = this.locations.get(locationId).getName();
                 }
-                NhcAction nhcAction = new NhcAction(id, name, type, location);
+                NhcAction nhcAction = new NhcAction(id, name, type, location, openTime, closeTime);
                 nhcAction.setState(state);
                 nhcAction.setNhcComm(this);
                 this.actions.put(id, nhcAction);
@@ -357,7 +361,7 @@ public final class NikoHomeControlCommunication {
         for (Map<String, String> action : data) {
             int id = Integer.valueOf(action.get("id"));
             if (!this.actions.containsKey(id)) {
-                logger.warn("Niko Home Control: action in controller not known to openHab {}", id);
+                logger.warn("Niko Home Control: action in controller not known {}", id);
                 return;
             }
             Integer state = Integer.valueOf(action.get("value1"));

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlDiscover.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlDiscover.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * The IP-address from the Niko Home Control IP-interface is then extracted from the response packet.
  * The data content of the response packet is used as a unique identifier for the bridge.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  */
 public final class NikoHomeControlDiscover {
 

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlMessageDeserializer.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlMessageDeserializer.java
@@ -26,7 +26,7 @@ import com.google.gson.JsonParseException;
  * Class {@link NikoHomeControlMessageDeserializer} deserializes all json messages from Niko Home Control. Various json
  * message formats are supported. The format is selected based on the content of the cmd and event json objects.
  *
- * @author Mark Herwege
+ * @author Mark Herwege - Initial Contribution
  *
  */
 class NikoHomeControlMessageDeserializer implements JsonDeserializer<NhcMessageBase> {

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlMessageDeserializer.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlMessageDeserializer.java
@@ -54,9 +54,7 @@ class NikoHomeControlMessageDeserializer implements JsonDeserializer<NhcMessageB
             NhcMessageBase message = null;
 
             if (jsonData != null) {
-
                 if (jsonData.isJsonObject()) {
-
                     message = new NhcMessageMap();
 
                     Map<String, String> data = new HashMap<>();
@@ -66,7 +64,6 @@ class NikoHomeControlMessageDeserializer implements JsonDeserializer<NhcMessageB
                     ((NhcMessageMap) message).setData(data);
 
                 } else if (jsonData.isJsonArray()) {
-
                     JsonArray jsonDataArray = jsonData.getAsJsonArray();
 
                     message = new NhcMessageListMap();
@@ -83,7 +80,6 @@ class NikoHomeControlMessageDeserializer implements JsonDeserializer<NhcMessageB
                     }
                     ((NhcMessageListMap) message).setData(dataList);
                 }
-
             }
 
             if (message != null) {


### PR DESCRIPTION
Previous implementation only mirrors native Niko Home Control app functionality for rollershutters, i.e. up/down/stop. PercentType commands were send as up or down. This PR adds a stop calculated based on current position and total time to open/close for PercentType commands.
An invert flag is also introduced to allow the open/close positions and direction to be switched.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>