### PR TITLE
[homematic] Support thing status "OFFLINE - GONE" and add auto-delete option

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
@@ -91,6 +91,12 @@
 				<description>Time in seconds that the controller will be in install mode when a device discovery is initiated</description>
 				<default>60</default>
 			</parameter>
+			<parameter name="unpairOnDeletion" type="boolean">
+				<label>Unpair Devices on Deletion</label>
+				<description>If set to true, devices are unpaired from the gateway when their corresponding things are removed</description>
+				<advanced>true</advanced>
+				<default>false</default>
+			</parameter>
 
 		</config-description>
 	</bridge-type>

--- a/addons/binding/org.openhab.binding.homematic/README.md
+++ b/addons/binding/org.openhab.binding.homematic/README.md
@@ -140,6 +140,9 @@ The port number of the CUxD daemon (default = 8701)
 -   **installModeDuration**
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)
 
+-   **unpairOnDeletion**
+If true, devices are automatically unpaired from a gateway when the corresponding thing is deleted (default = false)
+
 The syntax for a bridge is:
 
 ```java

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
@@ -311,7 +312,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
             discoveryService.deviceDiscovered(device);
         }
 
-        Thing hmThing = getThingByUID(UidUtils.generateThingUID(device, getThing())); // check if necessary
+        Thing hmThing = getThingByUID(UidUtils.generateThingUID(device, getThing()));
         if (hmThing != null && hmThing.getHandler() != null) {
             ((HomematicThingHandler) hmThing.getHandler()).deviceLoaded(device);
         }
@@ -335,6 +336,28 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 logger.warn("{}", ex.getMessage());
             }
         }
+    }
+
+    @Override
+    public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+        if (((HomematicThingHandler) childHandler).isDeletionPending()) {
+            deleteFromGateway(UidUtils.getHomematicAddress(childThing), false, true, false);
+        }
+    }
+
+    /**
+     * Deletes a device from the gateway.
+     *
+     * @param address The address of the device to be deleted
+     * @param reset <i>true</i> will perform a factory reset on the device before deleting it.
+     * @param force <i>true</i> will delete the device even if it is not reachable.
+     * @param defer <i>true</i> will delete the device once it becomes available.
+     */
+    public void deleteFromGateway(String address, boolean reset, boolean force, boolean defer) {
+        scheduler.submit(() -> {
+            logger.debug("Deleting the device '{}' from gateway '{}'", address, getBridge());
+            getGateway().deleteDevice(address, reset, force, defer);
+        });
     }
 
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicBridgeHandler.java
@@ -286,6 +286,11 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
     public void onDeviceDeleted(HmDevice device) {
         discoveryService.deviceRemoved(device);
         updateThing(device);
+
+        Thing hmThing = getThingByUID(UidUtils.generateThingUID(device, getThing()));
+        if (hmThing != null && hmThing.getHandler() != null) {
+            ((HomematicThingHandler) hmThing.getHandler()).deviceRemoved();
+        }
     }
 
     @Override
@@ -304,6 +309,11 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
         typeGenerator.generate(device);
         if (discoveryService != null) {
             discoveryService.deviceDiscovered(device);
+        }
+
+        Thing hmThing = getThingByUID(UidUtils.generateThingUID(device, getThing())); // check if necessary
+        if (hmThing != null && hmThing.getHandler() != null) {
+            ((HomematicThingHandler) hmThing.getHandler()).deviceLoaded(device);
         }
     }
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/handler/HomematicThingHandler.java
@@ -498,4 +498,25 @@ public class HomematicThingHandler extends BaseThingHandler {
             logger.error("Error setting thing properties: {}", ex.getMessage(), ex);
         }
     }
+
+    /**
+     * Called by the bridgeHandler when this device has been removed from the gateway.
+     */
+    public void deviceRemoved() {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE);
+    }
+
+    /**
+     * Called by the bridgeHandler when the device for this thing has been added to the gateway.
+     * This is used to reconnect a device that was previously unpaired.
+     */
+    public void deviceLoaded(HmDevice device) {
+        try {
+            updateStatus(device);
+        } catch (BridgeHandlerNotAvailableException ex) {
+            // ignore
+        } catch (IOException ex) {
+            logger.error("{}", ex.getMessage(), ex);
+        }
+    }
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -51,6 +51,7 @@ public class HomematicConfig {
     private int timeout = 15;
     private int installModeDuration = DEFAULT_INSTALL_MODE_DURATION;
     private long discoveryTimeToLive = -1;
+    private boolean unpairOnDeletion = false;
 
     private HmGatewayInfo gatewayInfo;
 
@@ -208,6 +209,25 @@ public class HomematicConfig {
      */
     public void setInstallModeDuration(int installModeDuration) {
         this.installModeDuration = installModeDuration;
+    }
+
+    /**
+     * Returns if devices are unpaired from the gateway when their corresponding things are removed
+     * 
+     * @return <i>true</i> if devices are unpaired from the gateway when their corresponding things are removed
+     */
+    public boolean isUnpairOnDeletion() {
+        return unpairOnDeletion;
+    }
+
+    /**
+     * Sets unpairOnDeletion
+     * 
+     * @param unpairOnDeletion if set to <i>true</i>, devices are unpaired from the gateway when their corresponding
+     *            things are removed
+     */
+    public void setUnpairOnDeletion(boolean unpairOnDeletion) {
+        this.unpairOnDeletion = unpairOnDeletion;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -846,6 +846,39 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         }
     }
 
+    @Override
+    public void deleteDevice(String address, boolean reset, boolean force, boolean defer) {
+        for (RpcClient<?> rpcClient : rpcClients.values()) {
+            try {
+                rpcClient.deleteDevice(getDevice(address), translateFlags(reset, force, defer));
+            } catch (HomematicClientException e) {
+                // thrown by getDevice(address) if no device for the given address is paired on the gateway
+                logger.info("Device deletion not possible: {}", e.getMessage());
+            } catch (IOException e) {
+                logger.warn("Device deletion failed: {}", e.getMessage(), e);
+            }
+        }
+    }
+
+    private int translateFlags(boolean reset, boolean force, boolean defer) {
+        final int resetFlag = 0b001;
+        final int forceFlag = 0b010;
+        final int deferFlag = 0b100;
+        int resultFlag = 0;
+
+        if (reset) {
+            resultFlag += resetFlag;
+        }
+        if (force) {
+            resultFlag += forceFlag;
+        }
+        if (defer) {
+            resultFlag += deferFlag;
+        }
+
+        return resultFlag;
+    }
+
     /**
      * Thread which validates the connection to the gateway and restarts the RPC client if necessary.
      */

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
@@ -111,4 +111,14 @@ public interface HomematicGateway {
      */
     public void startWatchdogs();
 
+    /**
+     * Deletes the device from the gateway.
+     *
+     * @param address The address of the device to be deleted
+     * @param reset <i>true</i> will perform a factory reset on the device before deleting it.
+     * @param force <i>true</i> will delete the device even if it is not reachable.
+     * @param defer <i>true</i> will delete the device once it becomes available.
+     */
+    public void deleteDevice(String address, boolean reset, boolean force, boolean defer);
+
 }


### PR DESCRIPTION
Solves issue #3510

### Improvement
This PR tries to make the deletion of homematic things in combination with the unpairing of devices from their gateway more comfortable.

The first problem addressed by this PR is that the thing status does not properly communicate whether a device has been deleted from the bridge or if it is otherwise unreachable. To fix this, we can react on the "deleteDevices" call from the homematic gateway. If a thing exists for a device that is being deleted from the gateway, we can set it to the state "OFFLINE - GONE". This signifies that the thing can be deleted. If the device should be paired to the gateway again before the thing is deleted, the thing will come back "ONLINE" again.

The second problem addressed by this PR is that unpairing a device from the gateway and deleting a thing is a three step process from Openhab side: Activate the delete mode of the device, trigger the delete device channel, and finally remove the thing. To make this more comfortable, this PR provides a new configuration property for the bridge called "unpairOnDeletion". If this is set to true, then the unpairing of a device from its gateway is automatically triggered once the thing for that device gets into the state "REMOVING".

### User impact
- The "OFFLINE - GONE" status will change the behavior of the binding slightly. It will allow users to easily recognize when a device has been unpaired from the gateway while the thing has not been deleted.
- The new config property will not affect existing users, since the default value of that property leaves everything as is. A user who knowingly activates this property will be able to unpair devices from a gateway more comfortably through Openhab.

### Documentation
The new configuration property has been added to the Readme.
