### PR TITLE
[Plugwise] Add null annotations and fix warnings

### DIFF
--- a/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.plugwise
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/AbstractSleepingEndDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/AbstractSleepingEndDeviceHandler.java
@@ -13,6 +13,7 @@ import static org.openhab.binding.plugwise.PlugwiseBindingConstants.CHANNEL_TRIG
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.plugwise.internal.protocol.AcknowledgementMessage;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractSleepingEndDeviceHandler extends AbstractPlugwiseThingHandler {
 
     private static final int SED_PROPERTIES_COUNT = 3;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseRelayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseRelayDeviceHandler.java
@@ -16,16 +16,20 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.plugwise.internal.PlugwiseDeviceTask;
 import org.openhab.binding.plugwise.internal.PlugwiseUtils;
 import org.openhab.binding.plugwise.internal.config.PlugwiseRelayConfig;
@@ -77,9 +81,9 @@ import com.google.common.collect.Lists;
  * A Stealth behaves like a Circle but it has a more compact form factor.
  * </p>
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
 
     private static final int INVALID_WATT_THRESHOLD = 10000;
@@ -217,15 +221,16 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
             energyUpdateTask, informationUpdateTask, realTimeClockUpdateTask, setClockTask);
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseRelayDeviceHandler.class);
+    private final DeviceType deviceType;
 
-    private PlugwiseRelayConfig configuration;
-    private DeviceType deviceType;
-    private MACAddress macAddress;
-
-    private PowerCalibration calibration;
-    private Energy energy;
     private int recentLogAddress = -1;
-    private PendingPowerStateChange pendingPowerStateChange;
+
+    private @NonNullByDefault({}) PlugwiseRelayConfig configuration;
+    private @NonNullByDefault({}) MACAddress macAddress;
+
+    private @Nullable PowerCalibration calibration;
+    private @Nullable Energy energy;
+    private @Nullable PendingPowerStateChange pendingPowerStateChange;
 
     // Flag that keeps track of the pending "measurement interval" device configuration update. When the corresponding
     // Thing configuration parameter changes it is set to true. When the Circle/Stealth goes online a command is sent to
@@ -364,20 +369,21 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
         recentLogAddress = message.getLogAddress();
         OnOffType powerState = message.getPowerState() ? OnOffType.ON : OnOffType.OFF;
 
-        if (pendingPowerStateChange != null) {
-            if (powerState == pendingPowerStateChange.onOff) {
+        PendingPowerStateChange change = pendingPowerStateChange;
+        if (change != null) {
+            if (powerState == change.onOff) {
                 pendingPowerStateChange = null;
             } else {
                 // Power state change message may be lost or the informationUpdateTask may have queried the power
                 // state just before the power state change message arrived
-                if (pendingPowerStateChange.retries < POWER_STATE_RETRIES) {
-                    pendingPowerStateChange.retries++;
-                    logger.warn("Retrying to switch {} ({}) {} (retry #{})", deviceType, macAddress,
-                            pendingPowerStateChange.onOff, pendingPowerStateChange.retries);
-                    handleOnOffCommand(pendingPowerStateChange.onOff);
+                if (change.retries < POWER_STATE_RETRIES) {
+                    change.retries++;
+                    logger.warn("Retrying to switch {} ({}) {} (retry #{})", deviceType, macAddress, change.onOff,
+                            change.retries);
+                    handleOnOffCommand(change.onOff);
                 } else {
-                    logger.warn("Failed to switch {} ({}) {} after {} retries", deviceType, macAddress,
-                            pendingPowerStateChange.onOff, pendingPowerStateChange.retries);
+                    logger.warn("Failed to switch {} ({}) {} after {} retries", deviceType, macAddress, change.onOff,
+                            change.retries);
                     pendingPowerStateChange = null;
                 }
             }
@@ -405,7 +411,8 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
     }
 
     private void handlePowerBufferResponse(PowerBufferResponseMessage message) {
-        if (!isCalibrated()) {
+        PowerCalibration localCalibration = calibration;
+        if (localCalibration == null) {
             calibrate();
             return;
         }
@@ -419,12 +426,14 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
 
             boolean isLastInterval = mostRecentEnergy.getEnd().isAfter(oneIntervalAgo);
             if (isLastInterval) {
+                mostRecentEnergy.setInterval(configuration.getMeasurementInterval());
                 energy = mostRecentEnergy;
-                energy.setInterval(configuration.getMeasurementInterval());
                 logger.trace("Updating {} ({}) energy with: {}", deviceType, macAddress, mostRecentEnergy);
-                updateState(CHANNEL_ENERGY,
-                        new QuantityType<>(correctSign(energy.tokWh(calibration)), SmartHomeUnits.KILOWATT_HOUR));
-                updateState(CHANNEL_ENERGY_STAMP, PlugwiseUtils.newDateTimeType(energy.getStart()));
+                updateState(CHANNEL_ENERGY, new QuantityType<>(correctSign(mostRecentEnergy.tokWh(localCalibration)),
+                        SmartHomeUnits.KILOWATT_HOUR));
+                LocalDateTime start = mostRecentEnergy.getStart();
+                updateState(CHANNEL_ENERGY_STAMP,
+                        start != null ? PlugwiseUtils.newDateTimeType(start) : UnDefType.NULL);
             } else {
                 logger.trace("Most recent energy in buffer of {} ({}) is older than one interval ago: {}", deviceType,
                         macAddress, mostRecentEnergy);
@@ -435,13 +444,14 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
     }
 
     private void handlePowerInformationResponse(PowerInformationResponseMessage message) {
-        if (!isCalibrated()) {
+        PowerCalibration localCalibration = calibration;
+        if (localCalibration == null) {
             calibrate();
             return;
         }
 
         Energy one = message.getOneSecond();
-        double watt = one.toWatt(calibration);
+        double watt = one.toWatt(localCalibration);
         if (watt > INVALID_WATT_THRESHOLD) {
             logger.debug("{} ({}) is in a kind of error state, skipping power information response", deviceType,
                     macAddress);
@@ -532,7 +542,8 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
         super.sendConfigurationUpdateCommands();
     }
 
-    private void setUpdateCommandFlags(PlugwiseRelayConfig oldConfiguration, PlugwiseRelayConfig newConfiguration) {
+    private void setUpdateCommandFlags(@Nullable PlugwiseRelayConfig oldConfiguration,
+            PlugwiseRelayConfig newConfiguration) {
         boolean fullUpdate = newConfiguration.isUpdateConfiguration() && !isConfigurationPending();
         if (fullUpdate) {
             logger.debug("Updating all configuration properties of {} ({})", deviceType, macAddress);
@@ -547,7 +558,8 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
 
     @Override
     protected boolean shouldOnlineTaskBeScheduled() {
-        return !configuration.isTemporarilyNotInNetwork() && (getBridge().getStatus() == ONLINE);
+        Bridge bridge = getBridge();
+        return !configuration.isTemporarilyNotInNetwork() && (bridge != null && bridge.getStatus() == ONLINE);
     }
 
     @Override
@@ -572,7 +584,7 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
     };
 
     @Override
-    protected void updateStatus(ThingStatus status, ThingStatusDetail statusDetail, String description) {
+    protected void updateStatus(ThingStatus status, ThingStatusDetail statusDetail, @Nullable String description) {
         super.updateStatus(status, statusDetail, description);
 
         if (status == ONLINE) {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseScanHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseScanHandler.java
@@ -12,6 +12,8 @@ import static org.openhab.binding.plugwise.PlugwiseBindingConstants.*;
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.plugwise.internal.config.PlugwiseScanConfig;
@@ -36,13 +38,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseScanHandler extends AbstractSleepingEndDeviceHandler {
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseScanHandler.class);
+    private final DeviceType deviceType = DeviceType.SCAN;
 
-    private PlugwiseScanConfig configuration;
-    private DeviceType deviceType = DeviceType.SCAN;
-    private MACAddress macAddress;
+    private @NonNullByDefault({}) PlugwiseScanConfig configuration;
+    private @NonNullByDefault({}) MACAddress macAddress;
 
     // Flags that keep track of the pending Scan configuration updates. When the corresponding Thing configuration
     // parameters change a flag is set to true. When the Scan goes online the respective command is sent to update the
@@ -141,7 +144,8 @@ public class PlugwiseScanHandler extends AbstractSleepingEndDeviceHandler {
         super.sendConfigurationUpdateCommands();
     }
 
-    private void setUpdateCommandFlags(PlugwiseScanConfig oldConfiguration, PlugwiseScanConfig newConfiguration) {
+    private void setUpdateCommandFlags(@Nullable PlugwiseScanConfig oldConfiguration,
+            PlugwiseScanConfig newConfiguration) {
         boolean fullUpdate = newConfiguration.isUpdateConfiguration() && !isConfigurationPending();
         if (fullUpdate) {
             logger.debug("Updating all configuration properties of {} ({})", deviceType, macAddress);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseSenseHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseSenseHandler.java
@@ -12,6 +12,8 @@ import static org.openhab.binding.plugwise.PlugwiseBindingConstants.*;
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
@@ -41,13 +43,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseSenseHandler extends AbstractSleepingEndDeviceHandler {
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseSenseHandler.class);
+    private final DeviceType deviceType = DeviceType.SENSE;
 
-    private PlugwiseSenseConfig configuration;
-    private DeviceType deviceType = DeviceType.SENSE;
-    private MACAddress macAddress;
+    private @NonNullByDefault({}) PlugwiseSenseConfig configuration;
+    private @NonNullByDefault({}) MACAddress macAddress;
 
     // Flags that keep track of the pending Sense configuration updates. When the corresponding Thing configuration
     // parameters change a flag is set to true. When the Sense goes online the respective command is sent to update the
@@ -174,7 +177,8 @@ public class PlugwiseSenseHandler extends AbstractSleepingEndDeviceHandler {
         super.sendConfigurationUpdateCommands();
     }
 
-    private void setUpdateCommandFlags(PlugwiseSenseConfig oldConfiguration, PlugwiseSenseConfig newConfiguration) {
+    private void setUpdateCommandFlags(@Nullable PlugwiseSenseConfig oldConfiguration,
+            PlugwiseSenseConfig newConfiguration) {
         boolean fullUpdate = newConfiguration.isUpdateConfiguration() && !isConfigurationPending();
         if (fullUpdate) {
             logger.debug("Updating all configuration properties of {} ({})", deviceType, macAddress);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseStickHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseStickHandler.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -52,9 +54,9 @@ import org.slf4j.LoggerFactory;
  * Plugwise ZigBee mesh network.
  * </p>
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseMessageListener {
 
     private final PlugwiseDeviceTask onlineStateUpdateTask = new PlugwiseDeviceTask("Online state update", scheduler) {
@@ -75,13 +77,13 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     };
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseStickHandler.class);
-
     private final PlugwiseCommunicationHandler communicationHandler = new PlugwiseCommunicationHandler();
-    private PlugwiseStickConfig configuration;
-    private List<PlugwiseStickStatusListener> statusListeners = new CopyOnWriteArrayList<>();
+    private final List<PlugwiseStickStatusListener> statusListeners = new CopyOnWriteArrayList<>();
 
-    private MACAddress circlePlusMAC;
-    private MACAddress stickMAC;
+    private @NonNullByDefault({}) PlugwiseStickConfig configuration;
+
+    private @Nullable MACAddress circlePlusMAC;
+    private @Nullable MACAddress stickMAC;
 
     public PlugwiseStickHandler(Bridge bridge) {
         super(bridge);
@@ -107,11 +109,11 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
         onlineStateUpdateTask.stop();
     }
 
-    public MACAddress getCirclePlusMAC() {
+    public @Nullable MACAddress getCirclePlusMAC() {
         return circlePlusMAC;
     }
 
-    public MACAddress getStickMAC() {
+    public @Nullable MACAddress getStickMAC() {
         return stickMAC;
     }
 
@@ -217,7 +219,7 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     }
 
     @Override
-    protected void updateStatus(ThingStatus status, ThingStatusDetail detail, String comment) {
+    protected void updateStatus(ThingStatus status, ThingStatusDetail detail, @Nullable String comment) {
         ThingStatus oldStatus = thing.getStatus();
         super.updateStatus(status, detail, comment);
         ThingStatus newStatus = thing.getStatus();

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseSwitchHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/handler/PlugwiseSwitchHandler.java
@@ -12,6 +12,8 @@ import static org.openhab.binding.plugwise.PlugwiseBindingConstants.*;
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -36,13 +38,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseSwitchHandler extends AbstractSleepingEndDeviceHandler {
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseSwitchHandler.class);
+    private final DeviceType deviceType = DeviceType.SWITCH;
 
-    private PlugwiseSwitchConfig configuration;
-    private DeviceType deviceType = DeviceType.SWITCH;
-    private MACAddress macAddress;
+    private @NonNullByDefault({}) PlugwiseSwitchConfig configuration;
+    private @NonNullByDefault({}) MACAddress macAddress;
 
     // Flag that keeps track of the pending "sleep parameters" Switch configuration update. When the corresponding
     // Thing configuration parameters change it is set to true. When the Switch goes online a command is sent to
@@ -120,7 +123,8 @@ public class PlugwiseSwitchHandler extends AbstractSleepingEndDeviceHandler {
         super.sendConfigurationUpdateCommands();
     }
 
-    private void setUpdateCommandFlags(PlugwiseSwitchConfig oldConfiguration, PlugwiseSwitchConfig newConfiguration) {
+    private void setUpdateCommandFlags(@Nullable PlugwiseSwitchConfig oldConfiguration,
+            PlugwiseSwitchConfig newConfiguration) {
         boolean fullUpdate = newConfiguration.isUpdateConfiguration() && !isConfigurationPending();
         if (fullUpdate) {
             logger.debug("Updating all configuration properties of {} ({})", deviceType, macAddress);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
@@ -10,6 +10,7 @@ package org.openhab.binding.plugwise.internal;
 
 import java.io.IOException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.config.PlugwiseStickConfig;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
 import org.openhab.binding.plugwise.internal.protocol.Message;
@@ -18,9 +19,9 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 /**
  * The {@link PlugwiseCommunicationHandler} handles all serial communication with the Plugwise Stick.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseCommunicationHandler {
 
     private final PlugwiseCommunicationContext context = new PlugwiseCommunicationContext();

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceTask.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceTask.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.plugwise.internal.protocol.field.DeviceType;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 import org.slf4j.Logger;
@@ -24,6 +26,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public abstract class PlugwiseDeviceTask {
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseDeviceTask.class);
@@ -32,11 +35,11 @@ public abstract class PlugwiseDeviceTask {
     private final String name;
     private final ScheduledExecutorService scheduler;
 
-    private DeviceType deviceType;
-    private Duration interval;
-    private MACAddress macAddress;
+    private @Nullable DeviceType deviceType;
+    private @Nullable Duration interval;
+    private @Nullable MACAddress macAddress;
 
-    private ScheduledFuture<?> future;
+    private @Nullable ScheduledFuture<?> future;
 
     private Runnable scheduledRunnable = new Runnable() {
         @Override
@@ -60,7 +63,7 @@ public abstract class PlugwiseDeviceTask {
 
     public abstract Duration getConfiguredInterval();
 
-    public Duration getInterval() {
+    public @Nullable Duration getInterval() {
         return interval;
     }
 
@@ -80,11 +83,12 @@ public abstract class PlugwiseDeviceTask {
         try {
             lock.lock();
             if (!isScheduled()) {
-                interval = getConfiguredInterval();
-                future = scheduler.scheduleWithFixedDelay(scheduledRunnable, 0, interval.getSeconds(),
+                Duration configuredInterval = getConfiguredInterval();
+                future = scheduler.scheduleWithFixedDelay(scheduledRunnable, 0, configuredInterval.getSeconds(),
                         TimeUnit.SECONDS);
+                interval = configuredInterval;
                 logger.debug("Scheduled '{}' Plugwise task for {} ({}) with {} seconds interval", name, deviceType,
-                        macAddress, interval.getSeconds());
+                        macAddress, configuredInterval.getSeconds());
             }
         } finally {
             lock.unlock();
@@ -95,7 +99,10 @@ public abstract class PlugwiseDeviceTask {
         try {
             lock.lock();
             if (isScheduled()) {
-                future.cancel(true);
+                ScheduledFuture<?> localFuture = future;
+                if (localFuture != null) {
+                    localFuture.cancel(true);
+                }
                 future = null;
                 logger.debug("Stopped '{}' Plugwise task for {} ({})", name, deviceType, macAddress);
             }
@@ -104,7 +111,7 @@ public abstract class PlugwiseDeviceTask {
         }
     }
 
-    public void update(DeviceType deviceType, MACAddress macAddress) {
+    public void update(DeviceType deviceType, @Nullable MACAddress macAddress) {
         this.deviceType = deviceType;
         this.macAddress = macAddress;
     }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseFilteredMessageListener.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseFilteredMessageListener.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.plugwise.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
 import org.openhab.binding.plugwise.internal.protocol.Message;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
@@ -17,16 +19,17 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseFilteredMessageListener {
 
     private final PlugwiseMessageListener listener;
-    private final MACAddress macAddress;
+    private final @Nullable MACAddress macAddress;
 
     public PlugwiseFilteredMessageListener(PlugwiseMessageListener listener) {
         this(listener, null);
     }
 
-    public PlugwiseFilteredMessageListener(PlugwiseMessageListener listener, MACAddress macAddress) {
+    public PlugwiseFilteredMessageListener(PlugwiseMessageListener listener, @Nullable MACAddress macAddress) {
         this.listener = listener;
         this.macAddress = macAddress;
     }
@@ -35,11 +38,12 @@ public class PlugwiseFilteredMessageListener {
         return listener;
     }
 
-    public MACAddress getMACAddress() {
+    public @Nullable MACAddress getMACAddress() {
         return macAddress;
     }
 
     public boolean matches(Message message) {
-        return macAddress == null || macAddress.equals(message.getMACAddress());
+        MACAddress localMACAddress = macAddress;
+        return localMACAddress == null || localMACAddress.equals(message.getMACAddress());
     }
 }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseFilteredMessageListenerList.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseFilteredMessageListenerList.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
 import org.openhab.binding.plugwise.internal.protocol.Message;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
@@ -24,6 +25,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseFilteredMessageListenerList {
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseFilteredMessageListenerList.class);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -35,18 +37,19 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.plugwise")
 public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
-
     @Override
-    protected ThingHandler createHandler(Thing thing) {
+    protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_STICK)) {
@@ -76,16 +79,13 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected void removeHandler(ThingHandler thingHandler) {
-        if (discoveryServiceRegistrations != null) {
-            ServiceRegistration<?> registration = this.discoveryServiceRegistrations
-                    .get(thingHandler.getThing().getUID());
-            if (registration != null) {
-                PlugwiseThingDiscoveryService discoveryService = (PlugwiseThingDiscoveryService) bundleContext
-                        .getService(registration.getReference());
-                discoveryService.deactivate();
-                registration.unregister();
-                discoveryServiceRegistrations.remove(thingHandler.getThing().getUID());
-            }
+        ServiceRegistration<?> registration = this.discoveryServiceRegistrations.get(thingHandler.getThing().getUID());
+        if (registration != null) {
+            PlugwiseThingDiscoveryService discoveryService = (PlugwiseThingDiscoveryService) bundleContext
+                    .getService(registration.getReference());
+            discoveryService.deactivate();
+            registration.unregister();
+            discoveryServiceRegistrations.remove(thingHandler.getThing().getUID());
         }
     }
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseInitializationException.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseInitializationException.java
@@ -8,12 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Exception used during Stick initialization.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseInitializationException extends Exception {
 
     private static final long serialVersionUID = 2095258016390913221L;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessagePriority.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessagePriority.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * When there are multiple queued messages, the message priority and date/time determine which message is sent first.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public enum PlugwiseMessagePriority {
 
     /**

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseQueuedMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseQueuedMessage.java
@@ -10,6 +10,7 @@ package org.openhab.binding.plugwise.internal;
 
 import java.time.LocalDateTime;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.Message;
 
 /**
@@ -17,6 +18,7 @@ import org.openhab.binding.plugwise.internal.protocol.Message;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseQueuedMessage {
 
     private final PlugwiseMessagePriority priority;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
@@ -49,9 +51,9 @@ import com.google.common.collect.Sets;
  * Sleeping end devices are discovered when they announce being awake with a {@link AnnounceAwakeRequestMessage}. To
  * reduce network traffic {@link InformationRequestMessage}s are only sent to undiscovered devices.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
         implements ExtendedDiscoveryService, PlugwiseMessageListener, PlugwiseStickStatusListener {
 
@@ -63,10 +65,9 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     }
 
     private static class DiscoveredNode {
-
-        private MACAddress macAddress;
+        private final MACAddress macAddress;
+        private final Map<String, String> properties = new HashMap<>();
         private DeviceType deviceType = DeviceType.UNKNOWN;
-        private Map<String, String> properties = new HashMap<>();
         private int attempts;
         private long lastRequestMillis;
 
@@ -75,9 +76,8 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
         }
 
         public boolean isDataComplete() {
-            return macAddress != null && deviceType != DeviceType.UNKNOWN && !properties.isEmpty();
+            return deviceType != DeviceType.UNKNOWN && !properties.isEmpty();
         }
-
     }
 
     private static final Set<ThingTypeUID> DISCOVERED_THING_TYPES_UIDS = Sets.difference(SUPPORTED_THING_TYPES_UIDS,
@@ -94,14 +94,14 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseThingDiscoveryService.class);
 
-    private PlugwiseStickHandler stickHandler;
-    private DiscoveryServiceCallback discoveryServiceCallback;
+    private final PlugwiseStickHandler stickHandler;
+    private @Nullable DiscoveryServiceCallback discoveryServiceCallback;
 
-    private ScheduledFuture<?> discoveryJob;
-    private ScheduledFuture<?> watchJob;
+    private @Nullable ScheduledFuture<?> discoveryJob;
+    private @Nullable ScheduledFuture<?> watchJob;
     private CurrentRoleCall currentRoleCall = new CurrentRoleCall();
 
-    private Map<MACAddress, DiscoveredNode> discoveredNodes = new ConcurrentHashMap<>();
+    private final Map<MACAddress, @Nullable DiscoveredNode> discoveredNodes = new ConcurrentHashMap<>();
 
     public PlugwiseThingDiscoveryService(PlugwiseStickHandler stickHandler) throws IllegalArgumentException {
         super(DISCOVERED_THING_TYPES_UIDS, 1, true);
@@ -150,9 +150,10 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     }
 
     protected void discoverNodes() {
+        MACAddress circlePlusMAC = getCirclePlusMAC();
         if (getStickStatus() != ThingStatus.ONLINE) {
             logger.debug("Discovery with role call not possible (Stick status is {})", getStickStatus());
-        } else if (getCirclePlusMAC() == null) {
+        } else if (circlePlusMAC == null) {
             logger.debug("Discovery with role call not possible (Circle+ MAC address is null)");
         } else if (currentRoleCall.isRoleCalling) {
             logger.debug("Discovery with role call not possible (already role calling)");
@@ -162,20 +163,20 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
             currentRoleCall.isRoleCalling = true;
             currentRoleCall.currentNodeID = Integer.MIN_VALUE;
 
-            discoverNewNodeDetails(getCirclePlusMAC());
+            discoverNewNodeDetails(circlePlusMAC);
 
-            logger.debug("Discovering nodes with role call on Circle+ ({})", getCirclePlusMAC());
+            logger.debug("Discovering nodes with role call on Circle+ ({})", circlePlusMAC);
             roleCall(MIN_NODE_ID);
             startDiscoveryWatchJob();
         }
     }
 
-    private MACAddress getCirclePlusMAC() {
-        return stickHandler != null ? stickHandler.getCirclePlusMAC() : null;
+    private @Nullable MACAddress getCirclePlusMAC() {
+        return stickHandler.getCirclePlusMAC();
     }
 
     private ThingStatus getStickStatus() {
-        return stickHandler != null ? stickHandler.getThing().getStatus() : ThingStatus.UNKNOWN;
+        return stickHandler.getThing().getStatus();
     }
 
     private void handleAnnounceAwakeRequest(AnnounceAwakeRequestMessage message) {
@@ -238,15 +239,16 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     }
 
     private boolean isAlreadyDiscovered(MACAddress macAddress) {
+        DiscoveryServiceCallback callback = discoveryServiceCallback;
         for (ThingTypeUID thingTypeUID : DISCOVERED_THING_TYPES_UIDS) {
             ThingUID thingUID = new ThingUID(thingTypeUID, macAddress.toString());
-            if (discoveryServiceCallback == null) {
+            if (callback == null) {
                 logger.debug("Assuming Node ({}) has not yet been discovered (callback null)", macAddress);
                 return false;
-            } else if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
+            } else if (callback.getExistingDiscoveryResult(thingUID) != null) {
                 logger.debug("Node ({}) has existing discovery result: {}", macAddress, thingUID);
                 return true;
-            } else if (discoveryServiceCallback.getExistingThing(thingUID) != null) {
+            } else if (callback.getExistingThing(thingUID) != null) {
                 logger.debug("Node ({}) has existing thing: {}", macAddress, thingUID);
                 return true;
             }
@@ -295,7 +297,8 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
             discoverNodes();
         };
 
-        if (discoveryJob == null || discoveryJob.isCancelled()) {
+        ScheduledFuture<?> localDiscoveryJob = discoveryJob;
+        if (localDiscoveryJob == null || localDiscoveryJob.isCancelled()) {
             discoveryJob = scheduler.scheduleWithFixedDelay(discoveryRunnable, 0, DISCOVERY_INTERVAL, TimeUnit.SECONDS);
         }
     }
@@ -317,16 +320,16 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
                 }
             }
 
-            Iterator<Entry<MACAddress, DiscoveredNode>> it = discoveredNodes.entrySet().iterator();
+            Iterator<Entry<MACAddress, @Nullable DiscoveredNode>> it = discoveredNodes.entrySet().iterator();
             while (it.hasNext()) {
-                Entry<MACAddress, DiscoveredNode> entry = it.next();
+                Entry<MACAddress, @Nullable DiscoveredNode> entry = it.next();
                 DiscoveredNode node = entry.getValue();
-                if ((System.currentTimeMillis() - node.lastRequestMillis) > (MESSAGE_TIMEOUT * 1000)
+                if (node != null && (System.currentTimeMillis() - node.lastRequestMillis) > (MESSAGE_TIMEOUT * 1000)
                         && node.attempts < MESSAGE_RETRY_ATTEMPTS) {
                     logger.debug("Resending timed out information request message to node ({})", node.macAddress);
                     updateInformation(node.macAddress);
                     node.attempts++;
-                } else if (node.attempts >= MESSAGE_RETRY_ATTEMPTS) {
+                } else if (node != null && node.attempts >= MESSAGE_RETRY_ATTEMPTS) {
                     logger.debug("Giving up on information request for node ({})", node.macAddress);
                     it.remove();
                 }
@@ -338,7 +341,8 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
             }
         };
 
-        if (watchJob == null || watchJob.isCancelled()) {
+        ScheduledFuture<?> localWatchJob = watchJob;
+        if (localWatchJob == null || localWatchJob.isCancelled()) {
             watchJob = scheduler.scheduleWithFixedDelay(watchRunnable, WATCH_INTERVAL, WATCH_INTERVAL,
                     TimeUnit.SECONDS);
         }
@@ -361,8 +365,9 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     @Override
     protected void stopBackgroundDiscovery() {
         logger.debug("Stopping Plugwise device background discovery");
-        if (discoveryJob != null && !discoveryJob.isCancelled()) {
-            discoveryJob.cancel(true);
+        ScheduledFuture<?> localDiscoveryJob = discoveryJob;
+        if (localDiscoveryJob != null && !localDiscoveryJob.isCancelled()) {
+            localDiscoveryJob.cancel(true);
             discoveryJob = null;
         }
         stopDiscoveryWatchJob();
@@ -370,8 +375,9 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
 
     private void stopDiscoveryWatchJob() {
         logger.debug("Stopping Plugwise discovery watch job");
-        if (watchJob != null && !watchJob.isCancelled()) {
-            watchJob.cancel(true);
+        ScheduledFuture<?> localWatchJob = watchJob;
+        if (localWatchJob != null && !localWatchJob.isCancelled()) {
+            localWatchJob.cancel(true);
             watchJob = null;
         }
     }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseUtils.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseUtils.java
@@ -17,6 +17,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.GregorianCalendar;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -29,6 +31,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.DeviceType;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public final class PlugwiseUtils {
 
     private PlugwiseUtils() {
@@ -53,7 +56,7 @@ public final class PlugwiseUtils {
         }
     }
 
-    public static ThingTypeUID getThingTypeUID(DeviceType deviceType) {
+    public static @Nullable ThingTypeUID getThingTypeUID(DeviceType deviceType) {
         if (deviceType == CIRCLE) {
             return THING_TYPE_CIRCLE;
         } else if (deviceType == CIRCLE_PLUS) {
@@ -79,7 +82,7 @@ public final class PlugwiseUtils {
         return new DateTimeType(GregorianCalendar.from(localDateTime.atZone(ZoneId.systemDefault())));
     }
 
-    public static void stopBackgroundThread(Thread thread) {
+    public static void stopBackgroundThread(@Nullable Thread thread) {
         if (thread != null) {
             thread.interrupt();
             try {
@@ -90,6 +93,7 @@ public final class PlugwiseUtils {
         }
     }
 
+    @SuppressWarnings("null")
     public static boolean updateProperties(Map<String, String> properties, InformationResponseMessage message) {
         boolean update = false;
 
@@ -129,5 +133,4 @@ public final class PlugwiseUtils {
 
         return update;
     }
-
 }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseRelayConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseRelayConfig.java
@@ -13,6 +13,7 @@ import static org.openhab.binding.plugwise.internal.config.PlugwiseRelayConfig.P
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseRelayConfig {
 
     public enum PowerStateChanging {
@@ -29,7 +31,7 @@ public class PlugwiseRelayConfig {
         ALWAYS_OFF;
     }
 
-    private String macAddress;
+    private String macAddress = "";
     private String powerStateChanging = UPPER_UNDERSCORE.to(LOWER_CAMEL, COMMAND_SWITCHING.name());
     private boolean suppliesPower = false;
     private int measurementInterval = 60; // minutes

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseScanConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseScanConfig.java
@@ -13,6 +13,7 @@ import static org.openhab.binding.plugwise.internal.protocol.field.Sensitivity.M
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 import org.openhab.binding.plugwise.internal.protocol.field.Sensitivity;
 
@@ -21,9 +22,10 @@ import org.openhab.binding.plugwise.internal.protocol.field.Sensitivity;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseScanConfig {
 
-    private String macAddress;
+    private String macAddress = "";
     private String sensitivity = UPPER_UNDERSCORE.to(LOWER_CAMEL, MEDIUM.name());
     private int switchOffDelay = 5; // minutes
     private boolean daylightOverride = false;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSenseConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSenseConfig.java
@@ -14,6 +14,7 @@ import static org.openhab.binding.plugwise.internal.protocol.field.BoundaryType.
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.field.BoundaryAction;
 import org.openhab.binding.plugwise.internal.protocol.field.BoundaryType;
 import org.openhab.binding.plugwise.internal.protocol.field.Humidity;
@@ -25,9 +26,10 @@ import org.openhab.binding.plugwise.internal.protocol.field.Temperature;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseSenseConfig {
 
-    private String macAddress;
+    private String macAddress = "";
     private int measurementInterval = 15; // minutes
     private String boundaryType = UPPER_UNDERSCORE.to(LOWER_CAMEL, NONE.name());
     private String boundaryAction = UPPER_UNDERSCORE.to(LOWER_CAMEL, OFF_BELOW_ON_ABOVE.name());

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseStickConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseStickConfig.java
@@ -8,14 +8,17 @@
  */
 package org.openhab.binding.plugwise.internal.config;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link PlugwiseStickConfig} class represents the configuration for a Plugwise Stick.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseStickConfig {
 
-    private String serialPort;
+    private String serialPort = "";
     private int messageWaitTime = 150; // milliseconds
 
     public String getSerialPort() {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSwitchConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSwitchConfig.java
@@ -10,6 +10,7 @@ package org.openhab.binding.plugwise.internal.config;
 
 import java.time.Duration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 
 /**
@@ -17,9 +18,10 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PlugwiseSwitchConfig {
 
-    private String macAddress;
+    private String macAddress = "";
     private int wakeupInterval = 1440; // minutes (1 day)
     private int wakeupDuration = 10; // seconds
     private boolean updateConfiguration = true;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/listener/PlugwiseMessageListener.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/listener/PlugwiseMessageListener.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.plugwise.internal.listener;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.Message;
 
 /**
@@ -15,6 +16,7 @@ import org.openhab.binding.plugwise.internal.protocol.Message;
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public interface PlugwiseMessageListener {
 
     void handleReponseMessage(Message message);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/listener/PlugwiseStickStatusListener.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/listener/PlugwiseStickStatusListener.java
@@ -8,14 +8,16 @@
  */
 package org.openhab.binding.plugwise.internal.listener;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.openhab.binding.plugwise.handler.PlugwiseStickHandler;
 
 /**
  * Interface for listeners of {@link PlugwiseStickHandler} thing status changes.
  *
- * @author Wouter Born- Initial contribution
+ * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public interface PlugwiseStickStatusListener {
 
     public void stickStatusChanged(ThingStatus status);

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/AcknowledgementMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/AcknowledgementMessage.java
@@ -23,8 +23,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MessageType;
  * message sent to the Stick by the host, as well as confirmation messages from nodes in the network for various
  * purposes. Not all purposes are yet reverse-engineered.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class AcknowledgementMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockGetRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockGetRequestMessage.java
@@ -16,8 +16,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Requests the current clock value of a device. This message is answered by a {@link ClockGetResponseMessage} which
  * contains the clock value.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class ClockGetRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockGetResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockGetResponseMessage.java
@@ -23,8 +23,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Contains the current clock value of a device. This message is the response of a {@link ClockGetRequestMessage}. Not
  * all response fields have been reverse engineered.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class ClockGetResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockSetRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/ClockSetRequestMessage.java
@@ -21,8 +21,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Sets the clock of the Circle+. Based on what is known about the Plugwise protocol, only the clock of the Circle+ has
  * to be set. The Circle+ sets the clock of all other network nodes.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class ClockSetRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/InformationRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/InformationRequestMessage.java
@@ -16,8 +16,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Requests generic device information. This message is answered by an {@link InformationResponseMessage} which contains
  * the device information.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class InformationRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/InformationResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/InformationResponseMessage.java
@@ -22,8 +22,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 /**
  * Contains generic device information. This message is the response of an {@link InformationRequestMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class InformationResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/Message.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/Message.java
@@ -28,8 +28,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MessageType;
  * Before sending off a message in the Plugwise network they are prepended with a protocol header and trailer is
  * added at the end.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public abstract class Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/MessageFactory.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/MessageFactory.java
@@ -8,14 +8,15 @@
  */
 package org.openhab.binding.plugwise.internal.protocol;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.plugwise.internal.protocol.field.MessageType;
 
 /**
  * Creates instances of messages received from the Plugwise network.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class MessageFactory {
 
     public Message createMessage(MessageType messageType, int sequenceNumber, String payload)

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkResetRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkResetRequestMessage.java
@@ -13,8 +13,7 @@ import static org.openhab.binding.plugwise.internal.protocol.field.MessageType.N
 /**
  * Requests the Plugwise network to be reset. Currently not used in the binding.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class NetworkResetRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkStatusRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkStatusRequestMessage.java
@@ -13,8 +13,7 @@ import static org.openhab.binding.plugwise.internal.protocol.field.MessageType.N
 /**
  * Requests the network status from the Stick. This message is answered by a {@link NetworkStatusResponseMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class NetworkStatusRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkStatusResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NetworkStatusResponseMessage.java
@@ -19,8 +19,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Contains the current network status as well as the MAC address of the Circle+ that coordinates the network. The Stick
  * sends this message as response of a {@link NetworkStatusRequestMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class NetworkStatusResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NodeAvailableMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NodeAvailableMessage.java
@@ -19,8 +19,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Node available messages are broadcasted by nodes that are not yet part of a network. They are currently unused
  * because typically the network is configured using the Plugwise Source software, and never changed after.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class NodeAvailableMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NodeAvailableResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/NodeAvailableResponseMessage.java
@@ -13,8 +13,7 @@ import static org.openhab.binding.plugwise.internal.protocol.field.MessageType.N
 /**
  * Response to a device when its {@link NodeAvailableMessage} is "accepted".
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class NodeAvailableResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerBufferRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerBufferRequestMessage.java
@@ -16,8 +16,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Requests the historical pulse measurements at a certain log address from a device (Circle, Circle+, Stealth). This
  * message is answered by a {@link PowerBufferResponseMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerBufferRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerBufferResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerBufferResponseMessage.java
@@ -24,8 +24,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.PowerCalibration;
  * message is the response of a {@link PowerBufferRequestMessage}. The consumed/produced {@link Energy} (kWh) of the
  * datapoints can be calculated using {@link PowerCalibration} data.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerBufferResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerCalibrationRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerCalibrationRequestMessage.java
@@ -17,8 +17,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.PowerCalibration;
  * Calibrates the power of a relay device (Circle, Circle+, Stealth). This message is answered by a
  * {@link PowerCalibrationResponseMessage} which contains the {@link PowerCalibration} data.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerCalibrationRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerCalibrationResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerCalibrationResponseMessage.java
@@ -22,8 +22,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.PowerCalibration;
  * {@link PowerCalibrationRequestMessage}. The {@link PowerCalibration} data is used to calculate power (W) and energy
  * (kWh) from pulses with the {@link Energy} class.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerCalibrationResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerChangeRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerChangeRequestMessage.java
@@ -17,8 +17,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * of a device is retrieved by sending a {@link InformationRequestMessage} and reading the
  * {@link InformationResponseMessage#getPowerState()} value.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerChangeRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerInformationRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerInformationRequestMessage.java
@@ -16,8 +16,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Request real-time energy consumption from a relay device (Circle, Circle+, Stealth). This
  * message is answered by a {@link PowerInformationResponseMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerInformationRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerInformationResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/PowerInformationResponseMessage.java
@@ -23,8 +23,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Contains the real-time energy consumption of a relay device (Circle, Circle+, Stealth). This
  * message is the response of a {@link PowerInformationRequestMessage}.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class PowerInformationResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RealTimeClockGetRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RealTimeClockGetRequestMessage.java
@@ -15,8 +15,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 /**
  * Requests the real-time clock value of a Circle+.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class RealTimeClockGetRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RealTimeClockGetResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RealTimeClockGetResponseMessage.java
@@ -23,8 +23,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * Contains the real-time clock value of a Circle+. This message is the response of a
  * {@link RealTimeClockGetRequestMessage}. The Circle+ is the only device that holds a real-time clock value.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class RealTimeClockGetResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RoleCallRequestMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RoleCallRequestMessage.java
@@ -17,8 +17,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * {@link RoleCallResponseMessage} which contains the MAC address. Because a Plugwise network can have 64 devices,
  * the node ID value has a range from 0 to 63.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class RoleCallRequestMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RoleCallResponseMessage.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/RoleCallResponseMessage.java
@@ -30,8 +30,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
  * {@link NetworkStatusRequestMessage}.
  * </p>
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
 public class RoleCallResponseMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/BoundaryAction.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/BoundaryAction.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The boundary switch action of a Sense when the value is below/above the boundary minimum/maximum.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public enum BoundaryAction {
 
     OFF_BELOW_ON_ABOVE(0, 1),

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/BoundaryType.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/BoundaryType.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The boundary type that a Sense uses for switching.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public enum BoundaryType {
 
     HUMIDITY(0),

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/DeviceType.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/DeviceType.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Enumerates Plugwise devices.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public enum DeviceType {
 
     STICK("Stick", false, false),

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Energy.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Energy.java
@@ -14,22 +14,26 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * A simple class to represent energy usage, converting between Plugwise data representations.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public class Energy {
 
     private static final int WATTS_PER_KILOWATT = 1000;
     private static final double PULSES_PER_KW_SECOND = 468.9385193;
     private static final double PULSES_PER_W_SECOND = PULSES_PER_KW_SECOND / WATTS_PER_KILOWATT;
 
-    private ZonedDateTime utcStart; // using UTC resolves wrong local start/end timestamps when DST changes occur
+    private @Nullable ZonedDateTime utcStart; // using UTC resolves wrong local start/end timestamps when DST changes
+                                              // occur
     private ZonedDateTime utcEnd;
     private long pulses;
-    private Duration interval;
+    private @Nullable Duration interval;
 
     public Energy(ZonedDateTime utcEnd, long pulses) {
         this.utcEnd = utcEnd;
@@ -61,7 +65,7 @@ public class Energy {
         return utcEnd.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
     }
 
-    public Duration getInterval() {
+    public @Nullable Duration getInterval() {
         return interval;
     }
 
@@ -69,13 +73,22 @@ public class Energy {
         return pulses;
     }
 
-    public LocalDateTime getStart() {
-        return utcStart.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+    public @Nullable LocalDateTime getStart() {
+        ZonedDateTime localUtcStart = utcStart;
+        if (localUtcStart == null) {
+            return null;
+        }
+        return localUtcStart.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
     }
 
     private double intervalSeconds() {
-        double seconds = interval.getSeconds();
-        seconds += interval.getNano() / ChronoUnit.SECONDS.getDuration().toNanos();
+        Duration localInterval = interval;
+        if (localInterval == null) {
+            throw new IllegalStateException("Failed to calculate seconds because interval is null");
+        }
+
+        double seconds = localInterval.getSeconds();
+        seconds += localInterval.getNano() / ChronoUnit.SECONDS.getDuration().toNanos();
         return seconds;
     }
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Humidity.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Humidity.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * A relative humidity class that is used for converting from and to Plugwise protocol values.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class Humidity {
 
     private static final String EMPTY_VALUE = "FFFF";

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/MACAddress.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/MACAddress.java
@@ -8,11 +8,15 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The media access control (MAC) address of a Plugwise device, e.g.: 000D6F0000A1B2C3
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class MACAddress {
 
     private final String macAddress;
@@ -25,12 +29,12 @@ public class MACAddress {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((macAddress == null) ? 0 : macAddress.hashCode());
+        result = prime * result + macAddress.hashCode();
         return result;
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -41,11 +45,7 @@ public class MACAddress {
             return false;
         }
         MACAddress other = (MACAddress) obj;
-        if (macAddress == null) {
-            if (other.macAddress != null) {
-                return false;
-            }
-        } else if (!macAddress.equals(other.macAddress)) {
+        if (!macAddress.equals(other.macAddress)) {
             return false;
         }
         return true;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/MessageType.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/MessageType.java
@@ -11,12 +11,15 @@ package org.openhab.binding.plugwise.internal.protocol.field;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Enumerates all Plugwise message types. Many are still missing, and require further protocol analysis.
  *
- * @author Karel Goderis
- * @author Wouter Born - Initial contribution
+ * @author Wouter Born, Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public enum MessageType {
 
     ACKNOWLEDGEMENT_V1(0x0000),
@@ -70,7 +73,7 @@ public enum MessageType {
         identifier = value;
     }
 
-    public static MessageType forValue(int value) {
+    public static @Nullable MessageType forValue(int value) {
         return TYPES_BY_VALUE.get(value);
     }
 

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/PowerCalibration.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/PowerCalibration.java
@@ -8,12 +8,15 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The power calibration data of a relay device (Circle, Circle+, Stealth). It is used in {@link Energy} to calculate
  * energy (kWh) and power (W) from pulses.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class PowerCalibration {
 
     private final double gainA;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Sensitivity.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Sensitivity.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The motion sensitivity range of a Scan.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public enum Sensitivity {
 
     HIGH(0x14),

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Temperature.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/protocol/field/Temperature.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal.protocol.field;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * A temperature (Celsius) class that is used for converting from and to Plugwise protocol values.
  *
  * @author Wouter Born - Initial contribution
  */
+@NonNullByDefault
 public class Temperature {
 
     private static final String EMPTY_VALUE = "FFFF";


### PR DESCRIPTION
Adds null annotations to all Plugwise classes except for the messages in the protocol package.
All SAT warnings about missing the "Initial contribution" message for the first `@author` are also fixed.