### PR TITLE
Update DHCPListenService.java

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/dhcp/DHCPListenService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/dhcp/DHCPListenService.java
@@ -36,10 +36,9 @@ public class DHCPListenService {
             instance = new DHCPPacketListenerServer((String ipAddress) -> {
                 IPRequestReceivedCallback listener = registeredListeners.get(ipAddress);
                 if (listener != null) {
-                    logger.info("DHCP request for registered address: {}", ipAddress);
                     listener.dhcpRequestReceived(ipAddress);
                 } else {
-                    logger.info("DHCP request for unknown address: {}", ipAddress);
+                    logger.trace("DHCP request for unknown address: {}", ipAddress);
                 }
             });
             instance.start();


### PR DESCRIPTION
DHCP requests for not observed addresses should be logged in trace mode only. Requests for known addresses don't need to be logged at all.

Edited on Github, so not signed. But shouldn't be an issue for two line changes :)

Cheers,
David