### PR TITLE
[homematic] Set a time to live on discovery results

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.homematic/ESH-INF/thing/bridge.xml
@@ -44,6 +44,12 @@
 				<advanced>true</advanced>
 				<default>15</default>
 			</parameter>
+			<parameter name="discoveryTimeToLive" type="integer">
+				<label>Discovery Time To Live</label>
+				<description>The time to live for discovery results of a Homematic gateway in seconds. (default = -1 -> infinite)</description>
+				<advanced>true</advanced>
+				<default>-1</default>
+			</parameter>
 			<parameter name="socketMaxAlive" type="integer">
 				<label>Socket maxAlive</label>
 				<description>The maximum lifetime of a pooled socket connection to the Homematic gateway in seconds (default = 900)</description>

--- a/addons/binding/org.openhab.binding.homematic/README.md
+++ b/addons/binding/org.openhab.binding.homematic/README.md
@@ -119,6 +119,9 @@ Think in hours when configuring (one hour = 3600)
 -   **timeout**  
 The timeout in seconds for connections to a Homematic gateway (default = 15)
 
+-   **discoveryTimeToLive**  
+The time to live in seconds for discovery results of a Homematic gateway (default = -1, which means infinite)
+
 -   **socketMaxAlive**  
 The maximum lifetime of a pooled socket connection to the Homematic gateway in seconds (default = 900)
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -50,6 +50,7 @@ public class HomematicConfig {
     private int socketMaxAlive = 900;
     private int timeout = 15;
     private int installModeDuration = DEFAULT_INSTALL_MODE_DURATION;
+    private long discoveryTimeToLive = -1;
 
     private HmGatewayInfo gatewayInfo;
 
@@ -159,6 +160,20 @@ public class HomematicConfig {
      */
     public void setTimeout(int timeout) {
         this.timeout = timeout;
+    }
+
+    /**
+     * Returns the time to live for discovery results of a Homematic gateway in seconds.
+     */
+    public long getDiscoveryTimeToLive() {
+        return discoveryTimeToLive;
+    }
+
+    /**
+     * Sets the time to live for discovery results of a Homematic gateway in seconds.
+     */
+    public void setDiscoveryTimeToLive(long discoveryTimeToLive) {
+        this.discoveryTimeToLive = discoveryTimeToLive;
     }
 
     /**
@@ -321,8 +336,8 @@ public class HomematicConfig {
                 .append("xmlCallbackPort", xmlCallbackPort).append("binCallbackPort", binCallbackPort)
                 .append("gatewayType", gatewayType).append("rfPort", getRfPort()).append("wiredPort", getWiredPort())
                 .append("hmIpPort", getHmIpPort()).append("cuxdPort", getCuxdPort()).append("groupPort", getGroupPort())
-                .append("timeout", timeout).append("installModeDuration", installModeDuration)
-                .append("socketMaxAlive", socketMaxAlive);
+                .append("timeout", timeout).append("discoveryTimeToLive", discoveryTimeToLive)
+                .append("installModeDuration", installModeDuration).append("socketMaxAlive", socketMaxAlive);
         return tsb.toString();
     }
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -214,9 +214,10 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
         ThingTypeUID typeUid = UidUtils.generateThingTypeUID(device);
         ThingUID thingUID = new ThingUID(typeUid, bridgeUID, device.getAddress());
         String label = device.getName() != null ? device.getName() : device.getAddress();
+        long timeToLive = bridgeHandler.getThing().getConfiguration().as(HomematicConfig.class).getDiscoveryTimeToLive();
 
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID).withLabel(label)
-                .build();
+                .withTTL(timeToLive).build();
         thingDiscovered(discoveryResult);
     }
 


### PR DESCRIPTION
### Improvement
Per default, discovery results from the homematic binding do not have a time to live, i.e. they remain in the inbox until they are either accepted or removed. The new advanced config property "discoveryTimeToLive" allows to customize the time to live for discovery results of each homematic bridge.

### User Impact
The new property is set to -1 by default, which means infinite time to live. This is equal to the current behavior.

### Documentation
The new configuration property has been added to the Readme.
