### PR TITLE
[network] [WIP] exclude point-to-point network interfaces from network interface list to fix false positive arping returns

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -94,7 +94,7 @@ public class NetworkUtils {
             // For each interface ...
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface networkInterface = en.nextElement();
-                if (!networkInterface.isLoopback()) {
+                if ((!networkInterface.isLoopback()) && (!networkInterface.isPointToPoint())) {
                     result.add(networkInterface.getName());
                 }
             }


### PR DESCRIPTION
The automatic inclusion of point to point interfaces (which are not "inactive", but do not have local IP addresses) appears to be creating false positive ARP ping results (at least on a Mac OS system). There does not appear to be a reason to include point to point interfaces in network presence detection, as we are looking for returns from devices on the network(s) which is/are local to the server.

https://community.openhab.org/t/oh2-network-binding-device-always-online/21755/31?u=raaahbin describes the behaviour currently observed (i.e. ARP ping detects devices ON which are not present on the local network at all, apparently due to attempted ARP pings from unusable interfaces).

There should be no changes to end users (provided the code works as intended - need to test the branched build).

This is my first attempt at a codebase pull request, so feel free to close and/or nuke if I've gone about it the wrong way.

Signed-off-by: Robin Darroch git@robin.darroch.id.au (github: raaahbin)
