### PR TITLE
provide proper logging message for unknown activity

### DIFF
--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
@@ -113,6 +113,8 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
                 } catch (NumberFormatException ignored) {
                     client.startActivityByName(command.toString());
                 }
+            } catch (IllegalArgumentException e) {
+                logger.warn("Activity '{}' is not known by the hub, ignoring it.", command);
             } catch (Exception e) {
                 logger.error("Could not start activity", e);
             }


### PR DESCRIPTION
Currently, you'll find an error with full stacktrace in the log if you try to start an unknown activity:

```
2018-04-09 19:27:35.752 [ERROR] [harmonyhub.handler.HarmonyHubHandler] - Could not start activity
java.lang.IllegalArgumentException: Unknown activity 'ABC'
	at net.whistlingfish.harmony.HarmonyClient.startActivityByName(HarmonyClient.java:431) [216:org.openhab.binding.harmonyhub:2.3.0.201803230940]
	at org.openhab.binding.harmonyhub.handler.HarmonyHubHandler.handleCommand(HarmonyHubHandler.java:114) [216:org.openhab.binding.harmonyhub:2.3.0.201803230940]
	at sun.reflect.GeneratedMethodAccessor96.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:?]
	at org.eclipse.smarthome.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:153) [97:org.eclipse.smarthome.core:0.10.0.201803222105]
	at org.eclipse.smarthome.core.internal.common.InvocationHandlerSync.invoke(InvocationHandlerSync.java:59) [97:org.eclipse.smarthome.core:0.10.0.201803222105]
	at com.sun.proxy.$Proxy134.handleCommand(Unknown Source) [216:org.openhab.binding.harmonyhub:2.3.0.201803230940]
	at org.eclipse.smarthome.core.thing.internal.profiles.ProfileCallbackImpl.handleCommand(ProfileCallbackImpl.java:75) [104:org.eclipse.smarthome.core.thing:0.10.0.201803222105]
	at org.eclipse.smarthome.core.thing.internal.profiles.SystemDefaultProfile.onCommandFromItem(SystemDefaultProfile.java:49) [104:org.eclipse.smarthome.core.thing:0.10.0.201803222105]
	at sun.reflect.GeneratedMethodAccessor97.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:?]
	at org.eclipse.smarthome.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:153) [97:org.eclipse.smarthome.core:0.10.0.201803222105]
	at org.eclipse.smarthome.core.internal.common.Invocation.call(Invocation.java:53) [97:org.eclipse.smarthome.core:0.10.0.201803222105]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:?]
	at java.lang.Thread.run(Thread.java:745) [?:?]
```
This PR reduces it to a warning with a simple message and no stacktrace.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
