### PR TITLE
[VoiceRSS] Add configurationPid to fix missing API key

### DIFF
--- a/addons/voice/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSService.java
+++ b/addons/voice/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Jochen Hiller - Initial contribution and API
  * @author Laurent Garnier - add support for OGG and AAC audio formats
  */
-@Component(property = { Constants.SERVICE_PID + "=org.openhab.voicerss",
+@Component(configurationPid = "org.openhab.voicerss", property = { Constants.SERVICE_PID + "=org.openhab.voicerss",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=voice:voicerss",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=VoiceRSS",
         ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=voice" })


### PR DESCRIPTION
Since the component name is now generated the default configurationPid (based on the name) changed. Defining the configurationPid fixes the issue for me @mhilbush .