### PR TITLE
Remove unused Groovy settings and natures from Eclipse projects

### DIFF
--- a/addons/binding/org.openhab.binding.feed.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/addons/binding/org.openhab.binding.feed.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/addons/binding/org.openhab.binding.max.test/.groovy/suggestions.xdsl
+++ b/addons/binding/org.openhab.binding.max.test/.groovy/suggestions.xdsl
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<projectSuggestions/>

--- a/addons/binding/org.openhab.binding.max.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/addons/binding/org.openhab.binding.max.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/addons/binding/org.openhab.binding.nibeheatpump.test/.project
+++ b/addons/binding/org.openhab.binding.nibeheatpump.test/.project
@@ -22,7 +22,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/addons/binding/org.openhab.binding.nibeheatpump.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/addons/binding/org.openhab.binding.nibeheatpump.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/addons/binding/org.openhab.binding.rfxcom.test/.classpath
+++ b/addons/binding/org.openhab.binding.rfxcom.test/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry exported="true" kind="con" path="GROOVY_DSL_SUPPORT"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/binding/org.openhab.binding.rfxcom.test/.project
+++ b/addons/binding/org.openhab.binding.rfxcom.test/.project
@@ -22,7 +22,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/addons/binding/org.openhab.binding.systeminfo.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/addons/binding/org.openhab.binding.systeminfo.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1


### PR DESCRIPTION
These files and settings are unused because all Groovy tests have been migrated to Java.