### PR TITLE
Removed immediate activation for 'DynamicStateDescriptionProvider' components

### DIFF
--- a/addons/binding/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
@@ -56,8 +56,7 @@ import com.google.gson.JsonSyntaxException;
  *
  * @author Michael Geramb - Initial contribution
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        AmazonEchoDynamicStateDescriptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, AmazonEchoDynamicStateDescriptionProvider.class })
 @NonNullByDefault
 public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDescriptionProvider {
 

--- a/addons/binding/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/HyperionStateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/HyperionStateDescriptionProvider.java
@@ -30,8 +30,7 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Gregory Moyer - Initial contribution
  * @author Daniel Walters - Adapted for Hyperion Binding
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        HyperionStateDescriptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, HyperionStateDescriptionProvider.class })
 @NonNullByDefault
 public class HyperionStateDescriptionProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
@@ -29,8 +29,7 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Gregory Moyer - Initial contribution
  * @author Christoph Weitkamp - Adapted to Kodi binding
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        KodiDynamicStateDescriptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, KodiDynamicStateDescriptionProvider.class })
 @NonNullByDefault
 public class KodiDynamicStateDescriptionProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();

--- a/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/internal/StateDescriptionOptionsProvider.java
+++ b/addons/binding/org.openhab.binding.lametrictime/src/main/java/org/openhab/binding/lametrictime/internal/StateDescriptionOptionsProvider.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Deactivate;
  *
  * @author Gregory Moyer - Initial contribution
  */
-@Component(service = { DynamicStateDescriptionProvider.class, StateDescriptionOptionsProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, StateDescriptionOptionsProvider.class })
 @NonNullByDefault
 public class StateDescriptionOptionsProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();

--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LoxoneDynamicStateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LoxoneDynamicStateDescriptionProvider.java
@@ -28,8 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pawel Pieczul - Initial contribution
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        LoxoneDynamicStateDescriptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, LoxoneDynamicStateDescriptionProvider.class })
 @NonNullByDefault
 public class LoxoneDynamicStateDescriptionProvider implements DynamicStateDescriptionProvider {
 

--- a/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NATherm1StateDescriptionProvider.java
+++ b/addons/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NATherm1StateDescriptionProvider.java
@@ -29,8 +29,7 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Gregory Moyer - Initial contribution
  * @author Gaël L'hopital - Ported as-is in Netatmo binding
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        NATherm1StateDescriptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, NATherm1StateDescriptionProvider.class })
 @NonNullByDefault
 public class NATherm1StateDescriptionProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxStateDescriptionOptionsProvider.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxStateDescriptionOptionsProvider.java
@@ -29,8 +29,7 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Gregory Moyer - Initial contribution
  * @author Mark Hilbush - Adapted to squeezebox binding
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        SqueezeBoxStateDescriptionOptionsProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, SqueezeBoxStateDescriptionOptionsProvider.class })
 @NonNullByDefault
 public class SqueezeBoxStateDescriptionOptionsProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
- Removed immediate activation for `DynamicStateDescriptionProvider` components

wrt https://github.com/eclipse/smarthome/pull/5682#discussion_r193424683

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>