### PR TITLE
[Hyperion] Use default Eclipse project settings

### DIFF
--- a/addons/binding/org.openhab.binding.hyperion/.settings/org.eclipse.core.resources.prefs
+++ b/addons/binding/org.openhab.binding.hyperion/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/addons/binding/org.openhab.binding.hyperion/.settings/org.eclipse.jdt.core.prefs
+++ b/addons/binding/org.openhab.binding.hyperion/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
It's unnecessary to override the default Eclipse settings for this project.

See also: https://github.com/openhab/openhab2-addons/pull/3472