### PR TITLE
[mihome] add cyclic thing status check (fix #3342) & fix NPE mentioned in #3384

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiBridgeHandler.java
@@ -287,6 +287,10 @@ public class XiaomiBridgeHandler extends ConfigStatusBridgeHandler implements Xi
             logger.warn("No key set in the gateway settings. Edit it in the configuration.");
             return "";
         }
+        if (gatewayToken == null) {
+            logger.warn("No token received from the gateway yet. Unable to encrypt the access key.");
+            return "";
+        }
         key = CRYPTER.encrypt(gatewayToken, key);
         return key;
     }

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiDeviceBaseHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiDeviceBaseHandler.java
@@ -13,6 +13,8 @@ import static org.openhab.binding.mihome.XiaomiGatewayBindingConstants.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -54,6 +56,7 @@ public abstract class XiaomiDeviceBaseHandler extends BaseThingHandler implement
             THING_TYPE_ACTOR_AQARA_ZERO2, THING_TYPE_ACTOR_CURTAIN));
 
     private static final long ONLINE_TIMEOUT_MILLIS = 2 * 60 * 60 * 1000; // 2 hours
+    private ScheduledFuture<?> onlineCheckTask;
 
     private JsonParser parser = new JsonParser();
 
@@ -74,7 +77,12 @@ public abstract class XiaomiDeviceBaseHandler extends BaseThingHandler implement
     @Override
     public void initialize() {
         setItemId((String) getConfig().get(ITEM_ID));
-        updateThingStatus();
+        onlineCheckTask = scheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                updateThingStatus();
+            }
+        }, 0, ONLINE_TIMEOUT_MILLIS / 2, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -87,6 +95,10 @@ public abstract class XiaomiDeviceBaseHandler extends BaseThingHandler implement
             }
             setItemId(null);
         }
+        if (!onlineCheckTask.isDone()) {
+            onlineCheckTask.cancel(false);
+        }
+
     }
 
     @Override
@@ -107,7 +119,9 @@ public abstract class XiaomiDeviceBaseHandler extends BaseThingHandler implement
     @Override
     public void onItemUpdate(String sid, String command, JsonObject message) {
         if (getItemId() != null && getItemId().equals(sid)) {
-            updateThingStatus();
+            if (getThing().getStatus() != ThingStatus.ONLINE) {
+                updateStatus(ThingStatus.ONLINE);
+            }
             logger.debug("Item got update: {}", message);
             try {
                 JsonObject data = parser.parse(message.get("data").getAsString()).getAsJsonObject();


### PR DESCRIPTION
add cyclic thing status check (fix #3342) 
- check if the device did not report for more than 2 hours (normally every device sends a heartbeat every 60 mins)

fix NPE mentioned in #3384
- if no token was received from the gateway yet (for example due to network issues) warn the user and suppress an NPE

