### PR TITLE
[homematic] Reduce Bin/XmlRpcServer to specified callback host address

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
@@ -43,7 +43,7 @@ public class BinRpcNetworkService implements Runnable {
 
         serverSocket = new ServerSocket();
         serverSocket.setReuseAddress(true);
-        serverSocket.bind(new InetSocketAddress(config.getBinCallbackPort()));
+        serverSocket.bind(new InetSocketAddress(config.getCallbackHost(), config.getBinCallbackPort()));
 
         this.rpcResponseHandler = new RpcResponseHandler<byte[]>(listener) {
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
@@ -10,6 +10,7 @@ package org.openhab.binding.homematic.internal.communicator.server;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.InetSocketAddress;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -74,7 +75,9 @@ public class XmlRpcServer implements RpcServer {
     public void start() throws IOException {
         logger.debug("Initializing XML-RPC server at port {}", config.getXmlCallbackPort());
 
-        xmlRpcHTTPD = new Server(config.getXmlCallbackPort());
+        InetSocketAddress callbackAddress = new InetSocketAddress(config.getCallbackHost(),
+                config.getXmlCallbackPort());
+        xmlRpcHTTPD = new Server(callbackAddress);
         xmlRpcHTTPD.setHandler(jettyResponseHandler);
 
         try {


### PR DESCRIPTION
Open Server on host specified in the property "callbackHost" instead of opening it without specification. This will prevent conflicts on machines which provide multiple network interfaces.

Further improvements for stability of the communication between binding and gateway:

* Improved error logging of ConnectionTrackerThread
* Synchronized AbstractHomematicGateway's start/stopServers to prevent starting of new servers while previous operation is still blocking

Signed-off-by: Michael Reitler <michael.reitler@telekom.de>