### PR TITLE
[meteostick] advanced channels for wind statistics

### DIFF
--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -43,7 +43,10 @@
 			<channel id="outdoor-temperature" typeId="outdoor-temperature" />
 			<channel id="humidity" typeId="humidity" />
 			<channel id="wind-direction" typeId="wind-direction" />
+            <channel id="wind-direction-last2min-average" typeId="wind-direction-last2min-average" />
 			<channel id="wind-speed" typeId="wind-speed" />
+            <channel id="wind-speed-last2min-average" typeId="wind-speed-last2min-average" />
+            <channel id="wind-speed-last2min-maximum" typeId="wind-speed-last2min-maximum" />
 			<channel id="rain-raw" typeId="rain-raw" />
 			<channel id="rain-currenthour" typeId="rain-currenthour" />
 			<channel id="rain-lasthour" typeId="rain-lasthour" />
@@ -122,6 +125,15 @@
 		</state>
 	</channel-type>
 
+    <channel-type id="wind-direction-last2min-average" advanced="true">
+        <item-type>Number:Angle</item-type>
+        <label>Wind Direction (Average)</label>
+        <description>Wind direction average over last two minutes</description>
+        <category>Wind</category>
+        <state readOnly="true" pattern="%.0f %unit%">
+        </state>
+    </channel-type>
+
 	<channel-type id="wind-speed">
 		<item-type>Number:Speed</item-type>
 		<label>Wind Speed</label>
@@ -130,6 +142,24 @@
 		<state readOnly="true" pattern="%.2f %unit%">
 		</state>
 	</channel-type>
+
+    <channel-type id="wind-speed-last2min-average" advanced="true">
+        <item-type>Number:Speed</item-type>
+        <label>Wind Speed (Average)</label>
+        <description>Wind speed average over last two minutes</description>
+        <category>Wind</category>
+        <state readOnly="true" pattern="%.2f %unit%">
+        </state>
+    </channel-type>
+
+    <channel-type id="wind-speed-last2min-maximum" advanced="true">
+        <item-type>Number:Speed</item-type>
+        <label>Wind Speed (Maximum)</label>
+        <description>Wind speed maximum over last two minutes</description>
+        <category>Wind</category>
+        <state readOnly="true" pattern="%.2f %unit%">
+        </state>
+    </channel-type>
 
 	<channel-type id="rain-raw" advanced="true">
 		<item-type>Number</item-type>

--- a/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.meteostick/ESH-INF/thing/thing-types.xml
@@ -43,10 +43,10 @@
 			<channel id="outdoor-temperature" typeId="outdoor-temperature" />
 			<channel id="humidity" typeId="humidity" />
 			<channel id="wind-direction" typeId="wind-direction" />
-            <channel id="wind-direction-last2min-average" typeId="wind-direction-last2min-average" />
+			<channel id="wind-direction-last2min-average" typeId="wind-direction-last2min-average" />
 			<channel id="wind-speed" typeId="wind-speed" />
-            <channel id="wind-speed-last2min-average" typeId="wind-speed-last2min-average" />
-            <channel id="wind-speed-last2min-maximum" typeId="wind-speed-last2min-maximum" />
+			<channel id="wind-speed-last2min-average" typeId="wind-speed-last2min-average" />
+			<channel id="wind-speed-last2min-maximum" typeId="wind-speed-last2min-maximum" />
 			<channel id="rain-raw" typeId="rain-raw" />
 			<channel id="rain-currenthour" typeId="rain-currenthour" />
 			<channel id="rain-lasthour" typeId="rain-lasthour" />
@@ -125,14 +125,14 @@
 		</state>
 	</channel-type>
 
-    <channel-type id="wind-direction-last2min-average" advanced="true">
-        <item-type>Number:Angle</item-type>
-        <label>Wind Direction (Average)</label>
-        <description>Wind direction average over last two minutes</description>
-        <category>Wind</category>
-        <state readOnly="true" pattern="%.0f %unit%">
-        </state>
-    </channel-type>
+	<channel-type id="wind-direction-last2min-average" advanced="true">
+		<item-type>Number:Angle</item-type>
+		<label>Wind Direction (Average)</label>
+		<description>Wind direction average over last two minutes</description>
+		<category>Wind</category>
+		<state readOnly="true" pattern="%.0f %unit%">
+		</state>
+	</channel-type>
 
 	<channel-type id="wind-speed">
 		<item-type>Number:Speed</item-type>
@@ -143,23 +143,23 @@
 		</state>
 	</channel-type>
 
-    <channel-type id="wind-speed-last2min-average" advanced="true">
-        <item-type>Number:Speed</item-type>
-        <label>Wind Speed (Average)</label>
-        <description>Wind speed average over last two minutes</description>
-        <category>Wind</category>
-        <state readOnly="true" pattern="%.2f %unit%">
-        </state>
-    </channel-type>
+	<channel-type id="wind-speed-last2min-average" advanced="true">
+		<item-type>Number:Speed</item-type>
+		<label>Wind Speed (Average)</label>
+		<description>Wind speed average over last two minutes</description>
+		<category>Wind</category>
+		<state readOnly="true" pattern="%.2f %unit%">
+		</state>
+	</channel-type>
 
-    <channel-type id="wind-speed-last2min-maximum" advanced="true">
-        <item-type>Number:Speed</item-type>
-        <label>Wind Speed (Maximum)</label>
-        <description>Wind speed maximum over last two minutes</description>
-        <category>Wind</category>
-        <state readOnly="true" pattern="%.2f %unit%">
-        </state>
-    </channel-type>
+	<channel-type id="wind-speed-last2min-maximum" advanced="true">
+		<item-type>Number:Speed</item-type>
+		<label>Wind Speed (Maximum)</label>
+		<description>Wind speed maximum over last two minutes</description>
+		<category>Wind</category>
+		<state readOnly="true" pattern="%.2f %unit%">
+		</state>
+	</channel-type>
 
 	<channel-type id="rain-raw" advanced="true">
 		<item-type>Number</item-type>

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -71,6 +71,13 @@ Set mode to one of the following depending on your device and region:
 | signal-strength     | Number                | Received signal strength                        |
 | low-battery         | Switch                | Low battery warning                             |
 
+Advanced channels:
+
+| Channel Type ID                 | Item Type    | Description                                  |
+|---------------------------------|--------------|----------------------------------------------|
+| wind-direction-last2min-average | Number:Angle | Wind direction average over last 2 minutes   |
+| wind-speed-last2min-average     | Number:Speed | Wind speed average over last 2 minutes       |
+| wind-speed-last2min-maximum     | Number:Speed | Wind speed maximum over last 2 minutes       |
 
 #### Rainfall
 

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -63,21 +63,16 @@ Set mode to one of the following depending on your device and region:
 | outdoor-temperature | Number:Temperature    | Outside temperature                             |
 | humidity            | Number                | Humidity                                        |
 | wind-direction      | Number:Angle          | Wind direction                                  |
+| wind-direction-last2min-average | Number:Angle | Wind direction average over last 2 minutes   |
 | wind-speed          | Number:Speed          | Wind speed                                      |
-| rain-raw            | Number                | Raw rain counter from the tipping bucket sensor |
+| wind-speed-last2min-average     | Number:Speed | Wind speed average over last 2 minutes       |
+| wind-speed-last2min-maximum     | Number:Speed | Wind speed maximum over last 2 minutes       |
+| rain-raw            | Number                | Raw rain counter from the tipping spoon sensor  |
 | rain-currenthour    | Number:Length         | The rainfall in the last 60 minutes             |
 | rain-lasthour       | Number:Length         | The rainfall in the previous hour               |
 | solar-power         | Number                | Solar power from the sensor station             |
 | signal-strength     | Number                | Received signal strength                        |
 | low-battery         | Switch                | Low battery warning                             |
-
-Advanced channels:
-
-| Channel Type ID                 | Item Type    | Description                                  |
-|---------------------------------|--------------|----------------------------------------------|
-| wind-direction-last2min-average | Number:Angle | Wind direction average over last 2 minutes   |
-| wind-speed-last2min-average     | Number:Speed | Wind speed average over last 2 minutes       |
-| wind-speed-last2min-maximum     | Number:Speed | Wind speed maximum over last 2 minutes       |
 
 #### Rainfall
 

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -34,8 +34,8 @@ Set mode to one of the following depending on your device and region:
 | Mode  | Device       | Region           | Frequency |
 |-------|--------------|------------------|-----------|
 | 0     | Davis        | North America    | 915 Mhz   |
-| 1     | Davis        | Australia        | 915 Mhz   |
-| 2     | Davis        | Europe           | 868 Mhz   |
+| 1     | Davis        | Europe           | 868 Mhz   |
+| 2     | Davis        | Australia        | 915 Mhz   |
 | 3     | Fine Offset  | North America    | 915 Mhz   |
 | 4     | Fine Offset  | Europe           | 868 Mhz   |
 | 5     | Davis        | New Zealand      | 931.5 Mhz |
@@ -82,9 +82,93 @@ The rainfall in the previous hour is the rainfall for each hour of the day and i
 
 ## Full Example
 
-Things can be defined in the .things file as follows
+This example uploads weather data to for your personal weather station at Weather Underground every two minutes.
+
+Steps:
+
+1. Install the [MeteoStick](http://www.smartbedded.com/wiki/index.php/Meteostick) binding for use with your [Davis Vantage Vue Integrated Sensor Suite (ISS)](https://www.davisnet.com/solution/vantage-vue/).
+1. [Register](https://www.wunderground.com/personal-weather-station/signup.asp) your personal weather station with Weather Underground and make note of the station ID and password issued.
+1. Add the following files to your openHAB configuration:
+
+### things/meteostick.things 
+
+Things can be defined in the .things file as follows:
 
 ```
 meteostick:meteostick_bridge:receiver [ port="/dev/tty.usbserial-AI02XA60", mode=1 ]
 meteostick:meteostick_davis_iss:iss (meteostick:meteostick_bridge:receiver) [ channel=1, spoon=0.2 ]
 ```
+
+Note the configuration options for `port`, `mode`, `channel` and `spoon` above and adjust as needed for your specific hardware.
+
+### items/meteostick.items
+
+```
+Number:Pressure MeteoStickPressure "Meteostick Pressure [%.1f hPa]"{ channel="meteostick:meteostick_bridge:receiver:pressure" }
+Number:Temperature DavisVantageVueOutdoorTemperature "ISS Outdoor Temp [%.1f °C]" { channel="meteostick:meteostick_davis_iss:iss:outdoor-temperature" }
+Number DavisVantageVueHumidity "ISS Humidity [%.0f %%]" { channel="meteostick:meteostick_davis_iss:iss:humidity" }
+Number:Angle DavisVantageVueWindDirection "ISS Wind Direction [%.0f °]" { channel="meteostick:meteostick_davis_iss:iss:wind-direction" }
+Number:Angle DavisVantageVueWindDirectionAverage "ISS Average Wind Direction [%.0f °]" { channel="meteostick:meteostick_davis_iss:iss:wind-direction-last2min-average" }
+Number:Speed DavisVantageVueWindSpeed "ISS Wind Speed [%.1f m/s]" { channel="meteostick:meteostick_davis_iss:iss:wind-speed" }
+Number:Speed DavisVantageVueWindSpeedAverage "ISS Average Wind Speed [%.1f m/s]" { channel="meteostick:meteostick_davis_iss:iss:wind-speed-last2min-average" }
+Number:Speed DavisVantageVueWindSpeedMaximum "ISS Maximum Wind Speed [%.1f m/s]" { channel="meteostick:meteostick_davis_iss:iss:wind-speed-last2min-maximum" }
+Number:Length DavisVantageVueRainCurrentHour "ISS Rain Current Hour [%.1f mm]" { channel="meteostick:meteostick_davis_iss:iss:rain-currenthour" }
+```
+
+### rules/meteostick.rules
+
+Replace `YOUR_ID` and `your_password` below with the values from the the Weather Underground registration process.
+
+```
+import java.net.URLEncoder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Map
+import java.util.TimeZone
+
+/* Uploads weather station data using this format:
+
+   http://wiki.wunderground.com/index.php/PWS_-_Upload_Protocol
+ */
+
+rule PWS
+when
+	Item DavisVantageVueWindDirectionAverage received update
+then
+	val id = 'YOUR_ID'
+	val pw = 'your_password'
+	val sdf = new SimpleDateFormat('yyyy-MM-dd HH:mm:ss')
+	sdf.setTimeZone(TimeZone.getTimeZone('UTC'))
+	val Map<String, Object> params = newLinkedHashMap(
+		'action' ->           'updateraw',
+		'ID' ->               id,
+		'PASSWORD' ->         pw,
+		'dateutc' ->          sdf.format(new Date()),
+		'winddir' ->          DavisVantageVueWindDirection.getStateAs(QuantityType).toUnit('°').intValue,
+		'windspeedmph' ->     DavisVantageVueWindSpeed.getStateAs(QuantityType).toUnit('mph').doubleValue,
+		'windgustmph' ->      DavisVantageVueWindSpeedMaximum.getStateAs(QuantityType).toUnit('mph').doubleValue,
+		'windgustdir' ->      DavisVantageVueWindDirectionAverage.getStateAs(QuantityType).toUnit('°').intValue,
+		'windspdmph_avg2m' -> DavisVantageVueWindSpeedAverage.getStateAs(QuantityType).toUnit('mph').doubleValue,
+		'winddir_avg2m' ->    DavisVantageVueWindDirectionAverage.getStateAs(QuantityType).toUnit('°').intValue,
+		'humidity' ->         DavisVantageVueHumidity.state,
+		'tempf' ->            DavisVantageVueOutdoorTemperature.getStateAs(QuantityType).toUnit('°F').doubleValue,
+		'rainin' ->           DavisVantageVueRainCurrentHour.getStateAs(QuantityType).toUnit('in').doubleValue,
+		'baromin' ->          MeteoStickPressure.getStateAs(QuantityType).toUnit('inHg').doubleValue,
+		'softwaretype' ->     'openHAB 2.3')
+
+	var url = 'https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php?'
+	var first = true
+	for (key : params.keySet()) {
+		if (!first) {
+			url += '&'
+		}
+		url += key + '=' + URLEncoder::encode(params.get(key).toString, 'UTF-8')
+		first = false
+	}
+
+	logDebug('PWS', 'url is {}', url)
+	sendHttpGetRequest(url)
+end
+```
+
+openHAB will now report your weather station data to Weather Underground every two minutes.

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/MeteostickBindingConstants.java
@@ -36,6 +36,9 @@ public class MeteostickBindingConstants {
     public static final String CHANNEL_RAIN_LASTHOUR = "rain-lasthour";
     public static final String CHANNEL_WIND_SPEED = "wind-speed";
     public static final String CHANNEL_WIND_DIRECTION = "wind-direction";
+    public static final String CHANNEL_WIND_SPEED_LAST2MIN_AVERAGE = "wind-speed-last2min-average";
+    public static final String CHANNEL_WIND_SPEED_LAST2MIN_MAXIMUM = "wind-speed-last2min-maximum";
+    public static final String CHANNEL_WIND_DIRECTION_LAST2MIN_AVERAGE = "wind-direction-last2min-average";
     public static final String CHANNEL_SOLAR_POWER = "solar-power";
     public static final String CHANNEL_SIGNAL_STRENGTH = "signal-strength";
     public static final String CHANNEL_LOW_BATTERY = "low-battery";

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Chris Jackson - Initial contribution
+ * @author John Cocula - Added variable spoon size, UoM, wind stats, bug fixes
  */
 public class MeteostickSensorHandler extends BaseThingHandler implements MeteostickEventListener {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_DAVIS);
@@ -52,8 +53,10 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
     private int channel = 0;
     private BigDecimal spoon = new BigDecimal(PARAMETER_SPOON_DEFAULT);
     private MeteostickBridgeHandler bridgeHandler;
-    private SlidingTimeWindow rainHourlyWindow = new SlidingTimeWindow(HOUR_IN_MSEC);
+    private RainHistory rainHistory = new RainHistory(HOUR_IN_MSEC);
+    private WindHistory windHistory = new WindHistory(2 * 60 * 1000); // 2 minutes
     private ScheduledFuture<?> rainHourlyJob;
+    private ScheduledFuture<?> wind2MinJob;
     private ScheduledFuture<?> offlineTimerJob;
 
     private Date lastData;
@@ -74,8 +77,8 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
         }
         logger.debug("Initializing MeteoStick handler - Channel {}, Spoon size {} mm.", channel, spoon);
 
-        Runnable pollingRunnable = () -> {
-            BigDecimal rainfall = BigDecimal.valueOf(rainHourlyWindow.getTotal()).multiply(spoon);
+        Runnable rainRunnable = () -> {
+            BigDecimal rainfall = rainHistory.getTotal(spoon);
             rainfall.setScale(1, RoundingMode.DOWN);
             updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_LASTHOUR),
                     new QuantityType<>(rainfall, MILLI(METRE)));
@@ -83,7 +86,20 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
 
         // Scheduling a job on each hour to update the last hour rainfall
         long start = HOUR_IN_SEC - ((System.currentTimeMillis() % HOUR_IN_MSEC) / 1000);
-        rainHourlyJob = scheduler.scheduleWithFixedDelay(pollingRunnable, start, HOUR_IN_SEC, TimeUnit.SECONDS);
+        rainHourlyJob = scheduler.scheduleWithFixedDelay(rainRunnable, start, HOUR_IN_SEC, TimeUnit.SECONDS);
+
+        Runnable windRunnable = () -> {
+            WindStats stats = windHistory.getStats();
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_SPEED_LAST2MIN_AVERAGE),
+                    new QuantityType<>(stats.averageSpeed, METRE_PER_SECOND));
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_SPEED_LAST2MIN_MAXIMUM),
+                    new QuantityType<>(stats.maxSpeed, METRE_PER_SECOND));
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_DIRECTION_LAST2MIN_AVERAGE),
+                    new QuantityType<>(stats.averageDirection, DEGREE_ANGLE));
+        };
+
+        // Scheduling a job to run every two minutes to update wind statistics
+        wind2MinJob = scheduler.scheduleWithFixedDelay(windRunnable, 2, 2, TimeUnit.MINUTES);
 
         updateStatus(ThingStatus.UNKNOWN);
     }
@@ -92,6 +108,10 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
     public void dispose() {
         if (rainHourlyJob != null) {
             rainHourlyJob.cancel(true);
+        }
+
+        if (wind2MinJob != null) {
+            wind2MinJob.cancel(true);
         }
 
         if (offlineTimerJob != null) {
@@ -169,18 +189,22 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
                 processSignalStrength(data[3]);
                 processBattery(data.length == 5);
 
-                rainHourlyWindow.put(rain);
+                rainHistory.put(rain);
 
-                BigDecimal rainfall = BigDecimal.valueOf(rainHourlyWindow.getTotal()).multiply(spoon);
+                BigDecimal rainfall = rainHistory.getTotal(spoon);
                 rainfall.setScale(1, RoundingMode.DOWN);
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_RAIN_CURRENTHOUR),
                         new QuantityType<>(rainfall, MILLI(METRE)));
                 break;
             case "W": // Wind
+                BigDecimal windSpeed = new BigDecimal(data[2]);
+                int windDirection = Integer.parseInt(data[3]);
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_SPEED),
-                        new QuantityType<>(new BigDecimal(data[2]), METRE_PER_SECOND));
+                        new QuantityType<>(windSpeed, METRE_PER_SECOND));
                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_WIND_DIRECTION),
-                        new QuantityType<>(Integer.parseInt(data[3]), DEGREE_ANGLE));
+                        new QuantityType<>(windDirection, DEGREE_ANGLE));
+
+                windHistory.put(windSpeed, windDirection);
 
                 processSignalStrength(data[4]);
                 processBattery(data.length == 6);
@@ -208,9 +232,9 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
         }
     }
 
-    class SlidingTimeWindow {
-        long period = 0;
-        private final Map<Long, Integer> storage = new TreeMap<>();
+    class SlidingTimeWindow<T> {
+        private long period = 0;
+        protected final Map<Long, T> storage = new TreeMap<>();
 
         /**
          *
@@ -220,24 +244,35 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
             this.period = period;
         }
 
-        public void put(int value) {
+        public void put(T value) {
             storage.put(System.currentTimeMillis(), value);
         }
 
-        public int getTotal() {
-            int least = -1;
-            int total = 0;
-
+        public void removeOldEntries() {
             long old = System.currentTimeMillis() - period;
             for (Iterator<Long> iterator = storage.keySet().iterator(); iterator.hasNext();) {
                 long time = iterator.next();
                 if (time < old) {
-                    // Remove
                     iterator.remove();
-                    continue;
                 }
+            }
+        }
+    }
 
-                int value = storage.get(time);
+    class RainHistory extends SlidingTimeWindow<Integer> {
+
+        public RainHistory(long period) {
+            super(period);
+        }
+
+        public BigDecimal getTotal(BigDecimal spoon) {
+
+            removeOldEntries();
+
+            int least = -1;
+            int total = 0;
+
+            for (int value : storage.values()) {
                 if (least == -1) {
                     least = value;
                     continue;
@@ -250,7 +285,74 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
                 }
             }
 
-            return total;
+            return BigDecimal.valueOf(total).multiply(spoon);
+        }
+    }
+
+    /**
+     * Store the wind direction as an east-west vector and a north-south vector
+     * so that an average direction can be calculated based on the wind speed
+     * at the time of the direction sample.
+     */
+    class WindSample {
+        double speed;
+        double ewVector;
+        double nsVector;
+
+        public WindSample(BigDecimal speed, int directionDegrees) {
+            this.speed = speed.doubleValue();
+            double direction = Math.toRadians(directionDegrees);
+            this.ewVector = this.speed * Math.sin(direction);
+            this.nsVector = this.speed * Math.cos(direction);
+        }
+    }
+
+    class WindStats {
+        BigDecimal averageSpeed;
+        int averageDirection;
+        BigDecimal maxSpeed;
+    }
+
+    class WindHistory extends SlidingTimeWindow<WindSample> {
+
+        public WindHistory(long period) {
+            super(period);
+        }
+
+        public void put(BigDecimal speed, int directionDegrees) {
+            put(new WindSample(speed, directionDegrees));
+        }
+
+        public WindStats getStats() {
+
+            removeOldEntries();
+
+            double ewSum = 0;
+            double nsSum = 0;
+            double totalSpeed = 0;
+            double maxSpeed = 0;
+            int size = storage.size();
+            for (WindSample sample : storage.values()) {
+                ewSum += sample.ewVector;
+                nsSum += sample.nsVector;
+                totalSpeed += sample.speed;
+                if (sample.speed > maxSpeed) {
+                    maxSpeed = sample.speed;
+                }
+            }
+
+            WindStats stats = new WindStats();
+
+            stats.averageDirection = (int) Math.toDegrees(Math.atan2(ewSum, nsSum));
+            if (stats.averageDirection < 0) {
+                stats.averageDirection += 360;
+            }
+
+            stats.averageSpeed = new BigDecimal(size > 0 ? totalSpeed / size : 0).setScale(3, RoundingMode.HALF_DOWN);
+
+            stats.maxSpeed = new BigDecimal(maxSpeed).setScale(3, RoundingMode.HALF_DOWN);
+
+            return stats;
         }
     }
 

--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -18,8 +18,8 @@ import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -234,7 +234,7 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
 
     class SlidingTimeWindow<T> {
         private long period = 0;
-        protected final Map<Long, T> storage = new TreeMap<>();
+        protected final SortedMap<Long, T> storage = Collections.synchronizedSortedMap(new TreeMap<>());
 
         /**
          *
@@ -250,10 +250,12 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
 
         public void removeOldEntries() {
             long old = System.currentTimeMillis() - period;
-            for (Iterator<Long> iterator = storage.keySet().iterator(); iterator.hasNext();) {
-                long time = iterator.next();
-                if (time < old) {
-                    iterator.remove();
+            synchronized (storage) {
+                for (Iterator<Long> iterator = storage.keySet().iterator(); iterator.hasNext();) {
+                    long time = iterator.next();
+                    if (time < old) {
+                        iterator.remove();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add three advanced channels to summarise wind speed and direction over last two minutes. Instantaneous wind speed and direction samples are not useful in isolation, and relying on automation to compute statistics is much more burdensome on the system than doing so directly in the binding. (The same thinking applies to the existing current and last hour rain channels.)

The use case of using openHAB as a personal weather station for data upload to Wunderground, for example, is made easy with this change, along with unit-of-measure support.

Signed-off-by: John Cocula <john@cocula.com>