### PR TITLE
Standardize DS annotation usage

### DIFF
--- a/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/AirQualityHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/AirQualityHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.airquality.handler.AirQualityHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link AirQualityHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Kuba Wolanin - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.airquality", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.airquality")
 public class AirQualityHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_AQI);

--- a/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java
@@ -31,7 +31,6 @@ import org.openhab.binding.allplay.handler.AllPlayHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,7 @@ import de.kaizencode.tchaikovsky.exception.AllPlayException;
  *
  * @author Dominic Lerbs - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.allplay", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.allplay")
 public class AllPlayHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(AllPlayHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/discovery/AllPlaySpeakerDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/discovery/AllPlaySpeakerDiscoveryService.java
@@ -36,7 +36,7 @@ import de.kaizencode.tchaikovsky.speaker.Speaker;
  *
  * @author Dominic Lerbs - Initial contribution
  */
-@Component(service = DiscoveryService.class, immediate = true)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.allplay")
 public class AllPlaySpeakerDiscoveryService extends AbstractDiscoveryService implements SpeakerAnnouncedListener {
 
     private final Logger logger = LoggerFactory.getLogger(AllPlaySpeakerDiscoveryService.class);

--- a/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/AmazonDashButtonHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/AmazonDashButtonHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.amazondashbutton.handler.AmazonDashButtonHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link AmazonDashButtonHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Oliver Libutzki - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.amazondashbutton", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.amazondashbutton")
 public class AmazonDashButtonHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(DASH_BUTTON_THING_TYPE);

--- a/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/AtlonaHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/AtlonaHandlerFactory.java
@@ -19,7 +19,6 @@ import org.openhab.binding.atlona.AtlonaBindingConstants;
 import org.openhab.binding.atlona.internal.pro3.AtlonaPro3Capabilities;
 import org.openhab.binding.atlona.internal.pro3.AtlonaPro3Handler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Tim Roberts - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.atlona", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.atlona")
 public class AtlonaHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(AtlonaHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzHandlerFactory.java
@@ -33,7 +33,6 @@ import org.openhab.binding.avmfritz.handler.Powerline546EHandler;
 import org.openhab.binding.avmfritz.internal.discovery.AVMFritzDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Robert Bausdorf - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.avmfritz", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.avmfritz")
 public class AVMFritzHandlerFactory extends BaseThingHandlerFactory {
     /**
      * Logger

--- a/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/BigAssFanHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/BigAssFanHandlerFactory.java
@@ -18,7 +18,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.bigassfan.handler.BigAssFanHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -27,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Mark Hilbush - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.bigassfan", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.bigassfan")
 public class BigAssFanHandlerFactory extends BaseThingHandlerFactory {
 
     private NetworkAddressService networkAddressService;

--- a/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/BoschIndegoHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/BoschIndegoHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.boschindego.handler.BoschIndegoHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link BoschIndegoHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Jonas Fleck - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.boschindego", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.boschindego")
 public class BoschIndegoHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_INDEGO);

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastHandlerFactory.java
@@ -8,6 +8,11 @@
  */
 package org.openhab.binding.chromecast.internal;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.eclipse.smarthome.core.audio.AudioHTTPServer;
 import org.eclipse.smarthome.core.audio.AudioSink;
 import org.eclipse.smarthome.core.net.HttpServiceUtil;
@@ -22,15 +27,9 @@ import org.openhab.binding.chromecast.handler.ChromecastHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The {@link ChromecastHandlerFactory} is responsible for creating things and thing
@@ -38,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.chromecast", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.chromecast")
 public class ChromecastHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(ChromecastHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/Cm11aHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/Cm11aHandlerFactory.java
@@ -25,7 +25,6 @@ import org.openhab.binding.cm11a.handler.Cm11aApplianceHandler;
 import org.openhab.binding.cm11a.handler.Cm11aBridgeHandler;
 import org.openhab.binding.cm11a.handler.Cm11aLampHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Raker - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.cm11a", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.cm11a")
 public class Cm11aHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(Cm11aHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/CoolMasterNetHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/CoolMasterNetHandlerFactory.java
@@ -18,7 +18,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.coolmasternet.handler.HVACHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link CoolMasterNetHandlerFactory} is responsible for creating things and thing
@@ -26,7 +25,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Angus Gratton - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.coolmasternet", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.coolmasternet")
 public class CoolMasterNetHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.dlinksmarthome/src/main/java/org/openhab/binding/dlinksmarthome/internal/DLinkSmartHomeHandlerFactory.java
@@ -17,7 +17,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.dlinksmarthome.handler.DLinkMotionSensorHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link DLinkSmartHomeHandlerFactory} is responsible for creating things and thing
@@ -25,7 +24,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Mike Major - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.dlinksmarthome", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.dlinksmarthome")
 public class DLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/factory/DSCAlarmHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/factory/DSCAlarmHandlerFactory.java
@@ -40,7 +40,6 @@ import org.openhab.binding.dscalarm.internal.config.TCPServerBridgeConfiguration
 import org.openhab.binding.dscalarm.internal.discovery.DSCAlarmDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Russell Stephens - Initial Contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.dscalarm", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.dscalarm")
 public class DSCAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(DSCAlarmHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/FeedHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/FeedHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.feed.handler.FeedHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link FeedHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Svilen Valkanov - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.feed", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.feed")
 public class FeedHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(FEED_THING_TYPE_UID);

--- a/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/internal/FeicanDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/internal/FeicanDiscoveryService.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @NonNullByDefault
-@Component(service = DiscoveryService.class, immediate = true)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.feican")
 public class FeicanDiscoveryService extends AbstractDiscoveryService {
 
     private static final int DISCOVERY_TIMEOUT_SECONDS = 5;

--- a/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/internal/FeicanHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/internal/FeicanHandlerFactory.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.feican")
 public class FeicanHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.folding/src/main/java/org/openhab/binding/folding/internal/FoldingHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.folding/src/main/java/org/openhab/binding/folding/internal/FoldingHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.folding.FoldingBindingConstants;
 import org.openhab.binding.folding.handler.FoldingClientHandler;
 import org.openhab.binding.folding.handler.SlotHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link FoldingHandlerFactory} is responsible for creating things and thing
@@ -30,7 +29,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Marius Bjoernstad - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.folding", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.folding")
 public class FoldingHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>(

--- a/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/FreeboxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/FreeboxHandlerFactory.java
@@ -35,7 +35,6 @@ import org.openhab.binding.freebox.internal.discovery.FreeboxDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +48,7 @@ import com.google.common.collect.Sets;
  * @author Gaël L'hopital - Initial contribution
  * @author Laurent Garnier - several thing types and handlers + discovery service
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.freebox", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.freebox")
 public class FreeboxHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(FreeboxHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/FroniusHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/FroniusHandlerFactory.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.fronius.handler.FroniusBridgeHandler;
 import org.openhab.binding.fronius.handler.FroniusSymoInverterHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link FroniusHandlerFactory} is responsible for creating things and thing
@@ -30,7 +29,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Thomas Rokohl - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.fronius", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.fronius")
 public class FroniusHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>() {

--- a/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/handler/GardenaHandlerFactory.java
@@ -17,14 +17,13 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link GardenaHandlerFactory} is responsible for creating Gardena things and thing handlers.
  *
  * @author Gerhard Riegler - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.gardena", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.gardena")
 public class GardenaHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/GlobalCacheHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/GlobalCacheHandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.globalcache.handler.GlobalCacheHandler;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Mark Hilbush - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.globalcache", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.globalcache")
 public class GlobalCacheHandlerFactory extends BaseThingHandlerFactory {
     private Logger logger = LoggerFactory.getLogger(GlobalCacheHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
@@ -37,7 +37,6 @@ import org.openhab.binding.harmonyhub.handler.HarmonyHubHandler;
 import org.openhab.binding.harmonyhub.internal.discovery.HarmonyDeviceDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Sets;
 
@@ -48,7 +47,7 @@ import com.google.common.collect.Sets;
  * @author Dan Cunningham - Initial contribution
  */
 @Component(service = { ThingHandlerFactory.class,
-        ChannelTypeProvider.class }, immediate = true, configurationPid = "binding.harmonyhub", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+        ChannelTypeProvider.class }, immediate = true, configurationPid = "binding.harmonyhub")
 public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements ChannelTypeProvider {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyHubDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyHubDiscoveryService.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dan Cunningham - Initial contribution
  */
-@Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.harmonyhub")
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.harmonyhub")
 public class HarmonyHubDiscoveryService extends AbstractDiscoveryService {
 
     private Logger logger = LoggerFactory.getLogger(HarmonyHubDiscoveryService.class);

--- a/addons/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/internal/HDanywhereHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/internal/HDanywhereHandlerFactory.java
@@ -23,7 +23,6 @@ import org.openhab.binding.hdanywhere.HDanywhereBindingConstants;
 import org.openhab.binding.hdanywhere.handler.Mhub4K431Handler;
 import org.openhab.binding.hdanywhere.handler.MultiroomPlusHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Sets;
 
@@ -33,7 +32,7 @@ import com.google.common.collect.Sets;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.hdanywhere", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.hdanywhere")
 public class HDanywhereHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_MULTIROOMPLUS,

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.hdpowerview.handler.HDPowerViewHubHandler;
 import org.openhab.binding.hdpowerview.handler.HDPowerViewShadeHandler;
 import org.openhab.binding.hdpowerview.internal.discovery.HDPowerViewShadeDiscoveryService;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link HDPowerViewHandlerFactory} is responsible for creating things and thing
@@ -30,7 +29,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Andy Lintner - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.hdpowerview", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.hdpowerview")
 public class HDPowerViewHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.helios/src/main/java/org/openhab/binding/helios/internal/HeliosHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.helios/src/main/java/org/openhab/binding/helios/internal/HeliosHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.helios.handler.HeliosHandler221;
 import org.openhab.binding.helios.handler.HeliosHandler27;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Lists;
 
@@ -30,7 +29,7 @@ import com.google.common.collect.Lists;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.helios", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.helios")
 public class HeliosHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.homematic.internal.type.HomematicTypeGenerator;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -27,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.homematic", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.homematic")
 public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
     private HomematicTypeGenerator typeGenerator;
     private NetworkAddressService networkAddressService;

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/CcuDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/CcuDiscoveryService.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-@Component(immediate = true, service = DiscoveryService.class)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.homematic")
 public class CcuDiscoveryService extends AbstractDiscoveryService {
     private final Logger logger = LoggerFactory.getLogger(CcuDiscoveryService.class);
 

--- a/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/InnogyHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/InnogyHandlerFactory.java
@@ -37,7 +37,7 @@ import com.google.common.collect.Sets;
  *
  * @author Oliver Kuhl - Initial contribution
  */
-@Component(immediate = true, name = "binding.innogysmarthome")
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.innogysmarthome")
 public class InnogyHandlerFactory extends BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.union(InnogyBridgeHandler.SUPPORTED_THING_TYPES,

--- a/addons/binding/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/IppHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/IppHandlerFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.ipp.IppBindingConstants;
 import org.openhab.binding.ipp.handler.IppPrinterHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Tobias Braeutigam - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.ipp", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.ipp")
 public class IppHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(IppHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/IRtransHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/IRtransHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.irtrans.IRtransBindingConstants;
 import org.openhab.binding.irtrans.handler.BlasterHandler;
 import org.openhab.binding.irtrans.handler.EthernetBridgeHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Lists;
 
@@ -34,7 +33,7 @@ import com.google.common.collect.Lists;
  * @since 2.3.0
  *
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.irtrans", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.irtrans")
 public class IRtransHandlerFactory extends BaseThingHandlerFactory {
 
     public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandlerFactory.java
@@ -25,7 +25,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.jeelink.internal.discovery.SensorDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Volker Bier - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.jeelink", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.jeelink")
 public class JeeLinkHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(JeeLinkHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.keba.handler.KeContactHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link KebaHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.keba", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.keba")
 public class KebaHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_KECONTACTP20);

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Simon Kaufmann - Initial contribution and API
  */
-@Component(service = ThingHandlerFactory.class)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.knx")
 public class KNXHandlerFactory extends BaseThingHandlerFactory {
 
     public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Arrays.asList(THING_TYPE_DEVICE,

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiHandlerFactory.java
@@ -28,7 +28,6 @@ import org.openhab.binding.kodi.handler.KodiHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Frank - Initial contribution
  * @author Christoph Weitkamp - Improvements on channels for opening PVR TV or Radio streams
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.kodi", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.kodi")
 public class KodiHandlerFactory extends BaseThingHandlerFactory {
 
     private Logger logger = LoggerFactory.getLogger(KodiHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostal/inverter/WebscrapeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostal/inverter/WebscrapeHandlerFactory.java
@@ -14,12 +14,11 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * @author Christian Schneider - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.kostalinverter", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.kostalinverter")
 public class WebscrapeHandlerFactory extends BaseThingHandlerFactory {
     public static final ThingTypeUID KOSTAL_INVERTER = new ThingTypeUID("kostalinverter", "kostalinverter");
 

--- a/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/internal/LaMetricTimeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/internal/LaMetricTimeHandlerFactory.java
@@ -44,7 +44,7 @@ import com.google.common.collect.Sets;
  *
  * @author Gregory Moyer - Initial contribution
  */
-@Component(immediate = true, service = ThingHandlerFactory.class)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.lametrictime")
 public class LaMetricTimeHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPE_UIDS = Sets.newHashSet(THING_TYPE_DEVICE,

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Sebastian Prehn - initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.lgwebos")
 public class LGWebOSHandlerFactory extends BaseThingHandlerFactory {
     private LGWebOSDiscovery discovery;
 

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LoxoneHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LoxoneHandlerFactory.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Sets;
  *
  * @author Pawel Pieczul - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.loxone")
 public class LoxoneHandlerFactory extends BaseThingHandlerFactory {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets

--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/Mcp23017HandlerFactory.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/Mcp23017HandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.mcp23017.handler.Mcp23017Handler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,7 @@ import com.google.common.collect.Lists;
  *
  * @author Anatol Ogorek - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.mcp23017", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.mcp23017")
 public class Mcp23017HandlerFactory extends BaseThingHandlerFactory {
 
     private static final List<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(THING_TYPE_MCP23017);

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/internal/MeteostickHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/internal/MeteostickHandlerFactory.java
@@ -17,7 +17,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.meteostick.handler.MeteostickBridgeHandler;
 import org.openhab.binding.meteostick.handler.MeteostickSensorHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +26,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Chris Jackson - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.meteostick", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.meteostick")
 public class MeteostickHandlerFactory extends BaseThingHandlerFactory {
     private Logger logger = LoggerFactory.getLogger(MeteostickHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiHandlerFactory.java
@@ -44,7 +44,6 @@ import org.openhab.binding.mihome.handler.XiaomiSensorWaterHandler;
 import org.openhab.binding.mihome.internal.discovery.XiaomiItemDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Sets;
 
@@ -57,7 +56,7 @@ import com.google.common.collect.Sets;
  * @author Daniel Walters - Added Aqara Door/Window sensor and Aqara temperature, humidity and pressure sensor
  * @author Kuba Wolanin - Added Water Leak sensor and Aqara motion sensor
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.mihome", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.mihome")
 public class XiaomiHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets

--- a/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/MinecraftHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/MinecraftHandlerFactory.java
@@ -24,7 +24,6 @@ import org.openhab.binding.minecraft.handler.MinecraftPlayerHandler;
 import org.openhab.binding.minecraft.handler.MinecraftServerHandler;
 import org.openhab.binding.minecraft.handler.MinecraftSignHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Mattias Markehed - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.minecraft", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.minecraft")
 public class MinecraftHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MinecraftHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.nest.test/OSGI-INF/org.openhab.binding.nest.test.NestTestHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.nest.test/OSGI-INF/org.openhab.binding.nest.test.NestTestHandlerFactory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" configuration-policy="optional" immediate="true" name="org.openhab.binding.nest.test.NestTestHandlerFactory">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" configuration-pid="binding.nest.test" configuration-policy="optional" immediate="true" name="org.openhab.binding.nest.test.NestTestHandlerFactory">
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
    </service>

--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/test/NestTestHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/test/NestTestHandlerFactory.java
@@ -24,14 +24,13 @@ import org.openhab.binding.nest.handler.NestBridgeHandler;
 import org.openhab.binding.nest.internal.discovery.NestDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link NestTestHandlerFactory} is responsible for creating test things and thing handlers.
  *
  * @author Wouter Born - Increase test coverage
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nest.test")
 public class NestTestHandlerFactory extends BaseThingHandlerFactory {
 
     private String redirectUrl = "http://localhost";

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
@@ -33,7 +33,6 @@ import org.openhab.binding.nest.handler.NestThermostatHandler;
 import org.openhab.binding.nest.internal.discovery.NestDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link NestHandlerFactory} is responsible for creating things and thing
@@ -42,7 +41,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author David Bennett - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nest", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nest")
 public class NestHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream.of(THING_TYPE_THERMOSTAT,
             THING_TYPE_CAMERA, THING_TYPE_BRIDGE, THING_TYPE_STRUCTURE, THING_TYPE_SMOKE_DETECTOR).collect(toSet());

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Modified;
  *
  * @author David Graeff
  */
-@Component(immediate = true, service = ThingHandlerFactory.class)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.network")
 public class NetworkHandlerFactory extends BaseThingHandlerFactory {
     @NonNull
     final NetworkBindingConfiguration configuration = new NetworkBindingConfiguration();

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -46,7 +46,7 @@ import com.google.common.collect.Sets;
  * @author David Graeff - Rewritten
  * @author Marc Mettke - Initial contribution
  */
-@Component(immediate = true, service = DiscoveryService.class)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.network")
 public class NetworkDiscoveryService extends AbstractDiscoveryService implements PresenceDetectionListener {
     static final int PING_TIMEOUT_IN_MS = 500;
     static final int MAXIMUM_IPS_PER_INTERFACE = 255;

--- a/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
@@ -27,7 +27,6 @@ import org.openhab.binding.nikohomecontrol.handler.NikoHomeControlHandler;
 import org.openhab.binding.nikohomecontrol.internal.discovery.NikoHomeControlDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link NikoHomeControlHandlerFactory} is responsible for creating things and thing
@@ -36,7 +35,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  * @author Mark Herwege
  */
 
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nikohomecontrol", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.nikohomecontrol")
 public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
 
     private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();

--- a/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/internal/OceanicHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.oceanic/src/main/java/org/openhab/binding/oceanic/internal/OceanicHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.oceanic.handler.NetworkOceanicThingHandler;
 import org.openhab.binding.oceanic.handler.SerialOceanicThingHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Lists;
 
@@ -30,7 +29,7 @@ import com.google.common.collect.Lists;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.oceanic", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.oceanic")
 public class OceanicHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(THING_TYPE_SERIAL,

--- a/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/internal/OneBusAwayHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.onebusaway/src/main/java/org/openhab/binding/onebusaway/internal/OneBusAwayHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.onebusaway.internal.handler.ApiHandler;
 import org.openhab.binding.onebusaway.internal.handler.RouteHandler;
 import org.openhab.binding.onebusaway.internal.handler.StopHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -32,7 +31,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Shawn Wilsher - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.onebusaway", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.onebusaway")
 public class OneBusAwayHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(ApiHandler.SUPPORTED_THING_TYPE,

--- a/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGPIOHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGPIOHandlerFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Anatol Ogorek - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, name = "binding.onewiregpio")
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.onewiregpio")
 public class OneWireGPIOHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE);

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoHandlerFactory.java
@@ -29,7 +29,6 @@ import org.openhab.binding.onkyo.handler.OnkyoHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Frank - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.onkyo", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.onkyo")
 public class OnkyoHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(OnkyoHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerHandlerFactory.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.opensprinkler.handler.OpenSprinklerHTTPHandler;
 import org.openhab.binding.opensprinkler.handler.OpenSprinklerPiHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link OpenSprinklerHandlerFactory} is responsible for creating things and thing
@@ -30,7 +29,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Chris Graham - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.opensprinkler", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.opensprinkler")
 public class OpenSprinklerHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(
             Arrays.asList(OPENSPRINKLER_THING, OPENSPRINKLERPI_THING));

--- a/addons/binding/org.openhab.binding.orvibo/src/main/java/org/openhab/binding/orvibo/internal/OrviboHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.orvibo/src/main/java/org/openhab/binding/orvibo/internal/OrviboHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.orvibo.handler.S20Handler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link OrviboHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Daniel Walters - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.orvibo", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.orvibo")
 public class OrviboHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_S20);

--- a/addons/binding/org.openhab.binding.pentair/src/main/java/org/openhab/binding/pentair/internal/PentairHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.pentair/src/main/java/org/openhab/binding/pentair/internal/PentairHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.pentair.handler.PentairIntelliChlorHandler;
 import org.openhab.binding.pentair.handler.PentairIntelliFloHandler;
 import org.openhab.binding.pentair.handler.PentairSerialBridgeHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link PentairHandlerFactory} is responsible for creating things and thing
@@ -30,7 +29,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Jeff James - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pentair", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pentair")
 public class PentairHandlerFactory extends BaseThingHandlerFactory {
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AvrHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AvrHandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.pioneeravr.PioneerAvrBindingConstants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Sets;
 
@@ -28,7 +27,7 @@ import com.google.common.collect.Sets;
  *
  * @author Antoine Besnard - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pioneeravr", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pioneeravr")
 public class AvrHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
@@ -29,14 +29,13 @@ import org.openhab.binding.plugwise.handler.PlugwiseStickHandler;
 import org.openhab.binding.plugwise.handler.PlugwiseSwitchHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link PlugwiseHandlerFactory} is responsible for creating Plugwise things and thing handlers.
  *
  * @author Wouter Born - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.plugwise", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.plugwise")
 public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
@@ -54,7 +54,7 @@ import gnu.io.CommPortIdentifier;
  *
  * @author Wouter Born - Initial contribution
  */
-@Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.plugwise")
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.plugwise")
 public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
         implements ExtendedDiscoveryService, PlugwiseMessageListener {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
@@ -31,7 +31,6 @@ import org.openhab.binding.pulseaudio.internal.discovery.PulseaudioDeviceDiscove
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +42,7 @@ import com.google.common.collect.Sets;
  *
  * @author Tobias Bräutigam - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pulseaudio", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.pulseaudio")
 public class PulseaudioHandlerFactory extends BaseThingHandlerFactory {
     private Logger logger = LoggerFactory.getLogger(PulseaudioHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/RegoHeatPumpHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/RegoHeatPumpHandlerFactory.java
@@ -25,7 +25,6 @@ import org.openhab.binding.regoheatpump.handler.IpRego6xxHeatPumpHandler;
 import org.openhab.binding.regoheatpump.handler.SerialHusdataHandler;
 import org.openhab.binding.regoheatpump.handler.SerialRego6xxHeatPumpHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link RegoHeatPumpHandlerFactory} is responsible for creating things and thing
@@ -33,7 +32,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Boris Krivonog - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.regoheatpump", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.regoheatpump")
 public class RegoHeatPumpHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream

--- a/addons/binding/org.openhab.binding.rme/src/main/java/org/openhab/binding/rme/internal/RMEHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.rme/src/main/java/org/openhab/binding/rme/internal/RMEHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.rme.handler.RMEThingHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link RMEHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.rme", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.rme")
 public class RMEHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_MANAGER);

--- a/addons/binding/org.openhab.binding.rotelra1x/src/main/java/org/openhab/binding/rotelra1x/internal/RotelRa1xHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.rotelra1x/src/main/java/org/openhab/binding/rotelra1x/internal/RotelRa1xHandlerFactory.java
@@ -17,6 +17,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.rotelra1x.handler.RotelRa1xHandler;
 import org.osgi.service.component.annotations.Component;
 
@@ -27,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Marius Bjørnstad - Initial contribution
  */
 
-@Component
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.rotelra1x")
 public class RotelRa1xHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_AMP);

--- a/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/RussoundHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/RussoundHandlerFactory.java
@@ -25,7 +25,6 @@ import org.openhab.binding.russound.internal.rio.source.RioSourceHandler;
 import org.openhab.binding.russound.internal.rio.system.RioSystemHandler;
 import org.openhab.binding.russound.internal.rio.zone.RioZoneHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +36,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Tim Roberts - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.russound", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.russound")
 public class RussoundHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(RussoundHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelHandlerFactory.java
@@ -38,7 +38,6 @@ import org.openhab.binding.satel.internal.config.SatelThingConfig;
 import org.openhab.binding.satel.internal.discovery.SatelDeviceDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link SatelHandlerFactory} is responsible for creating things and thing
@@ -46,7 +45,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Krzysztof Goworek - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.satel", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.satel")
 public class SatelHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream

--- a/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxHandlerFactory.java
@@ -13,14 +13,13 @@ import static org.openhab.binding.sensebox.SenseBoxBindingConstants.THING_TYPE_B
 import java.util.Collections;
 import java.util.Set;
 
-import org.openhab.binding.sensebox.handler.SenseBoxHandler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.sensebox.handler.SenseBoxHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link SenseBoxHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Hakan Tandogan - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sensebox", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sensebox")
 public class SenseBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BOX);

--- a/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/internal/SilvercrestWifiSocketHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.silvercrestwifisocket/src/main/java/org/openhab/binding/silvercrestwifisocket/internal/SilvercrestWifiSocketHandlerFactory.java
@@ -21,7 +21,6 @@ import org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketHa
 import org.openhab.binding.silvercrestwifisocket.handler.SilvercrestWifiSocketMediator;
 import org.openhab.binding.silvercrestwifisocket.internal.exceptions.MacAddressNotValidException;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jaime Vaz - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.silvercrestwifisocket", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.silvercrestwifisocket")
 public class SilvercrestWifiSocketHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections

--- a/addons/binding/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/SleepIQHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/SleepIQHandlerFactory.java
@@ -26,7 +26,6 @@ import org.openhab.binding.sleepiq.handler.SleepIQDualBedHandler;
 import org.openhab.binding.sleepiq.internal.discovery.SleepIQBedDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +36,7 @@ import com.google.common.collect.Sets;
  *
  * @author Gregory Moyer - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sleepiq", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sleepiq")
 public class SleepIQHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPE_UIDS = Sets
             .union(SleepIQCloudHandler.SUPPORTED_THING_TYPE_UIDS, SleepIQDualBedHandler.SUPPORTED_THING_TYPE_UIDS);

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/internal/SMAEnergyMeterHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/internal/SMAEnergyMeterHandlerFactory.java
@@ -17,7 +17,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.smaenergymeter.handler.SMAEnergyMeterHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link SMAEnergyMeterHandlerFactory} is responsible for creating things and thing
@@ -25,7 +24,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Osman Basha - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.smaenergymeter", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.smaenergymeter")
 public class SMAEnergyMeterHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
@@ -36,7 +36,6 @@ import org.openhab.binding.squeezebox.handler.SqueezeBoxServerHandler;
 import org.openhab.binding.squeezebox.internal.discovery.SqueezeBoxPlayerDiscoveryParticipant;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * @author Dan Cunningham - Initial contribution
  * @author Mark Hilbush - Cancel request player job when handler removed
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.squeezebox", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.squeezebox")
 public class SqueezeBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private Logger logger = LoggerFactory.getLogger(SqueezeBoxHandlerFactory.class);

--- a/addons/binding/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/internal/SynopAnalyzerHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/internal/SynopAnalyzerHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.synopanalyzer.handler.SynopAnalyzerHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link SynopAnalyzerHandlerFactory} is responsible for creating things and thing
@@ -29,7 +28,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  * @author Gaël L'hopital - Initial contribution
  */
 
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.synopanalyzer")
 public class SynopAnalyzerHandlerFactory extends BaseThingHandlerFactory {
 
     private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_SYNOP);

--- a/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoHandlerFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.systeminfo.handler.SysteminfoHandler;
 import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -31,7 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Svilen Valkanov - Initial contribution
  * @author Lyubomir Papazov - Pass systeminfo service to the SysteminfoHandler constructor
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.systeminfo", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.systeminfo")
 public class SysteminfoHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_COMPUTER);

--- a/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/TankerkoenigHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tankerkoenig/src/main/java/org/openhab/binding/tankerkoenig/internal/TankerkoenigHandlerFactory.java
@@ -22,7 +22,6 @@ import org.openhab.binding.tankerkoenig.TankerkoenigBindingConstants;
 import org.openhab.binding.tankerkoenig.handler.StationHandler;
 import org.openhab.binding.tankerkoenig.handler.WebserviceHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Sets;
 
@@ -32,7 +31,7 @@ import com.google.common.collect.Sets;
  *
  * @author Dennis Dollinger - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tankerkoenig", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tankerkoenig")
 public class TankerkoenigHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.union(BRIDGE_THING_TYPES_UIDS,
             TankerkoenigBindingConstants.SUPPORTED_THING_TYPES_UIDS);

--- a/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaHandlerFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.tesla.handler.TeslaHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -31,7 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Karel Goderis - Initial contribution
  * @author Nicolai Grødum - Adding token based auth
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tesla", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tesla")
 public class TeslaHandlerFactory extends BaseThingHandlerFactory {
 
     private StorageService storageService;

--- a/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/internal/ToonHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.toon/src/main/java/org/openhab/binding/toon/internal/ToonHandlerFactory.java
@@ -25,7 +25,6 @@ import org.openhab.binding.toon.handler.ToonPlugHandler;
 import org.openhab.binding.toon.internal.discovery.ToonDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jorg de Jong - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.toon", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.toon")
 public class ToonHandlerFactory extends BaseThingHandlerFactory {
     private Logger logger = LoggerFactory.getLogger(ToonHandlerFactory.class);
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Christian Fischer - Initial contribution
  * @author Hilbrand Bouwkamp - Complete make-over, reorganized code and code cleanup.
  */
-@Component(service = DiscoveryService.class, immediate = true)
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.tplinksmarthome")
 public class TPLinkSmartHomeDiscoveryService extends AbstractDiscoveryService {
 
     private static final String BROADCAST_IP = "255.255.255.255";

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Hilbrand Bouwkamp - Specific handlers for different type of devices.
  */
 @NonNullByDefault
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tplinksmarthome")
 public class TPLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/addons/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiHandlerFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.urtsi.handler.RtsDeviceHandler;
 import org.openhab.binding.urtsi.handler.UrtsiDeviceHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.Lists;
 
@@ -31,7 +30,7 @@ import com.google.common.collect.Lists;
  *
  * @author Oliver Libutzki - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.urtsi", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.urtsi")
 public class UrtsiHandlerFactory extends BaseThingHandlerFactory {
 
     private static final List<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(URTSI_DEVICE_THING_TYPE,

--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/WiFiLEDHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/WiFiLEDHandlerFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.wifiled.handler.WiFiLEDHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link WiFiLEDHandlerFactory} is responsible for creating things and thing
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Osman Basha - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.wifiled", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.wifiled")
 public class WiFiLEDHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WIFILED);

--- a/addons/binding/org.openhab.binding.windcentrale/src/main/java/org/openhab/binding/windcentrale/internal/WindcentraleHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.windcentrale/src/main/java/org/openhab/binding/windcentrale/internal/WindcentraleHandlerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.windcentrale.handler.WindcentraleHandler;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 /**
  * The {@link WindcentraleHandlerFactory} is responsible for creating things and thing
@@ -27,7 +26,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  *
  * @author Marcel Verpaalen - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.windcentrale", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.windcentrale")
 @NonNullByDefault
 public class WindcentraleHandlerFactory extends BaseThingHandlerFactory {
 

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerFactory.java
@@ -31,7 +31,7 @@ import com.google.common.collect.Sets;
  *
  * @author David Graeff -- Intial contribution
  */
-@Component(immediate = true, service = ThingHandlerFactory.class)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.yamahareceiver")
 public class YamahaReceiverHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.union(
             YamahaReceiverBindingConstants.BRIDGE_THING_TYPES_UIDS,

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/ZWayHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/ZWayHandlerFactory.java
@@ -27,7 +27,6 @@ import org.openhab.binding.zway.handler.ZWayZWaveDeviceHandler;
 import org.openhab.binding.zway.internal.discovery.ZWayDeviceDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -37,7 +36,7 @@ import com.google.common.collect.ImmutableSet;
  *
  * @author Patrick Hecker - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.zway", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.zway")
 public class ZWayHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(

--- a/addons/io/org.openhab.io.azureiothub/src/main/java/org/openhab/io/internal/azureiothub/CloudService.java
+++ b/addons/io/org.openhab.io.azureiothub/src/main/java/org/openhab/io/internal/azureiothub/CloudService.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.items.events.ItemStateEvent;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Niko Tanghe - Initial contribution
  *
  */
-@Component(immediate = true, configurationPid = "org.openhab.azureiothub", configurationPolicy = ConfigurationPolicy.OPTIONAL, property = {
+@Component(immediate = true, configurationPid = "org.openhab.azureiothub", property = {
         "service.pid=org.openhab.azureiothub", "service.config.description.uri=io:azureiothub",
         "service.config.label=Azure IoT Hub", "service.config.category=io" })
 public class CloudService implements EventSubscriber {


### PR DESCRIPTION
* Remove use of ConfigurationPolicy.OPTIONAL which is the default configuration policy
* Add missing configurationPid values (used in configuration files, see [documentation](https://www.eclipse.org/smarthome/documentation/features/dsl.html#default-configuration-file))
* Add missing immediate = true

Bindings created with the skeleton script use DS annotations the same way.
