### PR TITLE
[Kodi] Added handling for new 'Player.OnResume' event

### DIFF
--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
@@ -43,9 +43,6 @@ public class KodiDynamicStateDescriptionProvider implements DynamicStateDescript
     public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
             @Nullable Locale locale) {
         List<StateOption> options = channelOptionsMap.get(channel.getUID());
-        if (options == null) {
-            return null;
-        }
 
         if (original != null) {
             return new StateDescription(original.getMinimum(), original.getMaximum(), original.getStep(),

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/protocol/KodiConnection.java
@@ -483,6 +483,8 @@ public class KodiConnection implements KodiClientSocketEventListener {
             requestPlayerUpdate(playerId);
         } else if ("Player.OnPause".equals(method)) {
             updateState(KodiState.Pause);
+        } else if ("Player.OnResume".equals(method)) {
+            updateState(KodiState.Play);
         } else if ("Player.OnStop".equals(method)) {
             // get the end parameter and send an End state if true
             JsonObject data = json.get("data").getAsJsonObject();
@@ -507,7 +509,7 @@ public class KodiConnection implements KodiClientSocketEventListener {
                 updateState(KodiState.FastForward);
             }
         } else {
-            logger.debug("Unknown event from Kodi {}: {}", method, json.toString());
+            logger.debug("Unknown event from Kodi {}: {}", method, json);
         }
         listener.updateConnectionState(true);
     }
@@ -528,7 +530,7 @@ public class KodiConnection implements KodiClientSocketEventListener {
 
             this.volume = volume;
         } else {
-            logger.debug("Unknown event from Kodi {}: {}", method, json.toString());
+            logger.debug("Unknown event from Kodi {}: {}", method, json);
         }
         listener.updateConnectionState(true);
     }
@@ -539,27 +541,19 @@ public class KodiConnection implements KodiClientSocketEventListener {
         } else if ("System.OnWake".equals(method)) {
             listener.updateConnectionState(true);
         } else {
-            logger.debug("Unknown event from Kodi {}: {}", method, json.toString());
+            logger.debug("Unknown event from Kodi {}: {}", method, json);
         }
     }
 
     private void processScreensaverStateChanged(String method, JsonObject json) {
         if ("GUI.OnScreensaverDeactivated".equals(method)) {
-            updateScreenSaverStatus(false);
+            listener.updateScreenSaverState(false);
         } else if ("GUI.OnScreensaverActivated".equals(method)) {
-            updateScreenSaverStatus(true);
+            listener.updateScreenSaverState(true);
         } else {
-            logger.debug("Unknown event from Kodi {}: {}", method, json.toString());
+            logger.debug("Unknown event from Kodi {}: {}", method, json);
         }
         listener.updateConnectionState(true);
-    }
-
-    private void updateScreenSaverStatus(boolean screenSaverActive) {
-        try {
-            listener.updateScreenSaverState(screenSaverActive);
-        } catch (Exception e) {
-            logger.error("Event listener invoking error", e);
-        }
     }
 
     public synchronized void close() {


### PR DESCRIPTION
xbmc/xbmc#13726 introduced a new notification event `Player.OnResume` which results in a regression 
for the Kodi binding.

- Added handling for new `Player.OnResume` event
- Minor code cleanups

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>