### PR TITLE
[tado] automatically recover things from offline state

### DIFF
--- a/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/BaseHomeThingHandler.java
+++ b/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/BaseHomeThingHandler.java
@@ -10,6 +10,7 @@ package org.openhab.binding.tado.handler;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.openhab.binding.tado.internal.api.TadoApiClient;
 
@@ -35,5 +36,12 @@ abstract public class BaseHomeThingHandler extends BaseThingHandler {
 
     protected TadoApiClient getApi() {
         return getHomeHandler().getApi();
+    }
+
+    protected void onSuccessfulOperation() {
+        // update without error -> we're back online
+        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+            updateStatus(ThingStatus.ONLINE);
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoHomeHandler.java
+++ b/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoHomeHandler.java
@@ -59,11 +59,17 @@ public class TadoHomeHandler extends BaseBridgeHandler {
         api = new TadoApiClientFactory().create(configuration.username, configuration.password);
 
         if (this.initializationFuture == null || this.initializationFuture.isDone()) {
-            initializationFuture = scheduler.schedule(this::initializeBridgeStatusAndProperties, 0, TimeUnit.SECONDS);
+            initializationFuture = scheduler.scheduleWithFixedDelay(this::initializeBridgeStatusAndPropertiesIfOffline,
+                    0, 300, TimeUnit.SECONDS);
         }
     }
 
-    private void initializeBridgeStatusAndProperties() {
+    private void initializeBridgeStatusAndPropertiesIfOffline() {
+        Bridge bridge = getBridge();
+        if (bridge != null && bridge.getStatus() == ThingStatus.ONLINE) {
+            return;
+        }
+
         try {
             // Get user info to verify successful authentication and connection to server
             User user = api.getUserDetails();

--- a/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoMobileDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoMobileDeviceHandler.java
@@ -125,6 +125,7 @@ public class TadoMobileDeviceHandler extends BaseHomeThingHandler {
             throw new IOException(message);
         }
 
+        onSuccessfulOperation();
         return device;
     }
 

--- a/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoZoneHandler.java
+++ b/addons/binding/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/handler/TadoZoneHandler.java
@@ -214,6 +214,7 @@ public class TadoZoneHandler extends BaseHomeThingHandler {
 
         try {
             ZoneState zoneState = getZoneState();
+
             if (zoneState == null) {
                 return;
             }
@@ -235,6 +236,8 @@ public class TadoZoneHandler extends BaseHomeThingHandler {
             updateState(TadoBindingConstants.CHANNEL_ZONE_TIMER_DURATION, state.getRemainingTimerDuration());
 
             updateState(TadoBindingConstants.CHANNEL_ZONE_OVERLAY_EXPIRY, state.getOverlayExpiration());
+
+            onSuccessfulOperation();
         } catch (IOException | TadoClientException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Could not connect to server due to " + e.getMessage());


### PR DESCRIPTION
The tado binding did not recover automatically from OFFLINE state, but a restart of OH was required instead. This PR fixes the issue and #3628.

There are 2 scenarios:

**Bridge goes offline**
The binding retries every 5 minutes to initialise the binding again, in case it's offline. As soon as the bridge is back online, the `bridgeStatusChanged` methods of the children are called, bringing them back online.

**Individual things are offline**
This can happen if individual requests are failing. In that case, scheduled status updates are not cancelled. As soon as a status update was executed successfully, the thing's status is set to ONLINE again.
