### PR TITLE
2.2.x

### DIFF
--- a/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat3.xml
+++ b/addons/binding/org.openhab.binding.rfxcom/ESH-INF/thing/thermostat3.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="rfxcom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="thermostat3">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+			<bridge-type-ref id="tcpbridge" />
+			<bridge-type-ref id="RFXtrx433" />
+			<bridge-type-ref id="RFXrec433" />
+		</supported-bridge-type-refs>
+
+		<label>RFXCOM Thermostat3</label>
+		<description>A Thermostat3 device.</description>
+
+		<channels>
+			<channel id="command" typeId="command" />
+			<channel id="signalLevel" typeId="system.signal-strength" />
+		</channels>
+
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device Id</label>
+				<description>Unit Id. Example 56923</description>
+			</parameter>
+			<parameter name="subType" type="text" required="true">
+				<label>Sub Type</label>
+				<description>Specifies device sub type.</description>
+				<options>
+					<option value="MERTIK__G6R_H4T1">Mertik (G6R H4T1)</option>
+					<option value="MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22">Mertik (G6R H4TB, G6R H4T, or G6R H4T21-Z22)</option>
+					<option value="MERTIK__G6R_H4TD__G6R_H4T16">Mertik (G6R H4TD or G6R H4T16)</option>
+					<option value="MERTIK__G6R_H4S_TRANSMIT_ONLY">Mertik (G6R H4S - transmit only)</option>					
+				</options>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
@@ -50,7 +50,7 @@ public class RFXComMessageFactory {
                     // put(PacketType.REMOTE_CONTROL, RFXComRemoteControlMessage.class);
                     put(PacketType.THERMOSTAT1, RFXComThermostat1Message.class);
                     // put(PacketType.THERMOSTAT2, RFXComThermostat2Message.class);
-                    // put(PacketType.THERMOSTAT3, RFXComThermostat3Message.class);
+                    put(PacketType.THERMOSTAT3, RFXComThermostat3Message.class);
                     // put(PacketType.RADIATOR1, RFXComRadiator1Message.class);
                     put(PacketType.BBQ, RFXComBBQTemperatureMessage.class);
                     put(PacketType.TEMPERATURE_RAIN, RFXComTemperatureRainMessage.class);

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -11,10 +11,7 @@ package org.openhab.binding.rfxcom.internal.messages;
 import static org.openhab.binding.rfxcom.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
 
-import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
@@ -154,8 +151,8 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
 	            switch (command) {
 	            	case OFF: return OnOffType.OFF;
 					case ON: return OnOffType.ON;
-					case UP: return OpenClosedType.CLOSED;
-					case DOWN: return OpenClosedType.OPEN;
+					case UP: return UpDownType.UP;
+					case DOWN: return UpDownType.DOWN;
 			        default:
 		                    throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
 	            }

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
+
+import org.eclipse.smarthome.core.types.Type;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+
+/**
+ * RFXCOM data class for thermostat3 message.
+ * Mertik G6R-H4x gas heater
+ *
+ * @author Ruud Beukema - Initial contribution
+ */
+public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComThermostat3Message.SubType> {
+    public enum SubType implements ByteEnumWrapper {
+        MERTIK__G6R_H4T1(0),
+        MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22(1),
+        MERTIK__G6R_H4TD__G6R_H4T16(2),
+        MERTIK__G6R_H4S_TRANSMIT_ONLY(3);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        @Override
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    /* Operating mode */
+    public enum Commands implements ByteEnumWrapper {
+        OFF(0),
+        ON(1),
+        UP(2),
+        DOWN(3),
+        RUN_UP__2ND_OFF(4), // G6R_H4T1 and G6R_H4TB respectively only
+        RUN_DOWN__2ND_ON(5), // G6R_H4T1 and G6R_H4TB respectively only
+        STOP(6); // G6R_H4T1 only
+
+        private final int command;
+
+        Commands(int command) {
+            this.command = command;
+        }
+
+        @Override
+        public byte toByte() {
+            return (byte) command;
+        }
+
+        public String toString(SubType subtype) {
+            Commands _command = Commands.values()[this.command];
+            switch (_command) {
+                case OFF:
+                    return new String("OFF");
+                case ON:
+                    return new String("ON");
+                case UP:
+                    return new String("UP");
+                case DOWN:
+                    return new String("DOWN");
+                case RUN_UP__2ND_OFF:
+                    if (subtype == SubType.MERTIK__G6R_H4T1) {
+                        return new String("RUN_UP");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
+                        return new String("2ND_OFF");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
+                        return new String("Command not supported by Mertik G6R H4TD");
+                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
+                        return new String("Command not supported by Mertik G6R H4S");
+                    }
+
+                case RUN_DOWN__2ND_ON:
+                    if (subtype == SubType.MERTIK__G6R_H4T1) {
+                        return new String("RUN_DOWN");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
+                        return new String("2ND_ON");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
+                        return new String("Command not supported by Mertik G6R H4TD");
+                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
+                        return new String("Command not supported by Mertik G6R H4S");
+                    }
+                case STOP:
+                    if (subtype == SubType.MERTIK__G6R_H4T1) {
+                        return new String("STOP");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
+                        return new String("Command not supported by Mertik G6R H4TB");
+                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
+                        return new String("Command not supported by Mertik G6R H4TD");
+                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
+                        return new String("Command not supported by Mertik G6R H4S");
+                    }
+                default:
+                    return new String("Unknown command");
+            }
+        }
+    }
+
+    public SubType subType;
+    public int unitId;
+    public Commands command;
+
+    public RFXComThermostat3Message() {
+        super(PacketType.THERMOSTAT3);
+    }
+
+    public RFXComThermostat3Message(byte[] data) throws RFXComException {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += ", Sub type = " + subType;
+        str += ", Device Id = " + getDeviceId();
+        str += ", Command = " + command.toString(subType);
+        str += ", Signal level = " + signalLevel;
+
+        return str;
+    }
+
+    @Override
+    public String getDeviceId() {
+        return String.valueOf(unitId);
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) throws RFXComException {
+        super.encodeMessage(data);
+
+        subType = fromByte(SubType.class, super.subType);
+        unitId = (data[4] & 0xFF) << 16 | (data[5] & 0xFF) << 8 | (data[6] & 0xFF);
+        command = fromByte(Commands.class, (data[7]));
+        // Ignore filler byte at data[8]
+        signalLevel = (byte) ((data[9] & 0xF0) >> 4);
+    }
+
+    @Override
+    public byte[] decodeMessage() throws RFXComException {
+        byte[] data = new byte[10];
+
+        data[0] = 0x08;
+        data[1] = RFXComBaseMessage.PacketType.THERMOSTAT3.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((unitId >> 16) & 0xFF);
+        data[5] = (byte) ((unitId >> 8) & 0xFF);
+        data[6] = (byte) (unitId & 0xFF);
+        data[7] = command.toByte();
+        data[8] = (byte) 0xFF; // filler
+        data[9] = (byte) ((signalLevel & 0x0F) << 4);
+
+        return data;
+    }
+    
+    @Override
+    public State convertToState(String channelId) throws RFXComUnsupportedChannelException {
+		switch (channelId) {
+	        case CHANNEL_COMMAND:
+	        case CHANNEL_CONTACT:
+	            switch (command) {
+	            	case OFF: return OnOffType.OFF;
+					case ON: return OnOffType.ON;
+//					case UP:
+//					case DOWN:
+//					case RUN_UP__2ND_OFF: // G6R_H4T1 and G6R_H4TB respectively only
+//					case RUN_DOWN__2ND_ON: // G6R_H4T1 and G6R_H4TB respectively only
+//					case STOP: // G6R_H4T1 only
+			        default:
+		                    throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
+	            }
+			default:
+	            return super.convertToState(channelId);
+        }
+    }
+    
+    @Override
+    public void convertFromState(String channelId, Type type) throws RFXComUnsupportedChannelException {
+        switch (channelId) {
+            case CHANNEL_COMMAND:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
+
+                } else {
+                    throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
+                }
+                break;
+
+            default:
+                throw new RFXComUnsupportedChannelException("Channel " + channelId + " is not relevant here");
+        }
+    }
+
+    @Override
+    public SubType convertSubType(String subType) throws RFXComUnsupportedValueException {
+        return ByteEnumUtil.convertSubType(SubType.class, subType);
+    }
+
+    @Override
+    public void setSubType(SubType subType) {
+        this.subType = subType;
+    }
+
+    @Override
+    public void setDeviceId(String deviceId) throws RFXComException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -53,10 +53,12 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         OFF(0),
         ON(1),
         UP(2),
-        DOWN(3),
-        RUN_UP__2ND_OFF(4), // G6R_H4T1 and G6R_H4TB respectively only
-        RUN_DOWN__2ND_ON(5), // G6R_H4T1 and G6R_H4TB respectively only
-        STOP(6); // G6R_H4T1 only
+        DOWN(3);
+        
+        // For now unimplemented commands
+        // RUN_UP__2ND_OFF(4), // G6R_H4T1 and G6R_H4TB respectively only
+        // RUN_DOWN__2ND_ON(5), // G6R_H4T1 and G6R_H4TB respectively only
+        // STOP(6); // G6R_H4T1 only
 
         private final int command;
 
@@ -80,37 +82,6 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
                     return new String("UP");
                 case DOWN:
                     return new String("DOWN");
-                case RUN_UP__2ND_OFF:
-                    if (subtype == SubType.MERTIK__G6R_H4T1) {
-                        return new String("RUN_UP");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
-                        return new String("2ND_OFF");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
-                        return new String("Command not supported by Mertik G6R H4TD");
-                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
-                        return new String("Command not supported by Mertik G6R H4S");
-                    }
-
-                case RUN_DOWN__2ND_ON:
-                    if (subtype == SubType.MERTIK__G6R_H4T1) {
-                        return new String("RUN_DOWN");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
-                        return new String("2ND_ON");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
-                        return new String("Command not supported by Mertik G6R H4TD");
-                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
-                        return new String("Command not supported by Mertik G6R H4S");
-                    }
-                case STOP:
-                    if (subtype == SubType.MERTIK__G6R_H4T1) {
-                        return new String("STOP");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TB__G6_H4T__G6R_H4T21_Z22) {
-                        return new String("Command not supported by Mertik G6R H4TB");
-                    } else if (subtype == SubType.MERTIK__G6R_H4TD__G6R_H4T16) {
-                        return new String("Command not supported by Mertik G6R H4TD");
-                    } else if (subtype == SubType.MERTIK__G6R_H4S_TRANSMIT_ONLY) {
-                        return new String("Command not supported by Mertik G6R H4S");
-                    }
                 default:
                     return new String("Unknown command");
             }
@@ -180,15 +151,11 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
     public State convertToState(String channelId) throws RFXComUnsupportedChannelException {
 		switch (channelId) {
 	        case CHANNEL_COMMAND:
-	        case CHANNEL_CONTACT:
 	            switch (command) {
 	            	case OFF: return OnOffType.OFF;
 					case ON: return OnOffType.ON;
-//					case UP:
-//					case DOWN:
-//					case RUN_UP__2ND_OFF: // G6R_H4T1 and G6R_H4TB respectively only
-//					case RUN_DOWN__2ND_ON: // G6R_H4T1 and G6R_H4TB respectively only
-//					case STOP: // G6R_H4T1 only
+					case UP: return OpenClosedType.CLOSED;
+					case DOWN: return OpenClosedType.OPEN;
 			        default:
 		                    throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
 	            }
@@ -203,7 +170,8 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
             case CHANNEL_COMMAND:
                 if (type instanceof OnOffType) {
                     command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
-
+				} else if (type instanceof UpDownType) {
+					command = (type == UpDownType.DOWN ? Commands.DOWN : Commands.UP);
                 } else {
                     throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
                 }

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -8,9 +8,17 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.openhab.binding.rfxcom.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
 
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
+
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.openhab.binding.rfxcom.RFXComBindingConstants.*;
+import static org.openhab.binding.rfxcom.RFXComBindingConstants.CHANNEL_COMMAND;
 import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
-
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
@@ -50,12 +49,11 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         OFF(0),
         ON(1),
         UP(2),
-        DOWN(3);
-        
+        DOWN(3),
         // For now unimplemented commands
-        // RUN_UP__2ND_OFF(4), // G6R_H4T1 and G6R_H4TB respectively only
-        // RUN_DOWN__2ND_ON(5), // G6R_H4T1 and G6R_H4TB respectively only
-        // STOP(6); // G6R_H4T1 only
+        RUN_UP__2ND_OFF(4), // G6R_H4T1 and G6R_H4TB respectively only
+        RUN_DOWN__2ND_ON(5), // G6R_H4T1 and G6R_H4TB respectively only
+        STOP(6); // G6R_H4T1 only
 
         private final int command;
 
@@ -66,22 +64,6 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         @Override
         public byte toByte() {
             return (byte) command;
-        }
-
-        public String toString(SubType subtype) {
-            Commands _command = Commands.values()[this.command];
-            switch (_command) {
-                case OFF:
-                    return new String("OFF");
-                case ON:
-                    return new String("ON");
-                case UP:
-                    return new String("UP");
-                case DOWN:
-                    return new String("DOWN");
-                default:
-                    return new String("Unknown command");
-            }
         }
     }
 
@@ -104,7 +86,7 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         str += super.toString();
         str += ", Sub type = " + subType;
         str += ", Device Id = " + getDeviceId();
-        str += ", Command = " + command.toString(subType);
+        str += ", Command = " + command;
         str += ", Signal level = " + signalLevel;
 
         return str;
@@ -143,32 +125,36 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
 
         return data;
     }
-    
+
     @Override
     public State convertToState(String channelId) throws RFXComUnsupportedChannelException {
-		switch (channelId) {
-	        case CHANNEL_COMMAND:
-	            switch (command) {
-	            	case OFF: return OnOffType.OFF;
-					case ON: return OnOffType.ON;
-					case UP: return UpDownType.UP;
-					case DOWN: return UpDownType.DOWN;
-			        default:
-		                    throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
-	            }
-			default:
-	            return super.convertToState(channelId);
+        switch (channelId) {
+            case CHANNEL_COMMAND:
+                switch (command) {
+                    case OFF:
+                        return OnOffType.OFF;
+                    case ON:
+                        return OnOffType.ON;
+                    case UP:
+                        return UpDownType.UP;
+                    case DOWN:
+                        return UpDownType.DOWN;
+                    default:
+                        throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
+                }
+            default:
+                return super.convertToState(channelId);
         }
     }
-    
+
     @Override
     public void convertFromState(String channelId, Type type) throws RFXComUnsupportedChannelException {
         switch (channelId) {
             case CHANNEL_COMMAND:
                 if (type instanceof OnOffType) {
                     command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
-				} else if (type instanceof UpDownType) {
-					command = (type == UpDownType.DOWN ? Commands.DOWN : Commands.UP);
+                } else if (type instanceof UpDownType) {
+                    command = (type == UpDownType.DOWN ? Commands.DOWN : Commands.UP);
                 } else {
                     throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
                 }
@@ -191,6 +177,6 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
 
     @Override
     public void setDeviceId(String deviceId) throws RFXComException {
-        throw new UnsupportedOperationException();
+        this.unitId = Integer.parseInt(deviceId);
     }
 }


### PR DESCRIPTION
[rfxcom] Add support for Mertik gas heaters

This PR adds support for controlling several types of Mertik gas heaters using the RFXComThermostat3Message communication protocol. Currently, support for the commands ON, OFF, UP, and DOWN is implemented. These commands work on all types of Mertik gas heaters.

Here's the URL to the built JAR of this PR:
https://www.ruudenmarijke.nl:668/sharing/1bPode7qO

This is my first work for OpenHAB (actually my first Java code in 10+ years) there are probably things that I should have done different. Some things I struggled a bit with are:
- The sub-type enumeration: Since multiple sub-types share the same number, I've simply combined them in the enumeration. Somehow I feel that there should be one entry only for each actual sub-type, but this gives problems in the message encoding/decoding functions.
- The currently unsupported commands: it seems as if I can't use the same channel for multiple commands, which means that for e.g. the RUN_UP/RUN_DOWN commands I probably need to create a new channel type?

Suggestions are welcome!
