### PR TITLE
removed "addons" from group id of artifacts

### DIFF
--- a/addons/io/org.openhab.io.azureiothub/pom.xml
+++ b/addons/io/org.openhab.io.azureiothub/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/org.openhab.io.homekit/pom.xml
+++ b/addons/io/org.openhab.io.homekit/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/org.openhab.io.hueemulation/pom.xml
+++ b/addons/io/org.openhab.io.hueemulation/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/org.openhab.io.imperihome/pom.xml
+++ b/addons/io/org.openhab.io.imperihome/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/org.openhab.io.openhabcloud/pom.xml
+++ b/addons/io/org.openhab.io.openhabcloud/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/org.openhab.io.transport.feed/pom.xml
+++ b/addons/io/org.openhab.io.transport.feed/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.io</groupId>
+    <groupId>org.openhab.io</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/io/pom.xml
+++ b/addons/io/pom.xml
@@ -9,7 +9,7 @@
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.io</groupId>
+  <groupId>org.openhab.io</groupId>
   <artifactId>pom</artifactId>
 
   <packaging>pom</packaging>

--- a/addons/voice/org.openhab.voice.kaldi/pom.xml
+++ b/addons/voice/org.openhab.voice.kaldi/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.voice</groupId>
+    <groupId>org.openhab.voice</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/voice/org.openhab.voice.marytts/pom.xml
+++ b/addons/voice/org.openhab.voice.marytts/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.voice</groupId>
+    <groupId>org.openhab.voice</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/voice/org.openhab.voice.voicerss/pom.xml
+++ b/addons/voice/org.openhab.voice.voicerss/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <artifactId>pom</artifactId>
-    <groupId>org.openhab.addons.voice</groupId>
+    <groupId>org.openhab.voice</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 

--- a/addons/voice/pom.xml
+++ b/addons/voice/pom.xml
@@ -9,7 +9,7 @@
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.voice</groupId>
+  <groupId>org.openhab.voice</groupId>
   <artifactId>pom</artifactId>
 
   <packaging>pom</packaging>


### PR DESCRIPTION
Fixes issue reported in https://github.com/openhab/openhab2-addons/pull/3464#issuecomment-386813984

Signed-off-by: Kai Kreuzer <kai@openhab.org>