### PR TITLE
[KNX2] Add Color Channel

### DIFF
--- a/addons/binding/org.openhab.binding.knx/ESH-INF/config/channelConfig.xml
+++ b/addons/binding/org.openhab.binding.knx/ESH-INF/config/channelConfig.xml
@@ -2,99 +2,99 @@
 <config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
-        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+		http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
-    <!-- Dimmer -->
-    <config-description uri="channel-type:knx:dimmer">
-        <parameter name="switch" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="position" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="increaseDecrease" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
-            <required>false</required>
-        </parameter>
-    </config-description>
-    <config-description uri="channel-type:knx:dimmer-control">
-        <parameter name="switch" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="position" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="increaseDecrease" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="frequency" type="integer">
-            <label>Frequency</label>
-            <description>Increase/decrease send frequency if dimming should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
-            <default>0</default>
-        </parameter>
-    </config-description>
-    
-    <!-- Color -->
-    <config-description uri="channel-type:knx:color">
-        <parameter name="hsb" type="text">
-            <label>Color value</label>
-            <description>The group address(es) in Group Address Notation for the color value</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="switch" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to toggle the color on or off</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="position" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="increaseDecrease" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to increase or decrease the color</description>
-            <required>false</required>
-        </parameter>
-    </config-description>
-    <config-description uri="channel-type:knx:color-control">
-        <parameter name="hsb" type="text">
-            <label>Color value</label>
-            <description>The group address(es) in Group Address Notation for the color value</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="switch" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to toggle the color on or off</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="position" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="increaseDecrease" type="text">
-            <label>Address</label>
-            <description>The group address(es) in Group Address Notation to increase or decrease the color</description>
-            <required>false</required>
-        </parameter>
-        <parameter name="frequency" type="integer">
-            <label>Frequency</label>
-            <description>Increase/decrease send frequency if color should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
-            <default>0</default>
-        </parameter>
-    </config-description>
+	<!-- Dimmer -->
+	<config-description uri="channel-type:knx:dimmer">
+		<parameter name="switch" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="position" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="increaseDecrease" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
+			<required>false</required>
+		</parameter>
+	</config-description>
+	<config-description uri="channel-type:knx:dimmer-control">
+		<parameter name="switch" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="position" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="increaseDecrease" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="frequency" type="integer">
+			<label>Frequency</label>
+			<description>Increase/decrease send frequency if dimming should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
+			<default>0</default>
+		</parameter>
+	</config-description>
+	
+	<!-- Color -->
+	<config-description uri="channel-type:knx:color">
+		<parameter name="hsb" type="text">
+			<label>Color value</label>
+			<description>The group address(es) in Group Address Notation for the color value</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="switch" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to toggle the color on or off</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="position" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="increaseDecrease" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to increase or decrease the color</description>
+			<required>false</required>
+		</parameter>
+	</config-description>
+	<config-description uri="channel-type:knx:color-control">
+		<parameter name="hsb" type="text">
+			<label>Color value</label>
+			<description>The group address(es) in Group Address Notation for the color value</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="switch" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to toggle the color on or off</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="position" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="increaseDecrease" type="text">
+			<label>Address</label>
+			<description>The group address(es) in Group Address Notation to increase or decrease the color</description>
+			<required>false</required>
+		</parameter>
+		<parameter name="frequency" type="integer">
+			<label>Frequency</label>
+			<description>Increase/decrease send frequency if color should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
+			<default>0</default>
+		</parameter>
+	</config-description>
 
 	<!-- Rollershutter -->
 	<config-description uri="channel-type:knx:rollershutter">

--- a/addons/binding/org.openhab.binding.knx/ESH-INF/config/channelConfig.xml
+++ b/addons/binding/org.openhab.binding.knx/ESH-INF/config/channelConfig.xml
@@ -4,46 +4,97 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
         http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
-	<!-- Dimmer -->
-	<config-description uri="channel-type:knx:dimmer">
-		<parameter name="switch" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
-			<required>false</required>
-		</parameter>
-		<parameter name="position" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
-			<required>false</required>
-		</parameter>
-		<parameter name="increaseDecrease" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
-			<required>false</required>
-		</parameter>
-	</config-description>
-	<config-description uri="channel-type:knx:dimmer-control">
-		<parameter name="switch" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
-			<required>false</required>
-		</parameter>
-		<parameter name="position" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
-			<required>false</required>
-		</parameter>
-		<parameter name="increaseDecrease" type="text">
-			<label>Address</label>
-			<description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
-			<required>false</required>
-		</parameter>
-		<parameter name="frequency" type="integer">
-			<label>Frequency</label>
-			<description>Increase/decrease send frequency if dimming should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
-			<default>0</default>
-		</parameter>
-	</config-description>
+    <!-- Dimmer -->
+    <config-description uri="channel-type:knx:dimmer">
+        <parameter name="switch" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="position" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="increaseDecrease" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
+            <required>false</required>
+        </parameter>
+    </config-description>
+    <config-description uri="channel-type:knx:dimmer-control">
+        <parameter name="switch" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to toggle the dimmer on or off</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="position" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to set the absolute position of the dimmer</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="increaseDecrease" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to increase or decrease the dimmer</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="frequency" type="integer">
+            <label>Frequency</label>
+            <description>Increase/decrease send frequency if dimming should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
+            <default>0</default>
+        </parameter>
+    </config-description>
+    
+    <!-- Color -->
+    <config-description uri="channel-type:knx:color">
+        <parameter name="hsb" type="text">
+            <label>Color value</label>
+            <description>The group address(es) in Group Address Notation for the color value</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="switch" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to toggle the color on or off</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="position" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="increaseDecrease" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to increase or decrease the color</description>
+            <required>false</required>
+        </parameter>
+    </config-description>
+    <config-description uri="channel-type:knx:color-control">
+        <parameter name="hsb" type="text">
+            <label>Color value</label>
+            <description>The group address(es) in Group Address Notation for the color value</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="switch" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to toggle the color on or off</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="position" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to set the absolute position of the color</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="increaseDecrease" type="text">
+            <label>Address</label>
+            <description>The group address(es) in Group Address Notation to increase or decrease the color</description>
+            <required>false</required>
+        </parameter>
+        <parameter name="frequency" type="integer">
+            <label>Frequency</label>
+            <description>Increase/decrease send frequency if color should be handled by the binding (in ms) - set to 0 if the KNX device sends them repeatedly itself</description>
+            <default>0</default>
+        </parameter>
+    </config-description>
 
 	<!-- Rollershutter -->
 	<config-description uri="channel-type:knx:rollershutter">

--- a/addons/binding/org.openhab.binding.knx/ESH-INF/thing/device.xml
+++ b/addons/binding/org.openhab.binding.knx/ESH-INF/thing/device.xml
@@ -78,19 +78,19 @@
 		<config-description-ref uri="channel-type:knx:rollershutter" />
 	</channel-type>
 
-    <!-- Color -->
-    <channel-type id="color">
-        <item-type>Color</item-type>
-        <label>Color</label>
-        <description>A channel to control color information (RGB)</description>
-        <config-description-ref uri="channel-type:knx:color" />
-    </channel-type>
-    <channel-type id="color-control">
-        <item-type>Color</item-type>
-        <label>Color Control</label>
-        <description>Control a color item (i.e. the status is not owned by KNX)</description>
-        <config-description-ref uri="channel-type:knx:color-control" />
-    </channel-type>
+	<!-- Color -->
+	<channel-type id="color">
+		<item-type>Color</item-type>
+		<label>Color</label>
+		<description>A channel to control color information (RGB)</description>
+		<config-description-ref uri="channel-type:knx:color" />
+	</channel-type>
+	<channel-type id="color-control">
+		<item-type>Color</item-type>
+		<label>Color Control</label>
+		<description>Control a color item (i.e. the status is not owned by KNX)</description>
+		<config-description-ref uri="channel-type:knx:color-control" />
+	</channel-type>
 
 	<!-- Contact -->
 	<channel-type id="contact">

--- a/addons/binding/org.openhab.binding.knx/ESH-INF/thing/device.xml
+++ b/addons/binding/org.openhab.binding.knx/ESH-INF/thing/device.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="device"
-		extensible="switch, switch-control, dimmer, dimmer-control, rollershutter, rollershutter-control, contact, contact-control, number, number-control, string, string-control, datetime, datetime-control">
+		extensible="switch, switch-control, dimmer, dimmer-control, rollershutter, rollershutter-control, color, color-control, contact, contact-control, number, number-control, string, string-control, datetime, datetime-control">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ip" />
 			<bridge-type-ref id="serial" />
@@ -77,6 +77,20 @@
 		<description>Control a rollershutter item (i.e. the status is not owned by KNX)</description>
 		<config-description-ref uri="channel-type:knx:rollershutter" />
 	</channel-type>
+
+    <!-- Color -->
+    <channel-type id="color">
+        <item-type>Color</item-type>
+        <label>Color</label>
+        <description>A channel to control color information (RGB)</description>
+        <config-description-ref uri="channel-type:knx:color" />
+    </channel-type>
+    <channel-type id="color-control">
+        <item-type>Color</item-type>
+        <label>Color Control</label>
+        <description>Control a color item (i.e. the status is not owned by KNX)</description>
+        <config-description-ref uri="channel-type:knx:color-control" />
+    </channel-type>
 
 	<!-- Contact -->
 	<channel-type id="contact">

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/KNXBindingConstants.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/KNXBindingConstants.java
@@ -61,12 +61,8 @@ public class KNXBindingConstants {
     public static final String CHANNEL_DATETIME_CONTROL = "datetime-control";
     public static final String CHANNEL_DIMMER = "dimmer";
     public static final String CHANNEL_DIMMER_CONTROL = "dimmer-control";
-    // public static final String CHANNEL_LOCATION = "location";
-    // public static final String CHANNEL_LOCATION_CONTROL = "location-control";
     public static final String CHANNEL_NUMBER = "number";
     public static final String CHANNEL_NUMBER_CONTROL = "number-control";
-    // public static final String CHANNEL_PLAYER = "player";
-    // public static final String CHANNEL_PLAYER_CONTROL = "player-control";
     public static final String CHANNEL_ROLLERSHUTTER = "rollershutter";
     public static final String CHANNEL_ROLLERSHUTTER_CONTROL = "rollershutter-control";
     public static final String CHANNEL_STRING = "string";
@@ -78,9 +74,7 @@ public class KNXBindingConstants {
             CHANNEL_CONTACT_CONTROL, //
             CHANNEL_DATETIME_CONTROL, //
             CHANNEL_DIMMER_CONTROL, //
-            // CHANNEL_LOCATION_CONTROL, //
             CHANNEL_NUMBER_CONTROL, //
-            // CHANNEL_PLAYER_CONTROL, //
             CHANNEL_ROLLERSHUTTER_CONTROL, //
             CHANNEL_STRING_CONTROL, //
             CHANNEL_SWITCH_CONTROL //

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/KNXBindingConstants.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/KNXBindingConstants.java
@@ -53,14 +53,20 @@ public class KNXBindingConstants {
     public static final String DEFAULT_MULTICAST_IP = "224.0.23.12";
 
     // Channel Type IDs
+    public static final String CHANNEL_COLOR = "color";
+    public static final String CHANNEL_COLOR_CONTROL = "color-control";
     public static final String CHANNEL_CONTACT = "contact";
     public static final String CHANNEL_CONTACT_CONTROL = "contact-control";
     public static final String CHANNEL_DATETIME = "datetime";
     public static final String CHANNEL_DATETIME_CONTROL = "datetime-control";
     public static final String CHANNEL_DIMMER = "dimmer";
     public static final String CHANNEL_DIMMER_CONTROL = "dimmer-control";
+    // public static final String CHANNEL_LOCATION = "location";
+    // public static final String CHANNEL_LOCATION_CONTROL = "location-control";
     public static final String CHANNEL_NUMBER = "number";
     public static final String CHANNEL_NUMBER_CONTROL = "number-control";
+    // public static final String CHANNEL_PLAYER = "player";
+    // public static final String CHANNEL_PLAYER_CONTROL = "player-control";
     public static final String CHANNEL_ROLLERSHUTTER = "rollershutter";
     public static final String CHANNEL_ROLLERSHUTTER_CONTROL = "rollershutter-control";
     public static final String CHANNEL_STRING = "string";
@@ -68,25 +74,28 @@ public class KNXBindingConstants {
     public static final String CHANNEL_SWITCH = "switch";
     public static final String CHANNEL_SWITCH_CONTROL = "switch-control";
 
-    public static final Set<String> CONTROL_CHANNEL_TYPES = Collections
-            .unmodifiableSet(Stream.of(CHANNEL_CONTACT_CONTROL, //
-                    CHANNEL_DATETIME_CONTROL, //
-                    CHANNEL_DIMMER_CONTROL, //
-                    CHANNEL_NUMBER_CONTROL, //
-                    CHANNEL_ROLLERSHUTTER_CONTROL, //
-                    CHANNEL_STRING_CONTROL, //
-                    CHANNEL_SWITCH_CONTROL //
+    public static final Set<String> CONTROL_CHANNEL_TYPES = Collections.unmodifiableSet(Stream.of(CHANNEL_COLOR_CONTROL, //
+            CHANNEL_CONTACT_CONTROL, //
+            CHANNEL_DATETIME_CONTROL, //
+            CHANNEL_DIMMER_CONTROL, //
+            // CHANNEL_LOCATION_CONTROL, //
+            CHANNEL_NUMBER_CONTROL, //
+            // CHANNEL_PLAYER_CONTROL, //
+            CHANNEL_ROLLERSHUTTER_CONTROL, //
+            CHANNEL_STRING_CONTROL, //
+            CHANNEL_SWITCH_CONTROL //
     ).collect(toSet()));
 
     public static final String CHANNEL_RESET = "reset";
 
     // Channel Configuration parameters
     public static final String GA = "ga";
+    public static final String HSB_GA = "hsb";
     public static final String INCREASE_DECREASE_GA = "increaseDecrease";
     public static final String POSITION_GA = "position";
+    public static final String REPEAT_FREQUENCY = "frequency";
     public static final String STOP_MOVE_GA = "stopMove";
     public static final String SWITCH_GA = "switch";
     public static final String UP_DOWN_GA = "upDown";
-    public static final String REPEAT_FREQUENCY = "frequency";
 
 }

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelTypes.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelTypes.java
@@ -29,10 +29,13 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 public final class KNXChannelTypes {
 
     private static final Set<KNXChannelType> TYPES = Collections.unmodifiableSet(Stream.of(//
+            new TypeColor(), //
             new TypeContact(), //
             new TypeDateTime(), //
             new TypeDimmer(), //
+            // new TypeLocation(), //
             new TypeNumber(), //
+            // new TypePlayer(), //
             new TypeRollershutter(), //
             new TypeString(), //
             new TypeSwitch() //

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelTypes.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelTypes.java
@@ -33,9 +33,7 @@ public final class KNXChannelTypes {
             new TypeContact(), //
             new TypeDateTime(), //
             new TypeDimmer(), //
-            // new TypeLocation(), //
             new TypeNumber(), //
-            // new TypePlayer(), //
             new TypeRollershutter(), //
             new TypeString(), //
             new TypeSwitch() //

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/TypeColor.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/TypeColor.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.knx.internal.channel;
+
+import static java.util.stream.Collectors.toSet;
+import static org.openhab.binding.knx.KNXBindingConstants.*;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import tuwien.auto.calimero.dptxlator.DPTXlator3BitControlled;
+import tuwien.auto.calimero.dptxlator.DPTXlator8BitUnsigned;
+import tuwien.auto.calimero.dptxlator.DPTXlatorBoolean;
+import tuwien.auto.calimero.dptxlator.DPTXlatorRGB;
+
+/**
+ * color channel type description
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ * @author Helmut Lehmeyer
+ *
+ */
+@NonNullByDefault
+class TypeColor extends KNXChannelType {
+
+    TypeColor() {
+        super(CHANNEL_COLOR, CHANNEL_COLOR_CONTROL);
+    }
+
+    @Override
+    protected Set<String> getAllGAKeys() {
+        return Stream.of(SWITCH_GA, POSITION_GA, INCREASE_DECREASE_GA, HSB_GA).collect(toSet());
+    }
+
+    @Override
+    protected String getDefaultDPT(String gaConfigKey) {
+        if (Objects.equals(gaConfigKey, HSB_GA)) {
+            return DPTXlatorRGB.DPT_RGB.getID();
+        }
+        if (Objects.equals(gaConfigKey, INCREASE_DECREASE_GA)) {
+            return DPTXlator3BitControlled.DPT_CONTROL_DIMMING.getID();
+        }
+        if (Objects.equals(gaConfigKey, SWITCH_GA)) {
+            return DPTXlatorBoolean.DPT_SWITCH.getID();
+        }
+        if (Objects.equals(gaConfigKey, POSITION_GA)) {
+            return DPTXlator8BitUnsigned.DPT_SCALING.getID();
+        }
+        throw new IllegalArgumentException("GA configuration '" + gaConfigKey + "' is not supported");
+    }
+}

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/TypeColor.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/TypeColor.java
@@ -11,7 +11,6 @@ package org.openhab.binding.knx.internal.channel;
 import static java.util.stream.Collectors.toSet;
 import static org.openhab.binding.knx.KNXBindingConstants.*;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -25,8 +24,7 @@ import tuwien.auto.calimero.dptxlator.DPTXlatorRGB;
 /**
  * color channel type description
  *
- * @author Simon Kaufmann - initial contribution and API.
- * @author Helmut Lehmeyer
+ * @author Helmut Lehmeyer - initial contribution
  *
  */
 @NonNullByDefault
@@ -43,16 +41,16 @@ class TypeColor extends KNXChannelType {
 
     @Override
     protected String getDefaultDPT(String gaConfigKey) {
-        if (Objects.equals(gaConfigKey, HSB_GA)) {
+        if (gaConfigKey.equals(HSB_GA)) {
             return DPTXlatorRGB.DPT_RGB.getID();
         }
-        if (Objects.equals(gaConfigKey, INCREASE_DECREASE_GA)) {
+        if (gaConfigKey.equals(INCREASE_DECREASE_GA)) {
             return DPTXlator3BitControlled.DPT_CONTROL_DIMMING.getID();
         }
-        if (Objects.equals(gaConfigKey, SWITCH_GA)) {
+        if (gaConfigKey.equals(SWITCH_GA)) {
             return DPTXlatorBoolean.DPT_SWITCH.getID();
         }
-        if (Objects.equals(gaConfigKey, POSITION_GA)) {
+        if (gaConfigKey.equals(POSITION_GA)) {
             return DPTXlator8BitUnsigned.DPT_SCALING.getID();
         }
         throw new IllegalArgumentException("GA configuration '" + gaConfigKey + "' is not supported");


### PR DESCRIPTION
Signed-off-by: lewie <helmut.lehmeyer@gmail.com>

[KNX2] Add Color Channel


Adds the ability for Color (control) to KNX2.
Use PaperUI or Things file like:

```
Type color : demoColor "Demo Color" [ hsb="232.600:<7/0/25", switch="1.001:<7/0/26", position="5.001:<7/0/27", increaseDecrease="3.007:<7/0/28" ]
Type color : demoColorControl "Demo Color Control" [ hsb="232.600:<7/0/25", switch="1.001:<7/0/26", position="5.001:<7/0/27", increaseDecrease="3.007:<7/0/28" ]
```
Fixes issue: #3411 

