### PR TITLE
[Chromecast] cleanup manifest

### DIFF
--- a/addons/binding/org.openhab.binding.chromecast/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.chromecast/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Export-Package:
  org.openhab.binding.chromecast,
  org.openhab.binding.chromecast.handler
 Import-Package: 
- com.fasterxml.jackson.annotation,
  javax.jmdns,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -32,8 +31,6 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.net.http,
- org.jupnp.model.meta,
- org.jupnp.model.types,
  org.openhab.binding.chromecast,
  org.openhab.binding.chromecast.handler,
  org.osgi.framework,


### PR DESCRIPTION
* the "org.jupnp.model.*" packages seem to be a leftover from #1477
* the "com.fasterxml.jackson.annotation" does not make any sense to me
  as neither the binding code needs it nor does any of the included
  dependencies import it in their manifests.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>