### PR TITLE
Tycho POM improvements

### DIFF
--- a/addons/binding/org.openhab.binding.feed.test/pom.xml
+++ b/addons/binding/org.openhab.binding.feed.test/pom.xml
@@ -26,9 +26,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<providerHint>junit47</providerHint>
 					<providerProperties>

--- a/addons/binding/org.openhab.binding.hdpowerview/pom.xml
+++ b/addons/binding/org.openhab.binding.hdpowerview/pom.xml
@@ -15,21 +15,4 @@
 	<name>Hunter Douglas PowerView Binding</name>
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>${tycho-groupid}</groupId>
-					<artifactId>tycho-compiler-plugin</artifactId>
-					<version>${tycho-version}</version>
-					<configuration>
-						<encoding>UTF-8</encoding>
-						<source>1.8</source>
-						<target>1.8</target>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-
 </project>

--- a/addons/binding/org.openhab.binding.knx.test/pom.xml
+++ b/addons/binding/org.openhab.binding.knx.test/pom.xml
@@ -17,10 +17,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<configuration>
-					<environments combine.self="override"></environments>
 					<dependency-resolution>
 						<extraRequirements>
 							<dependency>
@@ -53,7 +52,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
 					<dependencies>

--- a/addons/binding/org.openhab.binding.max.test/pom.xml
+++ b/addons/binding/org.openhab.binding.max.test/pom.xml
@@ -20,9 +20,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<dependencies>
 						<dependency>

--- a/addons/binding/org.openhab.binding.rfxcom.test/pom.xml
+++ b/addons/binding/org.openhab.binding.rfxcom.test/pom.xml
@@ -18,9 +18,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<dependencies>
 						<dependency>

--- a/addons/binding/org.openhab.binding.systeminfo.test/pom.xml
+++ b/addons/binding/org.openhab.binding.systeminfo.test/pom.xml
@@ -20,9 +20,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<providerHint>junit47</providerHint>
 					<dependencies>


### PR DESCRIPTION
* Replace `org.eclipse.tycho` with `${tycho-groupid}` where applicable
* Remove `${tycho-version}` from plugins that is managed by parent POM
* Remove unnecessary tycho pluginManagement section from hdpowerview POM

This should also fix the following warning:

```
[WARNING] Some problems were encountered while building the effective model for org.openhab.binding:org.openhab.binding.knx.test:eclipse-test-plugin:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:target-platform-configuration is missing. @ org.openhab.binding:org.openhab.binding.knx.test:[unknown-version], /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.knx.test/pom.xml, line 19, column 12
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:tycho-surefire-plugin is missing. @ org.openhab.binding:org.openhab.binding.knx.test:[unknown-version], /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.knx.test/pom.xml, line 55, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[WARNING] No explicit target runtime environment configuration. Build is platform dependent.
```