### PR TITLE
[avmfritz] Refactored handler to use AIN for updating things instead of deriving it from the ThingID

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -92,7 +92,8 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void invalidDiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"11934 0110051-1\" id=\"2000\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\"><present>1</present><name>HAN-FUN #1</name><etsiunitinfo><etsideviceid>411</etsideviceid><unittype>514</unittype><interfaces>256</interfaces></etsiunitinfo><alert><state>0</state></alert></device></devicelist>";
+        // attribute productname is important for a valid discovery result
+        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>FRITZ!DECT 210 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -151,6 +152,33 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
         assertEquals(new ThingUID("avmfritz:FRITZ_DECT_200:1:087610000434"), discoveryResult.getThingUID());
         assertEquals(DECT200_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("087610000434", discoveryResult.getProperties().get(THING_AIN));
+        assertEquals("AVM", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("17", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("087610000434", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("03.83", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(THING_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validDECT210DiscoveryResult() throws JAXBException {
+        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 210\"><present>1</present><name>FRITZ!DECT 210 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:FRITZ_DECT_210:1:087610000434"), discoveryResult.getThingUID());
+        assertEquals(DECT210_THING_TYPE, discoveryResult.getThingTypeUID());
         assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
         assertEquals("087610000434", discoveryResult.getProperties().get(THING_AIN));
         assertEquals("AVM", discoveryResult.getProperties().get(PROPERTY_VENDOR));

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/AVMFritzBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/AVMFritzBaseThingHandler.java
@@ -76,13 +76,14 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
         logger.debug("Handle command '{}' for channel {}", command, channelId);
         FritzAhaWebInterface fritzBox = getWebInterface();
         if (fritzBox == null) {
+            logger.debug("Cannot handle command '{}' because connection is missing", command);
             return;
         }
-        if (getThing().getConfiguration().get(THING_AIN) == null) {
+        String ain = getIdentifier();
+        if (ain == null) {
             logger.debug("Cannot handle command '{}' because AIN is missing", command);
             return;
         }
-        String ain = getThing().getConfiguration().get(THING_AIN).toString();
         switch (channelId) {
             case CHANNEL_MODE:
             case CHANNEL_LOCKED:
@@ -192,6 +193,12 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
             }
         }
         return null;
+    }
+
+    @Nullable
+    public String getIdentifier() {
+        Object ain = getThing().getConfiguration().get(THING_AIN);
+        return ain != null ? ain.toString() : null;
     }
 
     @Nullable

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/Powerline546EHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/handler/Powerline546EHandler.java
@@ -10,6 +10,9 @@ package org.openhab.binding.avmfritz.handler;
 
 import static org.openhab.binding.avmfritz.BindingConstants.*;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
@@ -17,6 +20,9 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.types.Command;
@@ -56,16 +62,20 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
     }
 
     @Override
-    public void addDeviceList(AVMFritzBaseModel device) {
-        logger.debug("set device model: {}", device);
-        ThingUID thingUID = getThingUID(device);
-        if (getThing().getUID().equals(thingUID)) {
-            logger.debug("update self {} with device model: {}", thingUID, device);
+    public void addDeviceList(ArrayList<AVMFritzBaseModel> devicelist) {
+        Optional<AVMFritzBaseModel> optionalDevice = devicelist.stream()
+                .filter(it -> it.getIdentifier().equals(getIdentifier())).findFirst();
+        if (optionalDevice.isPresent()) {
+            AVMFritzBaseModel device = optionalDevice.get();
+            devicelist.remove(device);
+            logger.debug("update self {} with device model: {}", getThing().getUID(), device);
             setState(device);
             updateThingFromDevice(getThing(), device);
         } else {
-            super.addDeviceList(device);
+            getThing().setStatusInfo(
+                    new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "Device not present in response"));
         }
+        super.addDeviceList(devicelist);
     }
 
     /**
@@ -99,16 +109,14 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
         String ipAddress = getConfigAs(AVMFritzConfiguration.class).getIpAddress();
 
         if (PL546E_STANDALONE_THING_TYPE.equals(thingTypeUID)) {
-            String thingName = "fritz.powerline".equals(ipAddress) ? ipAddress : ipAddress.replaceAll(INVALID_PATTERN, "_");
+            String thingName = "fritz.powerline".equals(ipAddress) ? ipAddress
+                    : ipAddress.replaceAll(INVALID_PATTERN, "_");
             return new ThingUID(thingTypeUID, thingName);
         } else {
             return super.getThingUID(device);
         }
     }
 
-    /**
-     * Handle the commands for switchable outlets.
-     */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String channelId = channelUID.getIdWithoutGroup();
@@ -118,11 +126,11 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
             logger.debug("Cannot handle command '{}' because connection is missing", command);
             return;
         }
-        if (getThing().getConfiguration().get(THING_AIN) == null) {
+        String ain = getIdentifier();
+        if (ain == null) {
             logger.debug("Cannot handle command '{}' because AIN is missing", command);
             return;
         }
-        String ain = getThing().getConfiguration().get(THING_AIN).toString();
         switch (channelId) {
             case CHANNEL_MODE:
             case CHANNEL_LOCKED:
@@ -143,6 +151,12 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
                 super.handleCommand(channelUID, command);
                 break;
         }
+    }
+
+    @Nullable
+    public String getIdentifier() {
+        Object ain = getThing().getConfiguration().get(THING_AIN);
+        return ain != null ? ain.toString() : null;
     }
 
     @Nullable

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaUpdateXmlCallback.java
@@ -16,7 +16,6 @@ import javax.xml.bind.Unmarshaller;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.openhab.binding.avmfritz.handler.AVMFritzBaseBridgeHandler;
-import org.openhab.binding.avmfritz.internal.ahamodel.AVMFritzBaseModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.DevicelistModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
 import org.openhab.binding.avmfritz.internal.util.JAXBUtils;
@@ -59,9 +58,7 @@ public class FritzAhaUpdateXmlCallback extends FritzAhaReauthCallback {
                 Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
                 DevicelistModel model = (DevicelistModel) u.unmarshal(new StringReader(response));
                 if (model != null) {
-                    for (AVMFritzBaseModel device : model.getDevicelist()) {
-                        handler.addDeviceList(device);
-                    }
+                    handler.addDeviceList(model.getDevicelist());
                     handler.setStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, "FRITZ!Box online");
                 } else {
                     logger.warn("no model in response");


### PR DESCRIPTION
- Refactored handler to use AIN for updating things instead of deriving it from the ThingID
- Added handling for deleted devices and structures from FRITZ!OS

This allows users to choose their own ThingIDs if they wish. Addresses issue #1963.
This allows users to add things manually if the discovery doesn't work (e.g. old firmware for FRITZ!Box). See https://community.openhab.org/t/avm-fritz-dect210-not-detected/45474.

Test version: [org.openhab.binding.avmfritz-2.4.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab2-addons/files/2045510/org.openhab.binding.avmfritz-2.4.0-SNAPSHOT.jar.zip)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>