### PR TITLE
Adding missing javax.net packages for the Netatmo API client.

### DIFF
--- a/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
@@ -21,6 +21,8 @@ Export-Package:
 Import-Package: 
  javax.measure,
  javax.measure.quantity,
+ javax.net,
+ javax.net.ssl,
  javax.servlet,
  javax.servlet.http,
  org.eclipse.jdt.annotation;resolution:=optional,


### PR DESCRIPTION
Reproduced the issue https://github.com/openhab/openhab2-addons/issues/1070 while trying to use the [Netatmo Binding](https://github.com/openhab/openhab2-addons/tree/809e50532e0499ce85b85fd5c8fe4db309e57d79/addons/binding/org.openhab.binding.netatmo) in a custom distribution based on the Eclipse Smarthome Core. 