### PR TITLE
[rfxcom] Doc fix - heading was incorrect for Lighting1 section

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/README.md
+++ b/addons/binding/org.openhab.binding.rfxcom/README.md
@@ -470,7 +470,7 @@ A Humidity device.
         * HUM2 - LaCrosse WS2300
 
 
-#### Configuration options:
+### lighting1 - RFXCOM Lighting1 Actuator
 
 A Lighting1 device.
 


### PR DESCRIPTION
One line doc change.