### PR TITLE
[robonect] add optional jdt annotation dependency to MANIFEST

### DIFF
--- a/addons/binding/org.openhab.binding.robonect/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.robonect/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 2.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.library.unit,


### PR DESCRIPTION
This fixes a compilation issue in the IDE since JDT annotation dependency was missing from the MANIFEST.MF.

Signed-off-by: Henning Treu <henning.treu@telekom.de>