### PR TITLE
[lgwebos] Removed outdated items from demo site map.

### DIFF
--- a/addons/binding/org.openhab.binding.lgwebos/README.md
+++ b/addons/binding/org.openhab.binding.lgwebos/README.md
@@ -98,8 +98,6 @@ sitemap demo label="Main Menu"
         Text item=LG_TV0_ChannelNo
         Switch item=LG_TV0_ChannelDummy icon="television" label="Kanal" mappings=[1="▲", 0="▼"]
         Text item=LG_TV0_Channel
-        Switch item=LG_TV0_ChannelDown
-        Switch item=LG_TV0_ChannelUp
         Default item=LG_TV0_Player
         Text item=LG_TV0_Application
         Selection item=LG_TV0_Application mappings=[


### PR DESCRIPTION
User @tjakobi reported this bug in the binding's documentation. 