### PR TITLE
[homematic] Improve stability of resource loading

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -220,16 +220,18 @@ public class CcuGateway extends AbstractHomematicGateway {
      */
     private Map<String, String> loadTclRegaScripts() throws IOException {
         Bundle bundle = FrameworkUtil.getBundle(getClass());
-        InputStream stream = bundle.getResource("homematic/tclrega-scripts.xml").openStream();
-        TclScriptList scriptList = (TclScriptList) xStream.fromXML(stream);
-
-        Map<String, String> result = new HashMap<String, String>();
-        if (scriptList.getScripts() != null) {
-            for (TclScript script : scriptList.getScripts()) {
-                result.put(script.name, StringUtils.trimToNull(script.data));
+        try (InputStream stream = bundle.getResource("homematic/tclrega-scripts.xml").openStream()) {
+            TclScriptList scriptList = (TclScriptList) xStream.fromXML(stream);
+            Map<String, String> result = new HashMap<String, String>();
+            if (scriptList.getScripts() != null) {
+                for (TclScript script : scriptList.getScripts()) {
+                    result.put(script.name, StringUtils.trimToNull(script.data));
+                }
             }
+            return result;
+        } catch (IllegalStateException | IOException e) {
+            throw new IOException("The resource homematic/tclrega-scripts.xml could not be loaded!", e);
         }
-        return result;
     }
 
 }

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
@@ -10,11 +10,14 @@ package org.openhab.binding.homematic.internal.communicator.virtual;
 
 import static org.openhab.binding.homematic.internal.misc.HomematicConstants.VIRTUAL_DATAPOINT_NAME_BATTERY_TYPE;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 import org.openhab.binding.homematic.internal.model.HmDevice;
 import org.openhab.binding.homematic.internal.model.HmValueType;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,12 +32,11 @@ public class BatteryTypeVirtualDatapointHandler extends AbstractVirtualDatapoint
     private static final Properties batteries = new Properties();
 
     public BatteryTypeVirtualDatapointHandler() {
-        try {
-            InputStream is = Thread.currentThread().getContextClassLoader()
-                    .getResourceAsStream("homematic/batteries.properties");
-            batteries.load(is);
-        } catch (Exception e) {
-            logger.warn("Battery property file not found, battery type not available");
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        try (InputStream stream = bundle.getResource("homematic/batteries.properties").openStream()) {
+            batteries.load(stream);
+        } catch (IllegalStateException | IOException e) {
+            logger.warn("The resource homematic/batteries.properties could not be loaded! Battery types not available", e);
         }
     }
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -171,7 +171,8 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
         } catch (Exception ex) {
             logger.error("Error waiting for device discovery scan: {}", ex.getMessage(), ex);
         }
-        String gatewayId = bridgeHandler != null ? bridgeHandler.getGateway().getId() : "UNKNOWN";
+        String gatewayId = bridgeHandler != null && bridgeHandler.getGateway() != null
+                ? bridgeHandler.getGateway().getId() : "UNKNOWN";
         logger.debug("Finished Homematic device discovery scan on gateway '{}'", gatewayId);
     }
 

--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
@@ -12,6 +12,7 @@ import static org.openhab.binding.homematic.HomematicBindingConstants.*;
 import static org.openhab.binding.homematic.internal.misc.HomematicConstants.*;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,6 +31,8 @@ import org.apache.commons.lang.WordUtils;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmDevice;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,9 +68,9 @@ public class MetadataUtils {
      * Loads the standard datapoints for channel metadata generation.
      */
     private static void loadStandardDatapoints() {
-        try (InputStream is = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("homematic/standard-datapoints.properties")) {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        Bundle bundle = FrameworkUtil.getBundle(MetadataUtils.class);
+        try (InputStream stream = bundle.getResource("homematic/standard-datapoints.properties").openStream();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
 
             String line;
             while ((line = reader.readLine()) != null) {
@@ -84,8 +87,8 @@ public class MetadataUtils {
                     channelDatapoints.add(datapointName);
                 }
             }
-        } catch (IOException ex) {
-            logger.warn("Can't load standard-datapoints.properties file!");
+        } catch (IllegalStateException | IOException e) {
+            logger.warn("Can't load standard-datapoints.properties file!", e);
         }
     }
 


### PR DESCRIPTION
Resolve resources from bundle instead of class loader (see https://github.com/openhab/openhab2-addons/issues/3195) & refactor to try-with-ressources
Additionally: Prevent potential NullPointerException on HomematicDeviceDiscoveryService

Signed-off-by: Michael Reitler <michael.reitler@telekom.de>