### PR TITLE
[tplinksmarthome] Added support for HS210 and HS220, and some improvements

### DIFF
--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/handler/SmartHomeHandlerTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/handler/SmartHomeHandlerTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.tplinksmarthome.handler;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants.*;
@@ -100,7 +100,6 @@ public class SmartHomeHandlerTest {
 
     @Test
     public void testHandleCommandRefreshType() {
-        handler.initialize();
         assertHandleCommandRefreshType(-53);
     }
 
@@ -108,7 +107,6 @@ public class SmartHomeHandlerTest {
     public void testHandleCommandRefreshTypeRangeExtender() throws IOException {
         when(connection.sendCommand(Commands.getSysinfo()))
                 .thenReturn(ModelTestUtil.readJson("rangeextender_get_sysinfo_response"));
-        handler.initialize();
         assertHandleCommandRefreshType(-70);
     }
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollectorTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollectorTest.java
@@ -51,13 +51,23 @@ public class PropertiesCollectorTest {
         assertProperties("plug_get_sysinfo_response", TPLinkSmartHomeThingType.HS100, 12);
     }
 
+    /**
+     * Tests if properties for a range extender device are correctly parsed.
+     *
+     * @throws IOException exception in case device not reachable
+     */
+    @Test
+    public void testRangeExtenderProperties() throws IOException {
+        assertProperties("rangeextender_get_sysinfo_response", TPLinkSmartHomeThingType.RE270K, 11);
+    }
+
     private void assertProperties(@NonNull String responseFile, @NonNull TPLinkSmartHomeThingType thingType,
             int expectedSize) throws IOException {
         ThingTypeUID thingTypeUID = thingType.thingTypeUID();
         Map<String, Object> props = PropertiesCollector.collectProperties(thingTypeUID, "localhost",
                 ModelTestUtil.toJson(gson, responseFile, GetSysinfo.class).getSysinfo());
 
-        assertEquals("Number of properties not as expected for properties", expectedSize, props.size());
+        assertEquals("Number of properties not as expected for properties: " + props, expectedSize, props.size());
         props.entrySet().stream().forEach(
                 entry -> assertNotNull("Property '" + entry.getKey() + "' should not be null", entry.getValue()));
     }

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryServiceTest.java
@@ -18,11 +18,16 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketTimeoutException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryListener;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -35,7 +40,11 @@ import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@RunWith(value = Parameterized.class)
 public class TPLinkSmartHomeDiscoveryServiceTest {
+
+    private static final List<Object[]> TESTS = Arrays.asList(
+            new Object[][] { { "bulb_get_sysinfo_response_on", 11 }, { "rangeextender_get_sysinfo_response", 11 } });
 
     @Mock
     private DatagramSocket discoverSocket;
@@ -44,6 +53,19 @@ public class TPLinkSmartHomeDiscoveryServiceTest {
     private DiscoveryListener discoveryListener;
 
     private TPLinkSmartHomeDiscoveryService discoveryService;
+
+    private final String filename;
+    private final int propertiesSize;
+
+    public TPLinkSmartHomeDiscoveryServiceTest(String filename, int propertiesSize) {
+        this.filename = filename;
+        this.propertiesSize = propertiesSize;
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> data() {
+        return TESTS;
+    }
 
     @Before
     public void setUp() throws IOException {
@@ -64,7 +86,7 @@ public class TPLinkSmartHomeDiscoveryServiceTest {
                 }
                 DatagramPacket packet = (DatagramPacket) invocation.getArguments()[0];
                 packet.setAddress(InetAddress.getLocalHost());
-                packet.setData(CryptUtil.encrypt(ModelTestUtil.readJson("bulb_get_sysinfo_response_on")));
+                packet.setData(CryptUtil.encrypt(ModelTestUtil.readJson(filename)));
                 return null;
             }
 
@@ -83,7 +105,8 @@ public class TPLinkSmartHomeDiscoveryServiceTest {
         DiscoveryResult discoveryResult = discoveryResultCaptor.getValue();
         assertEquals("Check if correct binding id found", TPLinkSmartHomeBindingConstants.BINDING_ID,
                 discoveryResult.getBindingId());
-        assertEquals("Check if expected number of properties found", 11, discoveryResult.getProperties().size());
+        assertEquals("Check if expected number of properties found", propertiesSize,
+                discoveryResult.getProperties().size());
     }
 
 }

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryServiceTest.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.tplinksmarthome.internal;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants;
 import org.openhab.binding.tplinksmarthome.handler.SmartHomeHandler;
 import org.openhab.binding.tplinksmarthome.internal.device.BulbDevice;
+import org.openhab.binding.tplinksmarthome.internal.device.DimmerDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.EnergySwitchDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.RangeExtenderDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.SwitchDevice;
@@ -48,6 +49,7 @@ public class TPLinkSmartHomeHandlerFactoryTest {
             { "hs100", SwitchDevice.class },
             { "hs110", EnergySwitchDevice.class },
             { "hs200", SwitchDevice.class },
+            { "hs220", DimmerDevice.class },
             { "lb100", BulbDevice.class },
             { "lb120", BulbDevice.class },
             { "lb130", BulbDevice.class },

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
@@ -28,6 +28,7 @@ import org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants;
 import org.openhab.binding.tplinksmarthome.handler.SmartHomeHandler;
 import org.openhab.binding.tplinksmarthome.internal.device.BulbDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.EnergySwitchDevice;
+import org.openhab.binding.tplinksmarthome.internal.device.RangeExtenderDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.SwitchDevice;
 
 /**
@@ -51,7 +52,7 @@ public class TPLinkSmartHomeHandlerFactoryTest {
             { "lb120", BulbDevice.class },
             { "lb130", BulbDevice.class },
             { "lb230", BulbDevice.class },
-            { "re270", SwitchDevice.class },
+            { "re270", RangeExtenderDevice.class },
             { "unknown", null },
     });
     // @formatter:on

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDeviceTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDeviceTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.device;
+
+import static org.junit.Assert.*;
+import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants.CHANNEL_BRIGHTNESS;
+
+import java.io.IOException;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.junit.Test;
+import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
+
+/**
+ * Test class for {@link DimmerDevice}.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+public class DimmerDeviceTest extends DeviceTestBase {
+
+    private static final DecimalType BRIGHTNESS_VALUE = new DecimalType(50);
+
+    private final DimmerDevice device = new DimmerDevice();
+
+    public DimmerDeviceTest() throws IOException {
+        super("hs220_get_sysinfo_response_on");
+    }
+
+    @Test
+    public void testHandleCommandSwitch() throws IOException {
+        assertInput("dimmer_set_switch_state_on");
+        setSocketReturnAssert("dimmer_set_switch_state_response");
+        assertTrue("Switch channel should be handled",
+                device.handleCommand(CHANNEL_BRIGHTNESS, connection, OnOffType.ON, configuration));
+    }
+
+    @Test
+    public void testHandleCommandBrightness() throws IOException {
+        assertInput("dimmer_set_brightness", "dimmer_set_switch_state_on");
+        setSocketReturnAssert("dimmer_set_brightness_response", "dimmer_set_switch_state_response");
+        assertTrue("Brightness channel should be handled",
+                device.handleCommand(CHANNEL_BRIGHTNESS, connection, new DecimalType(17), configuration));
+    }
+
+    @Test
+    public void testUpdateChannelSwitch() throws IOException {
+        deviceState = new DeviceState(ModelTestUtil.readJson("hs220_get_sysinfo_response_off"));
+
+        assertSame("Dimmer device should be off", OnOffType.OFF,
+                ((DecimalType) device.updateChannel(CHANNEL_BRIGHTNESS, deviceState)).as(OnOffType.class));
+    }
+
+    @Test
+    public void testUpdateChannelBrightness() {
+        assertEquals("Dimmer brightness should be set", BRIGHTNESS_VALUE,
+                device.updateChannel(CHANNEL_BRIGHTNESS, deviceState));
+    }
+
+    @Test
+    public void testUpdateChannelOther() {
+        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF, device.updateChannel("OTHER", deviceState));
+    }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDeviceTest.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDeviceTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.device;
+
+import static org.junit.Assert.*;
+import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants.*;
+
+import java.io.IOException;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test class for {@link RangeExtenderDevice} class.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+public class RangeExtenderDeviceTest extends DeviceTestBase {
+    private final RangeExtenderDevice device = new RangeExtenderDevice();
+
+    public RangeExtenderDeviceTest() throws IOException {
+        super("rangeextender_get_sysinfo_response");
+    }
+
+    @Test
+    public void testHandleCommandSwitch() throws IOException {
+        assertFalse("Switch channel not yet supported so should not be handled",
+                device.handleCommand(CHANNEL_SWITCH, connection, OnOffType.ON, configuration));
+    }
+
+    @Ignore("Ignore handle led command because led support in binding not (yet) implemented.")
+    @Test
+    public void testHandleCommandLed() throws IOException {
+        // assertInput("rangeextender_set_led_on");
+        // setSocketReturnAssert("rangeextender_set_led_on");
+        assertFalse("Led channel should be handled",
+                device.handleCommand(CHANNEL_LED, connection, OnOffType.ON, configuration));
+    }
+
+    @Test
+    public void testUpdateChannelSwitch() {
+        assertSame("Switch should be on", OnOffType.ON, device.updateChannel(CHANNEL_SWITCH, deviceState));
+    }
+
+    @Test
+    public void testUpdateChannelLed() {
+        assertSame("Led should be on", OnOffType.ON, device.updateChannel(CHANNEL_LED, deviceState));
+    }
+
+    @Test
+    public void testUpdateChannelOther() {
+        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF, device.updateChannel("OTHER", deviceState));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/bulb_get_sysinfo_response_on.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/bulb_get_sysinfo_response_on.json
@@ -9,10 +9,10 @@
 			},
 			"description": "Smart Wi-Fi LED Bulb with Color Changing",
 			"dev_state": "normal",
-			"deviceId": "80123C4640E9FC33A9019A0F3FD8BF5C17B7D9A8",
+			"deviceId": "DEVID_HERE",
 			"disco_ver": "1.0",
 			"heapsize": 347000,
-			"hwId": "111E35908497A05512E259BB76801E10",
+			"hwId": "HWID_HERE",
 			"hw_ver": "1.0",
 			"is_color": 1,
 			"is_dimmable": 1,
@@ -26,10 +26,10 @@
 				"on_off": 1,
 				"saturation": 44
 			},
-			"mic_mac": "50C7BF104865",
+			"mic_mac": "MAC_HERE",
 			"mic_type": "IOT.SMARTBULB",
 			"model": "LB130(US)",
-			"oemId": "05BF7B3BE1675C5A6867B7A7E4C9F6F7",
+			"oemId": "EOMiID_HERE",
 			"preferred_state": [
 				{
 					"brightness": 50,

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_brightness.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_brightness.json
@@ -1,0 +1,1 @@
+{"smartlife.iot.dimmer":{"set_brightness":{"brightness":17}}}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_brightness_response.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_brightness_response.json
@@ -1,0 +1,1 @@
+{"smartlife.iot.dimmer":{"set_brightness":{"err_code":0}}}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_switch_state_on.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_switch_state_on.json
@@ -1,0 +1,1 @@
+{"smartlife.iot.dimmer":{"set_switch_state":{"state":1}}}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_switch_state_response.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/dimmer_set_switch_state_response.json
@@ -1,0 +1,1 @@
+{"smartlife.iot.dimmer":{"set_switch_state":{"err_code":0}}}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/hs220_get_sysinfo_response_off.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/hs220_get_sysinfo_response_off.json
@@ -1,0 +1,50 @@
+{
+  "system": {
+    "get_sysinfo": {
+      "sw_ver": "1.4.8 Build 180109 Rel.171240",
+      "hw_ver": "1.0",
+      "mic_type": "IOT.SMARTPLUGSWITCH",
+      "model": "HS220(US)",
+      "mac": "00:00:00:00:00:00",
+      "dev_name": "Smart Wi-Fi Dimmer",
+      "alias": "dimmer",
+      "relay_state": 0,
+      "brightness": 50,
+      "on_time": 0,
+      "active_mode": "none",
+      "feature": "TIM",
+      "updating": 0,
+      "icon_hash": "",
+      "rssi": -10,
+      "led_off": 0,
+      "longitude_i": 0,
+      "latitude_i": 0,
+      "hwId": "00000000000000000000000000000000",
+      "fwId": "00000000000000000000000000000000",
+      "deviceId": "00000000000000000000000000000000",
+      "oemId": "00000000000000000000000000000000",
+      "preferred_state": [
+        {
+          "index": 0,
+          "brightness": 100
+        },
+        {
+          "index": 1,
+          "brightness": 75
+        },
+        {
+          "index": 2,
+          "brightness": 50
+        },
+        {
+          "index": 3,
+          "brightness": 25
+        }
+      ],
+      "next_action": {
+        "type": -1
+      },
+      "err_code": 0
+    }
+  }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/hs220_get_sysinfo_response_on.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/hs220_get_sysinfo_response_on.json
@@ -1,0 +1,50 @@
+{
+  "system": {
+    "get_sysinfo": {
+      "sw_ver": "1.4.8 Build 180109 Rel.171240",
+      "hw_ver": "1.0",
+      "mic_type": "IOT.SMARTPLUGSWITCH",
+      "model": "HS220(US)",
+      "mac": "00:00:00:00:00:00",
+      "dev_name": "Smart Wi-Fi Dimmer",
+      "alias": "dimmer",
+      "relay_state": 1,
+      "brightness": 50,
+      "on_time": 0,
+      "active_mode": "none",
+      "feature": "TIM",
+      "updating": 0,
+      "icon_hash": "",
+      "rssi": -10,
+      "led_off": 0,
+      "longitude_i": 0,
+      "latitude_i": 0,
+      "hwId": "00000000000000000000000000000000",
+      "fwId": "00000000000000000000000000000000",
+      "deviceId": "00000000000000000000000000000000",
+      "oemId": "00000000000000000000000000000000",
+      "preferred_state": [
+        {
+          "index": 0,
+          "brightness": 100
+        },
+        {
+          "index": 1,
+          "brightness": 75
+        },
+        {
+          "index": 2,
+          "brightness": 50
+        },
+        {
+          "index": 3,
+          "brightness": 25
+        }
+      ],
+      "next_action": {
+        "type": -1
+      },
+      "err_code": 0
+    }
+  }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/rangeextender_get_sysinfo_response.json
+++ b/addons/binding/org.openhab.binding.tplinksmarthome.test/src/test/resources/org/openhab/binding/tplinksmarthome/internal/model/rangeextender_get_sysinfo_response.json
@@ -1,0 +1,49 @@
+{
+	"system": {
+		"get_sysinfo": {
+			"plug": {
+				"feature": "TIM",
+				"relay_status": "ON",
+				"on_time": 2880,
+				"next_action": {
+					"type": -1
+				}
+			},
+			"err_code": 0,
+			"rangeextender.wireless": {
+				"w5g_client_count": 0,
+				"w2g_uplink_time": 983,
+				"w5g_uplink_enabled": false,
+				"w5g_rssi": -256,
+				"w5g_uplink_time": 0,
+				"w2g_mac": "MAC_ADD_HERE",
+				"w2g_uplink_enabled": true,
+				"w2g_downlink_enabled": true,
+				"w5g_downlink_enabled": true,
+				"w2g_client_count": 0,
+				"w5g_uplink_connected": false,
+				"w2g_rssi": -70,
+				"w5g_mac": "MAC_ADD_HERE",
+				"w2g_uplink_connected": true
+			},
+			"system": {
+				"ethernet_mac": "MAC_ADD_HERE",
+				"type": "IOT.RANGEEXTENDER.SMARTPLUG",
+				"oemId": "OEMID_HERE",
+				"icon_hash": "",
+				"system_time": 1518198773,
+				"updating": false,
+				"deviceId": "DEVID_HERE",
+				"sw_ver": "1.1.10 Build 20170920 rel.41527",
+				"hwId": "HWID_HERE",
+				"longitude": 0,
+				"led_status": "ON",
+				"model": "RE270K(EU)",
+				"hw_ver": "1.0.0",
+				"latitude": 0,
+				"alias": "My Wi-Fi Extender+",
+				"dev_name": "AC750 Wi-Fi Range Extender with Smart Plug"
+			}
+		}
+	}
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/config/config.xml
@@ -16,7 +16,7 @@
 			<unitLabel>milliseconds</unitLabel>
 			<default>0</default>
 		</parameter>
-		<parameter name="refresh" type="integer" min="0">
+		<parameter name="refresh" type="integer" min="1">
 			<label>Refresh rate</label>
 			<description>Refresh of device state in seconds.</description>
 			<unitLabel>seconds</unitLabel>
@@ -30,7 +30,7 @@
 			<label>IP Address</label>
 			<description>IP Address of the device.</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
+		<parameter name="refresh" type="integer" min="1">
 			<label>Refresh rate</label>
 			<description>Refresh of device state in seconds.</description>
 			<unitLabel>seconds</unitLabel>
@@ -44,7 +44,7 @@
 			<label>IP Address</label>
 			<description>IP Address of the device.</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
+		<parameter name="refresh" type="integer" min="1">
 			<label>Refresh rate</label>
 			<description>Refresh of device state in seconds.</description>
 			<unitLabel>seconds</unitLabel>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
@@ -6,6 +6,7 @@
 	<thing-type id="hs100">
 		<label>HS100</label>
 		<description>TP-Link HS100 Smart Wi-Fi Plug</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
@@ -6,6 +6,7 @@
 	<thing-type id="hs105">
 		<label>HS105</label>
 		<description>TP-Link HS105 Smart Wi-Fi Plug</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
@@ -6,6 +6,7 @@
 	<thing-type id="hs110">
 		<label>HS110</label>
 		<description>TP-Link HS110 Smart Wi-Fi Plug with Energy Monitoring</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS200.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS200.xml
@@ -6,6 +6,7 @@
 	<thing-type id="hs200">
 		<label>HS200</label>
 		<description>TP-Link HS200 Smart Wi-Fi Switch</description>
+		<category>WallSwitch</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="hs210">
+        <label>HS210</label>
+        <description>TP-Link HS210 Smart Wi-Fi Light Switch 3-Way Kit</description>
+        <category>WallSwitch</category>
+
+        <channels>
+            <channel id="switch" typeId="switch" />
+            <channel id="rssi" typeId="rssi" />
+        </channels>
+
+        <config-description-ref uri="thing-type:device:switch" />
+    </thing-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <thing-type id="hs210">
-        <label>HS210</label>
-        <description>TP-Link HS210 Smart Wi-Fi Light Switch 3-Way Kit</description>
-        <category>WallSwitch</category>
+	<thing-type id="hs210">
+		<label>HS210</label>
+		<description>TP-Link HS210 Smart Wi-Fi Light Switch 3-Way Kit</description>
+		<category>WallSwitch</category>
 
-        <channels>
-            <channel id="switch" typeId="switch" />
-            <channel id="rssi" typeId="rssi" />
-        </channels>
+		<channels>
+			<channel id="switch" typeId="switch" />
+			<channel id="rssi" typeId="rssi" />
+		</channels>
 
-        <config-description-ref uri="thing-type:device:switch" />
-    </thing-type>
+		<config-description-ref uri="thing-type:device:switch" />
+	</thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS220.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS220.xml
@@ -4,13 +4,13 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="hs200">
-		<label>HS200</label>
-		<description>TP-Link HS200 Smart Wi-Fi Switch</description>
+	<thing-type id="hs220">
+		<label>HS210</label>
+		<description>TP-Link HS220 Smart Wi-Fi Light Switch, Dimmer</description>
 		<category>WallSwitch</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="brightness" typeId="brightness" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="kb100">
 		<label>KB100</label>
 		<description>TP-Link KB100 Kasa Smart Light Bulb</description>
-        <category>Lightbulb</category>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
@@ -6,6 +6,7 @@
 	<thing-type id="kb100">
 		<label>KB100</label>
 		<description>TP-Link KB100 Kasa Smart Light Bulb</description>
+        <category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
@@ -6,6 +6,7 @@
 	<thing-type id="kb130">
 		<label>KB130</label>
 		<description>TP-Link KB130 Kasa Multi-color Smart Light Bulb</description>
+        <category>Lightbulb</category>
 
 		<channels>
 			<channel id="color" typeId="color" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="kb130">
 		<label>KB130</label>
 		<description>TP-Link KB130 Kasa Multi-color Smart Light Bulb</description>
-        <category>Lightbulb</category>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="color" typeId="color" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
@@ -6,6 +6,7 @@
 	<thing-type id="kp100">
 		<label>KP100</label>
 		<description>TP-Link KP100 Kasa Wi-Fi Smart Plug - Slim Edition</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb100">
 		<label>LB100</label>
 		<description>TP-Link LB100 Smart Wi-Fi LED Bulb with Dimmable Light</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb110">
 		<label>LB110</label>
 		<description>TP-Link LB110 Smart Wi-Fi LED Bulb with Dimmable Light</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb120">
 		<label>LB120</label>
 		<description>TP-Link LB120 Smart Wi-Fi LED Bulb with Tunable White Light</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb130">
 		<label>LB130</label>
 		<description>TP-Link LB130 Smart Wi-Fi LED Bulb with Color Changing Hue</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="color" typeId="color" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb200">
 		<label>LB200</label>
 		<description>TP-Link LB200 Smart Wi-Fi LED Bulb with Dimmable Light</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="brightness" typeId="brightness" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
@@ -6,6 +6,7 @@
 	<thing-type id="lb230">
 		<label>LB230</label>
 		<description>TP-Link LB230 Smart Wi-Fi LED Bulb with Color Changing Hue</description>
+		<category>Lightbulb</category>
 
 		<channels>
 			<channel id="color" typeId="color" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE270K.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE270K.xml
@@ -6,6 +6,7 @@
 	<thing-type id="re270">
 		<label>RE270K</label>
 		<description>TP-Link AC750 Wi-Fi Range Extender with Smart Plug</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE270K.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE270K.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE370K.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE370K.xml
@@ -6,6 +6,7 @@
 	<thing-type id="re370">
 		<label>RE370K</label>
 		<description>TP-Link AC1200 Wi-Fi Range Extender with Smart Plug</description>
+		<category>PowerOutlet</category>
 
 		<channels>
 			<channel id="switch" typeId="switch" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE370K.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/RE370K.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="tplinksmarthome" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/channels.xml
@@ -69,7 +69,10 @@
 		<item-type>Dimmer</item-type>
 		<label>Brightness</label>
 		<description>This channel supports adjusting the brightness.</description>
-		<category>ColorLight</category>
+		<category>DimmableLight</category>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
 	</channel-type>
 
 	<!-- Misc Channel types -->

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/Commands.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/Commands.java
@@ -14,9 +14,12 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.openhab.binding.tplinksmarthome.internal.model.GetRealtime;
 import org.openhab.binding.tplinksmarthome.internal.model.GetSysinfo;
 import org.openhab.binding.tplinksmarthome.internal.model.GsonUtil;
+import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
 import org.openhab.binding.tplinksmarthome.internal.model.Realtime;
+import org.openhab.binding.tplinksmarthome.internal.model.SetBrightness;
 import org.openhab.binding.tplinksmarthome.internal.model.SetLedOff;
 import org.openhab.binding.tplinksmarthome.internal.model.SetRelayState;
+import org.openhab.binding.tplinksmarthome.internal.model.SetSwitchState;
 import org.openhab.binding.tplinksmarthome.internal.model.Sysinfo;
 import org.openhab.binding.tplinksmarthome.internal.model.TransitionLightState;
 import org.openhab.binding.tplinksmarthome.internal.model.TransitionLightState.LightOnOff;
@@ -117,6 +120,38 @@ public class Commands {
      */
     public SetRelayState setRelayStateResponse(String relayStateResponse) {
         return gsonWithExpose.fromJson(relayStateResponse, SetRelayState.class);
+    }
+
+    /**
+     * Returns the json for the set_switch_state command to switch a dimmer on or off.
+     *
+     * @param onOff the switch state to set
+     * @return The json string of the command to send to the device
+     */
+    public String setSwitchState(OnOffType onOff) {
+        SetSwitchState switchState = new SetSwitchState();
+        switchState.setSwitchState(onOff);
+        return gsonWithExpose.toJson(switchState);
+    }
+
+    /**
+     * Returns the json response of the set_switch_state command to the data object.
+     *
+     * @param setSwitchStateResponse the json string
+     * @return The data object containing the state data from the json string
+     */
+    public SetSwitchState setSwitchStateResponse(String switchStateResponse) {
+        return gsonWithExpose.fromJson(switchStateResponse, SetSwitchState.class);
+    }
+
+    public String setDimmerBrightness(int brightness) {
+        SetBrightness setBrightness = new SetBrightness();
+        setBrightness.setBrightness(brightness);
+        return gsonWithExpose.toJson(setBrightness);
+    }
+
+    public HasErrorResponse setDimmerBrightnessResponse(String dimmerBrightnessResponse) {
+        return gsonWithExpose.fromJson(dimmerBrightnessResponse, SetBrightness.class);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollector.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollector.java
@@ -41,11 +41,15 @@ public final class PropertiesCollector {
         Map<String, Object> properties = new TreeMap<>();
 
         putNonNull(properties, CONFIG_IP, ipAddress);
-        collectProperties(properties, sysinfo);
-        if (TPLinkSmartHomeThingType.isBulbDevice(thingTypeUID)) {
-            collectPropertiesBulb(properties, sysinfo);
+        if (TPLinkSmartHomeThingType.isRangeExtenderDevice(thingTypeUID)) {
+            collectPropertiesRangeExtender(properties, sysinfo);
         } else {
-            collectPropertiesOther(properties, sysinfo);
+            collectProperties(properties, sysinfo);
+            if (TPLinkSmartHomeThingType.isBulbDevice(thingTypeUID)) {
+                collectPropertiesBulb(properties, sysinfo);
+            } else {
+                collectPropertiesOther(properties, sysinfo);
+            }
         }
         return properties;
     }
@@ -72,10 +76,25 @@ public final class PropertiesCollector {
      * @param sysinfo system info data returned from the device
      */
     private static void collectPropertiesBulb(Map<String, Object> properties, Sysinfo sysinfo) {
-        putNonNull(properties, PROPERTY_TYPE, sysinfo.getMicType());
-        putNonNull(properties, PROPERTY_MAC, sysinfo.getMicMac());
+        putNonNull(properties, PROPERTY_TYPE, sysinfo.getType());
+        putNonNull(properties, PROPERTY_MAC, sysinfo.getMac());
         putNonNull(properties, PROPERTY_PROTOCOL_NAME, sysinfo.getProtocolName());
         putNonNull(properties, PROPERTY_PROTOCOL_VERSION, sysinfo.getProtocolVersion());
+    }
+
+    /**
+     * Collect Smart Range Extender specific properties.
+     *
+     * @param properties properties object to store properties in
+     * @param sysinfo system info data returned from the device
+     */
+    private static void collectPropertiesRangeExtender(Map<String, Object> properties, Sysinfo sysinfo) {
+        Sysinfo system = sysinfo.getSystem();
+        collectProperties(properties, system);
+        putNonNull(properties, PROPERTY_TYPE, system.getType());
+        putNonNull(properties, PROPERTY_MAC, system.getMac());
+        putNonNull(properties, PROPERTY_DEVICE_NAME, system.getDevName());
+        putNonNull(properties, PROPERTY_FEATURE, sysinfo.getPlug().getFeature());
     }
 
     /**

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
@@ -160,7 +160,8 @@ public class TPLinkSmartHomeDiscoveryService extends AbstractDiscoveryService {
     private void detectThing(DatagramPacket packet) throws IOException {
         String ipAddress = packet.getAddress().getHostAddress();
         String rawData = CryptUtil.decrypt(packet.getData(), packet.getLength());
-        Sysinfo sysinfo = commands.getSysinfoReponse(rawData);
+        Sysinfo sysinfoRaw = commands.getSysinfoReponse(rawData);
+        Sysinfo sysinfo = sysinfoRaw.getActualSysinfo();
 
         logger.trace("Detected TP-Link Smart Home device: {}", rawData);
         String deviceId = sysinfo.getDeviceId();
@@ -171,7 +172,7 @@ public class TPLinkSmartHomeDiscoveryService extends AbstractDiscoveryService {
             ThingUID thingUID = new ThingUID(thingTypeUID.get(),
                     deviceId.substring(deviceId.length() - 6, deviceId.length()));
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withLabel(sysinfo.getAlias())
-                    .withProperties(PropertiesCollector.collectProperties(thingTypeUID.get(), ipAddress, sysinfo))
+                    .withProperties(PropertiesCollector.collectProperties(thingTypeUID.get(), ipAddress, sysinfoRaw))
                     .build();
             thingDiscovered(discoveryResult);
         } else {

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.tplinksmarthome.handler.SmartHomeHandler;
 import org.openhab.binding.tplinksmarthome.internal.device.BulbDevice;
+import org.openhab.binding.tplinksmarthome.internal.device.DimmerDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.EnergySwitchDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.RangeExtenderDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.SmartHomeDevice;
@@ -49,6 +50,8 @@ public class TPLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
 
         if (HS110.is(thingTypeUID)) {
             device = new EnergySwitchDevice();
+        } else if (HS220.is(thingTypeUID)) {
+            device = new DimmerDevice();
         } else if (LB130.is(thingTypeUID) || LB230.is(thingTypeUID)) {
             device = new BulbDevice(thingTypeUID, COLOR_TEMPERATURE_LB130_MIN, COLOR_TEMPERATURE_LB130_MAX);
         } else if (LB120.is(thingTypeUID)) {

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.tplinksmarthome.handler.SmartHomeHandler;
 import org.openhab.binding.tplinksmarthome.internal.device.BulbDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.EnergySwitchDevice;
+import org.openhab.binding.tplinksmarthome.internal.device.RangeExtenderDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.SmartHomeDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.SwitchDevice;
 import org.osgi.service.component.annotations.Component;
@@ -56,6 +57,8 @@ public class TPLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
             device = new SwitchDevice();
         } else if (TPLinkSmartHomeThingType.isBulbDevice(thingTypeUID)) {
             device = new BulbDevice(thingTypeUID);
+        } else if (TPLinkSmartHomeThingType.isRangeExtenderDevice(thingTypeUID)) {
+            device = new RangeExtenderDevice();
         } else {
             return null;
         }

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -44,6 +44,7 @@ enum TPLinkSmartHomeThingType {
 
     // Switch Thing Type UIDs
     HS200("hs200", DeviceType.SWITCH),
+    HS210("hs210", DeviceType.SWITCH),
 
     // Range Extender Thing Type UIDs
     RE270K("re270", DeviceType.RANGE_EXTENDER),

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -96,7 +96,18 @@ enum TPLinkSmartHomeThingType {
      */
     public static boolean isSwitchingDevice(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_LIST.stream().filter(t -> t.is(thingTypeUID))
-                .anyMatch(t -> t.type != DeviceType.BULB);
+                .anyMatch(t -> t.type == DeviceType.PLUG || t.type == DeviceType.SWITCH);
+    }
+
+    /**
+     * Returns true if the given {@link ThingTypeUID} matches a device that is a range extender.
+     *
+     * @param thingTypeUID if the check
+     * @return true if it's a range extender
+     */
+    public static boolean isRangeExtenderDevice(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_LIST.stream().filter(t -> t.is(thingTypeUID))
+                .anyMatch(t -> t.type == DeviceType.RANGE_EXTENDER);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -46,6 +46,9 @@ enum TPLinkSmartHomeThingType {
     HS200("hs200", DeviceType.SWITCH),
     HS210("hs210", DeviceType.SWITCH),
 
+    // Dimmer Thing Type UIDs
+    HS220("hs220", DeviceType.DIMMER),
+
     // Range Extender Thing Type UIDs
     RE270K("re270", DeviceType.RANGE_EXTENDER),
     RE370K("re370", DeviceType.RANGE_EXTENDER);
@@ -129,6 +132,10 @@ enum TPLinkSmartHomeThingType {
          * Light Bulb device.
          */
         BULB,
+        /**
+         * Dimmer device.
+         */
+        DIMMER,
         /**
          * Plug device.
          */

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDevice.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDevice.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.device;
+
+import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstants.CHANNEL_BRIGHTNESS;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.tplinksmarthome.internal.Connection;
+import org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeConfiguration;
+import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
+
+/**
+ * TP-Link Smart Home device with a dimmer.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+@NonNullByDefault
+public class DimmerDevice extends SwitchDevice {
+
+    @Override
+    protected @Nullable HasErrorResponse setOnOffState(Connection connection, OnOffType onOff) throws IOException {
+        return commands.setSwitchStateResponse(connection.sendCommand(commands.setSwitchState(onOff)));
+    }
+
+    @Override
+    public boolean handleCommand(String channelId, Connection connection, Command command,
+            TPLinkSmartHomeConfiguration configuration) throws IOException {
+        return CHANNEL_BRIGHTNESS.equals(channelId) ? handleBrightness(channelId, connection, command, configuration)
+                : super.handleCommand(channelId, connection, command, configuration);
+    }
+
+    private boolean handleBrightness(String channelId, Connection connection, Command command,
+            TPLinkSmartHomeConfiguration configuration) throws IOException {
+        HasErrorResponse response = null;
+
+        if (command instanceof OnOffType) {
+            response = setOnOffState(connection, (OnOffType) command);
+        } else if (command instanceof DecimalType) {
+            DecimalType decimalCommand = (DecimalType) command;
+
+            response = commands.setDimmerBrightnessResponse(
+                    connection.sendCommand(commands.setDimmerBrightness((decimalCommand).intValue())));
+            checkErrors(response);
+            response = setOnOffState(connection, (OnOffType) decimalCommand.as(OnOffType.class));
+        }
+        checkErrors(response);
+        return response != null;
+    }
+
+    @Override
+    public State updateChannel(String channelId, DeviceState deviceState) {
+        if (CHANNEL_BRIGHTNESS.equals(channelId)) {
+            return deviceState.getSysinfo().getRelayState() == OnOffType.OFF ? DecimalType.ZERO
+                    : new DecimalType(deviceState.getSysinfo().getBrightness());
+        } else {
+            return super.updateChannel(channelId, deviceState);
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDevice.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDevice.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.device;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.tplinksmarthome.internal.Connection;
+import org.openhab.binding.tplinksmarthome.internal.model.SetRelayState;
+
+/**
+ * TP-Link Smart Home range extender with smart plug.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+@NonNullByDefault
+public class RangeExtenderDevice extends SwitchDevice {
+
+    @Override
+    protected State getOnOffState(DeviceState deviceState) {
+        return deviceState.getSysinfo().getPlug().getRelayStatus();
+    }
+
+    @Override
+    protected @Nullable SetRelayState setOnOffState(@NonNull Connection connection, @NonNull OnOffType onOff)
+            throws IOException {
+        // It's unknown what the command is to send to the device so it's not supported.
+        return null;
+    }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDevice.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDevice.java
@@ -13,6 +13,7 @@ import static org.openhab.binding.tplinksmarthome.TPLinkSmartHomeBindingConstant
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -21,6 +22,7 @@ import org.openhab.binding.tplinksmarthome.internal.Commands;
 import org.openhab.binding.tplinksmarthome.internal.Connection;
 import org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeConfiguration;
 import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
+import org.openhab.binding.tplinksmarthome.internal.model.SetRelayState;
 
 /**
  * TP-Link Smart Home device with a switch, like Smart Plugs.
@@ -29,16 +31,6 @@ import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
  */
 @NonNullByDefault
 public class SwitchDevice extends SmartHomeDevice {
-
-    /**
-     * Returns the switch state.
-     *
-     * @param deviceState data object containing the state
-     * @return the switch state
-     */
-    protected State getOnOffState(DeviceState deviceState) {
-        return deviceState.getSysinfo().getRelayState();
-    }
 
     @Override
     public String getUpdateCommand() {
@@ -51,16 +43,37 @@ public class SwitchDevice extends SmartHomeDevice {
         return command instanceof OnOffType && handleOnOffType(channelID, connection, (OnOffType) command);
     }
 
+    /**
+     * Returns the switch state.
+     *
+     * @param deviceState data object containing the state
+     * @return the switch state
+     */
+    protected State getOnOffState(DeviceState deviceState) {
+        return deviceState.getSysinfo().getRelayState();
+    }
+
     private boolean handleOnOffType(String channelID, Connection connection, OnOffType onOff) throws IOException {
         HasErrorResponse response = null;
 
         if (CHANNEL_SWITCH.equals(channelID)) {
-            response = commands.setRelayStateResponse(connection.sendCommand(commands.setRelayState(onOff)));
+            response = setOnOffState(connection, onOff);
         } else if (CHANNEL_LED.equals(channelID)) {
             response = commands.setLedOnResponse(connection.sendCommand(commands.setLedOn(onOff)));
         }
         checkErrors(response);
         return response != null;
+    }
+
+    /**
+     * Sends the {@link OnOffType} command to the device and returns the returned answer.
+     *
+     * @param connection Connection to use
+     * @param onOff command to the send
+     * @return state returned by the device
+     */
+    protected @Nullable SetRelayState setOnOffState(Connection connection, OnOffType onOff) throws IOException {
+        return commands.setRelayStateResponse(connection.sendCommand(commands.setRelayState(onOff)));
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDevice.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDevice.java
@@ -22,10 +22,9 @@ import org.openhab.binding.tplinksmarthome.internal.Commands;
 import org.openhab.binding.tplinksmarthome.internal.Connection;
 import org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeConfiguration;
 import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
-import org.openhab.binding.tplinksmarthome.internal.model.SetRelayState;
 
 /**
- * TP-Link Smart Home device with a switch, like Smart Plugs.
+ * TP-Link Smart Home device with a switch, like Smart Plugs and Switches.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
@@ -72,7 +71,7 @@ public class SwitchDevice extends SmartHomeDevice {
      * @param onOff command to the send
      * @return state returned by the device
      */
-    protected @Nullable SetRelayState setOnOffState(Connection connection, OnOffType onOff) throws IOException {
+    protected @Nullable HasErrorResponse setOnOffState(Connection connection, OnOffType onOff) throws IOException {
         return commands.setRelayStateResponse(connection.sendCommand(commands.setRelayState(onOff)));
     }
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetBrightness.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetBrightness.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.model;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Data class to set the Brightness of a Smart Home dimmer (HS220).
+ * Setter methods for data and getter for error response.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+@NonNullByDefault
+public class SetBrightness implements HasErrorResponse {
+
+    public static class Brightness extends ErrorResponse {
+        @Expose(deserialize = false)
+        private int brightness;
+
+        @Override
+        public String toString() {
+            return "brightness:" + brightness + super.toString();
+        }
+    }
+
+    public static class Dimmer {
+        @Expose
+        private Brightness setBrightness = new Brightness();
+
+        @Override
+        public String toString() {
+            return "set_brightness:{" + setBrightness + "}";
+        }
+    }
+
+    @Expose
+    @SerializedName("smartlife.iot.dimmer")
+    private Dimmer dimmer = new Dimmer();
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return dimmer.setBrightness;
+    }
+
+    public void setBrightness(int brightness) {
+        dimmer.setBrightness.brightness = brightness;
+    }
+
+    @Override
+    public String toString() {
+        return "smartlife.iot.dimmer:{" + dimmer + "}";
+    }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetRelayState.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetRelayState.java
@@ -13,7 +13,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import com.google.gson.annotations.Expose;
 
 /**
- * Data class for setting the tp-Link Smart Plug state and retrieving the result.
+ * Data class for setting the TP-Link Smart Plug state and retrieving the result.
  * Only setter methods as the values are set by gson based on the retrieved json.
  *
  * @author Hilbrand Bouwkamp - Initial contribution

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetSwitchState.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/SetSwitchState.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tplinksmarthome.internal.model;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Data class for setting the TP-Link Smart Dimmer (HS220) state and retrieving the result.
+ * Only setter methods as the values are set by gson based on the retrieved json.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+public class SetSwitchState implements HasErrorResponse {
+
+    public static class State extends ErrorResponse {
+        @Expose(deserialize = false)
+        private int state;
+
+        @Override
+        public String toString() {
+            return "state:" + state;
+        }
+    }
+
+    public static class Dimmer {
+        @Expose
+        private State setSwitchState = new State();
+
+        @Override
+        public String toString() {
+            return "set_switch_state:{" + setSwitchState + "}";
+        }
+    }
+
+    @Expose
+    @SerializedName("smartlife.iot.dimmer")
+    private Dimmer dimmer = new Dimmer();
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return dimmer.setSwitchState;
+    }
+
+    public void setSwitchState(OnOffType onOff) {
+        dimmer.setSwitchState.state = onOff == OnOffType.ON ? 1 : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "SetSwitchState {smartlife.iot.dimmer:{" + dimmer + "}";
+    }
+}

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Sysinfo.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Sysinfo.java
@@ -60,6 +60,33 @@ public class Sysinfo extends ErrorResponse {
         }
     }
 
+    /**
+     * Status of the plug as set in the range extender products.
+     */
+    public static class Plug {
+        private String feature;
+        private String relayStatus;
+
+        public String getFeature() {
+            return feature;
+        }
+
+        public OnOffType getRelayStatus() {
+            return "ON".equals(relayStatus) ? OnOffType.ON : OnOffType.OFF;
+        }
+    }
+
+    /**
+     * Status of the range extended Wi-Fi.
+     */
+    public static class RangeextenderWireless {
+        private int w2gRssi;
+
+        public int getW2gRssi() {
+            return w2gRssi;
+        }
+    }
+
     private String swVer;
     private String hwVer;
     private String model;
@@ -72,10 +99,12 @@ public class Sysinfo extends ErrorResponse {
     private String alias;
     private String activeMode;
     private int rssi;
+    @SerializedName(value = "type", alternate = "mic_type")
+    private String type;
+    @SerializedName(value = "mac", alternate = { "mic_mac", "ethernet_mac" })
+    private String mac;
 
     // switch and plug specific system info
-    private String type;
-    private String mac;
     @SerializedName("fwId")
     private String fwId;
     private String devName;
@@ -83,18 +112,24 @@ public class Sysinfo extends ErrorResponse {
     private int relayState; // 0 is off, 1 is on
     private long onTime;
     private String feature; // HS100 -> TIM, HS110 -> TIM:ENE
-    private int updating;
+    // Disabled updating as it's a different type for different devices.
+    // private int updating;
     private int ledOff;
     private double latitude;
     private double longitude;
 
     // bulb specific system info
-    private String mic_type;
-    private String mic_mac;
     private boolean isFactory;
     private String discoVer;
     private CtrlProtocols ctrlProtocols;
     private WithDefaultLightState lightState = new WithDefaultLightState();
+
+    // range extender specific system info
+    private String ledStatus;
+    private Plug plug = new Plug();
+    private Sysinfo system;
+    @SerializedName("rangeextender.wireless")
+    private RangeextenderWireless reWireless;
 
     public String getSwVer() {
         return swVer;
@@ -160,12 +195,9 @@ public class Sysinfo extends ErrorResponse {
         return feature;
     }
 
-    public int getUpdating() {
-        return updating;
-    }
-
     public int getRssi() {
-        return rssi;
+        // for range extender use the 2g rssi.
+        return reWireless == null ? rssi : reWireless.getW2gRssi();
     }
 
     public OnOffType getLedOff() {
@@ -178,14 +210,6 @@ public class Sysinfo extends ErrorResponse {
 
     public double getLongitude() {
         return longitude;
-    }
-
-    public String getMicType() {
-        return mic_type;
-    }
-
-    public String getMicMac() {
-        return mic_mac;
     }
 
     public boolean isFactory() {
@@ -208,15 +232,42 @@ public class Sysinfo extends ErrorResponse {
         return lightState.getLightState();
     }
 
+    public OnOffType getLedStatus() {
+        return "ON".equals(ledStatus) ? OnOffType.OFF : OnOffType.ON;
+    }
+
+    public Plug getPlug() {
+        return plug;
+    }
+
+    public Sysinfo getSystem() {
+        return system;
+    }
+
+    /**
+     * Returns the {@link Sysinfo} object independent of the device. The range extender devices have the system
+     * information in another place as the other devices. This method returns the object independent of how the device
+     * returns it.
+     *
+     * @return device independent {@link Sysinfo} object.
+     */
+    public Sysinfo getActualSysinfo() {
+        return system == null ? this : system;
+    }
+
+    public RangeextenderWireless getReWireless() {
+        return reWireless;
+    }
+
     @Override
     public String toString() {
-        return "Sysinfo {swVer:" + swVer + ", hwVer:" + hwVer + ", model:" + model + ", deviceId:" + deviceId
-                + ", hwId:" + hwId + ", oemId:" + oemId + ", alias:" + alias + ", activeMode:" + activeMode + ", rssi:"
-                + rssi + ", type:" + type + ", mac:" + mac + ", fwId:" + fwId + ", devName:" + devName + ", iconHash:"
-                + iconHash + ", relayState:" + relayState + ", onTime:" + onTime + ", feature:" + feature
-                + ", updating:" + updating + ", ledOff:" + ledOff + ", latitude:" + latitude + ", longitude:"
-                + longitude + ", mic_type:" + mic_type + ", mic_mac:" + mic_mac + ", isFactory:" + isFactory
-                + ", discoVer:" + discoVer + ", ctrlProtocols:" + ctrlProtocols + ", lightState:" + lightState + "}"
-                + super.toString();
+        return "Sysinfo [swVer=" + swVer + ", hwVer=" + hwVer + ", model=" + model + ", deviceId=" + deviceId
+                + ", hwId=" + hwId + ", oemId=" + oemId + ", alias=" + alias + ", activeMode=" + activeMode + ", rssi="
+                + rssi + ", type=" + type + ", mac=" + mac + ", fwId=" + fwId + ", devName=" + devName + ", iconHash="
+                + iconHash + ", relayState=" + relayState + ", onTime=" + onTime + ", feature=" + feature + ", ledOff="
+                + ledOff + ", latitude=" + latitude + ", longitude=" + longitude + ", isFactory=" + isFactory
+                + ", discoVer=" + discoVer + ", ctrlProtocols=" + ctrlProtocols + ", lightState=" + lightState
+                + ", ledStatus=" + ledStatus + ", plug=" + plug + ", system=" + system + ", reWireless=" + reWireless
+                + "]";
     }
 }

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Sysinfo.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/model/Sysinfo.java
@@ -118,6 +118,9 @@ public class Sysinfo extends ErrorResponse {
     private double latitude;
     private double longitude;
 
+    // dimmer specific system info
+    private int brightness;
+
     // bulb specific system info
     private boolean isFactory;
     private String discoVer;
@@ -181,6 +184,10 @@ public class Sysinfo extends ErrorResponse {
 
     public OnOffType getRelayState() {
         return relayState == 1 ? OnOffType.ON : OnOffType.OFF;
+    }
+
+    public int getBrightness() {
+        return brightness;
     }
 
     public long getOnTime() {
@@ -264,10 +271,10 @@ public class Sysinfo extends ErrorResponse {
         return "Sysinfo [swVer=" + swVer + ", hwVer=" + hwVer + ", model=" + model + ", deviceId=" + deviceId
                 + ", hwId=" + hwId + ", oemId=" + oemId + ", alias=" + alias + ", activeMode=" + activeMode + ", rssi="
                 + rssi + ", type=" + type + ", mac=" + mac + ", fwId=" + fwId + ", devName=" + devName + ", iconHash="
-                + iconHash + ", relayState=" + relayState + ", onTime=" + onTime + ", feature=" + feature + ", ledOff="
-                + ledOff + ", latitude=" + latitude + ", longitude=" + longitude + ", isFactory=" + isFactory
-                + ", discoVer=" + discoVer + ", ctrlProtocols=" + ctrlProtocols + ", lightState=" + lightState
-                + ", ledStatus=" + ledStatus + ", plug=" + plug + ", system=" + system + ", reWireless=" + reWireless
-                + "]";
+                + iconHash + ", relayState=" + relayState + ", brightness=" + brightness + ", onTime=" + onTime
+                + ", feature=" + feature + ", ledOff=" + ledOff + ", latitude=" + latitude + ", longitude=" + longitude
+                + ", isFactory=" + isFactory + ", discoVer=" + discoVer + ", ctrlProtocols=" + ctrlProtocols
+                + ", lightState=" + lightState + ", ledStatus=" + ledStatus + ", plug=" + plug + ", system=" + system
+                + ", reWireless=" + reWireless + "]";
     }
 }


### PR DESCRIPTION
This pull request adds/improves the following to the tplink smart home binding:
* Added support for HS210 and HS220 (See https://community.openhab.org/t/tp-link-dimmer-switch-binding/42192)
* Improved support for TP-Link range extenders.
* Added category tags to thing types.