### PR TITLE
Fix IllegalArgumentExceptions in SysteminfoOSGiTest

### DIFF
--- a/addons/binding/org.openhab.binding.systeminfo.test/src/test/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
+++ b/addons/binding/org.openhab.binding.systeminfo.test/src/test/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
@@ -919,7 +919,9 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
             assertThat(discoveryService, is(notNullValue()));
         });
         SysteminfoDiscoveryServiceMock discoveryServiceMock = new SysteminfoDiscoveryServiceMock(hostname);
-        unregisterService(discoveryService);
+        if (discoveryService != null) {
+            unregisterService(DiscoveryService.class);
+        }
         registerService(discoveryServiceMock, DiscoveryService.class.getName(), new Hashtable<>());
 
         ThingTypeUID computerType = SysteminfoBindingConstants.THING_TYPE_COMPUTER;


### PR DESCRIPTION
The tests started throwing the following IAE due to changes in https://github.com/eclipse/smarthome/pull/5838:

```
java.lang.IllegalArgumentException: The given reference (class: class org.openhab.binding.systeminfo.internal.discovery.SysteminfoDiscoveryService) does not implement an interface.
	at org.eclipse.smarthome.test.java.JavaOSGiTest.getInterfaceName(JavaOSGiTest.java:289)
	at org.eclipse.smarthome.test.java.JavaOSGiTest.unregisterService(JavaOSGiTest.java:258)
	at org.openhab.binding.systeminfo.test.SysteminfoOSGiTest.testDiscoveryService(SysteminfoOSGiTest.java:922)
	at org.openhab.binding.systeminfo.test.SysteminfoOSGiTest.testDiscoveryWithUnresolvedHostname(SysteminfoOSGiTest.java:904)
```

I'm passing the `DiscoveryService.class` and not `discoveryService` as argument because `getInterfaceName` does not get inherited interfaces. Only the first interface of the object class itself is used.
