### PR TITLE
[innogy] Added missing channels to wall mounted thermostat

### DIFF
--- a/addons/binding/org.openhab.binding.innogysmarthome/ESH-INF/thing/WRT.xml
+++ b/addons/binding/org.openhab.binding.innogysmarthome/ESH-INF/thing/WRT.xml
@@ -14,7 +14,11 @@
 		<channels>
 			<channel id="set_temperature" typeId="ThermostatActuator_PointTemperature" />
 			<channel id="temperature" typeId="TemperatureSensor_Temperature" />
+			<channel id="frost_warning" typeId="TemperatureSensor_FrostWarning" />
 			<channel id="humidity" typeId="HumiditySensor_Humidity" />
+			<channel id="mold_warning" typeId="HumiditySensor_MoldWarning" />
+			<channel id="operation_mode" typeId="ThermostatActuator_OperationMode" />
+			<channel id="window_reduction_active" typeId="ThermostatActuator_WindowReductionActive" />
 			<channel id="battery_low" typeId="system.low-battery" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.innogysmarthome/README.md
+++ b/addons/binding/org.openhab.binding.innogysmarthome/README.md
@@ -181,11 +181,33 @@ Bridge innogysmarthome:bridge:mybride "innogy SmartHome Controller" [ refreshtok
 }
 ```
 
+## Items configuration
+
 You can then configure your items in your *.items config files as usual, for example:
 
 ```
-Contact myWindowContact       "Kitchen"     <window>  {channel="innogysmarthome:WDS:mybridge:myWindowContact:contact"}
-Switch myWindowContactBattery "Battery low" <battery> {channel="innogysmarthome:WDS:mybridge:myWindowContact:battery_low"}
+Contact myWindowContact        "Kitchen"                <window>      {channel="innogysmarthome:WDS:mybridge:myWindowContact:contact"}
+Switch myWindowContactBattery  "Battery low"            <battery>     {channel="innogysmarthome:WDS:mybridge:myWindowContact:battery_low"}
+Number myHeatingTemp           "Bath [%.1f °C]"         <temperature> {channel="innogysmarthome:RST:mybridge:myHeating:temperature"}
+Number myHeatingModeTempTarget "Settemp bath [%.1f °C]" <temperature> {channel="innogysmarthome:RST:mybridge:myHeating:set_temperature"}
+String myHeatingMode           "Mode bath [%s]"         <temperature> {channel="innogysmarthome:RST:mybridge:myHeating:operation_mode"}
+Number myHeatingHumidity       "Bath [%.1f %%]"         <humidity>    {channel="innogysmarthome:RST:mybridge:myHeating:humidity"}
+
+```
+
+## Sitemap configuration
+
+The site configuration works a usual. One special example 
+
+```
+sitemap default label="Home" {
+    Frame {
+        Text item=myHeatingTemp label="Temperature"
+        Text item=myHeatingHumidity label="Humidity"
+        Switch item=myHeatingMode label="Mode" mappings=[Manu="Manual", Auto="Auto"]
+        Setpoint item=myHeatingModeTempTarget label="Target temperature" minValue=16 maxValue=25 step=1
+    }
+}
 ```
 
 


### PR DESCRIPTION
Added missing channels to wall mounted room thermostat and updated documentation:

- channels frost_warning, mold_warning, operation_mode, window_reduction_active added
- updated README with thermostat examples, especially operation_mode mappings are important to be documented

Signed-off-by: Oliver Kuhl <oliver.kuhl@gmail.com> (github: ollie-dev)
