### PR TITLE
Pioneer AVRs in [onkyo] binding

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channel-groups.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channel-groups.xml
@@ -11,6 +11,7 @@
 			<channel id="power" typeId="power" />
 			<channel id="input" typeId="input" />
 			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
 			<channel id="mute" typeId="mute" />
 		</channels>
 	</channel-group-type>
@@ -21,6 +22,7 @@
 			<channel id="power" typeId="power" />
 			<channel id="input" typeId="input" />
 			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
 			<channel id="mute" typeId="mute" />
 		</channels>
 	</channel-group-type>
@@ -31,6 +33,7 @@
 			<channel id="power" typeId="power" />
 			<channel id="input" typeId="input" />
 			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
 			<channel id="mute" typeId="mute" />
 		</channels>
 	</channel-group-type>

--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/channels.xml
@@ -57,6 +57,13 @@
 		<state min="0" max="100" step="1" pattern="%d %%">
 		</state>
 	</channel-type>
+	<channel-type id="volumedb">
+		<item-type>Number</item-type>
+		<label>Volume</label>
+		<description>Volume of your device (dB)</description>
+		<state min="-82" max="0" step="0.5" pattern="%.1f dB">
+		</state>
+	</channel-type>
 	<channel-type id="control" advanced="true">
 		<item-type>Player</item-type>
 		<label>Control</label>

--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/vsx-1131.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/thing/vsx-1131.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="onkyo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="VSX-1131">
+		<label>Pioneer VSX-1131 AV Receiver</label>
+		<description>Network enabled Pioneer AV Receivers</description>
+
+		<channel-groups>
+			<channel-group typeId="zone1Controls" id="zone1" />
+			<channel-group typeId="zone2Controls" id="zone2" />
+			<channel-group typeId="playerControls" id="player" />
+			<channel-group typeId="netMenuControls" id="netmenu" />
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:onkyo:config" />
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -34,6 +34,10 @@ This binding can discover the supported Onkyo AV Receivers. At the moment only t
 -   TX-NR828
 -   TX-NR838
 
+This binding also discover the supported newer Pioneer AV Reveicers (since 2015)
+
+-   VSX-1131
+
 ## Binding Configuration
 
 The binding can auto-discover the Onkyo AVRs present on your local network.
@@ -99,14 +103,17 @@ The Onkyo AVR supports the following channels (some channels are model specific)
 | zone1#mute                | Switch    | Mute/unmute zone 1                                                                                               |
 | zone1#input               | Number    | The input for zone 1                                                                                             |
 | zone1#volume              | Dimmer    | Volume of zone 1                                                                                                 |
+| zone1#volumedb            | Number    | Volume (dB) of zone 1                                                                                            |
 | zone2#power               | Switch    | Power on/off zone 2                                                                                              |
 | zone2#mute                | Switch    | Mute/unmute zone 2                                                                                               |
 | zone2#input               | Number    | The input for zone 2                                                                                             |
 | zone2#volume              | Dimmer    | Volume of zone 2                                                                                                 |
+| zone2#volumedb            | Number    | Volume (dB) of zone 2                                                                                            |
 | zone3#power               | Switch    | Power on/off zone 3                                                                                              |
 | zone3#mute                | Switch    | Mute/unmute zone 3                                                                                               |
 | zone3#input               | Number    | The input for zone 3                                                                                             |
 | zone3#volume              | Dimmer    | Volume of zone 3                                                                                                 |
+| zone3#volumedb            | Number    | Volume (dB) of zone 3                                                                                            |
 | player#control            | Player    | Control the Zone Player, e.g.  play/pause/next/previous/ffward/rewind (available if playing from Network or USB) |
 | player#title              | String    | Title of the current song (available if playing from Network or USB)                                             |
 | player#album              | String    | Album name of the current song (available if playing from Network or USB)                                        |
@@ -162,15 +169,17 @@ Here after are the ID values of the input sources:
 demo.items
 
 ```java
-Switch avrLrZ1_Power  "Power"       <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone1#power" }
-Switch avrLrZ1_Mute   "Mute"        <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#mute" }
-Number avrLrZ1_Input  "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone1#input" }
-Dimmer avrLrZ1_Volume "Volume [%d]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#volume" }
+Switch avrLrZ1_Power    "Power"       <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone1#power" }
+Switch avrLrZ1_Mute     "Mute"        <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#mute" }
+Number avrLrZ1_Input    "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone1#input" }
+Dimmer avrLrZ1_Volume   "Volume [%d]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#volume" }
+Number avrLrZ1_Volumedb "Volume [%.1f] dB]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#volumedb" }
 
-Switch avrLrZ2_Power  "Power [%s]"  <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone2#power" }
-Switch avrLrZ2_Mute   "Mute [%s]"                 { channel="onkyo:onkyoAVR:avr-livingroom:zone2#mute" }
-Number avrLrZ2_Input  "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone2#input" }
-Dimmer avrLrZ2_Volume "Volume [%s]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone2#volume" }
+Switch avrLrZ2_Power    "Power [%s]"  <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone2#power" }
+Switch avrLrZ2_Mute     "Mute [%s]"                 { channel="onkyo:onkyoAVR:avr-livingroom:zone2#mute" }
+Number avrLrZ2_Input    "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone2#input" }
+Dimmer avrLrZ2_Volume   "Volume [%s]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone2#volume" }
+Number avrLrZ2_Volumedb "Volume [%.1f] dB]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone2#volumedb" }
 
 Player avrLrPlayer_Control            "Control"                 <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#control" }
 String avrLrPlayer_Title              "Title [%s]"              <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#title" }
@@ -209,6 +218,7 @@ sitemap demo label="Onkyo AVR"
         Switch    item=avrLrZ1_Mute
         Selection item=avrLrZ1_Input  mappings=[ 0='DVR/VCR', 1='SATELLITE/CABLE', 2='GAME', 3='AUX', 4='GAME', 5='PC', 16='BLURAY/DVD', 32='TAPE1', 33='TAPE2', 34='PHONO', 35='CD', 36='FM', 37='AM', 38='TUNER', 39='MUSICSERVER', 40='INTERNETRADIO', 41='USB', 42='USB_BACK', 43='NETWORK', 45='AIRPLAY', 48='MULTICH', 50='SIRIUS' ]
         Slider    item=avrLrZ1_Volume
+		Setpoint  item=avrLrZ1_Volumedb label="Volume [%.1f dB]" minValue=-82 maxValue=0 step=0.5
     }
 
     Frame label="Zone 2" {
@@ -216,6 +226,7 @@ sitemap demo label="Onkyo AVR"
         Switch    item=avrLrZ2_Mute
         Selection item=avrLrZ2_Input  mappings=[ 0='DVR/VCR', 1='SATELLITE/CABLE', 2='GAME', 3='AUX', 4='GAME', 5='PC', 16='BLURAY/DVD', 32='TAPE1', 33='TAPE2', 34='PHONO', 35='CD', 36='FM', 37='AM', 38='TUNER', 39='MUSICSERVER', 40='INTERNETRADIO', 41='USB', 42='USB_BACK', 43='NETWORK', 45='AIRPLAY', 48='MULTICH', 50='SIRIUS' ]
         Slider    item=avrLrZ2_Volume
+		Setpoint  item=avrLrZ2_Volumedb label="Volume [%.1f dB]" minValue=-82 maxValue=0 step=0.5
     }
 
     Frame label="Player" {

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/OnkyoBindingConstants.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Paul Frank - Initial contribution
  * @author Pauli Anttila
+ * @author Herbert Sigg - Extension for new Pioneer AVRs
  */
 @NonNullByDefault
 public class OnkyoBindingConstants {
@@ -47,12 +48,15 @@ public class OnkyoBindingConstants {
     public static final String ONKYO_TYPE_TXNR828 = "TX-NR828";
     public static final String ONKYO_TYPE_TXNR838 = "TX-NR838";
 
+    // List of all supported Pioneer Models
+    public static final String PIONEER_TYPE_VSX1131 = "VSX-1131";
+
     // Extend this set with all successfully tested models
     public static final Set<String> SUPPORTED_DEVICE_MODELS = Stream
             .of(ONKYO_TYPE_TXNR414, ONKYO_TYPE_TXNR509, ONKYO_TYPE_TXNR515, ONKYO_TYPE_TXNR525, ONKYO_TYPE_TXNR535,
                     ONKYO_TYPE_TXNR555, ONKYO_TYPE_TXNR616, ONKYO_TYPE_TXNR626, ONKYO_TYPE_TXNR646, ONKYO_TYPE_TXNR656,
                     ONKYO_TYPE_TXNR717, ONKYO_TYPE_TXNR727, ONKYO_TYPE_TXNR737, ONKYO_TYPE_TXNR747, ONKYO_TYPE_TXNR757,
-                    ONKYO_TYPE_TXNR818, ONKYO_TYPE_TXNR828, ONKYO_TYPE_TXNR838)
+                    ONKYO_TYPE_TXNR818, ONKYO_TYPE_TXNR828, ONKYO_TYPE_TXNR838, PIONEER_TYPE_VSX1131)
             .collect(Collectors.toSet());
 
     // List of all Thing Type UIDs
@@ -76,12 +80,14 @@ public class OnkyoBindingConstants {
     public static final ThingTypeUID THING_TYPE_TXNR818 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR818);
     public static final ThingTypeUID THING_TYPE_TXNR828 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR828);
     public static final ThingTypeUID THING_TYPE_TXNR838 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR838);
+    public static final ThingTypeUID THING_TYPE_VSX1131 = new ThingTypeUID(BINDING_ID, PIONEER_TYPE_VSX1131);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
             .of(THING_TYPE_ONKYOAV, THING_TYPE_ONKYO_UNSUPPORTED, THING_TYPE_TXNR414, THING_TYPE_TXNR515,
                     THING_TYPE_TXNR525, THING_TYPE_TXNR535, THING_TYPE_TXNR555, THING_TYPE_TXNR616, THING_TYPE_TXNR626,
                     THING_TYPE_TXNR646, THING_TYPE_TXNR656, THING_TYPE_TXNR717, THING_TYPE_TXNR727, THING_TYPE_TXNR737,
-                    THING_TYPE_TXNR747, THING_TYPE_TXNR757, THING_TYPE_TXNR818, THING_TYPE_TXNR828, THING_TYPE_TXNR838)
+                    THING_TYPE_TXNR747, THING_TYPE_TXNR757, THING_TYPE_TXNR818, THING_TYPE_TXNR828, THING_TYPE_TXNR838,
+                    THING_TYPE_VSX1131)
             .collect(Collectors.toSet());
 
     // List of thing parameters names
@@ -95,16 +101,19 @@ public class OnkyoBindingConstants {
     public static final String CHANNEL_INPUT = "zone1#input";
     public static final String CHANNEL_MUTE = "zone1#mute";
     public static final String CHANNEL_VOLUME = "zone1#volume";
+    public static final String CHANNEL_VOLUMEDB = "zone1#volumedb";
 
     public static final String CHANNEL_POWERZONE2 = "zone2#power";
     public static final String CHANNEL_INPUTZONE2 = "zone2#input";
     public static final String CHANNEL_MUTEZONE2 = "zone2#mute";
     public static final String CHANNEL_VOLUMEZONE2 = "zone2#volume";
+    public static final String CHANNEL_VOLUMEDBZONE2 = "zone2#volumedb";
 
     public static final String CHANNEL_POWERZONE3 = "zone3#power";
     public static final String CHANNEL_INPUTZONE3 = "zone3#input";
     public static final String CHANNEL_MUTEZONE3 = "zone3#mute";
     public static final String CHANNEL_VOLUMEZONE3 = "zone3#volume";
+    public static final String CHANNEL_VOLUMEDBZONE3 = "zone3#volumedb";
 
     public static final String CHANNEL_CONTROL = "player#control";
     public static final String CHANNEL_CURRENTPLAYINGTIME = "player#currentPlayingTime";


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

[onkyo] support for newer Pioneer AVRs (e.g. VSX-1131)

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  http://docs.openhab.org/developers/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  http://docs.openhab.org/developers/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  http://docs.openhab.org/developers/contributing/contributing#sign-your-work
-->

Newer Pioneer AVRs (since 2015) also works with Onkyo protocol. But volume control works different to Onkyo: AVRs have a volume range from -82dB to 0dB and cannot controlled with the existing volume channels of the Onkyo binding (e.g. onkyo:onkyoAVR:myavr:zone1#volume) because type dimmer doesn't fit to this values. For this I added new channels "volumedb" as type number (for all three zones).

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
