### PR TITLE
correctly declare dependency to UPnP in Kodi binding

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -190,6 +190,7 @@
 
     <feature name="openhab-binding-kodi" description="Kodi Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-upnp</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.kodi/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
fixes #3394

Signed-off-by: Kai Kreuzer <kai@openhab.org>