### PR TITLE
[avmfritz] Switched to shared instance of HttpClient

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.avmfritz/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: AVM FRITZ! Binding

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -18,7 +18,6 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -87,7 +86,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
      *
      * @param bridge Bridge object representing a FRITZ!Box
      */
-    public BoxHandler(@NonNull Bridge bridge, @NonNull HttpClient httpClient) {
+    public BoxHandler(Bridge bridge, HttpClient httpClient) {
         super(bridge);
         this.httpClient = httpClient;
     }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -86,7 +87,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
      *
      * @param bridge Bridge object representing a FRITZ!Box
      */
-    public BoxHandler(Bridge bridge, HttpClient httpClient) {
+    public BoxHandler(@NonNull Bridge bridge, HttpClient httpClient) {
         super(bridge);
         this.httpClient = httpClient;
     }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/BoxHandler.java
@@ -8,16 +8,18 @@
  */
 package org.openhab.binding.avmfritz.handler;
 
-import static org.eclipse.smarthome.core.thing.Thing.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.BindingConstants.*;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -75,14 +77,19 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
      * Schedule for polling
      */
     private ScheduledFuture<?> pollingJob;
+    /**
+     * shared instance of HTTP client for asynchronous calls
+     */
+    private HttpClient httpClient;
 
     /**
      * Constructor
      *
      * @param bridge Bridge object representing a FRITZ!Box
      */
-    public BoxHandler(@NonNull Bridge bridge) {
+    public BoxHandler(@NonNull Bridge bridge, @NonNull HttpClient httpClient) {
         super(bridge);
+        this.httpClient = httpClient;
     }
 
     /**
@@ -97,7 +104,7 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
         logger.debug("Discovered FRITZ!Box initialized: {}", config);
 
         this.refreshInterval = config.getPollingInterval();
-        this.connection = new FritzahaWebInterface(config, this);
+        this.connection = new FritzahaWebInterface(config, this, httpClient);
         if (config.getPassword() != null) {
             this.onUpdate();
         } else {
@@ -205,9 +212,10 @@ public class BoxHandler extends BaseBridgeHandler implements IFritzHandler {
                     if (device.getHkr().getNextchange().getEndperiod() == 0) {
                         updateThingChannelState(thing, CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
                     } else {
-                        final Calendar calendar = Calendar.getInstance();
-                        calendar.setTime(new Date(device.getHkr().getNextchange().getEndperiod() * 1000L));
-                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
+                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE,
+                                new DateTimeType(ZonedDateTime.ofInstant(
+                                        Instant.ofEpochMilli(device.getHkr().getNextchange().getEndperiod()),
+                                        ZoneId.systemDefault())));
                     }
                     if (HeatingModel.TEMP_FRITZ_UNDEFINED.equals(device.getHkr().getNextchange().getTchange())) {
                         updateThingChannelState(thing, CHANNEL_NEXTTEMP, UnDefType.UNDEF);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -18,7 +18,6 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -93,7 +92,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
      *
      * @param thing Thing object representing a FRITZ! device
      */
-    public DeviceHandler(@NonNull Thing thing, @NonNull HttpClient httpClient) {
+    public DeviceHandler(Thing thing, HttpClient httpClient) {
         super(thing);
         this.httpClient = httpClient;
     }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -8,16 +8,18 @@
  */
 package org.openhab.binding.avmfritz.handler;
 
-import static org.eclipse.smarthome.core.thing.Thing.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.BindingConstants.*;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
@@ -76,6 +78,10 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
      * Schedule for polling
      */
     private ScheduledFuture<?> pollingJob;
+    /**
+     * shared instance of HTTP client for asynchronous calls
+     */
+    private HttpClient httpClient;
 
     /**
      * keeps track of the current state for handling of increase/decrease
@@ -87,8 +93,9 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
      *
      * @param thing Thing object representing a FRITZ! device
      */
-    public DeviceHandler(@NonNull Thing thing) {
+    public DeviceHandler(@NonNull Thing thing, @NonNull HttpClient httpClient) {
         super(thing);
+        this.httpClient = httpClient;
     }
 
     /**
@@ -105,7 +112,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
             logger.debug("discovered PL546E initialized: {}", config);
 
             this.refreshInterval = config.getPollingInterval();
-            this.connection = new FritzahaWebInterface(config, this);
+            this.connection = new FritzahaWebInterface(config, this, httpClient);
             if (config.getPassword() != null) {
                 this.onUpdate();
             } else {
@@ -148,8 +155,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
     }
 
     /**
-     * Handle the commands for switchable outlets or heating thermostats. TODO:
-     * test switch behaviour on PL546E stand-alone
+     * Handle the commands for switchable outlets or heating thermostats.
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
@@ -223,15 +229,15 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                         updateState(CHANNEL_SETTEMP,
                                 new DecimalType(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_OFF)));
                     } else if (MODE_COMFORT.equals(commandString)) {
-                        BigDecimal comfort_temp = state.getHkr().getKomfort();
-                        state.getHkr().setTsoll(comfort_temp);
-                        fritzBox.setSetTemp(ain, comfort_temp);
-                        updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(comfort_temp)));
+                        BigDecimal comfortTemperature = state.getHkr().getKomfort();
+                        state.getHkr().setTsoll(comfortTemperature);
+                        fritzBox.setSetTemp(ain, comfortTemperature);
+                        updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(comfortTemperature)));
                     } else if (MODE_ECO.equals(commandString)) {
-                        BigDecimal eco_temp = state.getHkr().getAbsenk();
-                        state.getHkr().setTsoll(eco_temp);
-                        fritzBox.setSetTemp(ain, eco_temp);
-                        updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(eco_temp)));
+                        BigDecimal ecoTemperature = state.getHkr().getAbsenk();
+                        state.getHkr().setTsoll(ecoTemperature);
+                        fritzBox.setSetTemp(ain, ecoTemperature);
+                        updateState(CHANNEL_SETTEMP, new DecimalType(HeatingModel.toCelsius(ecoTemperature)));
                     } else if (MODE_BOOST.equals(commandString)) {
                         state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_MAX);
                         fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_MAX);
@@ -344,9 +350,10 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
                     if (device.getHkr().getNextchange().getEndperiod() == 0) {
                         updateThingChannelState(thing, CHANNEL_NEXTCHANGE, UnDefType.UNDEF);
                     } else {
-                        final Calendar calendar = Calendar.getInstance();
-                        calendar.setTime(new Date(device.getHkr().getNextchange().getEndperiod() * 1000L));
-                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE, new DateTimeType(calendar));
+                        updateThingChannelState(thing, CHANNEL_NEXTCHANGE,
+                                new DateTimeType(ZonedDateTime.ofInstant(
+                                        Instant.ofEpochMilli(device.getHkr().getNextchange().getEndperiod()),
+                                        ZoneId.systemDefault())));
                     }
                     if (HeatingModel.TEMP_FRITZ_UNDEFINED.equals(device.getHkr().getNextchange().getTchange())) {
                         updateThingChannelState(thing, CHANNEL_NEXTTEMP, UnDefType.UNDEF);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/DeviceHandler.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -92,7 +93,7 @@ public class DeviceHandler extends BaseThingHandler implements IFritzHandler {
      *
      * @param thing Thing object representing a FRITZ! device
      */
-    public DeviceHandler(Thing thing, HttpClient httpClient) {
+    public DeviceHandler(@NonNull Thing thing, HttpClient httpClient) {
         super(thing);
         this.httpClient = httpClient;
     }


### PR DESCRIPTION
- Switched to shared instance of `HttpClient` using `HttpClientFactory`
- Removed deprecated usage of the constructor `DateTimeType(Calendar)`
- Minor code cleanups to fix sat findings

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>