### PR TITLE
[Nest] Add missing null annotations and fix warnings

### DIFF
--- a/addons/binding/org.openhab.binding.nest.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nest.test/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.nest.test
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Nest Binding Tests

--- a/addons/binding/org.openhab.binding.nest/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.nest/ESH-INF/config/config.xml
@@ -34,7 +34,6 @@
 			<description>The access token used for authenticating to the Nest API.
 			It is automatically obtained from Nest when the value is empty and 
 			a valid pincode parameter is entered</description>
-			<required>false</required>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.nest
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
@@ -121,6 +121,7 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestThingD
         }
     }
 
+    @SuppressWarnings("unchecked")
     protected <U extends Quantity<U>> QuantityType<U> commandToQuantityType(Command command, Unit<U> defaultUnit) {
         if (command instanceof QuantityType) {
             return (QuantityType<U>) command;
@@ -175,7 +176,7 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestThingD
         return value == null ? UnDefType.NULL : new StringType(value.toString());
     }
 
-    protected State getAsStringTypeListOrNull(@Nullable Collection<? extends Object> values) {
+    protected State getAsStringTypeListOrNull(@Nullable Collection<?> values) {
         return values == null || values.isEmpty() ? UnDefType.NULL : new StringType(StringUtils.join(values, ","));
     }
 

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestBridgeConfiguration.java
@@ -8,25 +8,29 @@
  */
 package org.openhab.binding.nest.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The configuration for the Nest bridge, allowing it to talk to Nest.
  *
  * @author David Bennett - Initial contribution
  */
+@NonNullByDefault
 public class NestBridgeConfiguration {
     public static final String PRODUCT_ID = "productId";
     /** Product ID from the Nest product page. */
-    public String productId;
+    public String productId = "";
 
     public static final String PRODUCT_SECRET = "productSecret";
     /** Product secret from the Nest product page. */
-    public String productSecret;
+    public String productSecret = "";
 
     public static final String PINCODE = "pincode";
     /** Product pincode from the Nest authorization page. */
-    public String pincode;
+    public @Nullable String pincode;
 
     public static final String ACCESS_TOKEN = "accessToken";
     /** The access token to use once retrieved from Nest. */
-    public String accessToken;
+    public @Nullable String accessToken;
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestDeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestDeviceConfiguration.java
@@ -8,14 +8,17 @@
  */
 package org.openhab.binding.nest.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The configuration for Nest devices.
  *
  * @author Wouter Born - Initial contribution
  * @author Wouter Born - Add device configuration to allow file based configuration
  */
+@NonNullByDefault
 public class NestDeviceConfiguration {
     public static final String DEVICE_ID = "deviceId";
     /** Device ID which can be retrieved with the Nest API. */
-    public String deviceId;
+    public String deviceId = "";
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestStructureConfiguration.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/config/NestStructureConfiguration.java
@@ -8,14 +8,17 @@
  */
 package org.openhab.binding.nest.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The configuration for structures.
  *
  * @author Wouter Born - Initial contribution
  * @author Wouter Born - Add device configuration to allow file based configuration
  */
+@NonNullByDefault
 public class NestStructureConfiguration {
     public static final String STRUCTURE_ID = "structureId";
     /** Structure ID which can be retrieved with the Nest API. */
-    public String structureId;
+    public String structureId = "";
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/discovery/NestDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/discovery/NestDiscoveryService.java
@@ -61,6 +61,7 @@ public class NestDiscoveryService extends AbstractDiscoveryService {
     private final DiscoveryDataListener<Thermostat> thermostatDiscoveryDataListener = new DiscoveryDataListener<>(
             Thermostat.class, THING_TYPE_THERMOSTAT, this::addDeviceDiscoveryResult);
 
+    @SuppressWarnings("rawtypes")
     private final List<DiscoveryDataListener> discoveryDataListeners = Stream.of(cameraDiscoveryDataListener,
             smokeDetectorDiscoveryDataListener, structureDiscoveryDataListener, thermostatDiscoveryDataListener)
             .collect(Collectors.toList());

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedResolvingNestUrlException.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedResolvingNestUrlException.java
@@ -14,6 +14,7 @@ package org.openhab.binding.nest.internal.exceptions;
  * @author Wouter Born - Initial contribution
  * @author Wouter Born - Improve exception handling while sending data
  */
+@SuppressWarnings("serial")
 public class FailedResolvingNestUrlException extends Exception {
     public FailedResolvingNestUrlException(String message) {
         super(message);

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedRetrievingNestDataException.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedRetrievingNestDataException.java
@@ -14,7 +14,9 @@ package org.openhab.binding.nest.internal.exceptions;
  * @author Martin van Wingerden - Initial contribution
  * @author Martin van Wingerden - Added more centralized handling of failure when retrieving data
  */
+@SuppressWarnings("serial")
 public class FailedRetrievingNestDataException extends Exception {
+
     public FailedRetrievingNestDataException(String message) {
         super(message);
     }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedSendingNestDataException.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/FailedSendingNestDataException.java
@@ -14,6 +14,7 @@ package org.openhab.binding.nest.internal.exceptions;
  * @author Wouter Born - Initial contribution
  * @author Wouter Born - Improve exception handling while sending data
  */
+@SuppressWarnings("serial")
 public class FailedSendingNestDataException extends Exception {
     public FailedSendingNestDataException(String message) {
         super(message);

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/InvalidAccessTokenException.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/exceptions/InvalidAccessTokenException.java
@@ -14,6 +14,7 @@ package org.openhab.binding.nest.internal.exceptions;
  * @author Martin van Wingerden - Initial contribution
  * @author Martin van Wingerden - Added more centralized handling of invalid access tokens
  */
+@SuppressWarnings("serial")
 public class InvalidAccessTokenException extends Exception {
     public InvalidAccessTokenException(Exception cause) {
         super(cause);


### PR DESCRIPTION
Add missing null annotation to all binding packages except for `org.openhab.binding.nest.internal.data`.

I don't know if it is a good idea to also add null annotations to the Gson data classes. Currently the binding is very defensive and assumes everything could be null in these data classes. There are also unit tests to test it can handle all null values. Data could be null due to lack of API permissions or deprecated properties that may get removed some day.

So you might want to annotate all methods/fields with `@Nullable` but that seems quite laborious. There doesn't seem to be a `@NullByDefault` annotation for such classes. Also annotating the whole class with `@Nullable` doesn't work. 

@maggu2810 would it make sense to add null annotations to such data classes and if so how?