### PR TITLE
[lgwebos] Store deviceId in Thing Configuration instead of deriving it from ThingID

### DIFF
--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/binding/binding.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="lgwebos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+<binding:binding id="lgwebos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
 	<name>LG webOS Binding</name>
 	<description>Binding to connect LG's WebOS based smart TVs based on Connect SDK</description>
 	<author>Sebastian Prehn</author>
-	
+
 	<config-description>
 		<parameter name="localIP" type="text">
 			<label>Local IP</label>

--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/config/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+		http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:lgwebos:WebOSTV">
+		<parameter name="deviceId" type="text" required="true">
+            <label>Device ID</label>
+        </parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/config/config.xml
@@ -6,8 +6,8 @@
 
 	<config-description uri="thing-type:lgwebos:WebOSTV">
 		<parameter name="deviceId" type="text" required="true">
-            <label>Device ID</label>
-        </parameter>
+			<label>Device ID</label>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
@@ -17,8 +17,11 @@
 			<channel id="mediaPlayer" typeId="mediaPlayerType" />
 			<channel id="mediaStop" typeId="mediaStopType" />
 			<channel id="appLauncher" typeId="appLauncherChannelType" />
-
 		</channels>
+
+        <representation-property>deviceId</representation-property>
+        
+		<config-description-ref uri="thing-type:lgwebos:WebOSTV" />
 	</thing-type>
 
 	<channel-type id="powerType">

--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="lgwebos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="lgwebos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -19,8 +20,8 @@
 			<channel id="appLauncher" typeId="appLauncherChannelType" />
 		</channels>
 
-        <representation-property>deviceId</representation-property>
-        
+		<representation-property>deviceId</representation-property>
+
 		<config-description-ref uri="thing-type:lgwebos:WebOSTV" />
 	</thing-type>
 

--- a/addons/binding/org.openhab.binding.lgwebos/README.md
+++ b/addons/binding/org.openhab.binding.lgwebos/README.md
@@ -53,8 +53,18 @@ Please note that at least one channel must be bound to an item before the bindin
 
 ## Example
 
-This example assumes your TV has ThingID lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46. 
-You can find it in the discovery results in Paper UI.
+Assuming your TV has device ID 3aab9eea-953b-4272-bdbd-f0cd0ecf4a46. 
+By default this binding will create ThingIDs for discovery results with prefix lgwebos:WebOSTV: and the device ID. e.g. lgwebos:WebOSTV:3aab9eea-953b-4272-bdbd-f0cd0ecf4a46.
+Thus, you can find your TV's device ID by looking into discovery results in Paper UI.
+
+You could also specify an alternate ThingID using a .things file, specifying the deviceId as a mandatory configuration parameter:
+
+```
+Thing lgwebos:WebOSTV:tv1 [ deviceId="3aab9eea-953b-4272-bdbd-f0cd0ecf4a46" ]
+```
+
+However, for the next steps of this example we will assumes you are using automatic discovery and the default ThingID.
+
 
 demo.items:
 

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
@@ -28,6 +28,8 @@ public class LGWebOSBindingConstants {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WEBOSTV);
 
+    public static final String PROPERTY_DEVICE_ID = "deviceId";
+
     // List of all Channel ids. Values have to match ids in thing-types.xml
     public static final String CHANNEL_VOLUME = "volume";
     public static final String CHANNEL_POWER = "power";

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -101,6 +102,15 @@ public class LGWebOSHandler extends BaseThingHandler implements ConnectableDevic
 
     @Override
     public void initialize() {
+        if (!getConfig().containsKey(PROPERTY_DEVICE_ID)) {
+            logger.debug(
+                    "Migrating to new Thing configuration. Setting deviceID property based on ThingID {}. This is only required once, when upgrading existing LG WebOS things to binding version to 2.2.",
+                    getThing().getUID().getId());
+            Configuration config = editConfiguration();
+            config.put(PROPERTY_DEVICE_ID, getThing().getUID().getId());
+            updateConfiguration(config);
+        }
+
         discoveryManager.addListener(this);
 
         Optional<ConnectableDevice> device = getDevice();
@@ -230,7 +240,7 @@ public class LGWebOSHandler extends BaseThingHandler implements ConnectableDevic
     }
 
     private String getDeviceId() {
-        return getThing().getUID().getId();
+        return getConfig().get(PROPERTY_DEVICE_ID).toString();
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
@@ -104,7 +104,7 @@ public class LGWebOSHandler extends BaseThingHandler implements ConnectableDevic
     public void initialize() {
         if (!getConfig().containsKey(PROPERTY_DEVICE_ID)) {
             logger.debug(
-                    "Migrating to new Thing configuration. Setting deviceID property based on ThingID {}. This is only required once, when upgrading existing LG WebOS things to binding version to 2.2.",
+                    "Migrating to new Thing configuration. Setting deviceID property based on ThingID {}. This is only required once, when upgrading existing LG WebOS things to binding version to 2.3.",
                     getThing().getUID().getId());
             Configuration config = editConfiguration();
             config.put(PROPERTY_DEVICE_ID, getThing().getUID().getId());

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/handler/LGWebOSHandler.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -102,15 +101,6 @@ public class LGWebOSHandler extends BaseThingHandler implements ConnectableDevic
 
     @Override
     public void initialize() {
-        if (!getConfig().containsKey(PROPERTY_DEVICE_ID)) {
-            logger.debug(
-                    "Migrating to new Thing configuration. Setting deviceID property based on ThingID {}. This is only required once, when upgrading existing LG WebOS things to binding version to 2.3.",
-                    getThing().getUID().getId());
-            Configuration config = editConfiguration();
-            config.put(PROPERTY_DEVICE_ID, getThing().getUID().getId());
-            updateConfiguration(config);
-        }
-
         discoveryManager.addListener(this);
 
         Optional<ConnectableDevice> device = getDevice();

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
@@ -41,7 +41,7 @@ public class LGWebOSHandlerFactory extends BaseThingHandlerFactory {
     }
 
     protected void unbindDiscovery(LGWebOSDiscovery discovery) {
-        discovery = null;
+        this.discovery = null;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -8,11 +8,12 @@
  */
 package org.openhab.binding.lgwebos.internal.discovery;
 
-import static org.openhab.binding.lgwebos.LGWebOSBindingConstants.THING_TYPE_WEBOSTV;
+import static org.openhab.binding.lgwebos.LGWebOSBindingConstants.*;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -135,7 +136,11 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
     // Helpers for DiscoveryManagerListener Impl
     private DiscoveryResult createDiscoveryResult(ConnectableDevice device) {
         ThingUID thingUID = createThingUID(device);
-        return DiscoveryResultBuilder.create(thingUID).withLabel(device.getFriendlyName()).build();
+        Map<String, Object> properties = new HashMap<>(1);
+        properties.put(PROPERTY_DEVICE_ID, device.getId());
+
+        return DiscoveryResultBuilder.create(thingUID).withLabel(device.getFriendlyName()).withProperties(properties)
+                .withRepresentationProperty(PROPERTY_DEVICE_ID).build();
     }
 
     private ThingUID createThingUID(ConnectableDevice device) {

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -13,7 +13,6 @@ import static org.openhab.binding.lgwebos.LGWebOSBindingConstants.*;
 import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -136,11 +135,9 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
     // Helpers for DiscoveryManagerListener Impl
     private DiscoveryResult createDiscoveryResult(ConnectableDevice device) {
         ThingUID thingUID = createThingUID(device);
-        Map<String, Object> properties = new HashMap<>(1);
-        properties.put(PROPERTY_DEVICE_ID, device.getId());
-
-        return DiscoveryResultBuilder.create(thingUID).withLabel(device.getFriendlyName()).withProperties(properties)
-                .withRepresentationProperty(PROPERTY_DEVICE_ID).build();
+        return DiscoveryResultBuilder.create(thingUID).withLabel(device.getFriendlyName())
+                .withProperty(PROPERTY_DEVICE_ID, device.getId()).withRepresentationProperty(PROPERTY_DEVICE_ID)
+                .build();
     }
 
     private ThingUID createThingUID(ConnectableDevice device) {

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -206,7 +206,6 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
             logger.warn("Configured primary IP cannot be parsed: {} Details: {}", ipAddress, e.getMessage());
             return Optional.empty();
         }
-
     }
 
 }


### PR DESCRIPTION
This allows users to choose their own ThingIDs if they wish.
This addresses issue #3403 
