### PR TITLE
[meteostick] avert CME by synchronizing all iterations

### DIFF
--- a/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
+++ b/addons/binding/org.openhab.binding.meteostick/src/main/java/org/openhab/binding/meteostick/handler/MeteostickSensorHandler.java
@@ -274,16 +274,18 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
             int least = -1;
             int total = 0;
 
-            for (int value : storage.values()) {
-                if (least == -1) {
-                    least = value;
-                    continue;
-                }
+            synchronized (storage) {
+                for (int value : storage.values()) {
+                    if (least == -1) {
+                        least = value;
+                        continue;
+                    }
 
-                if (value < least) {
-                    total = 256 - least + value;
-                } else {
-                    total = value - least;
+                    if (value < least) {
+                        total = 256 - least + value;
+                    } else {
+                        total = value - least;
+                    }
                 }
             }
 
@@ -333,13 +335,16 @@ public class MeteostickSensorHandler extends BaseThingHandler implements Meteost
             double nsSum = 0;
             double totalSpeed = 0;
             double maxSpeed = 0;
-            int size = storage.size();
-            for (WindSample sample : storage.values()) {
-                ewSum += sample.ewVector;
-                nsSum += sample.nsVector;
-                totalSpeed += sample.speed;
-                if (sample.speed > maxSpeed) {
-                    maxSpeed = sample.speed;
+            int size = 0;
+            synchronized (storage) {
+                size = storage.size();
+                for (WindSample sample : storage.values()) {
+                    ewSum += sample.ewVector;
+                    nsSum += sample.nsVector;
+                    totalSpeed += sample.speed;
+                    if (sample.speed > maxSpeed) {
+                        maxSpeed = sample.speed;
+                    }
                 }
             }
 


### PR DESCRIPTION
There was still the rare (in my case after a month) possibility of

```
java.util.ConcurrentModificationException: null
	at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1211) ~[?:?]
	at java.util.TreeMap$ValueIterator.next(TreeMap.java:1256) ~[?:?]
	at org.openhab.binding.meteostick.handler.MeteostickSensorHandler$WindHistory.getStats(MeteostickSensorHandler.java:337) ~[?:?]
	...
```

Synchronized collection wrappers still require `synchronized` blocks on iteration stuff.

Signed-off-by: John Cocula <john@cocula.com>
