### PR TITLE
[denonmarantz] SurroundProgram was assigned to the wrong ChannelGroup

### DIFF
--- a/addons/binding/org.openhab.binding.denonmarantz/README.md
+++ b/addons/binding/org.openhab.binding.denonmarantz/README.md
@@ -58,27 +58,26 @@ The DenonMarantz AVR supports the following channels (some channels are model sp
 
 | Channel Type ID         | Item Type    | Description  |
 |-------------------------|--------------|--------------|
-| General
+| *General*
 |  general#power            | Switch (RW) | Power on/off 
 |  general#surroundProgram  | String (R) | current surround program (e.g. STEREO)
 |  general#artist | String (R) | artist of current track
 |  general#album | String (R) |  album of current track
 |  general#track | String (R) |  title of current track
 |  general#command          | String (W) | Command to send to the AVR (for use in Rules)
-|Now Playing
-| Main zone
+| *Main zone*
 |  mainZone#power    | Switch (RW) | Main zone power on/off
 |  mainZone#volume       | Dimmer (RW) | Main zone volume
 |  mainZone#volumeDB     | Number (RW) | Main zone volume in dB (-80 offset)
 |  mainZone#mute             | Switch (RW) | Main zone mute
 |  mainZone#input            | String (RW) | Main zone input (e.g. TV, TUNER, ..)
-|  Zone 2
+|  *Zone 2*
 |  zone2#power | Switch (RW) | Zone 2 power on/off
 |  zone2#volume | Dimmer (RW) | Zone 2 volume
 |  zone2#volumeDB | Number (RW) | Zone 2 volume in dB (-80 offset)
 |  zone2#mute | Switch (RW) | Zone 2 mute
 |  zone2#input | String (RW) | Zone 2 input
-|  Zone 3
+|  *Zone 3*
 |  zone3#power | Switch (RW) | Zone 3 power on/off
 |  zone3#volume | Dimmer (RW) | Zone 3 volume
 |  zone3#volumeDB | Number (RW) | Zone 3 volume in dB (-80 offset)

--- a/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/DenonMarantzBindingConstants.java
+++ b/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/DenonMarantzBindingConstants.java
@@ -38,6 +38,7 @@ public class DenonMarantzBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_POWER = "general#power";
+    public static final String CHANNEL_SURROUND_PROGRAM = "general#surroundProgram";
     public static final String CHANNEL_COMMAND = "general#command";
     public static final String CHANNEL_NOW_PLAYING_ARTIST = "general#artist";
     public static final String CHANNEL_NOW_PLAYING_ALBUM = "general#album";
@@ -48,7 +49,6 @@ public class DenonMarantzBindingConstants {
     public static final String CHANNEL_MAIN_VOLUME_DB = "mainZone#volumeDB";
     public static final String CHANNEL_MUTE = "mainZone#mute";
     public static final String CHANNEL_INPUT = "mainZone#input";
-    public static final String CHANNEL_SURROUND_PROGRAM = "mainZone#surroundProgram";
 
     public static final String CHANNEL_ZONE2_POWER = "zone2#power";
     public static final String CHANNEL_ZONE2_VOLUME = "zone2#volume";


### PR DESCRIPTION
Updated BindingConstants to map SurroundProgram to the the 'general' Channel Group.
Fixed table in README.md
Fixes #3724

