### PR TITLE
[avmfritz] Removed min/max/step attributes for set_temp channel

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/channel-types.xml
@@ -81,7 +81,7 @@
 		<label>Setpoint Temperature</label>
 		<description>Thermostat Setpoint temperature.</description>
 		<category>Temperature</category>
-		<state min="8" max="28" step="0.5" pattern="%.1f %unit%" />
+		<state pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="eco_temp">


### PR DESCRIPTION
- Removed min/max/step attributes for `set_temp` channel. They are currently not predictable.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>