### PR TITLE
Remove observer mechanism

### DIFF
--- a/addons/binding/org.openhab.binding.zway/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/binding/binding.xml
@@ -10,8 +10,7 @@
 		Z-Way is a home automation software to configure and control a Z-Wave network. The ZAutomation interface provides 
 		all Z-Wave devices and handles incoming commands. The Z-Way Binding uses this HTTP interface to load all device 
 		and make them available during the discovery process.<br>
-		Besides a continuous polling the opportunity to register items in Z-Way as observer is possible (for that function
-		the related Z-Way App is currently required).
+		Currently only a continuous polling is available!
 		]]>
 	</description>
 	<author>Patrick Hecker</author>

--- a/addons/binding/org.openhab.binding.zway/ESH-INF/config/bridge-config.xml
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/config/bridge-config.xml
@@ -5,11 +5,6 @@
 		http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd"
 >
 	<config-description uri="binding:zway:zwayServer">
-		<parameter-group name="openhab">
-			<label>openHAB</label>
-			<description>The Z-Way server requires this information to notify the openHAB server. If Z-Way and openHAB are running on the same machine, the default value can be used.</description>
-		</parameter-group>
-
 		<parameter-group name="zwayServer">
 			<label>Z-Way server</label>
 			<description>The configuration of the Z-Way server. Except for the username and password all the information detected during the discovery.</description>
@@ -19,34 +14,6 @@
 			<label>Options</label>
 			<description>These settings affect functions of the binding.</description>
 		</parameter-group>
-
-		<parameter name="openHABAlias" groupName="openhab" type="text" required="false">
-			<label>Alias</label>
-			<description>Alias used in openHAB connector. By default, the alias is generated.</description>
-		</parameter>
-
-		<parameter name="openHABIpAddress" groupName="openhab" type="text">
-			<context>network-address</context>
-			<label>IP address</label>
-			<description>The IP address or hostname of the openHAB server. If Z-Way and openHAB are running on the same machine, the default value can be used.</description>
-			<default>localhost</default>
-		</parameter>
-
-		<parameter name="openHABPort" groupName="openhab" type="integer" required="false" min="0" max="65335">
-			<label>Port</label>
-			<description>The port of the openHAB server.</description>
-			<default>8080</default>
-		</parameter>
-
-		<parameter name="openHABProtocol" groupName="openhab" type="text" required="false">
-			<label>Protocol</label>
-			<description>Protocol to connect to the openHAB server (http or https).</description>
-			<default>http</default>
-			<options>
-				<option value="http">HTTP</option>
-				<option value="https">HTTPS</option>
-			</options>
-		</parameter>
 
 		<parameter name="zwayServerIpAddress" groupName="zwayServer" type="text">
 			<context>network-address</context>
@@ -88,12 +55,6 @@
 			<description>Refresh device states and registration from Z-Way server.</description>
 			<unitLabel>Seconds</unitLabel>
 			<default>3600</default>
-		</parameter>
-
-		<parameter name="observerMechanismEnabled" groupName="binding" type="boolean" required="false">
-			<label>Observer mechanism enabled</label>
-			<description>The observer functionality is responsible for the item registration as observer in Z-Way. Attention: if disable this option, you have to setup an other synchronization mechanism like MQTT.</description>
-			<default>true</default>
 		</parameter>
 	</config-description>
 

--- a/addons/binding/org.openhab.binding.zway/ESH-INF/i18n/zway.properties
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/i18n/zway.properties
@@ -1,25 +1,15 @@
 # binding
 binding.zway.name = Z-Way Binding
-binding.zway.description = Z-Way is a home automation software to configure and control a Z-Wave network. The ZAutomation interface provides all Z-Wave devices and handles incoming commands. The Z-Way Binding uses this HTTP interface to load all device and make them available during the discovery process.<br> Besides a continuous polling of device states the opportunity to register items in Z-Way as observer is possible to get actively device state updates (for that function the related Z-Way App is currently required).
+binding.zway.description = Z-Way is a home automation software to configure and control a Z-Wave network. The ZAutomation interface provides all Z-Wave devices and handles incoming commands. The Z-Way Binding uses this HTTP interface to load all device and make them available during the discovery process.<br> Currently only a continuous polling is available!
 
 # thing types
 thing-type.zway.zwayServer.label = Z-Way Server
 thing-type.zway.zwayServer.description = The Z-Way server represents a bridge with general settings and communication tasks.
 
-thing-type.config.zway.zwayServer.openhab.label = openHAB
-thing-type.config.zway.zwayServer.openhab.description = The Z-Way server requires this information to notify the openHAB server. If Z-Way and openHAB are running on the same machine, the default value can be used.
 thing-type.config.zway.zwayServer.zwayServer.label = Z-Way server
 thing-type.config.zway.zwayServer.zwayServer.description = The configuration of the Z-Way server. Except for the username and password all the information detected during the discovery.
 thing-type.config.zway.zwayServer.binding.label = Options
 thing-type.config.zway.zwayServer.binding.description = These settings affect functions of the binding.
-thing-type.config.zway.zwayServer.openHABAlias.label=openHAB alias
-thing-type.config.zway.zwayServer.openHABAlias.description = Alias used in <i>openHAB connector</i>. By default, the alias is generated.
-thing-type.config.zway.zwayServer.openHABIpAddress.label = IP address
-thing-type.config.zway.zwayServer.openHABIpAddress.description = The IP address or hostname of the openHAB server. If Z-Way and openHAB are running on the same machine, the default value can be used.
-thing-type.config.zway.zwayServer.openHABPort.label = Port
-thing-type.config.zway.zwayServer.openHABPort.description = The port of the openHAB server.
-thing-type.config.zway.zwayServer.openHABProtocol.label = Protocol
-thing-type.config.zway.zwayServer.openHABProtocol.description = Protocol to connect to the openHAB server (http or https).
 
 thing-type.config.zway.zwayServer.zwayServerIpAddress.label = IP address
 thing-type.config.zway.zwayServer.zwayServerIpAddress.description = The IP address or hostname of the Z-Way server. If Z-Way and openHAB are running on the same machine, the default value can be used.
@@ -34,8 +24,6 @@ thing-type.config.zway.zwayServer.zwayServerPassword.description = Password to a
 
 thing-type.config.zway.zwayServer.pollingInterval.label = Polling Interval
 thing-type.config.zway.zwayServer.pollingInterval.description = Refresh device states and registration from Z-Way server.
-thing-type.config.zway.zwayServer.observerMechanismEnabled.label = Observer mechanism enabled
-thing-type.config.zway.zwayServer.observerMechanismEnabled.description = The observer functionality is responsible for the item registration as observer in Z-Way. Attention: if disable this option, you have to setup an other synchronization mechanism like MQTT.
 
 thing-type.zway.zwayDevice.label = Z-Wave Device
 thing-type.zway.zwayDevice.description = A Z-Wave device represents a device of real world. Each device function will be mapped to a separate channel. The bridge is necessary as an intermediary between openHAB thing and Z-Way device.

--- a/addons/binding/org.openhab.binding.zway/ESH-INF/i18n/zway_de.properties
+++ b/addons/binding/org.openhab.binding.zway/ESH-INF/i18n/zway_de.properties
@@ -1,26 +1,15 @@
 # binding
 binding.zway.name = Z-Way Binding
-binding.zway.description = Das Z-Way-System ist ein Softwarepaket für den Z-Wave Funkstandard. Das System besteht im wesentlichen aus einer Firmware für Z-Wave Transceiver, einer Kommunikations- und einer Automatisierungskomponente zur Steuerung und Konfiguration des Netzwerks. Das Z-Way Binding nutzt die HTTP-Schnittstelle um alle Geräte zu laden und im Discovery-Prozess zur Verfügung zu stellen.<br>Neben einem Polling der Gerätezustände werden optional die resultierenden Geräte als Observer im Z-Way System registriert, um Zustandsänderungen der Geräte zu erhalten (dazu wird aktuell die Z-Way App <i>OpenHAB Konnektor</i> benötigt).
+binding.zway.description = Das Z-Way-System ist ein Softwarepaket für den Z-Wave Funkstandard. Das System besteht im wesentlichen aus einer Firmware für Z-Wave Transceiver, einer Kommunikations- und einer Automatisierungskomponente zur Steuerung und Konfiguration des Netzwerks. Das Z-Way Binding nutzt die HTTP-Schnittstelle um alle Geräte zu laden und im Discovery-Prozess zur Verfügung zu stellen.<br>Aktuell wird nur Polling zum Aktualisieren der Gerätezustände verwendet!
 
 # thing types
 thing-type.zway.zwayServer.label = Z-Way Server
 thing-type.zway.zwayServer.description = Der Z-Way Server repräsentiert das Z-Way System als Bridge mit der grundlegendene Konfiguration zum Verbindungsaufbau. Die gesamte Kommunikation mit Z-Way organisiert diese Komponente.
 
-thing-type.config.zway.zwayServer.openhab.label = openHAB
-thing-type.config.zway.zwayServer.openhab.description = Der Z-Way Server benötigt diese Informationen um bei Statusänderungen openHAB zu benachrichtigen. Wenn Z-Way und openHAB auf dem gleichen Host ausgeführt werden, können die Standardwerte beibehalten werden.
 thing-type.config.zway.zwayServer.zwayServer.label = Z-Way Server
 thing-type.config.zway.zwayServer.zwayServer.description = Die Konfiguration des Z-Way Server wird bis auf den Benutzername und das Passwort während des Discovery-Prozesses ermittlt.
 thing-type.config.zway.zwayServer.binding.label = Optionen
 thing-type.config.zway.zwayServer.binding.description = Diese Einstellungen betreffen Funktionen des Bindings.
-
-thing-type.config.zway.zwayServer.openHABAlias.label = Alias
-thing-type.config.zway.zwayServer.openHABAlias.description = Der Bezeichner wird für den openHAB-Konnektor benötigt und ist optional und frei wählbar, aber muss eindeutig sein. (Standard: ein generierter Wert)
-thing-type.config.zway.zwayServer.openHABIpAddress.label = IP-Adresse
-thing-type.config.zway.zwayServer.openHABIpAddress.description = Die Adresse unter der das openHAB-System erreichbar ist. Sollte sich der Z-Way Server und openHAB auf dem selben Rechner befinden, kann der Standardwert beibehalten werden.
-thing-type.config.zway.zwayServer.openHABPort.label = Port
-thing-type.config.zway.zwayServer.openHABPort.description = Der Port unter dem das openHAB-System erreichbar ist.
-thing-type.config.zway.zwayServer.openHABProtocol.label = Protokoll
-thing-type.config.zway.zwayServer.openHABProtocol.description = HTTP/HTTPS
 
 thing-type.config.zway.zwayServer.zwayServerIpAddress.label = IP-Adresse
 thing-type.config.zway.zwayServer.zwayServerIpAddress.description = Die Adresse unter der Z-Way erreichbar ist. Sollte sich der Z-Way Server und openHAB auf dem selben Rechner befinden, kann der Standardwert beibehalten werden.
@@ -35,8 +24,6 @@ thing-type.config.zway.zwayServer.zwayServerPassword.description = Passwort für 
 
 thing-type.config.zway.zwayServer.pollingInterval.label = Polling Interval
 thing-type.config.zway.zwayServer.pollingInterval.description = Aktualisiert den Gerätezustand und die Registrierung beim <i>OpenHAB Konnektor</i>
-thing-type.config.zway.zwayServer.observerMechanismEnabled.label = Observer-Mechanismus
-thing-type.config.zway.zwayServer.observerMechanismEnabled.description = Diese Funktion ist veranwortlich für die Aktualisierung der Gerätestatus. Achtung: Sollte die Funktion deaktiviert werden, muss ein anderer Synchronisationsmechanismus konfiguriert werden, bspw. MQTT.
 
 thing-type.zway.zwayDevice.label = Z-Wave Gerät
 thing-type.zway.zwayDevice.description = Ein Z-Wave Gerät repräsentiert ein physisch existierendes Gerät. Dabei wird jede Gerätefunktion (Temperatursensor, Luftfeuchtigkeitsmesser usw.) einem Channel zugeordnet. Eine Bridge (Z-Way Server) wird als Vermittler zwischen openHAB und Z-Way benötigt.

--- a/addons/binding/org.openhab.binding.zway/README.md
+++ b/addons/binding/org.openhab.binding.zway/README.md
@@ -63,27 +63,21 @@ But the configuration and properties of things are changed at runtime and channe
 
 ### Z-Way Server (Bridge)
 
-The information about accessing openHAB are needed so that the Observer mechanism works.
 Besides the username and password all required Z-Way information are found during discovery.
 
 | Configuration Name       | Mandatory | Default   | Desciption                                                                                                                                                                                   |
 |--------------------------|-----------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| openHABAlias             |           |           | By default, the alias is generated during initialization or configuration update of thing handler.                                                                                           |
-| openHABIpAddress         |           | localhost | The IP address or hostname of the openHAB server. If Z-Way and openHAB are running on the same machine, the default value can be used.                                                       |
-| openHABPort              |           | 8080      | The port of the openHAB server (0 to 65335)                                                                                                                                                  |
-| openHABProtocol          |           | http      | Protocol to connect to the openHAB server (http or https)                                                                                                                                    |
 | zwayServerIpAddress      |           | localhost | The IP address or hostname of the Z-Way server. If Z-Way and openHAB are running on the same machine, the default value can be used.                                                         |
 | zwayServerPort           |           | 8083      | The port of the Z-Way server (0 to 65335)                                                                                                                                                    |
 | zwayServerProtocol       |           | http      | Protocol to connect to the Z-Way server (http or https)                                                                                                                                      |
 | zwayServerUsername       |           | admin     | Username to access the Z-Way server.                                                                                                                                                         |
 | zwayServerPassword       | X         |           | Password to access the Z-Way server.                                                                                                                                                         |
 | pollingInterval          |           | 3600      | Refresh device states and registration from Z-Way server in seconds (at least 60).                                                                                                           |
-| observerMechanismEnabled |           | true      | The observer functionality is responsible for the item registration as observer in Z-Way. Attention: if disable this option, you have to setup an other synchronization mechanism like MQTT. |
 
-Only the Z-Way server can be configured textual (Attention! *openHABAlias* has to be set because the bridge configuration can not be changed at runtime):
+Only the Z-Way server can be configured textual:
 
 ```
-Bridge zway:zwayServer:192_168_2_42 [ openHABAlias="development", openHABIpAddress="localhost", openHABPort=8080, openHABProtocol="http", zwayServerIpAddress="localhost", zwayServerPort=8083, zwayServerProtocol="http", zwayServerUsername="admin", zwayServerPassword="admin", pollingInterval=3600, observerMechanismEnabled=true ] {
+Bridge zway:zwayServer:192_168_2_42 [ zwayServerIpAddress="localhost", zwayServerPort=8083, zwayServerProtocol="http", zwayServerUsername="admin", zwayServerPassword="admin", pollingInterval=3600 ] {
     // associated things have to be created with the Paper UI
 }
 ```
@@ -157,22 +151,12 @@ Unsupported Z-Way device types: Camera, SensorMultiline, Text. The integration o
 
 ### Channels for the Z-Way Server (Bridge)
 
-
-Markdown Table Formatter
-
-This tool formats basic MultiMarkdown style tables for easier plain text reading.
-It adds padding to all the cells to line up the pipe separators when using a mono-space font.
-
-To see what it's all about, try one of these examples, or format your own.
-
-Load: Example 1 - Example 2 - Example 3
-
-For more information:
-I'm on Twitter as @TheIdOfAlan
-I sometimes post on my personal site alanwsmith.com
-This is an Open Source GitHub Project.
-It has a Jasmine Test Suite.
-What to show your appreciation? Buy me a book
+-| Channel Type ID | Item Type | Category | Description |
+-| --------------- | --------- | -------- | ----------- |
+-| actions         | String | -      | It is currently possible to update all devices. |
+-| secureInclusion | Switch | Switch | Change inclusion type for further inclusions. |
+-| inclusion       | Switch | Switch | Start inclusion mode (after a timeout the inclusion will be automatically finished). |
+-| exclusion       | Switch | Switch | Start exclusion mode (after a timeout the exclusion will be automatically finished). ||
 
 ## Locations
 
@@ -203,7 +187,7 @@ Because textual configuration isn't useful, follow the instructions in the [Gett
 
 -   Z-Way device types (especially the probe types) supported by openHAB channels with detailed information (scale types and so on) are not complete.
 -   Configuration of the Z-Wave network by the binding is currently not possible (physical device configuration)
--   Z-Way App "openHAB Connector" is required. Further versions will contain other mechanisms under usage of the WebSocket implementation of Z-Way or MQTT.
+-   Only polling is available. Further versions will contain other mechanisms under usage of the WebSocket implementation of Z-Way or MQTT.
 
 <br>
 <img src="doc/BMWi_4C_Gef_en.jpg" width="200">

--- a/addons/binding/org.openhab.binding.zway/doc/GETTING_STARTED.md
+++ b/addons/binding/org.openhab.binding.zway/doc/GETTING_STARTED.md
@@ -3,17 +3,6 @@
 # Prepare Z-Way Server
 
 1. [Download](https://razberry.z-wave.me/z-way-server/) Z-Way v2.2.3 or newer (further information about installing Z-Way you can find [here](http://razberry.z-wave.me/index.php?id=24))
-2. Install openHAB Connector
-    - via "ZWave.Me App Store"
-    - via Git
-
-    ```shell
-    cd /opt/z-way-server/automation/userModules
-    git clone https://github.com/pathec/ZWay-OpenHABConnector.git OpenHABConnector
-    service z-way-server restart
-    ```
-
-3. Instantiate the app once (under Configuration - Apps - Local Apps). Important: Change the selection from "Featured Apps" to "All Apps" to make the app visible. It is not necessary to make the configuration manually.
 
 # Prepare openHAB
 
@@ -52,11 +41,6 @@ Open the *Configuration* - *Things* and select Z-Way Server
 
 Change configuration: In order for the Observer mechanism works, the IP address, port and protocol of both systems are required.
 
-- **openHAB**
-    - **openHAB Alias** by default, the alias is generated
-    - **IP address** (default: localhost)
-    - **port** (default: 8080)
-    - **protocol** (default: http)
 - **Z-Way Server**
     - **IP address** (default: localhost)
     - **port** (default: 8083)
@@ -65,8 +49,8 @@ Change configuration: In order for the Observer mechanism works, the IP address,
     - **password** must be set (no default value)
 - **options**
     - **polling interval** (default: 3600) in seconds
-    - **Observer mechanism** (default: active)
 
+**The following picture is no longer up to date!**
 ![openHAB Thing settings](images/getting-started/06-Bridge-settings.png)
 
 ## Create and configure Z-Way Devices

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/ZWayBindingConstants.java
@@ -86,17 +86,12 @@ public class ZWayBindingConstants {
     public static final String ACTIONS_CHANNEL_OPTION_REFRESH = "REFRESH";
 
     /* Bridge config properties */
-    public static final String BRIDGE_CONFIG_OPENHAB_ALIAS = "openHABAlias";
-    public static final String BRIDGE_CONFIG_OPENHAB_IP_ADDRESS = "openHABIpAddress";
-    public static final String BRIDGE_CONFIG_OPENHAB_PORT = "openHABPort";
-    public static final String BRIDGE_CONFIG_OPENHAB_PROTOCOL = "openHABProtocol";
     public static final String BRIDGE_CONFIG_ZWAY_SERVER_IP_ADDRESS = "zwayServerIpAddress";
     public static final String BRIDGE_CONFIG_ZWAY_SERVER_PORT = "zwayServerPort";
     public static final String BRIDGE_CONFIG_ZWAY_SERVER_PROTOCOL = "zwayServerProtocol";
     public static final String BRIDGE_CONFIG_ZWAY_SERVER_USERNAME = "zwayServerUsername";
     public static final String BRIDGE_CONFIG_ZWAY_SERVER_PASSWORD = "zwayServerPassword";
     public static final String BRIDGE_CONFIG_POLLING_INTERVAL = "pollingInterval";
-    public static final String BRIDGE_CONFIG_OBSERVER_MECHANISM_ENABLED = "observerMechanismEnabled";
 
     public static final String DEVICE_CONFIG_NODE_ID = "nodeId";
     public static final String DEVICE_CONFIG_VIRTUAL_DEVICE_ID = "deviceId";

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayBridgeHandler.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -36,12 +35,9 @@ import de.fh_zwickau.informatik.sensor.ZWayApiHttp;
 import de.fh_zwickau.informatik.sensor.model.devicehistory.DeviceHistory;
 import de.fh_zwickau.informatik.sensor.model.devicehistory.DeviceHistoryList;
 import de.fh_zwickau.informatik.sensor.model.devices.Device;
-import de.fh_zwickau.informatik.sensor.model.devices.DeviceCommand;
 import de.fh_zwickau.informatik.sensor.model.devices.DeviceList;
 import de.fh_zwickau.informatik.sensor.model.instances.Instance;
 import de.fh_zwickau.informatik.sensor.model.instances.InstanceList;
-import de.fh_zwickau.informatik.sensor.model.instances.openhabconnector.OpenHABConnector;
-import de.fh_zwickau.informatik.sensor.model.instances.openhabconnector.OpenHabConnectorZWayServer;
 import de.fh_zwickau.informatik.sensor.model.locations.Location;
 import de.fh_zwickau.informatik.sensor.model.locations.LocationList;
 import de.fh_zwickau.informatik.sensor.model.modules.ModuleList;
@@ -60,15 +56,9 @@ import de.fh_zwickau.informatik.sensor.model.zwaveapi.devices.ZWaveDevice;
  * - load and check configuration
  * - instantiate a Z-Way API that used in the whole binding
  * - authenticate to the Z-Way server
- * - check existence of openHAB Connector in Z-Way server and configure openHAB server
- * - after update, perform refresh listener command to openHAB Connector
  * - initialize all containing device things
  *
- * During the removal process the following tasks are performed:
- * - clean up openHAB Connector configuration
- * - important: the configured devices not changed in openHAB Connector!
- *
- * @author Patrick Hecker - Initial contribution
+ * @author Patrick Hecker - Initial contribution, remove observer mechanism
  * @author Johannes Einig - Bridge now stores DeviceList
  */
 public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCallbacks {
@@ -112,11 +102,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
                     logger.info("Z-Way bridge successfully authenticated");
                     // Gets the latest deviceList from zWay during bridge initialization
                     deviceList = mZWayApi.getDevices();
-
-                    // Register openHAB server to Z-Way if observer mechanism is enabled
-                    if (mConfig.getObserverMechanismEnabled()) {
-                        updateOpenHabConnector(false);
-                    }
 
                     // Initialize bridge polling
                     if (pollingJob == null || pollingJob.isCancelled()) {
@@ -175,11 +160,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
                 } else {
                     logger.warn("Removing device failed (DeviceHandler is null): {}", thing.getLabel());
                 }
-            }
-
-            // Remove openHAB server to Z-Way if observer mechanism is enabled
-            if (mConfig.getObserverMechanismEnabled()) {
-                updateOpenHabConnector(true);
             }
 
             // status update will finally remove the thing
@@ -262,36 +242,14 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
         mConfig = loadAndCheckConfiguration();
 
         if (mConfig != null) {
-            // Check if openHAB alias already set
-            if (mConfig.getOpenHabAlias() == null) {
-                Configuration config = editConfiguration();
-                if (config != null) {
-                    Integer shortUnixTimestamp = (int) (System.currentTimeMillis() / 1000L);
-                    logger.debug("openHAB alias generated: {}", shortUnixTimestamp.toString());
-                    config.put(BRIDGE_CONFIG_OPENHAB_ALIAS, shortUnixTimestamp.toString());
-                    updateConfiguration(config);
+            logger.debug("Configuration complete: {}", mConfig);
 
-                    // update configuration instance
-                    mConfig.setOpenHabAlias(shortUnixTimestamp.toString());
-                } else {
-                    logger.error("Can't generate openHAB alias (editable configuration not available)");
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
-                            "Can't generate openHAB alias (editable configuration not available)");
-                }
-            } else {
-                logger.debug("openHAB alias manually set");
-            }
+            mZWayApi = new ZWayApiHttp(mConfig.getZWayIpAddress(), mConfig.getZWayPort(), mConfig.getZWayProtocol(),
+                    mConfig.getZWayUsername(), mConfig.getZWayPassword(), -1, false, this);
 
-            if (mConfig.getOpenHabAlias() != null) {
-                logger.debug("Configuration complete: {}", mConfig);
-
-                mZWayApi = new ZWayApiHttp(mConfig.getZWayIpAddress(), mConfig.getZWayPort(), mConfig.getZWayProtocol(),
-                        mConfig.getZWayUsername(), mConfig.getZWayPassword(), -1, false, this);
-
-                // Start an extra thread, because it takes sometimes more
-                // than 5000 milliseconds and the handler will suspend (ThingStatus.UNINITIALIZED).
-                scheduler.execute(new Initializer());
-            }
+            // Start an extra thread, because it takes sometimes more
+            // than 5000 milliseconds and the handler will suspend (ThingStatus.UNINITIALIZED).
+            scheduler.execute(new Initializer());
         }
     }
 
@@ -310,33 +268,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
         }
 
         super.dispose();
-    }
-
-    @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
-        logger.debug("Handle Z-Way bridge configuration update ...");
-
-        Boolean observerMechanismEnabledOld = null;
-        Boolean observerMechanismEnabledNew = null;
-
-        if (mConfig != null) {
-            observerMechanismEnabledOld = mConfig.getObserverMechanismEnabled();
-            observerMechanismEnabledNew = (Boolean) configurationParameters
-                    .get(BRIDGE_CONFIG_OBSERVER_MECHANISM_ENABLED);
-        }
-
-        if (observerMechanismEnabledOld != null && observerMechanismEnabledNew != null) {
-            logger.debug("Observer mechanism enabled changed from {} to {}", observerMechanismEnabledOld,
-                    observerMechanismEnabledNew);
-
-            if (observerMechanismEnabledOld && !observerMechanismEnabledNew) {
-                updateOpenHabConnector(true);
-            } else if (!observerMechanismEnabledOld && observerMechanismEnabledNew) {
-                updateOpenHabConnector(false);
-            }
-        } // if no old configuration available it's not an update
-
-        super.handleConfigurationUpdate(configurationParameters);
     }
 
     private class BridgePolling implements Runnable {
@@ -403,83 +334,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
         }
     };
 
-    /**
-     * Setup the openHAB server in openHAB Connector depending on configuration
-     *
-     * @param deleteOpenHabServer if true the configured openHAB server will be removed
-     */
-    private synchronized void updateOpenHabConnector(Boolean deleteOpenHabServer) {
-        InstanceList instanceList = mZWayApi.getInstances();
-        if (instanceList != null) {
-            logger.debug("Check existence of openHAB Connector in Z-Way server");
-
-            OpenHABConnector instance = (OpenHABConnector) instanceList.getInstanceByModuleId("OpenHABConnector");
-
-            if (instance != null) {
-                OpenHabConnectorZWayServer configuredServer = new OpenHabConnectorZWayServer(mConfig.getOpenHabAlias(),
-                        mConfig.getOpenHabIpAddress(), mConfig.getOpenHabPort());
-
-                if (deleteOpenHabServer) {
-                    if (instance.getParams().getCommonOptions().removeOpenHabServer(configuredServer)) {
-                        logger.debug("Configured openHAB server updated");
-
-                        Instance updatedInstance = mZWayApi.putInstance(instance);
-                        if (updatedInstance != null) {
-                            logger.debug("openHAB server successfully removed from openHAB Connector");
-
-                            refreshOpenConnector();
-                        } else {
-                            logger.warn("openHAB Connector configuration update failed");
-                        }
-                    } // else - update not necessary, no changes
-                } else {
-                    if (instance.getParams().getCommonOptions().updateOpenHabServer(configuredServer)) {
-                        logger.debug("Configured openHAB server updated");
-
-                        Instance updatedInstance = mZWayApi.putInstance(instance);
-                        if (updatedInstance != null) {
-                            logger.info("openHAB server successfully configured in openHAB Connector");
-
-                            refreshOpenConnector();
-                        } else {
-                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
-                                    "openHAB Connector configuration update failed");
-
-                            logger.warn("openHAB Connector configuration update failed");
-                        }
-                    } // else - update not necessary, no changes
-                }
-            } else {
-                if (!deleteOpenHabServer) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
-                            "openHAB Connector doesn't exist in Z-Way server");
-                } // else - error has no impact on the binding
-
-                logger.warn("openHAB Connector doesn't exist in Z-Way server");
-            }
-        } else {
-            if (!deleteOpenHabServer) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR, "Instances not loaded");
-            } // else - error has no impact on the binding
-
-            logger.warn("Instances not loaded");
-        }
-    }
-
-    /**
-     * Refresh listener in Z-Way server (otherwise the listener will only be refreshed at server restart)
-     */
-    private synchronized void refreshOpenConnector() {
-        DeviceCommand command = new DeviceCommand("OpenHabConnector", "refreshListener");
-
-        String message = mZWayApi.getDeviceCommand(command);
-        if (message != null) {
-            logger.debug("Refresh listener finished successfully: {}", message);
-        } else {
-            logger.warn("Refresh listener failed.");
-        }
-    }
-
     @Override
     public void handleRemoval() {
         logger.debug("Handle removal Z-Way bridge ...");
@@ -524,28 +378,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
     private ZWayBridgeConfiguration loadAndCheckConfiguration() {
         ZWayBridgeConfiguration config = getConfigAs(ZWayBridgeConfiguration.class);
 
-        /***********************************
-         ****** openHAB configuration ******
-         **********************************/
-
-        // openHAB Alias
-        // not required
-
-        // openHAB IP address
-        if (StringUtils.trimToNull(config.getOpenHabIpAddress()) == null) {
-            config.setOpenHabIpAddress("localhost"); // default value
-        }
-
-        // openHAB Port
-        if (config.getOpenHabPort() == null) {
-            config.setOpenHabPort(8080);
-        }
-
-        // openHAB Protocol
-        if (StringUtils.trimToNull(config.getOpenHabProtocol()) == null) {
-            config.setOpenHabProtocol("http");
-        }
-
         /****************************************
          ****** Z-Way server configuration ******
          ****************************************/
@@ -584,11 +416,6 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
         // Polling interval
         if (config.getPollingInterval() == null) {
             config.setPollingInterval(3600);
-        }
-
-        // Observer mechanism enabled
-        if (config.getObserverMechanismEnabled() == null) {
-            config.setObserverMechanismEnabled(true);
         }
 
         return config;

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/handler/ZWayDeviceHandler.java
@@ -15,11 +15,9 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -46,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.fh_zwickau.informatik.sensor.model.devices.Device;
-import de.fh_zwickau.informatik.sensor.model.devices.DeviceCommand;
 import de.fh_zwickau.informatik.sensor.model.devices.DeviceList;
 import de.fh_zwickau.informatik.sensor.model.devices.types.Battery;
 import de.fh_zwickau.informatik.sensor.model.devices.types.Doorlock;
@@ -66,7 +63,7 @@ import de.fh_zwickau.informatik.sensor.model.zwaveapi.devices.ZWaveDevice;
  * The {@link ZWayDeviceHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
- * @author Patrick Hecker - Initial contribution
+ * @author Patrick Hecker - Initial contribution, remove observer mechanism
  * @author Johannes Einig - Now uses the bridge handler cached device list
  */
 public abstract class ZWayDeviceHandler extends BaseThingHandler {
@@ -79,7 +76,7 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
     protected abstract void refreshLastUpdate();
 
     /**
-     * Initialize polling job and register all linked item in openHAB connector as observer
+     * Initialize polling job
      */
     private class Initializer implements Runnable {
 
@@ -107,24 +104,6 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                     // Called when thing or bridge updated ...
                     logger.debug("Polling is allready active");
                 }
-
-                // Register all linked items on server start
-                if (zwayBridgeHandler.getZWayBridgeConfiguration().getObserverMechanismEnabled()) {
-                    for (Channel channel : getThing().getChannels()) {
-                        if (isLinked(channel.getUID().getId())) {
-                            String deviceId = channel.getProperties().get("deviceId");
-                            if (deviceId != null) {
-                                Set<Item> items = linkRegistry.getLinkedItems(channel.getUID());
-                                for (Item item : items) {
-                                    logger.debug("Linked item found - starting register command for openHAB item: {}",
-                                            item);
-                                    zwayRegisterOpenHabItem(item, deviceId);
-                                }
-                            } // else - no channel for virtual device, channels for command classes can't register as
-                              // observer
-                        }
-                    }
-                }
             } catch (Throwable t) {
                 if (t instanceof Exception) {
                     logger.error("{}", t.getMessage());
@@ -135,15 +114,12 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                 }
                 if (getThing().getStatus() == ThingStatus.ONLINE) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
-                            "Error occurred when starting polling and registering item as observer.");
+                            "Error occurred when starting polling.");
                 }
             }
         }
     };
 
-    /**
-     * Remove all linked items from openHAB connector observer list
-     */
     private class Disposer implements Runnable {
 
         @Override
@@ -157,19 +133,6 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
                 updateStatus(ThingStatus.REMOVED);
 
                 return;
-            }
-
-            // Remove all linked items in Z-Way server
-            if (zwayBridgeHandler.getZWayBridgeConfiguration().getObserverMechanismEnabled()) {
-                for (Channel channel : getThing().getChannels()) {
-                    if (isLinked(channel.getUID().getId())) {
-                        Set<Item> items = linkRegistry.getLinkedItems(channel.getUID());
-                        for (Item item : items) {
-                            logger.debug("Linked item found - starting remove command for openHAB item: {}", item);
-                            zwayUnsubscribeOpenHabItem(item);
-                        }
-                    }
-                }
             }
 
             // status update will remove finally
@@ -375,20 +338,6 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
 
         // Method called when channel linked and not when server started!!!
 
-        if (zwayBridgeHandler.getZWayBridgeConfiguration().getObserverMechanismEnabled()) {
-            // Load device id from channel's properties for the compatibility of ZAutomation and ZWave devices
-            Channel channel = thing.getChannel(channelUID.getId());
-            String deviceId = channel.getProperties().get("deviceId");
-
-            if (deviceId != null) {
-                Set<Item> items = linkRegistry.getLinkedItems(channelUID);
-                for (Item item : items) {
-                    logger.debug("Linked item found - starting register command for openHAB item: {}", item);
-                    zwayRegisterOpenHabItem(item, deviceId);
-                }
-            } // else - no channel for virtual device, channels for command classes can't register as observer
-        }
-
         super.channelLinked(channelUID); // performs a refresh command
     }
 
@@ -402,66 +351,7 @@ public abstract class ZWayDeviceHandler extends BaseThingHandler {
             return;
         }
 
-        if (zwayBridgeHandler.getZWayBridgeConfiguration().getObserverMechanismEnabled()) {
-            // Load device id from channel's properties for the compatibility of ZAutomation and ZWave devices
-            Channel channel = thing.getChannel(channelUID.getId());
-            String deviceId = channel.getProperties().get("deviceId");
-
-            if (deviceId != null) {
-                // TODO no items for this channel available at this point!
-                // before method called by system the item removed
-                Set<Item> items = linkRegistry.getLinkedItems(channelUID);
-                for (Item item : items) {
-                    logger.debug("Linked item found - starting remove command for openHAB item: {}", item);
-                    zwayUnsubscribeOpenHabItem(item);
-                }
-            } // else - no channel for virtual device, channels for command classes can't register as observer
-        }
-
         super.channelUnlinked(channelUID);
-    }
-
-    private void zwayRegisterOpenHabItem(Item openHABItem, String deviceId) {
-        ZWayBridgeHandler zwayBridgeHandler = getZWayBridgeHandler();
-        if (zwayBridgeHandler == null || !zwayBridgeHandler.getThing().getStatus().equals(ThingStatus.ONLINE)) {
-            logger.debug("Z-Way bridge handler not found or not ONLINE.");
-            return;
-        }
-
-        // Preconditions are OK, starting registration ...
-        Map<String, String> params = new HashMap<>();
-        params.put("openHabAlias", zwayBridgeHandler.getZWayBridgeConfiguration().getOpenHabAlias());
-        params.put("openHabItemName", openHABItem.getName());
-        params.put("vDevName", deviceId);
-        DeviceCommand command = new DeviceCommand("OpenHabConnector", "registerOpenHabItem", params);
-
-        String message = zwayBridgeHandler.getZWayApi().getDeviceCommand(command);
-        if (message != null) {
-            logger.debug("Device registration finished successfully: {}", message);
-        } else {
-            logger.warn("Device registration failed");
-        }
-    }
-
-    private void zwayUnsubscribeOpenHabItem(Item openHABItem) {
-        ZWayBridgeHandler zwayBridgeHandler = getZWayBridgeHandler();
-        if (zwayBridgeHandler == null || !zwayBridgeHandler.getThing().getStatus().equals(ThingStatus.ONLINE)) {
-            logger.debug("Z-Way bridge handler not found or not ONLINE.");
-            return;
-        }
-
-        // Preconditions are OK, starting unsubscribing ...
-        Map<String, String> params = new HashMap<>();
-        params.put("openHabAlias", zwayBridgeHandler.getZWayBridgeConfiguration().getOpenHabAlias());
-        params.put("openHabItemName", openHABItem.getName());
-        DeviceCommand command = new DeviceCommand("OpenHabConnector", "removeOpenHabItem", params);
-
-        String message = zwayBridgeHandler.getZWayApi().getDeviceCommand(command);
-        if (message != null) {
-            logger.debug("Device unsubscribing finished successfully: {}", message);
-        } else {
-            logger.warn("Device unsubscribing failed");
-        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/config/ZWayBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/config/ZWayBridgeConfiguration.java
@@ -15,15 +15,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 /**
  * The {@link ZWayBridgeConfiguration} class defines the model for a bridge configuration.
  *
- * @author Patrick Hecker - Initial contribution
+ * @author Patrick Hecker - Initial contribution, remove openHAB configuration
  */
 public class ZWayBridgeConfiguration {
-    private String openHABAlias;
-
-    private String openHABIpAddress;
-    private Integer openHABPort;
-    private String openHABProtocol;
-
     private String zwayServerIpAddress;
     private Integer zwayServerPort;
     private String zwayServerProtocol;
@@ -32,39 +26,6 @@ public class ZWayBridgeConfiguration {
     private String zwayServerPassword;
 
     private Integer pollingInterval;
-    private Boolean observerMechanismEnabled;
-
-    public String getOpenHabAlias() {
-        return openHABAlias;
-    }
-
-    public void setOpenHabAlias(String openHabAlias) {
-        this.openHABAlias = openHabAlias;
-    }
-
-    public String getOpenHabIpAddress() {
-        return openHABIpAddress;
-    }
-
-    public void setOpenHabIpAddress(String ipAddress) {
-        this.openHABIpAddress = ipAddress;
-    }
-
-    public Integer getOpenHabPort() {
-        return openHABPort;
-    }
-
-    public void setOpenHabPort(Integer port) {
-        this.openHABPort = port;
-    }
-
-    public String getOpenHabProtocol() {
-        return openHABProtocol;
-    }
-
-    public void setOpenHabProtocol(String protocol) {
-        this.openHABProtocol = protocol;
-    }
 
     public String getZWayIpAddress() {
         return zwayServerIpAddress;
@@ -114,26 +75,13 @@ public class ZWayBridgeConfiguration {
         this.pollingInterval = pollingInterval;
     }
 
-    public Boolean getObserverMechanismEnabled() {
-        return observerMechanismEnabled;
-    }
-
-    public void setObserverMechanismEnabled(Boolean observerMechanismEnabled) {
-        this.observerMechanismEnabled = observerMechanismEnabled;
-    }
-
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append(BRIDGE_CONFIG_OPENHAB_ALIAS, this.getOpenHabAlias())
-                .append(BRIDGE_CONFIG_OPENHAB_IP_ADDRESS, this.getOpenHabIpAddress())
-                .append(BRIDGE_CONFIG_OPENHAB_PORT, this.getOpenHabPort())
-                .append(BRIDGE_CONFIG_OPENHAB_PROTOCOL, this.getOpenHabProtocol())
-                .append(BRIDGE_CONFIG_ZWAY_SERVER_IP_ADDRESS, this.getZWayIpAddress())
+        return new ToStringBuilder(this).append(BRIDGE_CONFIG_ZWAY_SERVER_IP_ADDRESS, this.getZWayIpAddress())
                 .append(BRIDGE_CONFIG_ZWAY_SERVER_PORT, this.getZWayPort())
                 .append(BRIDGE_CONFIG_ZWAY_SERVER_PROTOCOL, this.getZWayProtocol())
                 .append(BRIDGE_CONFIG_ZWAY_SERVER_USERNAME, this.getZWayUsername())
                 .append(BRIDGE_CONFIG_ZWAY_SERVER_PASSWORD, this.getZWayPassword())
-                .append(BRIDGE_CONFIG_POLLING_INTERVAL, this.getPollingInterval())
-                .append(BRIDGE_CONFIG_OBSERVER_MECHANISM_ENABLED, this.getObserverMechanismEnabled()).toString();
+                .append(BRIDGE_CONFIG_POLLING_INTERVAL, this.getPollingInterval()).toString();
     }
 }

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -116,6 +116,6 @@
     <module>org.openhab.binding.windcentrale</module>
     <module>org.openhab.binding.yamahareceiver</module>
     <module>org.openhab.binding.zoneminder</module>
-<!--<module>org.openhab.binding.zway</module>-->
+	<module>org.openhab.binding.zway</module>
   </modules>
 </project>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -492,11 +492,11 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zoneminder/${project.version}</bundle>
     </feature>
 
-<!--	<feature name="openhab-binding-zway" description="Z-Way Binding" version="${project.version}">
+    <feature name="openhab-binding-zway" description="Z-Way Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zway/${project.version}</bundle>
     </feature>
--->
+
     <!-- io -->
 
     <feature name="openhab-transport-feed" description="Feed Transport" version="${project.version}">


### PR DESCRIPTION
To eliminate the link registry dependency, the bbserver mechanism must be removed.

Initially, this PR is used to reactivate the binding. In a following PR, an update is implemented by WebSockets.

Signed-off-by: Patrick Hecker <pah111kg@fh-zwickau.de> (github: pathec)