### PR TITLE
Fixed oauth redirect URLs

### DIFF
--- a/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/InnogyBindingConstants.java
+++ b/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/InnogyBindingConstants.java
@@ -40,9 +40,9 @@ public class InnogyBindingConstants {
     public static final String CLIENT_SECRET_SMARTHOME_AUSTRIA = "no secret";
     public static final String CLIENT_SECRET_START_SMARTHOME = "no secret";
 
-    public static final String REDIRECT_URL_INNOGY_SMARTHOME = "https://www.openhab.org/oauth/innogy-smarthome/";
-    public static final String REDIRECT_URL_SMARTHOME_AUSTRIA = "https://www.openhab.org/oauth/smarthome-austria/";
-    public static final String REDIRECT_URL_START_SMARTHOME = "https://www.openhab.org/oauth/start-smarthome/";
+    public static final String REDIRECT_URL_INNOGY_SMARTHOME = "https://www.openhab.org/oauth/innogy/innogy-smarthome.html";
+    public static final String REDIRECT_URL_SMARTHOME_AUSTRIA = "https://www.openhab.org/oauth/innogy/smarthome-austria.html";
+    public static final String REDIRECT_URL_START_SMARTHOME = "https://www.openhab.org/oauth/innogy/start-smarthome.html";
 
     // Bridge config parameters
     public static final String CONFIG_BRAND = "brand";


### PR DESCRIPTION
Signed-off-by: Oliver Kuhl oliver.kuhl@gmail.com (github: ollie-dev)

Fixed the new innogy oauth redirect URLs. 

Important to mention: today there are still the old URLs active on the innogy backend, so that creating the auth code fails until the new ones are activated. I expect this to happen in the next days.