### PR TITLE
[meteostick] Allow configurable spoon, UoM support, bug fixes

### DIFF
--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -14,7 +14,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
-				<description>Serial port that the Meteostick is plugged in to</description>
+				<description>Serial port that the Meteostick is plugged into</description>
 			</parameter>
 			<parameter name="mode" type="integer" required="true">
 				<label>Frequency Band</label>
@@ -67,13 +67,20 @@
 					<option value="8">Channel 8</option>
 				</options>
 			</parameter>
+
+			<parameter name="spoon" type="decimal" required="false">
+				<label>Spoon</label>
+				<description>Specifies the amount of rain needed to tip spoon</description>
+				<default>0.254</default>
+				<unitLabel>mm</unitLabel>
+			</parameter>
 		</config-description>
 	</thing-type>
 
 	<channel-type id="indoor-temperature">
 		<item-type>Number</item-type>
 		<label>Indoor Temperature</label>
-		<description>Current temperature in degrees celsius</description>
+		<description>Current temperature in degrees Celsius</description>
 		<category>Temperature</category>
 		<state readOnly="true" pattern="%.1f °C">
 		</state>
@@ -82,7 +89,7 @@
 	<channel-type id="outdoor-temperature">
 		<item-type>Number</item-type>
 		<label>Outdoor Temperature</label>
-		<description>Current temperature in degrees celsius</description>
+		<description>Current temperature in degrees Celsius</description>
 		<category>Temperature</category>
 		<state readOnly="true" pattern="%.1f °C">
 		</state>
@@ -91,7 +98,7 @@
 	<channel-type id="humidity">
 		<item-type>Number</item-type>
 		<label>Outdoor Humidity</label>
-		<description>Current humidity in %</description>
+		<description>Current humidity in percent</description>
 		<category>Humidity</category>
 		<state readOnly="true" pattern="%d %%">
 		</state>
@@ -100,7 +107,7 @@
 	<channel-type id="pressure">
 		<item-type>Number</item-type>
 		<label>Pressure</label>
-		<description>Current pressure in millibar</description>
+		<description>Current pressure in hectopascal</description>
 		<category>Pressure</category>
 		<state readOnly="true" pattern="%.1f hPa">
 		</state>
@@ -127,7 +134,7 @@
 	<channel-type id="rain-raw" advanced="true">
 		<item-type>Number</item-type>
 		<label>Rainfall (Raw)</label>
-		<description>A counter between 0 and 255 in 0.01mm steps</description>
+		<description>A counter between 0 and 255 in spoon-sized steps</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.1f">
 		</state>

--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -78,20 +78,20 @@
 	</thing-type>
 
 	<channel-type id="indoor-temperature">
-		<item-type>Number</item-type>
+		<item-type>Number:Temperature</item-type>
 		<label>Indoor Temperature</label>
-		<description>Current temperature in degrees Celsius</description>
+		<description>Current indoor temperature</description>
 		<category>Temperature</category>
-		<state readOnly="true" pattern="%.1f °C">
+		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
 
 	<channel-type id="outdoor-temperature">
-		<item-type>Number</item-type>
+		<item-type>Number:Temperature</item-type>
 		<label>Outdoor Temperature</label>
-		<description>Current temperature in degrees Celsius</description>
+		<description>Current outdoor temperature</description>
 		<category>Temperature</category>
-		<state readOnly="true" pattern="%.1f °C">
+		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
 
@@ -105,29 +105,29 @@
 	</channel-type>
 
 	<channel-type id="pressure">
-		<item-type>Number</item-type>
+		<item-type>Number:Pressure</item-type>
 		<label>Pressure</label>
-		<description>Current pressure in hectopascal</description>
+		<description>Current atmospheric pressure</description>
 		<category>Pressure</category>
-		<state readOnly="true" pattern="%.1f hPa">
+		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
 
 	<channel-type id="wind-direction">
-		<item-type>Number</item-type>
+		<item-type>Number:Angle</item-type>
 		<label>Wind Direction</label>
 		<description>Wind direction</description>
 		<category>Wind</category>
-		<state readOnly="true" pattern="%.0f °">
+		<state readOnly="true" pattern="%.0f %unit%">
 		</state>
 	</channel-type>
 
 	<channel-type id="wind-speed">
-		<item-type>Number</item-type>
+		<item-type>Number:Speed</item-type>
 		<label>Wind Speed</label>
 		<description>Wind speed</description>
 		<category>Wind</category>
-		<state readOnly="true" pattern="%.2f m/s">
+		<state readOnly="true" pattern="%.2f %unit%">
 		</state>
 	</channel-type>
 
@@ -141,20 +141,20 @@
 	</channel-type>
 
 	<channel-type id="rain-lasthour">
-		<item-type>Number</item-type>
+		<item-type>Number:Length</item-type>
 		<label>Rainfall (previous hour)</label>
 		<description>Rainfall in the previous hour</description>
 		<category>Rain</category>
-		<state readOnly="true" pattern="%.1f mm">
+		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
 
 	<channel-type id="rain-currenthour">
-		<item-type>Number</item-type>
+		<item-type>Number:Length</item-type>
 		<label>Rainfall (60 minutes)</label>
 		<description>Rainfall in the last 60 minutes</description>
 		<category>Rain</category>
-		<state readOnly="true" pattern="%.1f mm">
+		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.meteostick/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.meteostick/META-INF/MANIFEST.MF
@@ -12,9 +12,11 @@ Export-Package:
  org.openhab.binding.meteostick.handler
 Import-Package: 
  gnu.io,
+ javax.measure.quantity,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -45,6 +45,7 @@ Set mode to one of the following depending on your device and region:
 | Option  | Description                               |
 |---------|-------------------------------------------|
 | channel | Sets the RF channel used for this sensor  |
+| spoon   | Size of rain spoon assembly for this sensor in mm.  Default value is 0.254 (0.01") for use with Davis part number 7345.280.  Set to 0.2 for use with Davis part number 7345.319 |
 
 ## Channels
 

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -51,25 +51,25 @@ Set mode to one of the following depending on your device and region:
 
 ### Meteostick
 
-| Channel Type ID    | Item Type | Description        |
-|--------------------|-----------|--------------------|
-| pressure           | Number    | Air pressure       |
-| indoor-temperature | Number    | Indoor temperature |
+| Channel Type ID    | Item Type          | Description        |
+|--------------------|--------------------|--------------------|
+| pressure           | Number:Pressure    | Air pressure       |
+| indoor-temperature | Number:Temperature | Indoor temperature |
 
 ### Davis ISS
 
-| Channel Type ID     | Item Type | Description                                     |
-|---------------------|-----------|-------------------------------------------------|
-| outdoor-temperature | Number    | Outside temperature                             |
-| humidity            | Number    | Humidity                                        |
-| wind-direction      | Number    | Wind direction                                  |
-| wind-speed          | Number    | Wind speed                                      |
-| rain-raw            | Number    | Raw rain counter from the tipping bucket sensor |
-| rain-currenthour    | Number    | The rainfall in the last 60 minutes             |
-| rain-lasthour       | Number    | The rainfall in the previous hour               |
-| solar-power         | Number    | Solar power from the sensor station             |
-| signal-strength     | Number    | Received signal strength                        |
-| low-battery         | Number    | Low battery warning                             |
+| Channel Type ID     | Item Type             | Description                                     |
+|---------------------|-----------------------|-------------------------------------------------|
+| outdoor-temperature | Number:Temperature    | Outside temperature                             |
+| humidity            | Number                | Humidity                                        |
+| wind-direction      | Number:Angle          | Wind direction                                  |
+| wind-speed          | Number:Speed          | Wind speed                                      |
+| rain-raw            | Number                | Raw rain counter from the tipping bucket sensor |
+| rain-currenthour    | Number:Length         | The rainfall in the last 60 minutes             |
+| rain-lasthour       | Number:Length         | The rainfall in the previous hour               |
+| solar-power         | Number                | Solar power from the sensor station             |
+| signal-strength     | Number                | Received signal strength                        |
+| low-battery         | Switch                | Low battery warning                             |
 
 
 #### Rainfall
@@ -80,9 +80,9 @@ The rainfall in the previous hour is the rainfall for each hour of the day and i
 
 ## Full Example
 
-Things can be defined in the .thing file as follows
+Things can be defined in the .things file as follows
 
 ```
 meteostick:meteostick_bridge:receiver [ port="/dev/tty.usbserial-AI02XA60", mode=1 ]
-meteostick:meteostick_davis_iss:iss (meteostick:meteostick_bridge:receiver) [ channel=1 ]
+meteostick:meteostick_davis_iss:iss (meteostick:meteostick_bridge:receiver) [ channel=1, spoon=0.2 ]
 ```

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
@@ -42,4 +42,6 @@ public class MeteostickBindingConstants {
 
     // List of parameters
     public static final String PARAMETER_CHANNEL = "channel";
+    public static final String PARAMETER_SPOON = "spoon";
+    public static final String PARAMETER_SPOON_DEFAULT = "0.254";
 }

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
@@ -44,4 +44,8 @@ public class MeteostickBindingConstants {
     public static final String PARAMETER_CHANNEL = "channel";
     public static final String PARAMETER_SPOON = "spoon";
     public static final String PARAMETER_SPOON_DEFAULT = "0.254";
+
+    // Miscellaneous constants
+    public static final long HOUR_IN_SEC = 60 * 60;
+    public static final long HOUR_IN_MSEC = HOUR_IN_SEC * 1000;
 }

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickBridgeHandler.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.meteostick.handler;
 
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.HECTO;
+import static org.eclipse.smarthome.core.library.unit.SIUnits.*;
 import static org.openhab.binding.meteostick.MeteostickBindingConstants.*;
 
 import java.io.IOException;
@@ -23,7 +25,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -254,11 +256,11 @@ public class MeteostickBridgeHandler extends BaseBridgeHandler {
                             case "B": // Barometer
                                 BigDecimal temperature = new BigDecimal(p[1]);
                                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_INDOOR_TEMPERATURE),
-                                        new DecimalType(temperature.setScale(1)));
+                                        new QuantityType<>(temperature.setScale(1), CELSIUS));
 
                                 BigDecimal pressure = new BigDecimal(p[2]);
                                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_PRESSURE),
-                                        new DecimalType(pressure.setScale(1, RoundingMode.HALF_UP)));
+                                        new QuantityType<>(pressure.setScale(1, RoundingMode.HALF_UP), HECTO(PASCAL)));
                                 break;
                             case "#":
                                 break;

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -52,7 +52,7 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
     private int channel = 0;
     private BigDecimal spoon = new BigDecimal(PARAMETER_SPOON_DEFAULT);
     private MeteostickBridgeHandler bridgeHandler;
-    private SlidingTimeWindow rainHourlyWindow = new SlidingTimeWindow(60000);
+    private SlidingTimeWindow rainHourlyWindow = new SlidingTimeWindow(HOUR_IN_MSEC);
     private ScheduledFuture<?> rainHourlyJob;
     private ScheduledFuture<?> offlineTimerJob;
 
@@ -82,8 +82,8 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
         };
 
         // Scheduling a job on each hour to update the last hour rainfall
-        long start = 3600 - ((System.currentTimeMillis() % 3600000) / 1000);
-        rainHourlyJob = scheduler.scheduleWithFixedDelay(pollingRunnable, start, 3600, TimeUnit.SECONDS);
+        long start = HOUR_IN_SEC - ((System.currentTimeMillis() % HOUR_IN_MSEC) / 1000);
+        rainHourlyJob = scheduler.scheduleWithFixedDelay(pollingRunnable, start, HOUR_IN_SEC, TimeUnit.SECONDS);
 
         updateStatus(ThingStatus.UNKNOWN);
     }
@@ -209,14 +209,14 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
     }
 
     class SlidingTimeWindow {
-        int period = 0;
+        long period = 0;
         private final Map<Long, Integer> storage = new TreeMap<>();
 
         /**
          *
          * @param period window period in milliseconds
          */
-        public SlidingTimeWindow(int period) {
+        public SlidingTimeWindow(long period) {
             this.period = period;
         }
 

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -225,7 +225,7 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
         }
 
         public int getTotal() {
-            int last = -1;
+            int least = -1;
             int total = 0;
 
             long old = System.currentTimeMillis() - period;
@@ -238,15 +238,15 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
                 }
 
                 int value = storage.get(time);
-                if (last == -1) {
-                    last = value;
+                if (least == -1) {
+                    least = value;
                     continue;
                 }
 
-                if (value < last) {
-                    total += 256 - last + value;
+                if (value < least) {
+                    total = 256 - least + value;
                 } else {
-                    total += value - last;
+                    total = value - least;
                 }
             }
 

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.meteostick.handler;
 
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.MILLI;
+import static org.eclipse.smarthome.core.library.unit.SIUnits.*;
+import static org.eclipse.smarthome.core.library.unit.SmartHomeUnits.*;
 import static org.openhab.binding.meteostick.MeteostickBindingConstants.*;
 
 import java.math.BigDecimal;
@@ -23,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -73,7 +77,8 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
         Runnable pollingRunnable = () -> {
             BigDecimal rainfall = BigDecimal.valueOf(rainHourlyWindow.getTotal()).multiply(spoon);
             rainfall.setScale(1, RoundingMode.DOWN);
-            updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_LASTHOUR), new DecimalType(rainfall));
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_LASTHOUR),
+                    new QuantityType<>(rainfall, MILLI(METRE)));
         };
 
         // Scheduling a job on each hour to update the last hour rainfall
@@ -168,13 +173,14 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
 
                 BigDecimal rainfall = BigDecimal.valueOf(rainHourlyWindow.getTotal()).multiply(spoon);
                 rainfall.setScale(1, RoundingMode.DOWN);
-                updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_CURRENTHOUR), new DecimalType(rainfall));
+                updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_CURRENTHOUR),
+                        new QuantityType<>(rainfall, MILLI(METRE)));
                 break;
             case "W": // Wind
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_SPEED),
-                        new DecimalType(new BigDecimal(data[2])));
+                        new QuantityType<>(new BigDecimal(data[2]), METRE_PER_SECOND));
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_DIRECTION),
-                        new DecimalType(Integer.parseInt(data[3])));
+                        new QuantityType<>(Integer.parseInt(data[3]), DEGREE_ANGLE));
 
                 processSignalStrength(data[4]);
                 processBattery(data.length == 6);
@@ -182,7 +188,7 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
             case "T": // Temperature
                 BigDecimal temperature = new BigDecimal(data[2]);
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_OUTDOOR_TEMPERATURE),
-                        new DecimalType(temperature.setScale(1)));
+                        new QuantityType<>(temperature.setScale(1), CELSIUS));
 
                 BigDecimal humidity = new BigDecimal(data[3]);
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_HUMIDITY),


### PR DESCRIPTION
- Add configurable spoon size, update doc. Fixes #3636
- Added support for UoM
- Make `rainHourlyWindow` hold last hour's worth of data instead of only one minute's worth of data.
- Don't add repeated differences to total ticks within time window because the MeteoStick repeatedly reports the same tick count (use `=` and not `+=`). `+=` causes the amount of rainfall to grow "out of control" within the time window.

