### PR TITLE
temporarily remove the ZWay binding

### DIFF
--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -113,6 +113,6 @@
 		<module>org.openhab.binding.windcentrale</module>
 		<module>org.openhab.binding.yamahareceiver</module>
 		<module>org.openhab.binding.zoneminder</module>
-		<module>org.openhab.binding.zway</module>
+<!--		<module>org.openhab.binding.zway</module>-->
 	</modules>
 </project>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -492,11 +492,11 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zoneminder/${project.version}</bundle>
     </feature>
 
-	<feature name="openhab-binding-zway" description="Z-Way Binding" version="${project.version}">
+<!--	<feature name="openhab-binding-zway" description="Z-Way Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zway/${project.version}</bundle>
     </feature>
-
+-->
     <!-- io -->
 
     <feature name="openhab-transport-feed" description="Feed Transport" version="${project.version}">


### PR DESCRIPTION
This is a temporary measure until we have a solution for https://github.com/openhab/openhab2-addons/issues/3402. To be added again before the 2.3 release!

Signed-off-by: Kai Kreuzer <kai@openhab.org>

