### PR TITLE
[AzureIOT] Add missing MQTT Transport to feature

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -570,6 +570,7 @@
 
     <feature name="openhab-misc-azureiothub" description="Azure IoT Hub Connector" version="${project.version}">
         <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-mqtt</feature>
         <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.azureiothub/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
Fixes the runtime failing to start when using misc-azureiothub in addons.cfg, see [community post](https://community.openhab.org/t/uis-not-installed-on-openhab-2-4-0-build-1300/46480/7?u=wborn). 

This would cause for example the following error to be logged:

`[ERROR] [core.karaf.internal.FeatureInstaller] - Failed installing 'openhab-binding-hue, openhab-binding-exec, openhab-binding-ftpupload, openhab-misc-openhabcloud, openhab-misc-restdocs, openhab-binding-network, openhab-persistence-influxdb, openhab-ui-habpanel, openhab-persistence-mysql, openhab-transformation-map, openhab-binding-logreader, openhab-ui-habmin, openhab-transformation-xslt, openhab-binding-lgtv1, openhab-transformation-exec, openhab-binding-systeminfo, openhab-ui-paper, openhab-binding-market:binding-3805847, openhab-transformation-scale, openhab-binding-http1, openhab-ui-homebuilder, openhab-persistence-jdbc-mysql, openhab-misc-market, openhab-binding-amazondashbutton, openhab-transformation-javascript, openhab-misc-azureiothub, openhab-binding-plex1, openhab-binding-weather1, openhab-transformation-regex, openhab-misc-ruleengine, openhab-binding-yamahareceiver, openhab-transformation-jsonpath, openhab-binding-zwave, openhab-binding-tankerkoenig, openhab-transformation-xpath, openhab-ui-basic, openhab-misc-homekit, openhab-binding-fritzboxtr0641, openhab-binding-astro, openhab-binding-icloud': Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=openhab-misc-azureiothub; type=karaf.feature; version="[2.4.0.SNAPSHOT,2.4.0.SNAPSHOT]"; filter:="(&(osgi.identity=openhab-misc-azureiothub)(type=karaf.feature)(version>=2.4.0.SNAPSHOT)(version<=2.4.0.SNAPSHOT))" [caused by: Unable to resolve openhab-misc-azureiothub/2.4.0.SNAPSHOT: missing requirement [openhab-misc-azureiothub/2.4.0.SNAPSHOT] osgi.identity; osgi.identity=org.openhab.io.azureiothub; type=osgi.bundle; version="[2.4.0.201806151417,2.4.0.201806151417]"; resolution:=mandatory [caused by: Unable to resolve org.openhab.io.azureiothub/2.4.0.201806151417: missing requirement [org.openhab.io.azureiothub/2.4.0.201806151417] osgi.wiring.package; filter:="(osgi.wiring.package=org.eclipse.paho.client.mqttv3)"]]`