### PR TITLE
Remove obsolete esh.releaseVersion property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
             <enabled>false</enabled>
           </snapshots>
           <id>p2-smarthome-release</id>
-          <url>http://download.eclipse.org/smarthome/updates-release/${esh.releaseVersion}</url>
+          <url>http://download.eclipse.org/smarthome/updates-release/${esh.version}</url>
           <layout>p2</layout>
         </repository>
       </repositories>


### PR DESCRIPTION
The `esh.releaseVersion` property became obsolete after PR #3406.

Signed-off-by: Patrick Fink <mail@pfink.de>