### PR TITLE
[Homematic] Properly stop JettyClient when XmlRpcClient is disposed

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -48,7 +48,11 @@ public class XmlRpcClient extends RpcClient<String> {
     @Override
     public void dispose() {
         if (httpClient != null) {
-            httpClient.destroy();
+            try {
+                httpClient.stop();
+            } catch (Exception e) {
+                // ignore
+            }
         }
     }
 


### PR DESCRIPTION
Previously, httpClient.destroy() was called during disposal of the
XmlRpcClient. This e.g. does not stop the threads created by the jetty
client. Now, httpClient.stop() is called.
In other places in the binding, e.g. the `CCUGateway` class, this call was already used to correctly dispose of the jetty client.

Contributes to fixing #3388

Signed-off-by: Florian Stolte <fstolte@gmx.de>
