### PR TITLE
[CoolMasterNet] Fix fan speed commands not working

### DIFF
--- a/addons/binding/org.openhab.binding.coolmasternet/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.coolmasternet/ESH-INF/thing/thing-types.xml
@@ -44,7 +44,7 @@
 		<channels>
 			<channel id="on" typeId="power" />
 			<channel id="mode" typeId="hvac_mode" />
-			<channel id="fan" typeId="fan_speed" />
+			<channel id="fan_speed" typeId="fan_speed" />
 			<channel id="set_temp" typeId="temperature_setpoint" />
 			<channel id="current_temp" typeId="temperature_readback" />
 			<channel id="louvre" typeId="louvre_angle" />

--- a/addons/binding/org.openhab.binding.coolmasternet/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.coolmasternet/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.openhab.binding.coolmasternet,
  org.openhab.binding.coolmasternet.handler
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,

--- a/addons/binding/org.openhab.binding.coolmasternet/README.md
+++ b/addons/binding/org.openhab.binding.coolmasternet/README.md
@@ -22,14 +22,14 @@ Bridge coolmasternet:controller:main [ host="192.168.0.100" ] {
 
 ## Channels
 
-| Channel      | Item Type | Description                                                                                                                                      |
-|--------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| on           | Switch    | Turn HVAC unit on and off.                                                                                                                       |
-| mode         | String    | HVAC Mode. "Auto", "Cool", "Heat", "Dry" or "Fan Only". Unit may not support all modes.                                                          |
-| fan          | String    | Fan Mode. "Auto", "Low", "Medium", "High" or "Top". Unit may not support all speeds.                                                             |
-| set_temp     | Number    | Temperature target setpoint.                                                                                                                     |
-| current_temp | Number    | Current temperature at HVAC unit.                                                                                                                |
-| louvre       | String    | Louvre angle. "No Control", "Auto Swing", "Horizontal", "30 degrees", "45 degrees", "60 degrees" or "Vertical". Unit may not support all angles. |
+| Channel      | Item Type | Description                                                                                                                                                                            |
+|--------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| on           | Switch    | Turn HVAC unit on and off.                                                                                                                                                             |
+| mode         | String    | HVAC mode (cool, heat, auto, dry, fan). Unit may not support all modes.                                                                                                                |
+| fan_speed    | String    | Fan speed (l, m, h, t, a ) for respectively "Low", "Medium", "High", "Top" or "Auto". Unit may not support all speeds.                                                                 |
+| set_temp     | Number    | Temperature target setpoint in Celsius.                                                                                                                                                |
+| current_temp | Number    | Current temperature in Celsius at HVAC unit.                                                                                                                                           |
+| louvre       | String    | Louvre angle (0, a, h, 3, 4, 6, v) for respectively "No Control", "Auto Swing", "Horizontal", "30 degrees", "45 degrees", "60 degrees" or "Vertical". Unit may not support all angles. |
 
 ## Item Configuration
 

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/CoolMasterNetBindingConstants.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/CoolMasterNetBindingConstants.java
@@ -8,6 +8,10 @@
  */
 package org.openhab.binding.coolmasternet;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
@@ -30,8 +34,11 @@ public class CoolMasterNetBindingConstants {
     public static final String ON = "on";
     public static final String MODE = "mode";
     public static final String SET_TEMP = "set_temp";
-    public static final String FAN = "fan_speed";
+    public static final String FAN_SPEED = "fan_speed";
     public static final String LOUVRE = "louvre_angle";
     public static final String CURRENT_TEMP = "current_temp";
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream.of(THING_TYPE_CONTROLLER, THING_TYPE_HVAC)
+            .collect(Collectors.toSet());
 
 }

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/handler/HVACHandler.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/handler/HVACHandler.java
@@ -66,7 +66,7 @@ public class HVACHandler extends BaseThingHandler {
                 } else if (channel.endsWith(MODE) && command instanceof StringType) {
                     /* the mode value in the command is the actual CoolMasterNet protocol command */
                     controller.sendCommand(String.format("%s %s", command, uid));
-                } else if (channel.endsWith(FAN) && command instanceof StringType) {
+                } else if (channel.endsWith(FAN_SPEED) && command instanceof StringType) {
                     controller.sendCommand(String.format("fspeed %s %s", uid, command));
                 } else if (channel.endsWith(LOUVRE) && command instanceof StringType) {
                     controller.sendCommand(String.format("swing %s %s", uid, command));
@@ -106,7 +106,7 @@ public class HVACHandler extends BaseThingHandler {
         }
         String fan = FAN_NUM_TO_STR.get(query("f"));
         if (fan != null) {
-            updateState(new ChannelUID(thingUID, FAN), new StringType(fan));
+            updateState(new ChannelUID(thingUID, FAN_SPEED), new StringType(fan));
         }
     }
 

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/CoolMasterNetHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/CoolMasterNetHandlerFactory.java
@@ -10,9 +10,6 @@ package org.openhab.binding.coolmasternet.internal;
 
 import static org.openhab.binding.coolmasternet.CoolMasterNetBindingConstants.*;
 
-import java.util.Collections;
-import java.util.Set;
-
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -23,8 +20,6 @@ import org.openhab.binding.coolmasternet.handler.HVACHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
-import com.google.common.collect.Sets;
-
 /**
  * The {@link CoolMasterNetHandlerFactory} is responsible for creating things and thing
  * handlers.
@@ -33,9 +28,6 @@ import com.google.common.collect.Sets;
  */
 @Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.coolmasternet", configurationPolicy = ConfigurationPolicy.OPTIONAL)
 public class CoolMasterNetHandlerFactory extends BaseThingHandlerFactory {
-
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets
-            .union(Collections.singleton(THING_TYPE_HVAC), Collections.singleton(THING_TYPE_CONTROLLER));
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {


### PR DESCRIPTION
* Rename fan channel to fan_speed so it is inline with documentation and the binding will also handle commands
* Update documentation so available states are listed
* Remove Guava dependency

---

@dirkypower I don't use this binding myself but I think this PR should fix the issue your reported in this [community post](https://community.openhab.org/t/coolmasternet-binding-fan-speed-not-working/40821?u=wborn). 

Can you test if this fixes your issue when you use this [org.openhab.binding.coolmasternet-2.3.0-SNAPSHOT.jar](http://www.maindrain.net/iot-marketplace/org.openhab.binding.coolmasternet-2.3.0-SNAPSHOT.jar) with OH 2.3.0-SNAPSHOT? You might need to remove and re-add the HVAC Thing so you have a `fan_speed` instead of a `fan` channel.

I've also updated the [binding documentation](https://github.com/wborn/openhab2-addons/blob/coolmasternet-bugfix/addons/binding/org.openhab.binding.coolmasternet/README.md) so it correctly lists the channel states.

Comments by @projectgus are also appreciated!



