### PR TITLE
Fix using deprecated MDNSDiscoveryParticipant

### DIFF
--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  .,
  lib/json-simple-1.1.1.jar,
@@ -29,6 +30,7 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.config.discovery.mdns,
  org.eclipse.smarthome.core.audio,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.library.types,
@@ -38,7 +40,6 @@ Import-Package:
  org.eclipse.smarthome.core.thing.util,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.net.http,
- org.eclipse.smarthome.io.transport.mdns.discovery,
  org.openhab.binding.freebox,
  org.openhab.binding.freebox.handler,
  org.osgi.framework,

--- a/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/discovery/FreeboxServerDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/discovery/FreeboxServerDiscoveryParticipant.java
@@ -16,10 +16,10 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
 import org.openhab.binding.freebox.FreeboxBindingConstants;
 import org.openhab.binding.freebox.internal.config.FreeboxServerConfiguration;
 import org.osgi.service.component.annotations.Component;

--- a/addons/binding/org.openhab.binding.innogysmarthome/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.innogysmarthome/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: innogy SmartHome Binding
 Bundle-SymbolicName: org.openhab.binding.innogysmarthome;singleton:=true
@@ -13,7 +14,6 @@ Bundle-ClassPath: .,
  lib/httpcore-4.0.1.jar,
  lib/jackson-core-2.1.3.jar
 Import-Package: 
- org.eclipse.jdt.annotation;resolution:=optional,
  com.google.common.collect,
  com.google.gson,
  com.google.gson.annotations,
@@ -21,6 +21,7 @@ Import-Package:
  org.apache.commons.io,
  org.apache.commons.lang,
  org.apache.commons.lang.exception,
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.jetty.io,
  org.eclipse.jetty.util,
  org.eclipse.jetty.util.component,
@@ -31,19 +32,18 @@ Import-Package:
  org.eclipse.jetty.websocket.common,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.config.discovery.mdns,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
- org.eclipse.smarthome.io.transport.mdns,
- org.eclipse.smarthome.io.transport.mdns.discovery,
  org.openhab.binding.innogysmarthome,
  org.openhab.binding.innogysmarthome.handler,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.openhab.binding.innogysmarthome,
+Export-Package: 
+ org.openhab.binding.innogysmarthome,
  org.openhab.binding.innogysmarthome.handler
- 

--- a/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/discovery/InnogyBridgeDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/discovery/InnogyBridgeDiscoveryParticipant.java
@@ -17,9 +17,9 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Use `org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant` 
instead of  `org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant`
because it is deprecated.