### PR TITLE
[Harmony] Add null annotations, bugfixes and improvements

### DIFF
--- a/addons/binding/org.openhab.binding.harmonyhub/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.harmonyhub/ESH-INF/thing/thing-types.xml
@@ -47,12 +47,12 @@
 		</channels>
 		<config-description>
 			<parameter name="id" type="integer" required="false">
-				<label>id</label>
-				<description>Numeric ID of the Harmony Device (id or name is required)</description>
+				<label>ID</label>
+				<description>Numeric ID of the Harmony Device (ID or name is required)</description>
 			</parameter>
 			<parameter name="name" type="text" required="false">
-				<label>id</label>
-				<description>Name of the Harmony Device (name or id is required)</description>
+				<label>Name</label>
+				<description>Name of the Harmony Device (name or ID is required)</description>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/HarmonyHubBindingConstants.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/HarmonyHubBindingConstants.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Dan Cunningham - Initial contribution
+ * @author Wouter Born - Add device properties
  */
 @NonNullByDefault
 public class HarmonyHubBindingConstants {
@@ -26,16 +27,18 @@ public class HarmonyHubBindingConstants {
     public static final ThingTypeUID HARMONY_HUB_THING_TYPE = new ThingTypeUID(BINDING_ID, "hub");
     public static final ThingTypeUID HARMONY_DEVICE_THING_TYPE = new ThingTypeUID(BINDING_ID, "device");
 
-    // List of all Channel ids
+    // List of all Channel IDs
     public static final String CHANNEL_CURRENT_ACTIVITY = "currentActivity";
     public static final String CHANNEL_ACTIVITY_STARTING_TRIGGER = "activityStarting";
     public static final String CHANNEL_ACTIVITY_STARTED_TRIGGER = "activityStarted";
 
     public static final String CHANNEL_BUTTON_PRESS = "buttonPress";
 
-    public static final String HUB_PROPERTY_SESSIONID = "sessionId";
-    public static final String HUB_PROPERTY_ACCOUNTID = "accountId";
-    public static final String HUB_PROPERTY_HOST = "host";
+    public static final String DEVICE_PROPERTY_ID = "id";
+    public static final String DEVICE_PROPERTY_NAME = "name";
+
     public static final String HUB_PROPERTY_ID = "id";
+    public static final String HUB_PROPERTY_HOST = "host";
+    public static final String HUB_PROPERTY_NAME = "name";
 
 }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.harmonyhub.handler;
 
-import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.HARMONY_DEVICE_THING_TYPE;
+import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,7 +16,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -34,7 +37,6 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.eclipse.smarthome.core.types.UnDefType;
-import org.openhab.binding.harmonyhub.HarmonyHubBindingConstants;
 import org.openhab.binding.harmonyhub.internal.HarmonyHubHandlerFactory;
 import org.openhab.binding.harmonyhub.internal.config.HarmonyDeviceConfig;
 import org.slf4j.Logger;
@@ -51,32 +53,36 @@ import net.whistlingfish.harmony.config.HarmonyConfig;
  * based on the device's available button press functions.
  *
  * @author Dan Cunningham - Initial contribution
- *
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class HarmonyDeviceHandler extends BaseThingHandler {
 
-    private Logger logger = LoggerFactory.getLogger(HarmonyDeviceHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(HarmonyDeviceHandler.class);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(HARMONY_DEVICE_THING_TYPE);
 
-    HarmonyHubHandler bridge;
-    HarmonyHubHandlerFactory factory;
-    int id;
-    String name;
-    String logName;
+    private HarmonyHubHandlerFactory factory;
+
+    private @NonNullByDefault({}) HarmonyDeviceConfig config;
 
     public HarmonyDeviceHandler(Thing thing, HarmonyHubHandlerFactory factory) {
         super(thing);
         this.factory = factory;
     }
 
+    protected @Nullable HarmonyHubHandler getHarmonyHubHandler() {
+        Bridge bridge = getBridge();
+        return bridge != null ? (HarmonyHubHandler) bridge.getHandler() : null;
+    }
+
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.trace("Command {} for {}", command, channelUID);
-        Channel channel = getThing().getChannel(channelUID.getId());
+        logger.trace("Handling command '{}' for {}", command, channelUID);
 
+        Channel channel = getThing().getChannel(channelUID.getId());
         if (channel == null) {
-            logger.warn("No such channel {} for device {}", channelUID, getThing());
+            logger.warn("No such channel: {}", channelUID);
             return;
         }
 
@@ -86,34 +92,43 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
         }
 
         if (!(command instanceof StringType)) {
-            logger.warn("Command {} is not a String type for channel {} for device {}", command, channelUID,
-                    getThing());
+            logger.warn("Command '{}' is not a String type for channel {}", command, channelUID);
             return;
         }
 
-        logger.debug("Pressing button {} on {}", command, id > 0 ? 0 : name);
-
-        if (id > 0) {
-            bridge.pressButton(id, command.toString());
-        } else {
-            bridge.pressButton(name, command.toString());
+        HarmonyHubHandler hubHandler = getHarmonyHubHandler();
+        if (hubHandler == null) {
+            logger.warn("Command '{}' cannot be handled because {} has no bridge", command, getThing().getUID());
+            return;
         }
 
+        int id = config.id;
+        String name = config.name;
+        String message = "Pressing button '{}' on {}";
+        if (id > 0) {
+            logger.debug(message, command, id);
+            hubHandler.pressButton(id, command.toString());
+        } else if (name != null) {
+            logger.debug(message, command, name);
+            hubHandler.pressButton(name, command.toString());
+        } else {
+            logger.warn("Command '{}' cannot be handled because {} has no valid id or name configured", command,
+                    getThing().getUID());
+        }
         // may need to ask the list if this can be set here?
         updateState(channelUID, UnDefType.UNDEF);
     }
 
     @Override
     public void initialize() {
-        id = getConfig().as(HarmonyDeviceConfig.class).id;
-        name = getConfig().as(HarmonyDeviceConfig.class).name;
-        if (!checkConfig()) {
+        config = getConfigAs(HarmonyDeviceConfig.class);
+        boolean validConfiguration = config.name != null || config.id >= 0;
+        if (validConfiguration) {
+            updateStatus(ThingStatus.UNKNOWN);
+            updateBridgeStatus();
+        } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "A harmony device thing must be configured with a device name OR a postive device id");
-        } else {
-            logName = id > 0 ? String.valueOf(id) : name;
-            logger.debug("initializing {}", logName);
-            updateBridgeStatus();
         }
     };
 
@@ -128,92 +143,86 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
     }
 
     /**
-     * Checks if we have a String name or numeric id
-     *
-     * @return
-     */
-    private boolean checkConfig() {
-        return name != null || id >= 0;
-    }
-
-    /**
      * Updates our state based on the bridge/hub
      */
     private void updateBridgeStatus() {
-        ThingStatus bridgeStatus = getBridge().getStatus();
-        if (bridgeStatus == ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.ONLINE) {
-            bridge = (HarmonyHubHandler) getBridge().getHandler();
+        Bridge bridge = getBridge();
+        ThingStatus bridgeStatus = bridge != null ? bridge.getStatus() : null;
+        HarmonyHubHandler hubHandler = getHarmonyHubHandler();
+
+        boolean bridgeOnline = bridgeStatus == ThingStatus.ONLINE;
+        boolean thingOnline = getThing().getStatus() == ThingStatus.ONLINE;
+
+        if (bridgeOnline && hubHandler != null && !thingOnline) {
             updateStatus(ThingStatus.ONLINE);
-            bridge.getConfigFuture().thenAcceptAsync(this::updateChannel, scheduler).exceptionally(e -> {
+            hubHandler.getConfigFuture().thenAcceptAsync(this::updateButtonPressChannel, scheduler).exceptionally(e -> {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Getting config failed: " + e.getMessage());
                 return null;
             });
-        } else if (bridgeStatus != ThingStatus.ONLINE) {
+        } else if (!bridgeOnline || hubHandler == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
     }
 
     /**
-     * Updates our channel with the available buttons as option states
+     * Updates the buttonPress channel with the available buttons as option states.
      */
-    private void updateChannel(HarmonyConfig config) {
-        try {
-            logger.debug("updateChannel for device {}", logName);
+    private void updateButtonPressChannel(@Nullable HarmonyConfig harmonyConfig) {
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(
+                getThing().getUID().getAsString() + ":" + CHANNEL_BUTTON_PRESS);
 
-            if (config == null) {
-                logger.debug("updateChannel: could not get config from bridge {}", logName);
-                return;
+        if (harmonyConfig == null) {
+            logger.debug("Cannot update {} when HarmonyConfig is null", channelTypeUID);
+            return;
+        }
+
+        logger.debug("Updating {}", channelTypeUID);
+
+        List<StateOption> states = getButtonStateOptions(harmonyConfig);
+
+        ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Send Button Press",
+                "Send a button press to device " + getThing().getLabel(), null, null,
+                new StateDescription(null, null, null, null, false, states), null);
+
+        factory.addChannelType(channelType);
+
+        Channel channel = ChannelBuilder.create(new ChannelUID(getThing().getUID(), CHANNEL_BUTTON_PRESS), "String")
+                .withType(channelTypeUID).build();
+
+        // replace existing buttonPress with updated one
+        List<Channel> newChannels = new ArrayList<Channel>();
+        for (Channel c : getThing().getChannels()) {
+            if (!c.getUID().equals(channel.getUID())) {
+                newChannels.add(c);
             }
+        }
+        newChannels.add(channel);
 
-            List<StateOption> states = new LinkedList<StateOption>();
-            List<Device> devices = config.getDevices();
+        ThingBuilder thingBuilder = editThing();
+        thingBuilder.withChannels(newChannels);
+        updateThing(thingBuilder.build());
+    }
 
-            // Iterate through button function commands and add them to our state list
-            for (Device device : devices) {
-                if (device.getId() != id) {
-                    continue;
-                }
-                List<ControlGroup> controlGroups = device.getControlGroup();
-                for (ControlGroup controlGroup : controlGroups) {
-                    List<Function> functions = controlGroup.getFunction();
-                    for (Function function : functions) {
+    private List<StateOption> getButtonStateOptions(HarmonyConfig harmonyConfig) {
+        int id = config.id;
+        String name = config.name;
+        List<StateOption> states = new LinkedList<StateOption>();
+
+        // Iterate through button function commands and add them to our state list
+        for (Device device : harmonyConfig.getDevices()) {
+            boolean sameId = name == null && device.getId() == id;
+            boolean sameName = name != null && name.equals(device.getLabel());
+
+            if (sameId || sameName) {
+                for (ControlGroup controlGroup : device.getControlGroup()) {
+                    for (Function function : controlGroup.getFunction()) {
                         states.add(new StateOption(function.getName(), function.getLabel()));
                     }
                 }
                 break;
             }
-
-            ThingBuilder thingBuilder = editThing();
-
-            ChannelTypeUID channelTypeUID = new ChannelTypeUID(
-                    getThing().getUID().getAsString() + ":" + HarmonyHubBindingConstants.CHANNEL_BUTTON_PRESS);
-
-            ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Send Button Press",
-                    "Send a button press to device " + getThing().getLabel(), null, null,
-                    new StateDescription(null, null, null, null, false, states), null);
-
-            factory.addChannelType(channelType);
-
-            Channel channel = ChannelBuilder
-                    .create(new ChannelUID(getThing().getUID(), HarmonyHubBindingConstants.CHANNEL_BUTTON_PRESS),
-                            "String")
-                    .withType(channelTypeUID).build();
-
-            // replace existing buttonPress with updated one
-            List<Channel> currentChannels = getThing().getChannels();
-            List<Channel> newChannels = new ArrayList<Channel>();
-            for (Channel c : currentChannels) {
-                if (!c.getUID().equals(channel.getUID())) {
-                    newChannels.add(c);
-                }
-            }
-            newChannels.add(channel);
-            thingBuilder.withChannels(newChannels);
-
-            updateThing(thingBuilder.build());
-        } catch (Exception e) {
-            logger.debug("Could not add button channels to device {}", logName, e);
         }
+        return states;
     }
 }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
@@ -191,7 +191,7 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
                 .withType(channelTypeUID).build();
 
         // replace existing buttonPress with updated one
-        List<Channel> newChannels = new ArrayList<Channel>();
+        List<Channel> newChannels = new ArrayList<>();
         for (Channel c : getThing().getChannels()) {
             if (!c.getUID().equals(channel.getUID())) {
                 newChannels.add(c);
@@ -207,7 +207,7 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
     private List<StateOption> getButtonStateOptions(HarmonyConfig harmonyConfig) {
         int id = config.id;
         String name = config.name;
-        List<StateOption> states = new LinkedList<StateOption>();
+        List<StateOption> states = new LinkedList<>();
 
         // Iterate through button function commands and add them to our state list
         for (Device device : harmonyConfig.getDevices()) {

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.harmonyhub.handler;
 
-import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.HARMONY_HUB_THING_TYPE;
+import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.cache.ExpiringCacheAsync;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -44,7 +46,6 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
-import org.openhab.binding.harmonyhub.HarmonyHubBindingConstants;
 import org.openhab.binding.harmonyhub.internal.HarmonyHubHandlerFactory;
 import org.openhab.binding.harmonyhub.internal.config.HarmonyHubConfig;
 import org.slf4j.Logger;
@@ -63,10 +64,12 @@ import net.whistlingfish.harmony.config.HarmonyConfig;
  *
  * @author Dan Cunningham - Initial contribution
  * @author Pawel Pieczul - added support for hub status changes
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubListener {
 
-    private Logger logger = LoggerFactory.getLogger(HarmonyHubHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(HarmonyHubHandler.class);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(HARMONY_HUB_THING_TYPE);
 
@@ -75,24 +78,20 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
 
     // one minute should be plenty short, but not overwhelm the hub with requests
     private static final long CONFIG_CACHE_TIME = TimeUnit.MINUTES.toMillis(1);
-
     private static final int RETRY_TIME = 60;
-
     private static final int HEARTBEAT_INTERVAL = 30;
-
-    private ScheduledExecutorService buttonExecutor;
 
     private List<HubStatusListener> listeners = new CopyOnWriteArrayList<HubStatusListener>();
 
-    private HarmonyClient client;
+    private final ExpiringCacheAsync<@Nullable HarmonyConfig> configCache = new ExpiringCacheAsync<>(CONFIG_CACHE_TIME);
+    private final HarmonyHubHandlerFactory factory;
 
-    private ExpiringCacheAsync<HarmonyConfig> configCache = new ExpiringCacheAsync<>(CONFIG_CACHE_TIME);
+    private @NonNullByDefault({}) ScheduledExecutorService buttonExecutor;
+    private @NonNullByDefault({}) HarmonyHubConfig config;
 
-    private HarmonyHubHandlerFactory factory;
-
-    private ScheduledFuture<?> retryJob;
-
-    private ScheduledFuture<?> heartBeatJob;
+    private @Nullable HarmonyClient client;
+    private @Nullable ScheduledFuture<?> retryJob;
+    private @Nullable ScheduledFuture<?> heartBeatJob;
 
     private int heartBeatInterval;
 
@@ -103,15 +102,23 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.trace("Handling command '{}' for {}", command, channelUID);
+
+        HarmonyClient localClient = client;
+        if (localClient == null) {
+            logger.warn("Cannot send command '{}' on {} because HarmonyClient is null", command, channelUID);
+            return;
+        }
+
         if (command instanceof RefreshType) {
-            updateState(client.getCurrentActivity());
+            updateState(localClient.getCurrentActivity());
         } else if (command instanceof StringType) {
             try {
                 try {
                     int actId = Integer.parseInt(command.toString());
-                    client.startActivity(actId);
+                    localClient.startActivity(actId);
                 } catch (NumberFormatException ignored) {
-                    client.startActivityByName(command.toString());
+                    localClient.startActivityByName(command.toString());
                 }
             } catch (IllegalArgumentException e) {
                 logger.warn("Activity '{}' is not known by the hub, ignoring it.", command);
@@ -120,7 +127,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
             }
         } else if (command instanceof DecimalType) {
             try {
-                client.startActivity(((DecimalType) command).intValue());
+                localClient.startActivity(((DecimalType) command).intValue());
             } catch (Exception e) {
                 logger.error("Could not start activity", e);
             }
@@ -132,7 +139,9 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     @Override
     public void initialize() {
         buttonExecutor = Executors.newSingleThreadScheduledExecutor();
+        config = getConfigAs(HarmonyHubConfig.class);
         cancelRetry();
+        updateStatus(ThingStatus.UNKNOWN);
         retryJob = scheduler.schedule(this::connect, 0, TimeUnit.SECONDS);
     }
 
@@ -146,7 +155,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     }
 
     @Override
-    protected void updateStatus(ThingStatus status, ThingStatusDetail detail, String comment) {
+    protected void updateStatus(ThingStatus status, ThingStatusDetail detail, @Nullable String comment) {
         super.updateStatus(status, detail, comment);
         logger.debug("Updating listeners with status {}", status);
         for (HubStatusListener listener : listeners) {
@@ -156,8 +165,9 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
 
     @Override
     public void channelLinked(ChannelUID channelUID) {
-        if (client != null) {
-            updateState(channelUID, new StringType(client.getCurrentActivity().getLabel()));
+        HarmonyClient localClient = client;
+        if (localClient != null) {
+            updateState(channelUID, new StringType(localClient.getCurrentActivity().getLabel()));
         }
     }
 
@@ -165,7 +175,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
      * HarmonyHubListener interface
      */
     @Override
-    public void removeFrom(HarmonyClient hc) {
+    public void removeFrom(@Nullable HarmonyClient hc) {
         // we have been removed from listening
     }
 
@@ -173,16 +183,20 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
      * HarmonyHubListener interface
      */
     @Override
-    public void addTo(HarmonyClient hc) {
+    public void addTo(@Nullable HarmonyClient hc) {
+        if (hc == null) {
+            logger.warn("Cannot add listeners to HarmonyClient that is null");
+            return;
+        }
         hc.addListener(new ActivityChangeListener() {
             @Override
-            public void activityStarted(Activity activity) {
+            public void activityStarted(@Nullable Activity activity) {
                 updateState(activity);
             }
         });
         hc.addListener(new ActivityStatusListener() {
             @Override
-            public void activityStatusChanged(Activity activity, Activity.Status status) {
+            public void activityStatusChanged(@Nullable Activity activity, Activity.@Nullable Status status) {
                 updateActivityStatus(activity, status);
             }
         });
@@ -194,7 +208,6 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     private synchronized void connect() {
         disconnectFromHub();
 
-        HarmonyHubConfig config = getConfig().as(HarmonyHubConfig.class);
         heartBeatInterval = config.heartBeatInterval > 0 ? config.heartBeatInterval : HEARTBEAT_INTERVAL;
 
         String host = config.host;
@@ -203,10 +216,10 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
         // this section is to not break that and also update older configurations to use the host configuration
         // option instead of name
         if (StringUtils.isBlank(host)) {
-            host = getThing().getProperties().get(HarmonyHubBindingConstants.HUB_PROPERTY_HOST);
+            host = getThing().getProperties().get(HUB_PROPERTY_HOST);
             if (StringUtils.isNotBlank(host)) {
                 Configuration genericConfig = getConfig();
-                genericConfig.put("host", host);
+                genericConfig.put(HUB_PROPERTY_HOST, host);
                 updateConfiguration(genericConfig);
             } else {
                 logger.debug("host not configured");
@@ -215,22 +228,23 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
             }
         }
 
-        client = HarmonyClient.getInstance();
-        client.addListener(this);
+        HarmonyClient localClient = HarmonyClient.getInstance();
+        localClient.addListener(this);
+        client = localClient;
 
         try {
             logger.debug("Connecting: host {}", host);
-            client.connect(host);
+            localClient.connect(host);
             heartBeatJob = scheduler.scheduleWithFixedDelay(() -> {
                 try {
-                    client.sendPing();
+                    localClient.sendPing();
                 } catch (Exception e) {
                     logger.warn("heartbeat failed", e);
                     setOfflineAndReconnect("Hearbeat failed");
                 }
             }, heartBeatInterval, heartBeatInterval, TimeUnit.SECONDS);
             updateStatus(ThingStatus.ONLINE);
-            getConfigFuture().thenAcceptAsync(harmonyConfig -> buildChannel(harmonyConfig), scheduler)
+            getConfigFuture().thenAcceptAsync(harmonyConfig -> updateCurrentActivityChannel(harmonyConfig), scheduler)
                     .exceptionally(e -> {
                         setOfflineAndReconnect("Getting config failed: " + e.getMessage());
                         return null;
@@ -242,13 +256,15 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     }
 
     private void disconnectFromHub() {
-        if (heartBeatJob != null && !heartBeatJob.isDone()) {
-            heartBeatJob.cancel(false);
+        ScheduledFuture<?> localHeartBeatJob = heartBeatJob;
+        if (localHeartBeatJob != null && !localHeartBeatJob.isDone()) {
+            localHeartBeatJob.cancel(false);
         }
 
-        if (client != null) {
-            client.removeListener(this);
-            client.disconnect();
+        HarmonyClient localClient = client;
+        if (localClient != null) {
+            localClient.removeListener(this);
+            localClient.disconnect();
         }
     }
 
@@ -259,27 +275,38 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     }
 
     private void cancelRetry() {
-        if (retryJob != null && !retryJob.isDone()) {
-            retryJob.cancel(false);
+        ScheduledFuture<?> localRetryJob = retryJob;
+        if (localRetryJob != null && !localRetryJob.isDone()) {
+            localRetryJob.cancel(false);
         }
     }
 
-    private void updateState(Activity activity) {
-        logger.debug("Updating current activity to {}", activity.getLabel());
-        updateState(new ChannelUID(getThing().getUID(), HarmonyHubBindingConstants.CHANNEL_CURRENT_ACTIVITY),
-                new StringType(activity.getLabel()));
+    private void updateState(@Nullable Activity activity) {
+        if (activity != null) {
+            logger.debug("Updating current activity to {}", activity.getLabel());
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_CURRENT_ACTIVITY),
+                    new StringType(activity.getLabel()));
+        }
     }
 
-    private void updateActivityStatus(Activity activity, Activity.Status status) {
+    private void updateActivityStatus(@Nullable Activity activity, Activity.@Nullable Status status) {
+        if (activity == null) {
+            logger.debug("Cannot update activity status of {} with activity that is null", getThing().getUID());
+            return;
+        } else if (status == null) {
+            logger.debug("Cannot update activity status of {} with status that is null", getThing().getUID());
+            return;
+        }
+
         logger.debug("Received {} activity status for {}", status, activity.getLabel());
         switch (status) {
             case ACTIVITY_IS_STARTING:
-                triggerChannel(HarmonyHubBindingConstants.CHANNEL_ACTIVITY_STARTING_TRIGGER, getEventName(activity));
+                triggerChannel(CHANNEL_ACTIVITY_STARTING_TRIGGER, getEventName(activity));
                 break;
             case ACTIVITY_IS_STARTED:
             case HUB_IS_OFF:
                 // hub is off is received with power-off activity
-                triggerChannel(HarmonyHubBindingConstants.CHANNEL_ACTIVITY_STARTED_TRIGGER, getEventName(activity));
+                triggerChannel(CHANNEL_ACTIVITY_STARTED_TRIGGER, getEventName(activity));
                 break;
             case HUB_IS_TURNING_OFF:
                 // hub is turning off is received for current activity, we will translate it into activity starting
@@ -288,8 +315,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
                     if (config != null) {
                         Activity powerOff = config.getActivityById(-1);
                         if (powerOff != null) {
-                            triggerChannel(HarmonyHubBindingConstants.CHANNEL_ACTIVITY_STARTING_TRIGGER,
-                                    getEventName(powerOff));
+                            triggerChannel(CHANNEL_ACTIVITY_STARTING_TRIGGER, getEventName(powerOff));
                         }
                     }
                 }).exceptionally(e -> {
@@ -306,49 +332,50 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
         return activity.getLabel().replaceAll("[^A-Za-z0-9]", "_");
     }
 
-    private void buildChannel(HarmonyConfig config) {
-        try {
-            List<Activity> activities = config.getActivities();
-            // sort our activities in order
-            Collections.sort(activities, ACTIVITY_COMPERATOR);
+    /**
+     * Updates the current activity channel with the available activities as option states.
+     */
+    private void updateCurrentActivityChannel(@Nullable HarmonyConfig config) {
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(getThing().getUID() + ":" + CHANNEL_CURRENT_ACTIVITY);
 
-            // add our activities as channel state options
-            List<StateOption> states = new LinkedList<StateOption>();
-            for (Activity activity : activities) {
-                states.add(new StateOption(activity.getLabel(), activity.getLabel()));
-            }
-
-            ChannelTypeUID channelTypeUID = new ChannelTypeUID(
-                    getThing().getUID() + ":" + HarmonyHubBindingConstants.CHANNEL_CURRENT_ACTIVITY);
-
-            ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Current Activity",
-                    "Current activity for " + getThing().getLabel(), null, null,
-                    new StateDescription(null, null, null, "%s", false, states), null);
-
-            factory.addChannelType(channelType);
-
-            BridgeBuilder thingBuilder = editThing();
-
-            Channel channel = ChannelBuilder
-                    .create(new ChannelUID(getThing().getUID(), HarmonyHubBindingConstants.CHANNEL_CURRENT_ACTIVITY),
-                            "String")
-                    .withType(channelTypeUID).build();
-
-            // replace existing currentActivity with updated one
-            List<Channel> currentChannels = getThing().getChannels();
-            List<Channel> newChannels = new ArrayList<Channel>();
-            for (Channel c : currentChannels) {
-                if (!c.getUID().equals(channel.getUID())) {
-                    newChannels.add(c);
-                }
-            }
-            newChannels.add(channel);
-            thingBuilder.withChannels(newChannels);
-
-            updateThing(thingBuilder.build());
-        } catch (Exception e) {
-            logger.debug("Could not add current activity channel to hub", e);
+        if (config == null) {
+            logger.debug("Cannot update {} when HarmonyConfig is null", channelTypeUID);
+            return;
         }
+
+        logger.debug("Updating {}", channelTypeUID);
+
+        List<Activity> activities = config.getActivities();
+        // sort our activities in order
+        Collections.sort(activities, ACTIVITY_COMPERATOR);
+
+        // add our activities as channel state options
+        List<StateOption> states = new LinkedList<StateOption>();
+        for (Activity activity : activities) {
+            states.add(new StateOption(activity.getLabel(), activity.getLabel()));
+        }
+
+        ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Current Activity",
+                "Current activity for " + getThing().getLabel(), null, null,
+                new StateDescription(null, null, null, "%s", false, states), null);
+
+        factory.addChannelType(channelType);
+
+        Channel channel = ChannelBuilder.create(new ChannelUID(getThing().getUID(), CHANNEL_CURRENT_ACTIVITY), "String")
+                .withType(channelTypeUID).build();
+
+        // replace existing currentActivity with updated one
+        List<Channel> newChannels = new ArrayList<>();
+        for (Channel c : getThing().getChannels()) {
+            if (!c.getUID().equals(channel.getUID())) {
+                newChannels.add(c);
+            }
+        }
+        newChannels.add(channel);
+
+        BridgeBuilder thingBuilder = editThing();
+        thingBuilder.withChannels(newChannels);
+        updateThing(thingBuilder.build());
     }
 
     /**
@@ -358,7 +385,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
      * @param button
      */
     public void pressButton(int device, String button) {
-        if (buttonExecutor != null && !buttonExecutor.isShutdown()) {
+        if (!buttonExecutor.isShutdown()) {
             buttonExecutor.execute(() -> {
                 if (client != null) {
                     client.pressButton(device, button);
@@ -374,7 +401,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
      * @param button
      */
     public void pressButton(String device, String button) {
-        if (buttonExecutor != null && !buttonExecutor.isShutdown()) {
+        if (!buttonExecutor.isShutdown()) {
             buttonExecutor.execute(() -> {
                 if (client != null) {
                     client.pressButton(device, button);
@@ -383,14 +410,15 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
         }
     }
 
-    public CompletableFuture<HarmonyConfig> getConfigFuture() {
-        Supplier<HarmonyConfig> configSupplier = () -> {
-            if (client == null) {
+    public CompletableFuture<@Nullable HarmonyConfig> getConfigFuture() {
+        Supplier<@Nullable HarmonyConfig> configSupplier = () -> {
+            HarmonyClient localClient = client;
+            if (localClient == null) {
                 throw new IllegalStateException("Client is null");
             }
             try {
                 logger.debug("Getting config from client");
-                return client.getConfig();
+                return localClient.getConfig();
             } catch (Exception e) {
                 logger.debug("Could not get config from client", e);
                 throw e;

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
@@ -81,7 +81,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
     private static final int RETRY_TIME = 60;
     private static final int HEARTBEAT_INTERVAL = 30;
 
-    private List<HubStatusListener> listeners = new CopyOnWriteArrayList<HubStatusListener>();
+    private List<HubStatusListener> listeners = new CopyOnWriteArrayList<>();
 
     private final ExpiringCacheAsync<@Nullable HarmonyConfig> configCache = new ExpiringCacheAsync<>(CONFIG_CACHE_TIME);
     private final HarmonyHubHandlerFactory factory;
@@ -350,7 +350,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
         Collections.sort(activities, ACTIVITY_COMPERATOR);
 
         // add our activities as channel state options
-        List<StateOption> states = new LinkedList<StateOption>();
+        List<StateOption> states = new LinkedList<>();
         for (Activity activity : activities) {
             states.add(new StateOption(activity.getLabel(), activity.getLabel()));
         }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HubStatusListener.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HubStatusListener.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.harmonyhub.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 
 /**
@@ -15,8 +16,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
  * to be called back when a HarmonyHub status changes
  *
  * @author Dan Cunningham - Initial contribution
- *
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public interface HubStatusListener {
     public void hubStatusChanged(ThingStatus status);
 }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
@@ -17,7 +17,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -38,25 +42,27 @@ import org.openhab.binding.harmonyhub.internal.discovery.HarmonyDeviceDiscoveryS
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 
-import com.google.common.collect.Sets;
-
 /**
  * The {@link HarmonyHubHandlerFactory} is responsible for creating things and thing
  * handlers.
  *
  * @author Dan Cunningham - Initial contribution
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 @Component(service = { ThingHandlerFactory.class,
         ChannelTypeProvider.class }, immediate = true, configurationPid = "binding.harmonyhub")
 public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements ChannelTypeProvider {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets
-            .union(HarmonyHubHandler.SUPPORTED_THING_TYPES_UIDS, HarmonyDeviceHandler.SUPPORTED_THING_TYPES_UIDS);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .concat(HarmonyHubHandler.SUPPORTED_THING_TYPES_UIDS.stream(),
+                    HarmonyDeviceHandler.SUPPORTED_THING_TYPES_UIDS.stream())
+            .collect(Collectors.toSet());
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
-    private List<ChannelType> channelTypes = new CopyOnWriteArrayList<ChannelType>();
-    private List<ChannelGroupType> channelGroupTypes = new CopyOnWriteArrayList<ChannelGroupType>();
+    private final List<ChannelType> channelTypes = new CopyOnWriteArrayList<ChannelType>();
+    private final List<ChannelGroupType> channelGroupTypes = new CopyOnWriteArrayList<ChannelGroupType>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -64,7 +70,7 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     @Override
-    protected ThingHandler createHandler(Thing thing) {
+    protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(HarmonyHubBindingConstants.HARMONY_HUB_THING_TYPE)) {
@@ -103,12 +109,12 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     @Override
-    public Collection<ChannelType> getChannelTypes(Locale locale) {
+    public @Nullable Collection<ChannelType> getChannelTypes(@Nullable Locale locale) {
         return channelTypes;
     }
 
     @Override
-    public ChannelType getChannelType(ChannelTypeUID channelTypeUID, Locale locale) {
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
         for (ChannelType channelType : channelTypes) {
             if (channelType.getUID().equals(channelTypeUID)) {
                 return channelType;
@@ -118,7 +124,8 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     @Override
-    public ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID, Locale locale) {
+    public @Nullable ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID,
+            @Nullable Locale locale) {
         for (ChannelGroupType channelGroupType : channelGroupTypes) {
             if (channelGroupType.getUID().equals(channelGroupTypeUID)) {
                 return channelGroupType;
@@ -128,7 +135,7 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     @Override
-    public Collection<ChannelGroupType> getChannelGroupTypes(Locale locale) {
+    public @Nullable Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
         return channelGroupTypes;
     }
 

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
@@ -61,8 +61,8 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
 
     private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
-    private final List<ChannelType> channelTypes = new CopyOnWriteArrayList<ChannelType>();
-    private final List<ChannelGroupType> channelGroupTypes = new CopyOnWriteArrayList<ChannelGroupType>();
+    private final List<ChannelType> channelTypes = new CopyOnWriteArrayList<>();
+    private final List<ChannelGroupType> channelGroupTypes = new CopyOnWriteArrayList<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -104,8 +104,8 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
      */
     private synchronized void registerHarmonyDeviceDiscoveryService(HarmonyHubHandler harmonyHubHandler) {
         HarmonyDeviceDiscoveryService discoveryService = new HarmonyDeviceDiscoveryService(harmonyHubHandler);
-        this.discoveryServiceRegs.put(harmonyHubHandler.getThing().getUID(), bundleContext
-                .registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
+        this.discoveryServiceRegs.put(harmonyHubHandler.getThing().getUID(),
+                bundleContext.registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<>()));
     }
 
     @Override
@@ -148,7 +148,7 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     public void removeChannelTypesForThing(ThingUID uid) {
-        List<ChannelType> removes = new ArrayList<ChannelType>();
+        List<ChannelType> removes = new ArrayList<>();
         for (ChannelType c : channelTypes) {
             if (c.getUID().getAsString().startsWith(uid.getAsString())) {
                 removes.add(c);

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/config/HarmonyDeviceConfig.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/config/HarmonyDeviceConfig.java
@@ -8,13 +8,17 @@
  */
 package org.openhab.binding.harmonyhub.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link HarmonyDeviceConfig} class represents the configuration for a device connected to a Harmony Hub
  *
  * @author Dan Cunningham - Initial contribution
- *
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class HarmonyDeviceConfig {
     public int id;
-    public String name;
+    public @Nullable String name;
 }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/config/HarmonyHubConfig.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/config/HarmonyHubConfig.java
@@ -8,13 +8,17 @@
  */
 package org.openhab.binding.harmonyhub.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link HarmonyHubConfig} class represents the configuration of a Harmony Hub
  *
  * @author Dan Cunningham - Initial contribution
- *
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class HarmonyHubConfig {
-    public String host;
+    public @Nullable String host;
     public int heartBeatInterval;
 }

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/discovery/HarmonyDeviceDiscoveryService.java
@@ -8,14 +8,11 @@
  */
 package org.openhab.binding.harmonyhub.internal.discovery;
 
-import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.HARMONY_DEVICE_THING_TYPE;
+import static org.openhab.binding.harmonyhub.HarmonyHubBindingConstants.*;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -31,15 +28,15 @@ import net.whistlingfish.harmony.config.HarmonyConfig;
  * The {@link HarmonyDeviceDiscoveryService} class discovers Harmony Devices connected to a Harmony Hub
  *
  * @author Dan Cunningham - Initial contribution
- *
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class HarmonyDeviceDiscoveryService extends AbstractDiscoveryService implements HubStatusListener {
-
-    private Logger logger = LoggerFactory.getLogger(HarmonyDeviceDiscoveryService.class);
 
     private static final int TIMEOUT = 5;
 
-    HarmonyHubHandler bridge;
+    private final Logger logger = LoggerFactory.getLogger(HarmonyDeviceDiscoveryService.class);
+    private final HarmonyHubHandler bridge;
 
     public HarmonyDeviceDiscoveryService(HarmonyHubHandler bridge) {
         super(HarmonyHubHandler.SUPPORTED_THING_TYPES_UIDS, TIMEOUT, true);
@@ -86,24 +83,27 @@ public class HarmonyDeviceDiscoveryService extends AbstractDiscoveryService impl
         });
     }
 
-    private void addDiscoveryResults(HarmonyConfig config) {
+    private void addDiscoveryResults(@Nullable HarmonyConfig config) {
         if (config == null) {
             logger.debug("addDiscoveryResults: skipping null config");
             return;
         }
 
-        List<Device> devices = config.getDevices();
-        for (Device device : devices) {
+        for (Device device : config.getDevices()) {
             String label = device.getLabel();
             int id = device.getId();
+
             ThingUID bridgeUID = bridge.getThing().getUID();
             ThingUID thingUID = new ThingUID(HARMONY_DEVICE_THING_TYPE, bridgeUID, String.valueOf(id));
-            Map<String, Object> properties = new HashMap<>(2);
-            properties.put("id", id);
-            properties.put("name", label);
-            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                    .withBridge(bridgeUID).withLabel(label).build();
-            thingDiscovered(discoveryResult);
+
+            // @formatter:off
+            thingDiscovered(DiscoveryResultBuilder.create(thingUID)
+                    .withLabel(label)
+                    .withBridge(bridgeUID)
+                    .withProperty(DEVICE_PROPERTY_ID, id)
+                    .withProperty(DEVICE_PROPERTY_NAME, label)
+                    .build());
+            // @formatter:on
         }
     }
 }


### PR DESCRIPTION
* Annotate all classes with null annotations
* Fix buttonPress channel has no state options when only the device name is configured
* Fix buttonPress channel has no state options when Thing is updated
* Set ThingStatus to UNKNOWN in initialize to trigger updates when Things are modified
* Fix wrong label for name parameter in device configuration
* Give discovery thread a proper name which includes TCP port
* Simplify code where possible
* Remove binding dependency on google.collect, it is still in the manifest because the harmony-client has a Guava dependency
* Use Channel/Thing UIDs in logging so logging is more clear when using multiple hubs
* Update HarmonyHubBindingConstants, add/remove missing/unused properties
* Update field modifiers, add private and final where possible

---

There's a [org.openhab.binding.harmonyhub-2.4.0-SNAPSHOT.jar](http://www.maindrain.net/iot-marketplace/org.openhab.binding.harmonyhub-2.4.0-SNAPSHOT.jar) which can be used for testing this PR.

Perhaps @digitaldan and @ppieczul want to help with testing and reviewing?