### PR TITLE
[homematic] Introduce the HttpClientFactory to the homematic binding

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
@@ -43,6 +43,7 @@ Import-Package:
  org.eclipse.smarthome.core.thing.link,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.net.http,
  org.jupnp.model.meta,
  org.openhab.binding.homematic,
  org.openhab.binding.homematic.handler,

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -57,16 +58,19 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
     private HomematicConfig config;
     private HomematicGateway gateway;
     private HomematicTypeGenerator typeGenerator;
+    private HttpClient httpClient;
 
     private HomematicDeviceDiscoveryService discoveryService;
     private ServiceRegistration<?> discoveryServiceRegistration;
 
     private String ipv4Address;
 
-    public HomematicBridgeHandler(@NonNull Bridge bridge, HomematicTypeGenerator typeGenerator, String ipv4Address) {
+    public HomematicBridgeHandler(@NonNull Bridge bridge, HomematicTypeGenerator typeGenerator, String ipv4Address,
+            HttpClient httpClient) {
         super(bridge);
         this.typeGenerator = typeGenerator;
         this.ipv4Address = ipv4Address;
+        this.httpClient = httpClient;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
         scheduler.execute(() -> {
             try {
                 String id = getThing().getUID().getId();
-                gateway = HomematicGatewayFactory.createGateway(id, config, instance);
+                gateway = HomematicGatewayFactory.createGateway(id, config, instance, httpClient);
                 configureThingProperties();
                 gateway.initialize();
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandlerFactory.java
@@ -10,6 +10,7 @@ package org.openhab.binding.homematic.handler;
 
 import static org.openhab.binding.homematic.HomematicBindingConstants.*;
 
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.net.NetworkAddressService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -17,6 +18,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientFactory;
 import org.openhab.binding.homematic.internal.type.HomematicTypeGenerator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -31,6 +33,7 @@ import org.osgi.service.component.annotations.Reference;
 public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
     private HomematicTypeGenerator typeGenerator;
     private NetworkAddressService networkAddressService;
+    private HttpClient httpClient;
 
     @Reference
     protected void setTypeGenerator(HomematicTypeGenerator typeGenerator) {
@@ -39,6 +42,15 @@ public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
 
     protected void unsetTypeGenerator(HomematicTypeGenerator typeGenerator) {
         this.typeGenerator = null;
+    }
+
+    @Reference
+    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = null;
     }
 
     @Reference
@@ -59,7 +71,7 @@ public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
     protected ThingHandler createHandler(Thing thing) {
         if (THING_TYPE_BRIDGE.equals(thing.getThingTypeUID())) {
             return new HomematicBridgeHandler((Bridge) thing, typeGenerator,
-                    networkAddressService.getPrimaryIpv4HostAddress());
+                    networkAddressService.getPrimaryIpv4HostAddress(), httpClient);
         } else {
             return new HomematicThingHandler(thing);
         }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.client.BinRpcClient;
@@ -88,6 +89,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
     private Map<TransferMode, RpcServer> rpcServers = new HashMap<TransferMode, RpcServer>();
 
     protected HomematicConfig config;
+    protected HttpClient httpClient;
     private String id;
     private HomematicGatewayAdapter gatewayAdapter;
     private DelayedExecuter sendDelayedExecutor = new DelayedExecuter();
@@ -125,10 +127,12 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         virtualDatapointHandlers.add(new PressVirtualDatapointHandler());
     }
 
-    public AbstractHomematicGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter) {
+    public AbstractHomematicGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,
+            HttpClient httpClient) {
         this.id = id;
         this.config = config;
         this.gatewayAdapter = gatewayAdapter;
+        this.httpClient = httpClient;
     }
 
     @Override
@@ -213,7 +217,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         for (TransferMode mode : availableInterfaces.values()) {
             if (!rpcClients.containsKey(mode)) {
                 rpcClients.put(mode,
-                        mode == TransferMode.XML_RPC ? new XmlRpcClient(config) : new BinRpcClient(config));
+                        mode == TransferMode.XML_RPC ? new XmlRpcClient(config, httpClient) : new BinRpcClient(config));
             }
         }
     }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -54,11 +54,11 @@ public class CcuGateway extends AbstractHomematicGateway {
     private final Logger logger = LoggerFactory.getLogger(CcuGateway.class);
 
     private Map<String, String> tclregaScripts;
-    private HttpClient httpClient;
     private XStream xStream = new XStream(new StaxDriver());
 
-    protected CcuGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter) {
-        super(id, config, gatewayAdapter);
+    protected CcuGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,
+            HttpClient httpClient) {
+        super(id, config, gatewayAdapter, httpClient);
 
         xStream.setClassLoader(CcuGateway.class.getClassLoader());
         xStream.autodetectAnnotations(true);
@@ -72,28 +72,12 @@ public class CcuGateway extends AbstractHomematicGateway {
         super.startClients();
 
         tclregaScripts = loadTclRegaScripts();
-
-        httpClient = new HttpClient();
-        httpClient.setConnectTimeout(config.getTimeout() * 1000L);
-        try {
-            httpClient.start();
-        } catch (Exception ex) {
-            throw new IOException(ex.getMessage(), ex);
-        }
     }
 
     @Override
     protected void stopClients() {
         super.stopClients();
         tclregaScripts = null;
-        if (httpClient != null) {
-            try {
-                httpClient.stop();
-            } catch (Exception e) {
-                // ignore
-            }
-            httpClient = null;
-        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/DefaultGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/DefaultGateway.java
@@ -11,6 +11,7 @@ package org.openhab.binding.homematic.internal.communicator;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
@@ -23,8 +24,9 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  */
 public class DefaultGateway extends AbstractHomematicGateway {
 
-    protected DefaultGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter) {
-        super(id, config, gatewayAdapter);
+    protected DefaultGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,
+            HttpClient httpClient) {
+        super(id, config, gatewayAdapter, httpClient);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomegearGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomegearGateway.java
@@ -11,6 +11,7 @@ package org.openhab.binding.homematic.internal.communicator;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
@@ -23,8 +24,9 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  */
 public class HomegearGateway extends AbstractHomematicGateway {
 
-    protected HomegearGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter) {
-        super(id, config, gatewayAdapter);
+    protected HomegearGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,
+            HttpClient httpClient) {
+        super(id, config, gatewayAdapter, httpClient);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayFactory.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayFactory.java
@@ -10,6 +10,7 @@ package org.openhab.binding.homematic.internal.communicator;
 
 import java.io.IOException;
 
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.client.RpcClient;
 import org.openhab.binding.homematic.internal.communicator.client.XmlRpcClient;
@@ -24,23 +25,24 @@ public class HomematicGatewayFactory {
     /**
      * Creates the HomematicGateway.
      */
-    public static HomematicGateway createGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter)
+    public static HomematicGateway createGateway(String id, HomematicConfig config,
+            HomematicGatewayAdapter gatewayAdapter, HttpClient httpClient)
             throws IOException {
-        loadGatewayInfo(config, id);
+        loadGatewayInfo(config, id, httpClient);
         if (config.getGatewayInfo().isCCU()) {
-            return new CcuGateway(id, config, gatewayAdapter);
+            return new CcuGateway(id, config, gatewayAdapter, httpClient);
         } else if (config.getGatewayInfo().isHomegear()) {
-            return new HomegearGateway(id, config, gatewayAdapter);
+            return new HomegearGateway(id, config, gatewayAdapter, httpClient);
         } else {
-            return new DefaultGateway(id, config, gatewayAdapter);
+            return new DefaultGateway(id, config, gatewayAdapter, httpClient);
         }
     }
 
     /**
      * Loads some metadata about the type of the Homematic gateway.
      */
-    private static void loadGatewayInfo(HomematicConfig config, String id) throws IOException {
-        RpcClient<String> rpcClient = new XmlRpcClient(config);
+    private static void loadGatewayInfo(HomematicConfig config, String id, HttpClient httpClient) throws IOException {
+        RpcClient<String> rpcClient = new XmlRpcClient(config, httpClient);
         try {
             config.setGatewayInfo(rpcClient.getGatewayInfo(id));
         } finally {

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -33,27 +33,13 @@ public class XmlRpcClient extends RpcClient<String> {
     private final Logger logger = LoggerFactory.getLogger(XmlRpcClient.class);
     private HttpClient httpClient;
 
-    public XmlRpcClient(HomematicConfig config) throws IOException {
+    public XmlRpcClient(HomematicConfig config, HttpClient httpClient) throws IOException {
         super(config);
-        httpClient = new HttpClient();
-        httpClient.setConnectTimeout(config.getTimeout() * 1000L);
-
-        try {
-            httpClient.start();
-        } catch (Exception ex) {
-            throw new IOException(ex.getMessage(), ex);
-        }
+        this.httpClient = httpClient;
     }
 
     @Override
     public void dispose() {
-        if (httpClient != null) {
-            try {
-                httpClient.stop();
-            } catch (Exception e) {
-                // ignore
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
Improvement/Bugfix:
The HttpClientFactory provides a common jetty http client for all
bundles. The homematic binding now uses this shared client.

This not only reduces the binding's memory footprint, but also gets rid
of some problems during the disposal of http clients.

Impact: The connection timeout of the client can no longer be customized since the shared client must not be modified by calling setter methods.

Fixes #3388

Signed-off-by: Florian Stolte <fstolte@gmx.de>