### PR TITLE
[Network] Fix the windows ping problem for local subnets.

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -34,8 +34,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.eclipse.smarthome.io.net.exec.ExecUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Network utility functions for pinging and for determining all interfaces and assigned IP addresses.
@@ -43,8 +41,6 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff <david.graeff@web.de>
  */
 public class NetworkUtils {
-    private final Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
-
     /**
      * Gets every IPv4 Address on each Interface except the loopback
      * The Address format is ip/subnet
@@ -277,11 +273,9 @@ public class NetworkUtils {
         try (BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
             String line = r.readLine();
             if (line == null) {
-                logger.trace("Received no output from ping process.");
-                return false;
+                throw new IOException("Received no output from ping process.");
             }
             do {
-                logger.trace("Examining ping process line: '{}'", line);
                 if (line.contains("host unreachable") || line.contains("timed out")
                         || line.contains("could not find host")) {
                     return false;
@@ -291,8 +285,7 @@ public class NetworkUtils {
 
             return true;
         } catch (IOException e) {
-            logger.warn("Failed while reading the output of the ping process", e);
-            return false;
+            throw e;
         }
     }
 

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -274,8 +274,7 @@ public class NetworkUtils {
             return false;
         }
 
-        try{
-            BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
             String line = r.readLine();
             if (line == null) {
                 logger.trace("Received no output from ping process.");
@@ -283,16 +282,15 @@ public class NetworkUtils {
             }
             do {
                 logger.trace("Examining ping process line: '{}'", line);
-                if (line.contains("host unreachable") ||
-                    line.contains("timed out") ||
-                    line.contains("could not find host")) {
+                if (line.contains("host unreachable") || line.contains("timed out")
+                        || line.contains("could not find host")) {
                     return false;
                 }
                 line = r.readLine();
-            }while(line != null);
+            } while (line != null);
 
             return true;
-        }catch(IOException e) {
+        } catch (IOException e) {
             logger.warn("Failed while reading the output of the ping process", e);
             return false;
         }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff <david.graeff@web.de>
  */
 public class NetworkUtils {
-    private Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
+    private final Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
 
     /**
      * Gets every IPv4 Address on each Interface except the loopback

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -284,8 +284,6 @@ public class NetworkUtils {
             } while (line != null);
 
             return true;
-        } catch (IOException e) {
-            throw e;
         }
     }
 


### PR DESCRIPTION
Related to #3502.

Fixes the problem described in [this community thread](https://community.openhab.org/t/windows-ping-does-not-work-correct/43776/24) where Windows pings from the Network binding to hosts on the local subnet are incorrectly parsed, leading to unreachable hosts being flagged as reachable.

This is the [test jar](https://drive.google.com/open?id=17CLqpE7mWSLggY8rtMW3SNNzkyiJDon5).

Signed-off-by: 9037568 <namraccr@gmail.com>

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
-->
