### PR TITLE
[homematic] Put controller into install_mode on DiscoveryService#start()

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
@@ -80,6 +80,11 @@
 				<advanced>true</advanced>
 				<default>9292</default>
 			</parameter>
+			<parameter name="installModeDuration" type="integer" min="10" max="300" unit="s">
+				<label>Install mode duration</label>
+				<description>Time in seconds that the controller will be in install mode when a device discovery is initiated</description>
+				<default>60</default>
+			</parameter>
 
 		</config-description>
 	</bridge-type>

--- a/addons/binding/org.openhab.binding.homematic/README.md
+++ b/addons/binding/org.openhab.binding.homematic/README.md
@@ -77,6 +77,14 @@ If you are using a YAHM for example, you have to manually set the gateway type i
 If autodetection can not identify the gateway, the binding uses the default gateway implementation.
 The difference is, that variables, scripts and device names are not supported, everything else is the same.
 
+### Automatic install mode during discovery
+
+Besides discovering devices that are already known by the gateway, it may be desired to connect new devices to your system - which requires your gateway to be in install mode. Starting the binding's DiscoveryService will automatically put your gateway(s) in install mode for a specified period of time (see installModeDuration).
+
+**Note:** Enabling / disabling of install mode is also available via GATEWAY_EXTRAS. You may use this if you prefer.
+
+**Exception:** If a gateway is not ONLINE, the install mode will not be set automatically. _For instance during initialization of the binding its DiscoveryService is started and will discover devices that are already connected. However, the install mode is not automatically enabled in this situation because the gateway is in the status INITIALIZING._
+
 ## Bridge Configuration
 
 There are several settings for a bridge:
@@ -125,6 +133,9 @@ The port number of the HMIP server (default = 2010)
 
 -   **cuxdPort**  
 The port number of the CUxD daemon (default = 8701)
+
+-   **installModeDuration**
+Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)
 
 The syntax for a bridge is:
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/HomematicBindingConstants.java
@@ -53,4 +53,6 @@ public class HomematicBindingConstants {
     public static final String PROPERTY_BATTERY_TYPE = "batteryType";
     public static final String PROPERTY_AES_KEY = "aesKey";
     public static final String PROPERTY_DYNAMIC_FUNCTION_FORMAT = "dynamicFunction-%d";
+    
+    public static final int INSTALL_MODE_NORMAL = 1;
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -81,8 +81,11 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 configureThingProperties();
                 gateway.initialize();
 
+                // scan for already known devices (new devices will not be discovered, 
+                // since installMode==true is only achieved if the bridge is online
                 discoveryService.startScan(null);
                 discoveryService.waitForScanFinishing();
+                
                 updateStatus(ThingStatus.ONLINE);
                 if (!config.getGatewayInfo().isHomegear()) {
                     try {
@@ -95,6 +98,8 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 gateway.startWatchdogs();
             } catch (IOException ex) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
+                logger.error("Homematic bridge was set to OFFLINE-COMMUNICATION_ERROR due to the following exception: {}",
+                        ex.getMessage(), ex);
                 dispose();
                 scheduleReinitialize();
             }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -32,6 +32,7 @@ public class HomematicConfig {
     private static final int DEFAULT_PORT_HMIP = 2010;
     private static final int DEFAULT_PORT_CUXD = 8701;
     private static final int DEFAULT_PORT_GROUP = 9292;
+    public static final int DEFAULT_INSTALL_MODE_DURATION = 60;
 
     private String gatewayAddress;
     private String gatewayType = GATEWAY_TYPE_AUTO;
@@ -48,6 +49,7 @@ public class HomematicConfig {
 
     private int socketMaxAlive = 900;
     private int timeout = 15;
+    private int installModeDuration = DEFAULT_INSTALL_MODE_DURATION;
 
     private HmGatewayInfo gatewayInfo;
 
@@ -171,6 +173,26 @@ public class HomematicConfig {
      */
     public void setGatewayType(String gatewayType) {
         this.gatewayType = gatewayType;
+    }
+    
+    /**
+     * Returns time in seconds that the controller will be in install mode when
+     * a device discovery is initiated
+     * 
+     * @return time in seconds that the controller remains in install mode
+     */
+    public int getInstallModeDuration() {
+        return installModeDuration;
+    }
+    
+    /**
+     * Sets installModeDuration
+     * 
+     * @param installModeDuration time in seconds that the controller remains in
+     *        install mode
+     */
+    public void setInstallModeDuration(int installModeDuration) {
+        this.installModeDuration = installModeDuration;
     }
 
     /**
@@ -299,7 +321,8 @@ public class HomematicConfig {
                 .append("xmlCallbackPort", xmlCallbackPort).append("binCallbackPort", binCallbackPort)
                 .append("gatewayType", gatewayType).append("rfPort", getRfPort()).append("wiredPort", getWiredPort())
                 .append("hmIpPort", getHmIpPort()).append("cuxdPort", getCuxdPort()).append("groupPort", getGroupPort())
-                .append("timeout", timeout).append("socketMaxAlive", socketMaxAlive);
+                .append("timeout", timeout).append("installModeDuration", installModeDuration)
+                .append("socketMaxAlive", socketMaxAlive);
         return tsb.toString();
     }
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
@@ -79,6 +79,27 @@ public interface HomematicGateway {
      * Returns the id of the HomematicGateway.
      */
     public String getId();
+    
+    /**
+     * Set install mode of homematic controller. During install mode the
+     * controller will accept any device (normal mode)
+     * 
+     * @param enable <i>true</i> will start install mode, whereas <i>false</i>
+     *         will stop it
+     * @param seconds specify how long the install mode should last
+     * @throws IOException if RpcClient fails to propagate command
+     */
+    public void setInstallMode(boolean enable, int seconds) throws IOException;
+
+    /**
+     * Get current install mode of homematic contoller
+     * 
+     * @return the current time in seconds that the controller remains in
+     *         <i>install_mode==true</i>, respectively <i>0</i> in case of
+     *         <i>install_mode==false</i>
+     * @throws IOException if RpcClient fails to propagate command
+     */
+    public int getInstallMode() throws IOException;
 
     /**
      * Loads all rssi values from the gateway.

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -10,15 +10,18 @@ package org.openhab.binding.homematic.internal.discovery;
 
 import static org.openhab.binding.homematic.HomematicBindingConstants.BINDING_ID;
 
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.homematic.handler.HomematicBridgeHandler;
+import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.HomematicGateway;
 import org.openhab.binding.homematic.internal.model.HmDevice;
 import org.openhab.binding.homematic.internal.type.UidUtils;
@@ -37,7 +40,10 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
     private static final int DISCOVER_TIMEOUT_SECONDS = 300;
 
     private HomematicBridgeHandler bridgeHandler;
-    private Future<?> scanFuture;
+    private Future<?> loadDevicesFuture;
+    private volatile boolean isInInstallMode = false;
+    private volatile Object installModeSync = new Object();
+    private volatile int installModeDuration = HomematicConfig.DEFAULT_INSTALL_MODE_DURATION;
 
     public HomematicDeviceDiscoveryService(HomematicBridgeHandler bridgeHandler) {
         super(ImmutableSet.of(new ThingTypeUID(BINDING_ID, "-")), DISCOVER_TIMEOUT_SECONDS, false);
@@ -59,51 +65,130 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
     @Override
     protected void startScan() {
         logger.debug("Starting Homematic discovery scan");
+        enableInstallMode();
         loadDevices();
+    }
+
+    /**
+     * Will set controller in <i>installMode==true</i>, but only if the bridge
+     * is ONLINE (e.g. not during INITIALIZATION).
+     */
+    private void enableInstallMode() {
+        try {
+            HomematicGateway gateway = bridgeHandler.getGateway();
+            ThingStatus bridgeStatus = null;
+            
+            if (bridgeHandler.getThing() != null) {
+                Thing bridge = bridgeHandler.getThing();
+                bridgeStatus = bridge.getStatus();
+                updateInstallModeDuration(bridge);
+            }
+            if (ThingStatus.ONLINE == bridgeStatus) {
+                gateway.setInstallMode(true, installModeDuration);
+
+                int remaining = gateway.getInstallMode();
+                if (remaining > 0) {
+                    setIsInInstallMode();
+                    logger.debug("Successfully put controller in install mode. Remaining time: {} seconds", remaining);
+                } else {
+                    logger.warn("Controller did not accept requested install mode");
+                }
+            } else {
+                logger.debug("Will not attempt to set controller in install mode, because bridge is not ONLINE.");
+            }
+        } catch (Exception ex) {
+            logger.warn("Failed to set Homematic controller in install mode", ex);
+        }
+    }
+    
+    private void updateInstallModeDuration(Thing bridge) {
+        HomematicConfig config = bridge.getConfiguration().as(HomematicConfig.class);
+        installModeDuration = config.getInstallModeDuration();
+    }
+    
+    @Override
+    public int getScanTimeout() {
+        return installModeDuration;
     }
 
     @Override
     public synchronized void stopScan() {
         logger.debug("Stopping Homematic discovery scan");
         if (bridgeHandler != null && bridgeHandler.getGateway() != null) {
+            disableInstallMode();
             bridgeHandler.getGateway().cancelLoadAllDeviceMetadata();
         }
         waitForScanFinishing();
         super.stopScan();
+    }
+    
+    private void disableInstallMode() {
+        try {
+            synchronized (installModeSync) {
+                if (isInInstallMode) {
+                    isInInstallMode = false;
+                    installModeSync.notify();
+                    bridgeHandler.getGateway().setInstallMode(false, 0);
+                }
+            }
+            
+        } catch (Exception ex) {
+            logger.warn("Failed to disable Homematic controller's install mode", ex);
+        }
+    }
+    
+    private void setIsInInstallMode() {
+        synchronized (installModeSync) {
+            isInInstallMode = true;
+        }
+    }
+    
+    private void waitForInstallModeFinished(int timeout) throws InterruptedException {
+        synchronized (installModeSync) {
+            while (isInInstallMode) {
+                installModeSync.wait(timeout);
+            }
+        }        
+    }
+    
+    private void waitForLoadDevicesFinished() throws InterruptedException, ExecutionException {
+        if (loadDevicesFuture != null) {
+            loadDevicesFuture.get();
+        }
     }
 
     /**
      * Waits for the discovery scan to finish and then returns.
      */
     public void waitForScanFinishing() {
-        if (scanFuture != null) {
-            logger.debug("Waiting for finishing Homematic device discovery scan");
-            try {
-                scanFuture.get();
-                logger.debug("Homematic device discovery scan finished");
-            } catch (CancellationException ex) {
-                // ignore
-            } catch (Exception ex) {
-                logger.error("Error waiting for device discovery scan: {}", ex.getMessage(), ex);
-            }
+    
+        logger.debug("Waiting for finishing Homematic device discovery scan"); 
+        try {
+            waitForInstallModeFinished(DISCOVER_TIMEOUT_SECONDS * 1000);
+            waitForLoadDevicesFinished();
+        } catch (ExecutionException | InterruptedException ex) {
+            // ignore
+        } catch (Exception ex) {
+            logger.error("Error waiting for device discovery scan: {}", ex.getMessage(), ex);
         }
+        String gatewayId = bridgeHandler != null ? bridgeHandler.getGateway().getId() : "UNKNOWN";
+        logger.debug("Finished Homematic device discovery scan on gateway '{}'", gatewayId);
     }
 
     /**
      * Starts a thread which loads all Homematic devices connected to the gateway.
      */
     public void loadDevices() {
-        if (scanFuture == null && bridgeHandler.getGateway() != null) {
-            scanFuture = scheduler.submit(() -> {
+        if (loadDevicesFuture == null && bridgeHandler.getGateway() != null) {
+            loadDevicesFuture = scheduler.submit(() -> {
                 try {
                     final HomematicGateway gateway = bridgeHandler.getGateway();
                     gateway.loadAllDeviceMetadata();
                     bridgeHandler.getTypeGenerator().validateFirmwares();
-                    logger.debug("Finished Homematic device discovery scan on gateway '{}'", gateway.getId());
                 } catch (Throwable ex) {
                     logger.error("{}", ex.getMessage(), ex);
                 } finally {
-                    scanFuture = null;
+                    loadDevicesFuture = null;
                     bridgeHandler.setOfflineStatus();
                     removeOlderResults(getTimestampOfLastScan());
                 }


### PR DESCRIPTION
Whenever the bindings DiscoveryService is started, the controller is set to install_mode==true for a well defined time period. During that time it accepts pairing of new devices. Since the RPC call for
enabling the install_mode is well documented, this can be achieved without using GATEWAY_EXTRAS. Henceforth it is optional to use GATEWAY_EXTRAS, since the most important function of this thing is
implicitely available on the DiscoveryService. For convenience desired duration may be specified on the homematic:bridge.

To be backwarts compatible with GATEWAY_EXTRAS the virtual datapoints are utilized. So in setups using GATEWAY_EXTRAS you will also see applications of install mode and duration on this thing.

Closes: #3330 

Signed-off-by: Michael Reitler <github@madpage.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  http://docs.openhab.org/developers/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  http://docs.openhab.org/developers/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  http://docs.openhab.org/developers/contributing/contributing#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
