### PR TITLE
[iCloud binding] Update help for things and change the transformation for items

### DIFF
--- a/addons/binding/org.openhab.binding.icloud/README.md
+++ b/addons/binding/org.openhab.binding.icloud/README.md
@@ -68,8 +68,7 @@ Bridge icloud:account:myaccount [appleId="mail@example.com", password="secure", 
 ```
 
 The device ID can be found in the Paper UI inbox.
-The information '@ "World"' is optional.
-
+The information *@ "World"* is optional.
 
 ### icloud.items
 

--- a/addons/binding/org.openhab.binding.icloud/README.md
+++ b/addons/binding/org.openhab.binding.icloud/README.md
@@ -67,13 +67,17 @@ Bridge icloud:account:myaccount [appleId="mail@example.com", password="secure", 
 }
 ```
 
+The device ID can be found in the Paper UI inbox.
+The information '@ "World"' is optional.
+
+
 ### icloud.items
 
 ```php
 Group    "iPhone" iCloud_Group
 
-String   iPhone_BatteryStatus             "Battery Status [%s %%]" <battery> (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:batteryStatus"}
-Number   iPhone_BatteryLevel              "Battery Level [%.0f]"   <battery> (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:batteryLevel"}
+String   iPhone_BatteryStatus             "Battery Status [%s]" <battery> (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:batteryStatus"}
+Number   iPhone_BatteryLevel              "Battery Level [%d %%]"   <battery> (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:batteryLevel"}
 Switch   iPhone_FindMyPhone               "Trigger Find My iPhone"           (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:findMyPhone", autoupdate="false"}
 Switch   iPhone_Refresh                   "Force iPhone Refresh"             (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:location", autoupdate="false"}
 Location iPhone_Location                  "Coordinates"                      (iCloud_Group) {channel="icloud:device:myaccount:myiPhone8:location"}


### PR DESCRIPTION
Adding informations about the device ID and location information in the .things file.
- It´s clear where to find the device ID. I had so search in the community to found someone mentioning where to find the device ID.

Changing the transformation for 'batteryStatus' and 'batteryLevel'.
- The transformation [%s %% ] for 'batteryStatus' is wrong and brings the information "Not charging %"
- The transformation [%.0f] for 'batteryLevel' is wrong and shows the battery level without '%'