### PR TITLE
[MCP23017] channel config "pull_mode=PULL_UP" not working

### DIFF
--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -27,7 +27,7 @@ mcp23017 supports 16 channels in 2 groups:
  | Group |                       Channels                                   |           Additional parameters           |
  |  ---  |                          ---                                     |                      ---                  |
  | input | A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7   | pull_mode (OFF, PULL_UP), default is OFF  |
- | output| A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7   | default_state (LOW, HIGH), defauld is LOW |
+ | output| A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7   | default_state (LOW, HIGH), default is LOW |
 
  Channel determines MCP23017 PIN we want to use.
 
@@ -50,8 +50,20 @@ Let's imagine a setup with:
 
 *   Things:
 
+Minimal configuration:
 ```
 Thing mcp23017:mcp23017:chipA  "MCP23017 chip A" [address=20,bus=1]
+```
+
+Configuration with default_state and pull_mode:
+```
+Thing mcp23017:mcp23017:chipA  "MCP23017 chip A" [address=20,bus=1] {
+    Type output_pin : output#A0 [default_state="HIGH"]
+    Type output_pin : output#A1 [default_state="LOW"]
+
+    Type input_pin : input#B0 [pull_mode="PULL_UP"]
+    Type input_pin : input#B1 [pull_mode="OFF"]
+}
 ```
 
 *   Items:

--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/handler/Mcp23017Handler.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/handler/Mcp23017Handler.java
@@ -158,7 +158,7 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
         Pin pin = PinMapper.get(channel.getIdWithoutGroup());
 
         String pullMode = DEFAULT_PULL_MODE;
-        if (thing.getChannel(channel.getIdWithoutGroup()) != null) {
+        if (thing.getChannel(channel.getId ()) != null) {
             Configuration configuration = thing.getChannel(channel.getId()).getConfiguration();
             pullMode = ((String) configuration.get(PULL_MODE)) != null ? ((String) configuration.get(PULL_MODE))
                     : DEFAULT_PULL_MODE;


### PR DESCRIPTION
Signed-off-by: Igor Arenz <igor.arenz@ia-it.de>

I want to be able to use the pull_mode PULL_UP at input-pins of a MCP23017-Binding. 
I need over a week with analysing xtext-files and debugging Java-Code and a lot of help of the community (Thank you, Udo! -> https://community.openhab.org/t/mcp23017-binding-items-file-configuration-additional-parameters/44603/12) to get a working configuration.
After I get a correct configuration, I found out, that the pull_mode-configuration is not working as expected. 

I do a oneliner-fix in the MCP23017Handler and improve the doc. 

If there is anything wrong with my pull-request, please give me a hint. Its my first one on openhab

Thank you,
Igor Arenz

