### PR TITLE
[Kodi] Streamlined and fixed deactivation of background discovery

### DIFF
--- a/addons/binding/org.openhab.binding.kodi/README.md
+++ b/addons/binding/org.openhab.binding.kodi/README.md
@@ -35,7 +35,7 @@ Auto-discovery is enabled by default.
 To disable it, you can add the following line to `<openHAB-conf>/services/runtime.cfg`:
 
 ```
-org.openhab.kodi:enableAutoDiscovery=false
+discovery.kodi:background=false
 ```
 
 ## Binding Configuration

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
@@ -11,11 +11,14 @@ package org.openhab.binding.kodi.internal.discovery;
 import static org.openhab.binding.kodi.KodiBindingConstants.*;
 
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant;
@@ -25,16 +28,18 @@ import org.jupnp.model.meta.RemoteDevice;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * An UpnpDiscoveryParticipant which allows to discover Kodi AVRs.
  *
- * @author Paul Frank
- *
+ * @author Paul Frank - Initial contribution
+ * @author Christoph Weitkamp - Use "discovery.kodi:background=false" to disable discovery service
  */
-@Component(service = UpnpDiscoveryParticipant.class, immediate = true)
+@Component(service = UpnpDiscoveryParticipant.class, immediate = true, configurationPid = "discovery.kodi")
+@NonNullByDefault
 public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     private Logger logger = LoggerFactory.getLogger(KodiUpnpDiscoveryParticipant.class);
@@ -44,11 +49,19 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     @Activate
     protected void activate(ComponentContext componentContext) {
-        if (componentContext.getProperties() != null) {
-            String autoDiscoveryPropertyValue = (String) componentContext.getProperties().get("enableAutoDiscovery");
-            if (StringUtils.isNotEmpty(autoDiscoveryPropertyValue)) {
-                isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-            }
+        activateOrModifyService(componentContext);
+    }
+
+    @Modified
+    protected void modified(ComponentContext componentContext) {
+        activateOrModifyService(componentContext);
+    }
+
+    private void activateOrModifyService(ComponentContext componentContext) {
+        Dictionary<String, Object> properties = componentContext.getProperties();
+        String autoDiscoveryPropertyValue = (String) properties.get("background");
+        if (StringUtils.isNotEmpty(autoDiscoveryPropertyValue)) {
+            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
         }
         supportedThingTypes = isAutoDiscoveryEnabled ? SUPPORTED_THING_TYPES_UIDS : Collections.emptySet();
     }
@@ -59,7 +72,7 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     }
 
     @Override
-    public DiscoveryResult createResult(RemoteDevice device) {
+    public @Nullable DiscoveryResult createResult(RemoteDevice device) {
         ThingUID thingUid = getThingUID(device);
         if (thingUid != null) {
             String label = StringUtils.isEmpty(device.getDetails().getFriendlyName()) ? device.getDisplayString()
@@ -76,7 +89,7 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     }
 
     @Override
-    public ThingUID getThingUID(RemoteDevice device) {
+    public @Nullable ThingUID getThingUID(RemoteDevice device) {
         if (isAutoDiscoveryEnabled) {
             String manufacturer = device.getDetails().getManufacturerDetails().getManufacturer();
             if (StringUtils.containsIgnoreCase(manufacturer, MANUFACTURER)) {

--- a/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
@@ -58,7 +58,7 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     }
 
     private void activateOrModifyService(ComponentContext componentContext) {
-        Dictionary<String, Object> properties = componentContext.getProperties();
+        Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
         String autoDiscoveryPropertyValue = (String) properties.get("background");
         if (StringUtils.isNotEmpty(autoDiscoveryPropertyValue)) {
             isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);


### PR DESCRIPTION
- Added null annotations to discovery service
- Use `discovery.kodi:background=false` to disable discovery service

Streamlined background discovery to be compliant with [Concept: Thing Discovery](https://www.openhab.org/docs/concepts/discovery.html#background-discovery).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>