### PR TITLE
[network] Interpret ConnectException as service absent rather than present.

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -159,11 +159,7 @@ public class NetworkUtils {
         try (Socket socket = new Socket()) {
             socket.connect(socketAddress, timeout);
             return true;
-        } catch (NoRouteToHostException ignored) {
-            return false;
-        } catch (SocketTimeoutException ignored) {
-            return false;
-        } catch (ConnectException e) {
+        } catch (ConnectException | SocketTimeoutException | NoRouteToHostException ignored) {
             return false;
         }
     }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -164,8 +164,7 @@ public class NetworkUtils {
         } catch (SocketTimeoutException ignored) {
             return false;
         } catch (ConnectException e) {
-            // Connection refused, there is a device on the other end though
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
See #3499 for details of the problem being addressed.  This is the minimal fix.  If you would like me to add a new property to control the interpretation of this exception, let me know and I can do that.

I was unable to add a unit test via mocking since servicePing currently creates a Socket directly rather than using a factory.

I tested manually via mvn clean install and then deploying the updated addon into my test OpenHab server and verifying the correct behavior with a test service.

Fixes #3499

Signed-off-by: John Sichi <jsichi@gmail.com> (github: jsichi)
