### PR TITLE
[mcp23017] New Feature "active_low" or "invert logic"

### DIFF
--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -60,8 +60,8 @@ Configuration with default_state and pull_mode:
 Thing mcp23017:mcp23017:chipA  "MCP23017 chip A" [address=20,bus=1] {
     Type output_pin : output#A0 [default_state="HIGH"]
     Type output_pin : output#A1 [default_state="LOW"]
-    Type output_pin : output#A2 [active_low="ON"]
-    Type output_pin : output#A2 [default_state="LOW", active_low="ON"]
+    Type output_pin : output#A2 [active_low="y"]
+    Type output_pin : output#A2 [default_state="LOW", active_low="y"]
 
     Type input_pin : input#B0 [pull_mode="PULL_UP"]
     Type input_pin : input#B1 [pull_mode="OFF"]

--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -60,6 +60,8 @@ Configuration with default_state and pull_mode:
 Thing mcp23017:mcp23017:chipA  "MCP23017 chip A" [address=20,bus=1] {
     Type output_pin : output#A0 [default_state="HIGH"]
     Type output_pin : output#A1 [default_state="LOW"]
+    Type output_pin : output#A2 [active_low="ON"]
+    Type output_pin : output#A2 [default_state="LOW", active_low="ON"]
 
     Type input_pin : input#B0 [pull_mode="PULL_UP"]
     Type input_pin : input#B1 [pull_mode="OFF"]

--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/Mcp23017BindingConstants.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/Mcp23017BindingConstants.java
@@ -39,6 +39,10 @@ public class Mcp23017BindingConstants {
     public static final String PIN = "pin";
     public static final String PULL_MODE = "pull_mode";
     public static final String DEFAULT_PULL_MODE = "OFF";
+    
+    public static final String ACTIVE_LOW = "active_low";
+    
+    public static final String ACTIVE_LOW_ENABLED = "y";
 
     public static final String CHANNEL_GROUP_INPUT = "input";
     public static final String CHANNEL_GROUP_OUTPUT = "output";

--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/handler/Mcp23017Handler.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/handler/Mcp23017Handler.java
@@ -110,12 +110,29 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
 
     private void handleOutputCommand(ChannelUID channelUID, Command command) {
         GpioPinDigitalOutput outputPin = pinStateHolder.getOutputPin(channelUID);
-        logger.debug("got output pin {} for channel {} and command {}", outputPin, channelUID, command);
-        if (OnOffType.ON == command) {
-            GPIODataHolder.GPIO.setState(PinState.HIGH, outputPin);
-        } else if (OnOffType.OFF == command) {
-            GPIODataHolder.GPIO.setState(PinState.LOW, outputPin);
+        
+        Configuration configuration = this.getThing().getChannel(channelUID.getId()).getConfiguration();
+        String invertLogic = (String) configuration.get(ACTIVE_LOW);        
+        PinState newState = null;
+        
+        // invertLogic is null if not configured
+        boolean activeLowFlag = ACTIVE_LOW_ENABLED.equalsIgnoreCase(invertLogic);
+        if (activeLowFlag) {
+            if (OnOffType.ON == command) {
+                newState = PinState.LOW;
+            } else if (OnOffType.OFF == command) {
+                newState = PinState.HIGH;
+            }
+        } else {
+            if (OnOffType.ON == command) {
+                newState = PinState.HIGH;
+            } else if (OnOffType.OFF == command) {
+                newState = PinState.LOW;
+            }
         }
+        
+        logger.debug("got output pin {} for channel {} and command {} [active_low={}, new_state={}]", outputPin, channelUID, command, activeLowFlag, newState);
+        GPIODataHolder.GPIO.setState(newState, outputPin);
     }
 
     private void handleInputCommand(ChannelUID channelUID, Command command) {


### PR DESCRIPTION

DESCRIPTION

There are som relay-devices triggert by the MCP23017, which switches to "ON" if the electrical level goes to GND. Therefor, its helpfull to invert the output-states of the chip. This is now configureable in the things-config.

Question: Its ok to access the config every time the handleOutputCommand-Method is triggered? Could this be an performance-Issue?

TESTING
Ive tested it locally with my raspi/openhabian
