### PR TITLE
[HD PowerView] Fix quoted ID issue

### DIFF
--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -61,11 +61,11 @@ public class HDPowerViewWebTargets {
         }
     }
 
-    public Response moveShade(String shadeId, ShadePosition position) throws IOException {
-        int intid = Integer.parseInt(shadeId);
-        WebTarget target = shadeMove.resolveTemplate("id", intid);
+    public Response moveShade(String shadeIdString, ShadePosition position) throws IOException {
+        int shadeId = Integer.parseInt(shadeIdString);
+        WebTarget target = shadeMove.resolveTemplate("id", shadeId);
 
-        String body = gson.toJson(new ShadeMove(intid, position));
+        String body = gson.toJson(new ShadeMove(shadeId, position));
         return invoke(target.request().buildPut(Entity.entity(body, MediaType.APPLICATION_JSON_TYPE)), shadeMove);
     }
 

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -62,8 +62,10 @@ public class HDPowerViewWebTargets {
     }
 
     public Response moveShade(String shadeId, ShadePosition position) throws IOException {
-        WebTarget target = shadeMove.resolveTemplate("id", shadeId);
-        String body = gson.toJson(new ShadeMove(shadeId, position));
+        int intid = Integer.parseInt(shadeId);
+        WebTarget target = shadeMove.resolveTemplate("id", intid);
+
+        String body = gson.toJson(new ShadeMove(intid, position));
         return invoke(target.request().buildPut(Entity.entity(body, MediaType.APPLICATION_JSON_TYPE)), shadeMove);
     }
 

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
@@ -20,8 +20,8 @@ class ShadeIdPosition {
     int id;
     ShadePosition positions;
 
-    public ShadeIdPosition(int intid, ShadePosition position) {
-        this.id = intid;
+    public ShadeIdPosition(int id, ShadePosition position) {
+        this.id = id;
         this.positions = position;
     }
 }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeIdPosition.java
@@ -17,11 +17,11 @@ import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
  */
 class ShadeIdPosition {
 
-    String id;
+    int id;
     ShadePosition positions;
 
-    public ShadeIdPosition(String id, ShadePosition position) {
-        this.id = id;
+    public ShadeIdPosition(int intid, ShadePosition position) {
+        this.id = intid;
         this.positions = position;
     }
 }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
@@ -19,7 +19,7 @@ public class ShadeMove {
 
     ShadeIdPosition shade;
 
-    public ShadeMove(int intid, ShadePosition position) {
-        this.shade = new ShadeIdPosition(intid, position);
+    public ShadeMove(int id, ShadePosition position) {
+        this.shade = new ShadeIdPosition(id, position);
     }
 }

--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeMove.java
@@ -19,7 +19,7 @@ public class ShadeMove {
 
     ShadeIdPosition shade;
 
-    public ShadeMove(String id, ShadePosition position) {
-        this.shade = new ShadeIdPosition(id, position);
+    public ShadeMove(int intid, ShadePosition position) {
+        this.shade = new ShadeIdPosition(intid, position);
     }
 }


### PR DESCRIPTION
<!-- TITLE -->
 
Fixes #3454

<!-- DESCRIPTION -->

As the shade ID was cast as a string, the json encoder correctly added double quotes in the PUT message. This however, resulted in a 404 (see original bug report). Recasting as an int under a new variable resolves this. Note, changing this to an int in the referencing functions seems to break other things. 

Signed-off-by: tomdc01 

<!-- TESTING -->

Tested on current version of HD PowerView 2 device. No regression testing at this point.

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
