### PR TITLE
[Nest] Use FieldNamingPolicy to reduce Gson annotations

### DIFF
--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
@@ -12,8 +12,8 @@ import static org.junit.Assert.*;
 import static org.openhab.binding.nest.internal.data.NestDataUtil.*;
 
 import java.io.IOException;
-import java.util.Calendar;
-import java.util.TimeZone;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.junit.Test;
@@ -23,6 +23,11 @@ import org.slf4j.LoggerFactory;
 public class GsonParsingTest {
 
     private final Logger logger = LoggerFactory.getLogger(GsonParsingTest.class);
+
+    private static void assertEqualDateTime(String expected, Date actual) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        assertEquals(expected, sdf.format(actual));
+    }
 
     @Test
     public void verifyCompleteInput() throws IOException {
@@ -76,11 +81,8 @@ public class GsonParsingTest {
         assertFalse(thermostat.isUsingEmergencyHeat());
         assertEquals(THERMOSTAT1_DEVICE_ID, thermostat.getDeviceId());
         assertEquals(Integer.valueOf(15), thermostat.getFanTimerDuration());
-        Calendar utcCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        utcCal.set(2017, 1, 2, 21, 0, 6);
-        assertEquals(utcCal.getTime().toString(), thermostat.getLastConnection().toString());
-        utcCal.set(1970, 0, 1, 0, 0, 0);
-        assertEquals(utcCal.getTime().toString(), thermostat.getFanTimerTimeout().toString());
+        assertEqualDateTime("2017-02-02T21:00:06.000Z", thermostat.getLastConnection());
+        assertEqualDateTime("1970-01-01T00:00:00.000Z", thermostat.getFanTimerTimeout());
         assertEquals(Double.valueOf(22.0), thermostat.getLockedTemperatureHigh());
         assertEquals(Double.valueOf(20.0), thermostat.getLockedTemperatureLow());
         assertEquals(Thermostat.Mode.HEAT, thermostat.getMode());
@@ -133,11 +135,8 @@ public class GsonParsingTest {
                 + "yeWNqdmRZVjdGQQ?auth=c.eQ5QBBPiFOTNzPHbmZPcE9yPZ7GayzLusifgQR2DQRFNyUS9ESvlhJF0D7vG8Y0TFV39zX1vIOsWrv"
                 + "8RKCMrFepNUb9FqHEboa4MtWLUsGb4tD9oBh0jrV4HooJUmz5sVA5KZR0dkxyLYyPc", camera.getAppUrl());
         assertEquals(CAMERA1_DEVICE_ID, camera.getDeviceId());
-        Calendar utcCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        // 2017-01-22T08:19:20.000Z
-        utcCal.set(2017, 0, 22, 8, 19, 20);
         assertNull(camera.getLastConnection());
-        assertEquals(utcCal.getTime().toString(), camera.getLastIsOnlineChange().toString());
+        assertEqualDateTime("2017-01-22T08:19:20.000Z", camera.getLastIsOnlineChange());
         assertNull(camera.getPublicShareUrl());
         assertEquals("https://www.dropcam.com/api/wwn.get_snapshot/CjZfTEs4ajlyUlh3Q0tFQk90RG83SnNrTnh6V"
                 + "2ZIQk9JbTNDTG91Q1QzRlFaenJ2b2tLX0R6RlESFm9wNVB2NW93NmJ6cUdvMkZQSGUxdEEaNld0Mkl5b2tIR0tKX2FpUVd1SkRnQj"
@@ -153,13 +152,9 @@ public class GsonParsingTest {
         assertEquals(2, camera.getLastEvent().getActivityZones().size());
         assertEquals("id1", camera.getLastEvent().getActivityZones().get(0));
         assertEquals("app_url", camera.getLastEvent().getAppUrl());
-        // 2017-01-22T07:40:38.680Z
-        utcCal.set(2017, 0, 22, 7, 40, 38);
-        assertEquals(utcCal.getTime().toString(), camera.getLastEvent().getEndTime().toString());
+        assertEqualDateTime("2017-01-22T07:40:38.680Z", camera.getLastEvent().getEndTime());
         assertEquals("image_url", camera.getLastEvent().getImageUrl());
-        // 2017-01-22T07:40:19.020Z
-        utcCal.set(2017, 0, 22, 7, 40, 19);
-        assertEquals(utcCal.getTime().toString(), camera.getLastEvent().getStartTime().toString());
+        assertEqualDateTime("2017-01-22T07:40:19.020Z", camera.getLastEvent().getStartTime());
         assertNull(camera.getLastEvent().getUrlsExpireTime());
         assertEquals("myurl", camera.getLastEvent().getWebUrl());
         assertTrue(camera.getLastEvent().isHasMotion());
@@ -177,10 +172,7 @@ public class GsonParsingTest {
         assertEquals(SMOKE1_DEVICE_ID, smokeDetector.getDeviceId());
         assertEquals("Downstairs", smokeDetector.getName());
         assertEquals("Downstairs Nest Protect", smokeDetector.getNameLong());
-        Calendar utcCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        // 2017-02-02T20:53:05.338Z
-        utcCal.set(2017, 1, 2, 20, 53, 5);
-        assertEquals(utcCal.getTime().toString(), smokeDetector.getLastConnection().toString());
+        assertEqualDateTime("2017-02-02T20:53:05.338Z", smokeDetector.getLastConnection());
         assertEquals(SmokeDetector.BatteryHealth.OK, smokeDetector.getBatteryHealth());
         assertEquals(SmokeDetector.AlarmState.OK, smokeDetector.getCoAlarmState());
         assertEquals(SmokeDetector.AlarmState.OK, smokeDetector.getSmokeAlarmState());
@@ -207,10 +199,7 @@ public class GsonParsingTest {
         assertEquals("US", structure.getCountryCode());
         assertEquals("98056", structure.getPostalCode());
         assertEquals(Structure.HomeAwayState.HOME, structure.getAway());
-        Calendar utcCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        // 2017-02-02T03:10:08.000Z
-        utcCal.set(2017, 1, 2, 3, 10, 8);
-        assertEquals(utcCal.getTime().toString(), structure.getEtaBegin().toString());
+        assertEqualDateTime("2017-02-02T03:10:08.000Z", structure.getEtaBegin());
         assertNull(structure.getEta());
         assertNull(structure.getPeakPeriodEndTime());
         assertNull(structure.getPeakPeriodStartTime());

--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/GsonParsingTest.java
@@ -38,11 +38,11 @@ public class GsonParsingTest {
         assertEquals(topLevel.getDevices().getCameras().size(), 2);
         assertNotNull(topLevel.getDevices().getCameras().get(CAMERA1_DEVICE_ID));
         assertNotNull(topLevel.getDevices().getCameras().get(CAMERA2_DEVICE_ID));
-        assertEquals(topLevel.getDevices().getSmokeDetectors().size(), 4);
-        assertNotNull(topLevel.getDevices().getSmokeDetectors().get(SMOKE1_DEVICE_ID));
-        assertNotNull(topLevel.getDevices().getSmokeDetectors().get(SMOKE2_DEVICE_ID));
-        assertNotNull(topLevel.getDevices().getSmokeDetectors().get(SMOKE3_DEVICE_ID));
-        assertNotNull(topLevel.getDevices().getSmokeDetectors().get(SMOKE4_DEVICE_ID));
+        assertEquals(topLevel.getDevices().getSmokeCoAlarms().size(), 4);
+        assertNotNull(topLevel.getDevices().getSmokeCoAlarms().get(SMOKE1_DEVICE_ID));
+        assertNotNull(topLevel.getDevices().getSmokeCoAlarms().get(SMOKE2_DEVICE_ID));
+        assertNotNull(topLevel.getDevices().getSmokeCoAlarms().get(SMOKE3_DEVICE_ID));
+        assertNotNull(topLevel.getDevices().getSmokeCoAlarms().get(SMOKE4_DEVICE_ID));
     }
 
     @Test
@@ -58,11 +58,11 @@ public class GsonParsingTest {
         assertEquals(data.getDevices().getCameras().size(), 2);
         assertNotNull(data.getDevices().getCameras().get(CAMERA1_DEVICE_ID));
         assertNotNull(data.getDevices().getCameras().get(CAMERA2_DEVICE_ID));
-        assertEquals(data.getDevices().getSmokeDetectors().size(), 4);
-        assertNotNull(data.getDevices().getSmokeDetectors().get(SMOKE1_DEVICE_ID));
-        assertNotNull(data.getDevices().getSmokeDetectors().get(SMOKE2_DEVICE_ID));
-        assertNotNull(data.getDevices().getSmokeDetectors().get(SMOKE3_DEVICE_ID));
-        assertNotNull(data.getDevices().getSmokeDetectors().get(SMOKE4_DEVICE_ID));
+        assertEquals(data.getDevices().getSmokeCoAlarms().size(), 4);
+        assertNotNull(data.getDevices().getSmokeCoAlarms().get(SMOKE1_DEVICE_ID));
+        assertNotNull(data.getDevices().getSmokeCoAlarms().get(SMOKE2_DEVICE_ID));
+        assertNotNull(data.getDevices().getSmokeCoAlarms().get(SMOKE3_DEVICE_ID));
+        assertNotNull(data.getDevices().getSmokeCoAlarms().get(SMOKE4_DEVICE_ID));
     }
 
     @Test
@@ -83,14 +83,14 @@ public class GsonParsingTest {
         assertEquals(Integer.valueOf(15), thermostat.getFanTimerDuration());
         assertEqualDateTime("2017-02-02T21:00:06.000Z", thermostat.getLastConnection());
         assertEqualDateTime("1970-01-01T00:00:00.000Z", thermostat.getFanTimerTimeout());
-        assertEquals(Double.valueOf(22.0), thermostat.getLockedTemperatureHigh());
-        assertEquals(Double.valueOf(20.0), thermostat.getLockedTemperatureLow());
+        assertEquals(Double.valueOf(22.0), thermostat.getLockedTempMax());
+        assertEquals(Double.valueOf(20.0), thermostat.getLockedTempMin());
         assertEquals(Thermostat.Mode.HEAT, thermostat.getMode());
         assertEquals("Living Room (Living Room)", thermostat.getName());
         assertEquals("Living Room Thermostat (Living Room)", thermostat.getNameLong());
-        assertEquals(null, thermostat.getPreviousMode());
+        assertEquals(null, thermostat.getPreviousHvacMode());
         assertEquals("5.6-7", thermostat.getSoftwareVersion());
-        assertEquals(Thermostat.State.OFF, thermostat.getState());
+        assertEquals(Thermostat.State.OFF, thermostat.getHvacState());
         assertEquals(STRUCTURE1_STRUCTURE_ID, thermostat.getStructureId());
         assertEquals(Double.valueOf(15.5), thermostat.getTargetTemperature());
         assertEquals(Double.valueOf(24.0), thermostat.getTargetTemperatureHigh());
@@ -205,7 +205,7 @@ public class GsonParsingTest {
         assertNull(structure.getPeakPeriodStartTime());
         assertEquals(STRUCTURE1_STRUCTURE_ID, structure.getStructureId());
         assertEquals("America/Los_Angeles", structure.getTimeZone());
-        assertFalse(structure.isRushHourRewardsEnrollement());
+        assertFalse(structure.isRhrEnrollment());
     }
 
     @Test

--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.nest.internal.data;
 
-import static org.openhab.binding.nest.internal.NestUtils.GSON;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -22,6 +20,7 @@ import javax.measure.quantity.Temperature;
 
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.openhab.binding.nest.internal.NestUtils;
 
 /**
  * Utility class for working with Nest test data in unit tests.
@@ -70,7 +69,7 @@ public final class NestDataUtil {
 
     public static <T> T fromJson(String fileName, Class<T> dataClass) throws IOException {
         try (Reader reader = openDataReader(fileName)) {
-            return GSON.fromJson(reader, dataClass);
+            return NestUtils.fromJson(reader, dataClass);
         }
     }
 

--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.nest.internal.data;
 
+import static org.openhab.binding.nest.internal.NestUtils.GSON;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -20,9 +22,6 @@ import javax.measure.quantity.Temperature;
 
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 /**
  * Utility class for working with Nest test data in unit tests.
@@ -71,8 +70,7 @@ public final class NestDataUtil {
 
     public static <T> T fromJson(String fileName, Class<T> dataClass) throws IOException {
         try (Reader reader = openDataReader(fileName)) {
-            Gson gson = new GsonBuilder().create();
-            return gson.fromJson(reader, dataClass);
+            return GSON.fromJson(reader, dataClass);
         }
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
@@ -10,7 +10,6 @@ package org.openhab.binding.nest.handler;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.openhab.binding.nest.NestBindingConstants.JSON_CONTENT_TYPE;
-import static org.openhab.binding.nest.internal.NestUtils.GSON;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -36,6 +35,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
+import org.openhab.binding.nest.internal.NestUtils;
 import org.openhab.binding.nest.internal.config.NestBridgeConfiguration;
 import org.openhab.binding.nest.internal.data.ErrorData;
 import org.openhab.binding.nest.internal.data.NestDevices;
@@ -327,7 +327,7 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
             String url = redirectUrlSupplier.getRedirectUrl() + request.getUpdatePath();
             logger.debug("Putting data to: {}", url);
 
-            String jsonContent = GSON.toJson(request.getValues());
+            String jsonContent = NestUtils.toJson(request.getValues());
             logger.debug("PUT content: {}", jsonContent);
 
             ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
@@ -335,7 +335,7 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
                     REQUEST_TIMEOUT);
             logger.debug("PUT response: {}", jsonResponse);
 
-            ErrorData error = GSON.fromJson(jsonResponse, ErrorData.class);
+            ErrorData error = NestUtils.fromJson(jsonResponse, ErrorData.class);
             if (StringUtils.isNotBlank(error.getError())) {
                 logger.debug("Nest API error: {}", error);
                 logger.warn("Nest API error: {}", error.getMessage());

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
@@ -10,6 +10,7 @@ package org.openhab.binding.nest.handler;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.openhab.binding.nest.NestBindingConstants.JSON_CONTENT_TYPE;
+import static org.openhab.binding.nest.internal.NestUtils.GSON;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -52,9 +53,6 @@ import org.openhab.binding.nest.internal.rest.NestUpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 /**
  * This bridge handler connects to Nest and handles all the API requests. It pulls down the
  * updated data, polls the system and does all the co-ordination with the other handlers
@@ -71,7 +69,6 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
 
     private final List<NestDeviceDataListener> listeners = new CopyOnWriteArrayList<>();
     private final List<NestUpdateRequest> nestUpdateRequests = new CopyOnWriteArrayList<>();
-    private final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
 
     private NestAuthorizer authorizer;
     private NestBridgeConfiguration config;
@@ -330,7 +327,7 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
             String url = redirectUrlSupplier.getRedirectUrl() + request.getUpdatePath();
             logger.debug("Putting data to: {}", url);
 
-            String jsonContent = gson.toJson(request.getValues());
+            String jsonContent = GSON.toJson(request.getValues());
             logger.debug("PUT content: {}", jsonContent);
 
             ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
@@ -338,7 +335,7 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
                     REQUEST_TIMEOUT);
             logger.debug("PUT response: {}", jsonResponse);
 
-            ErrorData error = gson.fromJson(jsonResponse, ErrorData.class);
+            ErrorData error = GSON.fromJson(jsonResponse, ErrorData.class);
             if (StringUtils.isNotBlank(error.getError())) {
                 logger.debug("Nest API error: {}", error);
                 logger.warn("Nest API error: {}", error.getMessage());

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBridgeHandler.java
@@ -211,8 +211,8 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
         if (devices.getCameras() != null) {
             devices.getCameras().values().forEach(listener::onNewNestCameraData);
         }
-        if (devices.getSmokeDetectors() != null) {
-            devices.getSmokeDetectors().values().forEach(listener::onNewNestSmokeDetectorData);
+        if (devices.getSmokeCoAlarms() != null) {
+            devices.getSmokeCoAlarms().values().forEach(listener::onNewNestSmokeDetectorData);
         }
     }
 
@@ -400,8 +400,8 @@ public class NestBridgeHandler extends BaseBridgeHandler implements NestStreamin
             if (data.getDevices().getCameras() != null) {
                 identifiers.addAll(data.getDevices().getCameras().keySet());
             }
-            if (data.getDevices().getSmokeDetectors() != null) {
-                identifiers.addAll(data.getDevices().getSmokeDetectors().keySet());
+            if (data.getDevices().getSmokeCoAlarms() != null) {
+                identifiers.addAll(data.getDevices().getSmokeCoAlarms().keySet());
             }
             if (data.getDevices().getThermostats() != null) {
                 identifiers.addAll(data.getDevices().getThermostats().keySet());

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestStructureHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestStructureHandler.java
@@ -55,7 +55,7 @@ public class NestStructureHandler extends NestBaseHandler<Structure> {
             case CHANNEL_POSTAL_CODE:
                 return getAsStringTypeOrNull(structure.getPostalCode());
             case CHANNEL_RUSH_HOUR_REWARDS_ENROLLMENT:
-                return getAsOnOffTypeOrNull(structure.isRushHourRewardsEnrollement());
+                return getAsOnOffTypeOrNull(structure.isRhrEnrollment());
             case CHANNEL_SMOKE_ALARM_STATE:
                 return getAsStringTypeOrNull(structure.getSmokeAlarmState());
             case CHANNEL_TIME_ZONE:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
@@ -72,9 +72,9 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
             case CHANNEL_LOCKED:
                 return getAsOnOffTypeOrNull(thermostat.isLocked());
             case CHANNEL_LOCKED_MAX_SET_POINT:
-                return getAsTemperatureOrNull(thermostat.getLockedTemperatureHigh(), thermostat.getTemperatureUnit());
+                return getAsTemperatureOrNull(thermostat.getLockedTempMax(), thermostat.getTemperatureUnit());
             case CHANNEL_LOCKED_MIN_SET_POINT:
-                return getAsTemperatureOrNull(thermostat.getLockedTemperatureLow(), thermostat.getTemperatureUnit());
+                return getAsTemperatureOrNull(thermostat.getLockedTempMin(), thermostat.getTemperatureUnit());
             case CHANNEL_MAX_SET_POINT:
                 return getAsTemperatureOrNull(thermostat.getTargetTemperatureHigh(), thermostat.getTemperatureUnit());
             case CHANNEL_MIN_SET_POINT:
@@ -82,11 +82,11 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
             case CHANNEL_MODE:
                 return getAsStringTypeOrNull(thermostat.getMode());
             case CHANNEL_PREVIOUS_MODE:
-                Mode previousMode = thermostat.getPreviousMode() != null ? thermostat.getPreviousMode()
+                Mode previousMode = thermostat.getPreviousHvacMode() != null ? thermostat.getPreviousHvacMode()
                         : thermostat.getMode();
                 return getAsStringTypeOrNull(previousMode);
             case CHANNEL_STATE:
-                return getAsStringTypeOrNull(thermostat.getState());
+                return getAsStringTypeOrNull(thermostat.getHvacState());
             case CHANNEL_SET_POINT:
                 return getAsTemperatureOrNull(thermostat.getTargetTemperature(), thermostat.getTemperatureUnit());
             case CHANNEL_SUNLIGHT_CORRECTION_ACTIVE:

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.nest.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Utility class for sharing utility methods between objects.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class NestUtils {
+
+    public static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+
+}

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
@@ -20,9 +20,13 @@ import com.google.gson.GsonBuilder;
  * @author Wouter Born - Initial contribution
  */
 @NonNullByDefault
-public class NestUtils {
+public final class NestUtils {
 
     public static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+
+    private NestUtils() {
+        // hidden utility class constructor
+    }
 
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestUtils.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.nest.internal;
 
+import java.io.Reader;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import com.google.gson.FieldNamingPolicy;
@@ -22,11 +24,23 @@ import com.google.gson.GsonBuilder;
 @NonNullByDefault
 public final class NestUtils {
 
-    public static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
 
     private NestUtils() {
         // hidden utility class constructor
+    }
+
+    public static <T> T fromJson(String json, Class<T> dataClass) {
+        return GSON.fromJson(json, dataClass);
+    }
+
+    public static <T> T fromJson(Reader reader, Class<T> dataClass) {
+        return GSON.fromJson(reader, dataClass);
+    }
+
+    public static String toJson(Object object) {
+        return GSON.toJson(object);
     }
 
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/AccessTokenData.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/AccessTokenData.java
@@ -8,17 +8,14 @@
  */
 package org.openhab.binding.nest.internal.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Deals with the access token data that comes back from Nest when it is requested.
  *
  * @author David Bennett - Initial Contribution
  */
 public class AccessTokenData {
-    @SerializedName("access_token")
+
     private String accessToken;
-    @SerializedName("expires_in")
     private Long expiresIn;
 
     public String getAccessToken() {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/BaseNestDevice.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/BaseNestDevice.java
@@ -10,29 +10,20 @@ package org.openhab.binding.nest.internal.data;
 
 import java.util.Date;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Default properties shared across all Nest devices.
  *
  * @author David Bennett
  */
 public class BaseNestDevice implements NestIdentifiable {
-    @SerializedName("device_id")
+
     private String deviceId;
-    @SerializedName("name")
     private String name;
-    @SerializedName("name_long")
     private String nameLong;
-    @SerializedName("last_connection")
     private Date lastConnection;
-    @SerializedName("is_online")
     private Boolean isOnline;
-    @SerializedName("software_version")
     private String softwareVersion;
-    @SerializedName("structure_id")
     private String structureId;
-    @SerializedName("where_id")
     private String whereId;
 
     @Override

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Camera.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Camera.java
@@ -11,35 +11,23 @@ package org.openhab.binding.nest.internal.data;
 import java.util.Date;
 import java.util.List;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * The data for the camera.
  *
  * @author David Bennett - Initial Contribution
  */
 public class Camera extends BaseNestDevice {
-    @SerializedName("is_streaming")
+
     private Boolean isStreaming;
-    @SerializedName("is_audio_input_enabled")
     private Boolean isAudioInputEnabled;
-    @SerializedName("last_is_online_change")
     private Date lastIsOnlineChange;
-    @SerializedName("is_video_history_enabled")
     private Boolean isVideoHistoryEnabled;
-    @SerializedName("web_url")
     private String webUrl;
-    @SerializedName("app_url")
     private String appUrl;
-    @SerializedName("is_public_share_enabled")
     private Boolean isPublicShareEnabled;
-    @SerializedName("activity_zones")
     private List<ActivityZone> activityZones;
-    @SerializedName("public_share_url")
     private String publicShareUrl;
-    @SerializedName("snapshot_url")
     private String snapshotUrl;
-    @SerializedName("last_event")
     private Event lastEvent;
 
     public Boolean isStreaming() {
@@ -87,9 +75,8 @@ public class Camera extends BaseNestDevice {
     }
 
     public static class ActivityZone {
-        @SerializedName("name")
+
         private String name;
-        @SerializedName("id")
         private int id;
 
         public String getName() {
@@ -103,28 +90,18 @@ public class Camera extends BaseNestDevice {
 
     /** Internal class to handle the camera event data. */
     public static class Event {
-        @SerializedName("has_sound")
+
         private Boolean hasSound;
-        @SerializedName("has_motion")
         private Boolean hasMotion;
-        @SerializedName("has_person")
         private Boolean hasPerson;
-        @SerializedName("start_time")
         private Date startTime;
-        @SerializedName("end_time")
         private Date endTime;
-        @SerializedName("urls_expire_time")
         private Date urlsExpireTime;
-        @SerializedName("web_url")
         private String webUrl;
-        @SerializedName("app_url")
         private String appUrl;
-        @SerializedName("image_url")
         private String imageUrl;
-        @SerializedName("animated_image_url")
         private String animatedImageUrl;
-        @SerializedName("activity_zone_ids")
-        private List<String> activityZones;
+        private List<String> activityZoneIds;
 
         public Boolean isHasSound() {
             return hasSound;
@@ -167,7 +144,7 @@ public class Camera extends BaseNestDevice {
         }
 
         public List<String> getActivityZones() {
-            return activityZones;
+            return activityZoneIds;
         }
 
     }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/ErrorData.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/ErrorData.java
@@ -8,21 +8,16 @@
  */
 package org.openhab.binding.nest.internal.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * The data of Nest API errors.
  *
  * @author Wouter Born - Improve exception handling
  */
 public class ErrorData {
-    @SerializedName("error")
+
     private String error;
-    @SerializedName("type")
     private String type;
-    @SerializedName("message")
     private String message;
-    @SerializedName("instance")
     private String instance;
 
     public String getError() {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestDevices.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestDevices.java
@@ -10,20 +10,16 @@ package org.openhab.binding.nest.internal.data;
 
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * All the Nest devices broken up by type.
  *
  * @author David Bennett - Initial Contribution
  */
 public class NestDevices {
-    @SerializedName("thermostats")
+
     private Map<String, Thermostat> thermostats;
-    @SerializedName("smoke_co_alarms")
-    private Map<String, SmokeDetector> smokeDetector;
-    @SerializedName("cameras")
-    private Map<String, Camera> camera;
+    private Map<String, SmokeDetector> smokeCoAlarms;
+    private Map<String, Camera> cameras;
 
     /** Id to thermostat mapping */
     public Map<String, Thermostat> getThermostats() {
@@ -32,19 +28,19 @@ public class NestDevices {
 
     /** Id to camera mapping */
     public Map<String, Camera> getCameras() {
-        return camera;
+        return cameras;
     }
 
     /** Id to smoke detector */
     public Map<String, SmokeDetector> getSmokeDetectors() {
-        return smokeDetector;
+        return smokeCoAlarms;
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("NestDevices [thermostats=").append(thermostats).append(", smokeDetector=").append(smokeDetector)
-                .append(", camera=").append(camera).append("]");
+        builder.append("NestDevices [thermostats=").append(thermostats).append(", smokeCoAlarms=").append(smokeCoAlarms)
+                .append(", cameras=").append(cameras).append("]");
         return builder.toString();
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestDevices.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestDevices.java
@@ -32,7 +32,7 @@ public class NestDevices {
     }
 
     /** Id to smoke detector */
-    public Map<String, SmokeDetector> getSmokeDetectors() {
+    public Map<String, SmokeDetector> getSmokeCoAlarms() {
         return smokeCoAlarms;
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestMetadata.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/NestMetadata.java
@@ -8,17 +8,14 @@
  */
 package org.openhab.binding.nest.internal.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * The meta data in the data downloads from Nest.
  *
  * @author David Bennett - Initial Contribution
  */
 public class NestMetadata {
-    @SerializedName("access_token")
+
     private String accessToken;
-    @SerializedName("client_version")
     private String clientVersion;
 
     public String getAccessToken() {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/SmokeDetector.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/SmokeDetector.java
@@ -18,17 +18,12 @@ import com.google.gson.annotations.SerializedName;
  * @author David Bennett - Initial Contribution
  */
 public class SmokeDetector extends BaseNestDevice {
-    @SerializedName("battery_health")
+
     private BatteryHealth batteryHealth;
-    @SerializedName("co_alarm_state")
     private AlarmState coAlarmState;
-    @SerializedName("last_manual_test_time")
     private Date lastManualTestTime;
-    @SerializedName("smoke_alarm_state")
     private AlarmState smokeAlarmState;
-    @SerializedName("is_manual_test_active")
     private Boolean isManualTestActive;
-    @SerializedName("ui_color_state")
     private UiColorState uiColorState;
 
     public UiColorState getUiColorState() {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Structure.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Structure.java
@@ -22,39 +22,23 @@ import com.google.gson.annotations.SerializedName;
  * @author David Bennett - Initial Contribution
  */
 public class Structure implements NestIdentifiable {
-    @SerializedName("structure_id")
+
     private String structureId;
-    @SerializedName("thermostats")
-    private List<String> thermostatIds;
-    @SerializedName("smoke_co_alarms")
-    private List<String> smokeAlarmIds;
-    @SerializedName("cameras")
-    private List<String> cameraIds;
-    @SerializedName("country_code")
+    private List<String> thermostats;
+    private List<String> smokeCoAlarms;
+    private List<String> cameras;
     private String countryCode;
-    @SerializedName("postal_code")
     private String postalCode;
-    @SerializedName("peak_period_start_time")
     private Date peakPeriodStartTime;
-    @SerializedName("peak_period_end_time")
     private Date peakPeriodEndTime;
-    @SerializedName("time_zone")
     private String timeZone;
-    @SerializedName("eta_begin")
     private Date etaBegin;
-    @SerializedName("co_alarm_state")
     private SmokeDetector.AlarmState coAlarmState;
-    @SerializedName("smoke_alarm_state")
     private SmokeDetector.AlarmState smokeAlarmState;
-    @SerializedName("rhr_enrollment")
-    private Boolean rushHourRewardsEnrollement;
-    @SerializedName("wheres")
-    private Map<String, Where> whereIds;
-    @SerializedName("away")
+    private Boolean rhrEnrollment;
+    private Map<String, Where> wheres;
     private HomeAwayState away;
-    @SerializedName("name")
     private String name;
-    @SerializedName("eta")
     private ETA eta;
 
     @Override
@@ -75,15 +59,15 @@ public class Structure implements NestIdentifiable {
     }
 
     public List<String> getThermostatIds() {
-        return thermostatIds;
+        return thermostats;
     }
 
     public List<String> getSmokeAlarmIds() {
-        return smokeAlarmIds;
+        return smokeCoAlarms;
     }
 
     public List<String> getCameraIds() {
-        return cameraIds;
+        return cameras;
     }
 
     public String getCountryCode() {
@@ -119,11 +103,11 @@ public class Structure implements NestIdentifiable {
     }
 
     public Boolean isRushHourRewardsEnrollement() {
-        return rushHourRewardsEnrollement;
+        return rhrEnrollment;
     }
 
     public Map<String, Where> getWhereIds() {
-        return whereIds;
+        return wheres;
     }
 
     public ETA getEta() {
@@ -146,11 +130,9 @@ public class Structure implements NestIdentifiable {
      * Used to set and update the eta values for Nest.
      */
     public class ETA {
-        @SerializedName("trip_id")
+
         private String tripId;
-        @SerializedName("estimated_arrival_window_begin")
         private Date estimatedArrivalWindowBegin;
-        @SerializedName("estimated_arrival_window_end")
         private Date estimatedArrivalWindowEnd;
 
         public String getTripId() {
@@ -179,9 +161,7 @@ public class Structure implements NestIdentifiable {
     }
 
     public class Where {
-        @SerializedName("where_id")
         private String whereId;
-        @SerializedName("name")
         private String name;
 
         public String getWhereId() {
@@ -205,15 +185,14 @@ public class Structure implements NestIdentifiable {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("Structure [structureId=").append(structureId).append(", thermostatIds=").append(thermostatIds)
-                .append(", smokeAlarmIds=").append(smokeAlarmIds).append(", cameraIds=").append(cameraIds)
+        builder.append("Structure [structureId=").append(structureId).append(", thermostats=").append(thermostats)
+                .append(", smokeCoAlarms=").append(smokeCoAlarms).append(", cameras=").append(cameras)
                 .append(", countryCode=").append(countryCode).append(", postalCode=").append(postalCode)
                 .append(", peakPeriodStartTime=").append(peakPeriodStartTime).append(", peakPeriodEndTime=")
                 .append(peakPeriodEndTime).append(", timeZone=").append(timeZone).append(", etaBegin=").append(etaBegin)
                 .append(", coAlarmState=").append(coAlarmState).append(", smokeAlarmState=").append(smokeAlarmState)
-                .append(", rushHourRewardsEnrollement=").append(rushHourRewardsEnrollement).append(", whereIds=")
-                .append(whereIds).append(", away=").append(away).append(", name=").append(name).append(", eta=")
-                .append(eta).append("]");
+                .append(", rhrEnrollment=").append(rhrEnrollment).append(", wheres=").append(wheres).append(", away=")
+                .append(away).append(", name=").append(name).append(", eta=").append(eta).append("]");
         return builder.toString();
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Structure.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Structure.java
@@ -58,15 +58,15 @@ public class Structure implements NestIdentifiable {
         return structureId;
     }
 
-    public List<String> getThermostatIds() {
+    public List<String> getThermostats() {
         return thermostats;
     }
 
-    public List<String> getSmokeAlarmIds() {
+    public List<String> getSmokeCoAlarms() {
         return smokeCoAlarms;
     }
 
-    public List<String> getCameraIds() {
+    public List<String> getCameras() {
         return cameras;
     }
 
@@ -102,11 +102,11 @@ public class Structure implements NestIdentifiable {
         return smokeAlarmState;
     }
 
-    public Boolean isRushHourRewardsEnrollement() {
+    public Boolean isRhrEnrollment() {
         return rhrEnrollment;
     }
 
-    public Map<String, Where> getWhereIds() {
+    public Map<String, Where> getWheres() {
         return wheres;
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
@@ -24,65 +24,36 @@ import com.google.gson.annotations.SerializedName;
  * @author David Bennett - Initial Contribution
  */
 public class Thermostat extends BaseNestDevice {
-    @SerializedName("can_cool")
+
     private Boolean canCool;
-    @SerializedName("can_heat")
     private Boolean canHeat;
-    @SerializedName("is_using_emergency_heat")
     private Boolean isUsingEmergencyHeat;
-    @SerializedName("has_fan")
     private Boolean hasFan;
-    @SerializedName("fan_timer_active")
     private Boolean fanTimerActive;
-    @SerializedName("fan_timer_timeout")
     private Date fanTimerTimeout;
-    @SerializedName("has_leaf")
     private Boolean hasLeaf;
-    @SerializedName("temperature_scale")
     private String temperatureScale;
-    @SerializedName("ambient_temperature_c")
     private Double ambientTemperatureC;
-    @SerializedName("ambient_temperature_f")
     private Double ambientTemperatureF;
-    @SerializedName("humidity")
     private Integer humidity;
-    @SerializedName("target_temperature_c")
     private Double targetTemperatureC;
-    @SerializedName("target_temperature_f")
     private Double targetTemperatureF;
-    @SerializedName("target_temperature_high_c")
     private Double targetTemperatureHighC;
-    @SerializedName("target_temperature_high_f")
     private Double targetTemperatureHighF;
-    @SerializedName("target_temperature_low_c")
     private Double targetTemperatureLowC;
-    @SerializedName("target_temperature_low_f")
     private Double targetTemperatureLowF;
-    @SerializedName("hvac_mode")
-    private Mode mode;
-    @SerializedName("previous_hvac_mode")
-    private Mode previousMode;
-    @SerializedName("hvac_state")
-    private State state;
-    @SerializedName("is_locked")
+    private Mode hvacMode;
+    private Mode previousHvacMode;
+    private State hvacState;
     private Boolean isLocked;
-    @SerializedName("locked_temp_max_c")
-    private Double lockedTemperatureHighC;
-    @SerializedName("locked_temp_max_f")
-    private Double lockedTemperatureHighF;
-    @SerializedName("locked_temp_min_c")
-    private Double lockedTemperatureLowC;
-    @SerializedName("locked_temp_min_f")
-    private Double lockedTemperatureLowF;
-    @SerializedName("sunlight_correction_enabled")
+    private Double lockedTempMaxC;
+    private Double lockedTempMaxF;
+    private Double lockedTempMinC;
+    private Double lockedTempMinF;
     private Boolean sunlightCorrectionEnabled;
-    @SerializedName("sunlight_correction_active")
     private Boolean sunlightCorrectionActive;
-    @SerializedName("fan_timer_duration")
     private Integer fanTimerDuration;
-    @SerializedName("time_to_target")
     private String timeToTarget;
-    @SerializedName("where_name")
     private String whereName;
 
     public Unit<Temperature> getTemperatureUnit() {
@@ -126,7 +97,7 @@ public class Thermostat extends BaseNestDevice {
     }
 
     public Mode getMode() {
-        return mode;
+        return hvacMode;
     }
 
     public Boolean isLocked() {
@@ -135,9 +106,9 @@ public class Thermostat extends BaseNestDevice {
 
     public Double getLockedTemperatureHigh() {
         if (getTemperatureUnit() == CELSIUS) {
-            return lockedTemperatureHighC;
+            return lockedTempMaxC;
         } else if (getTemperatureUnit() == FAHRENHEIT) {
-            return lockedTemperatureHighF;
+            return lockedTempMaxF;
         } else {
             return null;
         }
@@ -145,9 +116,9 @@ public class Thermostat extends BaseNestDevice {
 
     public Double getLockedTemperatureLow() {
         if (getTemperatureUnit() == CELSIUS) {
-            return lockedTemperatureLowC;
+            return lockedTempMinC;
         } else if (getTemperatureUnit() == FAHRENHEIT) {
-            return lockedTemperatureLowF;
+            return lockedTempMinF;
         } else {
             return null;
         }
@@ -182,11 +153,11 @@ public class Thermostat extends BaseNestDevice {
     }
 
     public Mode getPreviousMode() {
-        return previousMode;
+        return previousHvacMode;
     }
 
     public State getState() {
-        return state;
+        return hvacState;
     }
 
     public Boolean isSunlightCorrectionEnabled() {
@@ -269,15 +240,15 @@ public class Thermostat extends BaseNestDevice {
                 .append(targetTemperatureC).append(", targetTemperatureF=").append(targetTemperatureF)
                 .append(", targetTemperatureHighC=").append(targetTemperatureHighC).append(", targetTemperatureHighF=")
                 .append(targetTemperatureHighF).append(", targetTemperatureLowC=").append(targetTemperatureLowC)
-                .append(", targetTemperatureLowF=").append(targetTemperatureLowF).append(", mode=").append(mode)
-                .append(", previousMode=").append(previousMode).append(", state=").append(state).append(", isLocked=")
-                .append(isLocked).append(", lockedTemperatureHighC=").append(lockedTemperatureHighC)
-                .append(", lockedTemperatureHighF=").append(lockedTemperatureHighF).append(", lockedTemperatureLowC=")
-                .append(lockedTemperatureLowC).append(", lockedTemperatureLowF=").append(lockedTemperatureLowF)
-                .append(", sunlightCorrectionEnabled=").append(sunlightCorrectionEnabled)
-                .append(", sunlightCorrectionActive=").append(sunlightCorrectionActive).append(", fanTimerDuration=")
-                .append(fanTimerDuration).append(", timeToTarget=").append(timeToTarget).append(", whereName=")
-                .append(whereName).append(", getId()=").append(getId()).append(", getName()=").append(getName())
+                .append(", targetTemperatureLowF=").append(targetTemperatureLowF).append(", hvacMode=").append(hvacMode)
+                .append(", previousHvacMode=").append(previousHvacMode).append(", hvacState=").append(hvacState)
+                .append(", isLocked=").append(isLocked).append(", lockedTempMaxC=").append(lockedTempMaxC)
+                .append(", lockedTempMaxF=").append(lockedTempMaxF).append(", lockedTempMinC=").append(lockedTempMinC)
+                .append(", lockedTempMinF=").append(lockedTempMinF).append(", sunlightCorrectionEnabled=")
+                .append(sunlightCorrectionEnabled).append(", sunlightCorrectionActive=")
+                .append(sunlightCorrectionActive).append(", fanTimerDuration=").append(fanTimerDuration)
+                .append(", timeToTarget=").append(timeToTarget).append(", whereName=").append(whereName)
+                .append(", getId()=").append(getId()).append(", getName()=").append(getName())
                 .append(", getDeviceId()=").append(getDeviceId()).append(", getLastConnection()=")
                 .append(getLastConnection()).append(", isOnline()=").append(isOnline()).append(", getNameLong()=")
                 .append(getNameLong()).append(", getSoftwareVersion()=").append(getSoftwareVersion())

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/Thermostat.java
@@ -104,7 +104,7 @@ public class Thermostat extends BaseNestDevice {
         return isLocked;
     }
 
-    public Double getLockedTemperatureHigh() {
+    public Double getLockedTempMax() {
         if (getTemperatureUnit() == CELSIUS) {
             return lockedTempMaxC;
         } else if (getTemperatureUnit() == FAHRENHEIT) {
@@ -114,7 +114,7 @@ public class Thermostat extends BaseNestDevice {
         }
     }
 
-    public Double getLockedTemperatureLow() {
+    public Double getLockedTempMin() {
         if (getTemperatureUnit() == CELSIUS) {
             return lockedTempMinC;
         } else if (getTemperatureUnit() == FAHRENHEIT) {
@@ -152,11 +152,11 @@ public class Thermostat extends BaseNestDevice {
         return hasLeaf;
     }
 
-    public Mode getPreviousMode() {
+    public Mode getPreviousHvacMode() {
         return previousHvacMode;
     }
 
-    public State getState() {
+    public State getHvacState() {
         return hvacState;
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/TopLevelData.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/TopLevelData.java
@@ -10,19 +10,15 @@ package org.openhab.binding.nest.internal.data;
 
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Top level data for all the Nest stuff, this is the format the Nest data comes back from Nest in.
  *
  * @author David Bennett - Initial Contribution
  */
 public class TopLevelData {
-    @SerializedName("devices")
+
     private NestDevices devices;
-    @SerializedName("metadata")
     private NestMetadata metadata;
-    @SerializedName("structures")
     private Map<String, Structure> structures;
 
     public NestDevices getDevices() {
@@ -44,4 +40,5 @@ public class TopLevelData {
                 .append(", structures=").append(structures).append("]");
         return builder.toString();
     }
+
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/TopLevelStreamingData.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/data/TopLevelStreamingData.java
@@ -8,17 +8,14 @@
  */
 package org.openhab.binding.nest.internal.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * The top level data that is sent by Nest to a streaming REST client using SSE.
  *
  * @author Wouter Born - Replace polling with REST streaming
  */
 public class TopLevelStreamingData {
-    @SerializedName("path")
+
     private String path;
-    @SerializedName("data")
     private TopLevelData data;
 
     public String getPath() {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestAuthorizer.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestAuthorizer.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.nest.internal.rest;
 
+import static org.openhab.binding.nest.internal.NestUtils.GSON;
+
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
@@ -19,9 +21,6 @@ import org.openhab.binding.nest.internal.exceptions.InvalidAccessTokenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 /**
  * Retrieves the Nest access token using the OAuth 2.0 protocol using pin-based authorization.
  *
@@ -32,7 +31,6 @@ public class NestAuthorizer {
     private final Logger logger = LoggerFactory.getLogger(NestAuthorizer.class);
 
     private final NestBridgeConfiguration config;
-    private final Gson gson = new GsonBuilder().create();
 
     /**
      * Create the helper class for the Nest access token. Also creates the folder
@@ -71,7 +69,7 @@ public class NestAuthorizer {
             String responseContentAsString = HttpUtil.executeUrl("POST", urlBuilder.toString(), null, null,
                     "application/x-www-form-urlencoded", 10_000);
 
-            AccessTokenData data = gson.fromJson(responseContentAsString, AccessTokenData.class);
+            AccessTokenData data = GSON.fromJson(responseContentAsString, AccessTokenData.class);
             logger.debug("Received: {}", data);
 
             if (StringUtils.isEmpty(data.getAccessToken())) {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestAuthorizer.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestAuthorizer.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.binding.nest.internal.rest;
 
-import static org.openhab.binding.nest.internal.NestUtils.GSON;
-
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.openhab.binding.nest.NestBindingConstants;
+import org.openhab.binding.nest.internal.NestUtils;
 import org.openhab.binding.nest.internal.config.NestBridgeConfiguration;
 import org.openhab.binding.nest.internal.data.AccessTokenData;
 import org.openhab.binding.nest.internal.exceptions.InvalidAccessTokenException;
@@ -69,7 +68,7 @@ public class NestAuthorizer {
             String responseContentAsString = HttpUtil.executeUrl("POST", urlBuilder.toString(), null, null,
                     "application/x-www-form-urlencoded", 10_000);
 
-            AccessTokenData data = GSON.fromJson(responseContentAsString, AccessTokenData.class);
+            AccessTokenData data = NestUtils.fromJson(responseContentAsString, AccessTokenData.class);
             logger.debug("Received: {}", data);
 
             if (StringUtils.isEmpty(data.getAccessToken())) {

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
@@ -9,7 +9,6 @@
 package org.openhab.binding.nest.internal.rest;
 
 import static org.openhab.binding.nest.NestBindingConstants.KEEP_ALIVE_MILLIS;
-import static org.openhab.binding.nest.internal.NestUtils.GSON;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -26,6 +25,7 @@ import org.glassfish.jersey.media.sse.EventSource;
 import org.glassfish.jersey.media.sse.InboundEvent;
 import org.glassfish.jersey.media.sse.SseFeature;
 import org.openhab.binding.nest.handler.NestRedirectUrlSupplier;
+import org.openhab.binding.nest.internal.NestUtils;
 import org.openhab.binding.nest.internal.data.TopLevelData;
 import org.openhab.binding.nest.internal.data.TopLevelStreamingData;
 import org.openhab.binding.nest.internal.exceptions.FailedResolvingNestUrlException;
@@ -197,7 +197,7 @@ public class NestStreamingRestClient {
                 logger.debug("Event stream opened");
             } else if (PUT.equals(name)) {
                 logger.debug("Data has changed (or initial data sent)");
-                lastReceivedTopLevelData = GSON.fromJson(data, TopLevelStreamingData.class).getData();
+                lastReceivedTopLevelData = NestUtils.fromJson(data, TopLevelStreamingData.class).getData();
                 listeners.forEach(listener -> listener.onNewTopLevelData(lastReceivedTopLevelData));
             } else {
                 logger.debug("Received unhandled event with name '{}' and data '{}'", name, data);

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.nest.internal.rest;
 
 import static org.openhab.binding.nest.NestBindingConstants.KEEP_ALIVE_MILLIS;
+import static org.openhab.binding.nest.internal.NestUtils.GSON;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -32,9 +33,6 @@ import org.openhab.binding.nest.internal.listener.NestStreamingDataListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 /**
  * A client that generates events based on Nest streaming REST API Server-Sent Events (SSE).
  *
@@ -54,7 +52,6 @@ public class NestStreamingRestClient {
     private final Logger logger = LoggerFactory.getLogger(NestStreamingRestClient.class);
 
     private final List<NestStreamingDataListener> listeners = new CopyOnWriteArrayList<>();
-    private final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
     private final ScheduledExecutorService scheduler;
 
     private String accessToken;
@@ -200,7 +197,7 @@ public class NestStreamingRestClient {
                 logger.debug("Event stream opened");
             } else if (PUT.equals(name)) {
                 logger.debug("Data has changed (or initial data sent)");
-                lastReceivedTopLevelData = gson.fromJson(data, TopLevelStreamingData.class).getData();
+                lastReceivedTopLevelData = GSON.fromJson(data, TopLevelStreamingData.class).getData();
                 listeners.forEach(listener -> listener.onNewTopLevelData(lastReceivedTopLevelData));
             } else {
                 logger.debug("Received unhandled event with name '{}' and data '{}'", name, data);


### PR DESCRIPTION
* Use Gson with `FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES`
* Remove `@SerializedName` annotations from data objects where applicable
* Reuse Gson instance with NestUtils
* Simplify date time comparisons in GsonParsingTest