### PR TITLE
[Feed] Fix tests sometimes failing

### DIFF
--- a/addons/binding/org.openhab.binding.feed.test/src/test/java/org/openhab/binding/feed/test/FeedHandlerTest.java
+++ b/addons/binding/org.openhab.binding.feed.test/src/test/java/org/openhab/binding/feed/test/FeedHandlerTest.java
@@ -229,7 +229,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
         // This will ensure that the configuration is read before the channelLinked() method in FeedHandler is called !
         waitForAssert(() -> {
             assertThat(feedThing.getStatus(), anyOf(is(ONLINE), is(OFFLINE)));
-        });
+        }, 30000, DFL_SLEEP_TIME);
         initializeItem(channelUID);
     }
 

--- a/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/handler/FeedHandler.java
+++ b/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/handler/FeedHandler.java
@@ -70,8 +70,8 @@ public class FeedHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         checkConfiguration();
+        updateStatus(ThingStatus.UNKNOWN);
         startAutomaticRefresh();
-        updateStatus(ThingStatus.ONLINE);
     }
 
     /**


### PR DESCRIPTION
* Start refresh after updating Thing status to UNKNOWN so last status is always the refresh result
* Increase waitForAssert timeout because it sometimes takes more than 10s before the UnknownHostException occurs in the createThingWithInvalidUrlHostname test