### PR TITLE
[DSCALARM] Various Bug Fixes

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/DSCAlarmBaseBridgeHandler.java
@@ -631,8 +631,8 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
                     break;
                 }
 
-                if (password == null || password.length() < 1 || password.length() > 6) {
-                    logger.error("sendCommand(): Password is invalid, must be between 1 and 6 chars!");
+                if (password == null) {
+                    logger.error("sendCommand(): No password!");
                     break;
                 }
                 data = password;

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/KeypadThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/KeypadThingHandler.java
@@ -148,8 +148,12 @@ public class KeypadThingHandler extends DSCAlarmBaseThingHandler {
                     case KeypadLEDFlashState: /* 511 */
                         keypadLEDStateEventHandler(event);
                         break;
-                    case LCDUpdate:
-                    case LCDCursor:
+                    case LCDUpdate: /* 901 */
+                        channelUID = new ChannelUID(getThing().getUID(), KEYPAD_LCD_UPDATE);
+                        updateChannel(channelUID, 0, dscAlarmMessageData);
+                        break;
+                    case LCDCursor: /* 902 */
+                        channelUID = new ChannelUID(getThing().getUID(), KEYPAD_LCD_CURSOR);
                         updateChannel(channelUID, 0, dscAlarmMessageData);
                         break;
                     case LEDStatus: /* 903 */

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/PanelThingHandler.java
@@ -403,6 +403,35 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
         }
     }
 
+    /**
+     * Restores all partitions that are in alarm after special panel alarm conditions have been restored.
+     *
+     * @param dscAlarmCode
+     */
+    private void restorePartitionsInAlarm(DSCAlarmCode dscAlarmCode) {
+
+        logger.debug("restorePartitionsInAlarm(): DSC Alarm Code: {}!", dscAlarmCode.toString());
+
+        ChannelUID channelUID = null;
+
+        if (dscAlarmCode == DSCAlarmCode.FireKeyRestored || dscAlarmCode == DSCAlarmCode.AuxiliaryKeyRestored
+                || dscAlarmCode == DSCAlarmCode.PanicKeyRestored
+                || dscAlarmCode == DSCAlarmCode.AuxiliaryInputAlarmRestored) {
+            List<Thing> things = dscAlarmBridgeHandler.getThing().getThings();
+            for (Thing thg : things) {
+                if (thg.getThingTypeUID().equals(PARTITION_THING_TYPE)) {
+                    DSCAlarmBaseThingHandler handler = (DSCAlarmBaseThingHandler) thg.getHandler();
+                    if (handler != null) {
+                        channelUID = new ChannelUID(thg.getUID(), PARTITION_IN_ALARM);
+                        handler.updateChannel(channelUID, 0, "");
+
+                        logger.debug("restorePartitionsInAlarm(): Partition In Alarm Restored: {}!", thg.getUID());
+                    }
+                }
+            }
+        }
+    }
+
     @Override
     public void dscAlarmEventReceived(EventObject event, Thing thing) {
         if (thing != null) {
@@ -453,24 +482,28 @@ public class PanelThingHandler extends DSCAlarmBaseThingHandler {
                     case FireKeyRestored: /* 622 */
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_FIRE_KEY_ALARM);
                         updateChannel(channelUID, state, "");
+                        restorePartitionsInAlarm(dscAlarmCode);
                         break;
                     case AuxiliaryKeyAlarm: /* 623 */
                         state = 1;
                     case AuxiliaryKeyRestored: /* 624 */
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_AUX_KEY_ALARM);
                         updateChannel(channelUID, state, "");
+                        restorePartitionsInAlarm(dscAlarmCode);
                         break;
                     case PanicKeyAlarm: /* 625 */
                         state = 1;
                     case PanicKeyRestored: /* 626 */
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_PANIC_KEY_ALARM);
                         updateChannel(channelUID, state, "");
+                        restorePartitionsInAlarm(dscAlarmCode);
                         break;
                     case AuxiliaryInputAlarm: /* 631 */
                         state = 1;
                     case AuxiliaryInputAlarmRestored: /* 632 */
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_AUX_INPUT_ALARM);
                         updateChannel(channelUID, state, "");
+                        restorePartitionsInAlarm(dscAlarmCode);
                         break;
                     case TroubleLEDOn: /* 840 */
                         channelUID = new ChannelUID(getThing().getUID(), PANEL_TROUBLE_LED);

--- a/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/ZoneThingHandler.java
+++ b/addons/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/handler/ZoneThingHandler.java
@@ -102,16 +102,11 @@ public class ZoneThingHandler extends DSCAlarmBaseThingHandler {
         }
 
         if (dscAlarmBridgeHandler != null && dscAlarmBridgeHandler.isConnected()
-                && channelUID.getId() == ZONE_BYPASS_MODE) {
-            if (command == OnOffType.OFF) {
-                String data = String.valueOf(getPartitionNumber()) + "*1" + String.format("%02d", getZoneNumber())
-                        + "#";
-                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
-            } else if (command == OnOffType.ON) {
-                String data = String.valueOf(getPartitionNumber()) + "*1" + String.format("%02d", getZoneNumber())
-                        + "#";
-                dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
-            }
+                && channelUID.getId().equals(ZONE_BYPASS_MODE)) {
+
+            String data = String.valueOf(getPartitionNumber()) + "*1" + String.format("%02d", getZoneNumber()) + "#";
+
+            dscAlarmBridgeHandler.sendCommand(DSCAlarmCode.KeySequence, data);
         }
     }
 


### PR DESCRIPTION
Fixes:
* Special panel alarms when being restored were not turning the partition_in_alarm channel OFF (#3580).
* LCDCursor and LCDUpdate for the IT100 were not functioning (#3586).
* Network login password length checking has been removed for the Envisalink as discussed [here](https://community.openhab.org/t/dscalarmbinding-with-envisalink-4/6966/12).
* Zone Bypass Mode command wasn't working in the binding.

Signed-off-by: Russell Stephens rsstephens@gmail.com (github:RSStephens)