### PR TITLE
[fronius] Fixed the NullPointerException if timeout response received

### DIFF
--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/handler/FroniusSymoInverterHandler.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/handler/FroniusSymoInverterHandler.java
@@ -74,7 +74,8 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
     protected Object getValue(String channelId) {
         String[] fields = StringUtils.split(channelId, "#");
 
-        if (inverterRealtimeResponse == null) {
+        if (inverterRealtimeResponse == null || inverterRealtimeResponse.getBody() == null
+                || inverterRealtimeResponse.getBody().getData() == null) {
             return null;
         }
 
@@ -107,7 +108,9 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
                 return inverterRealtimeResponse.getBody().getData().getUdc();
         }
 
-        if (powerFlowResponse == null) {
+        if (powerFlowResponse == null || powerFlowResponse.getBody() == null
+                || powerFlowResponse.getBody().getData() == null
+                || powerFlowResponse.getBody().getData().getSite() == null) {
             return null;
         }
         switch (fieldName) {


### PR DESCRIPTION
Fixes Issue #3725

In case of an timeout error, the respone message of the fronius inverter does not contain a data node. This causes a NullPointerException in the inverter handler.
The message I received from the inverter was:
```
URL = http://192.168.2.76/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=CommonInverterData
2018-07-19 23:14:34.376 [DEBUG] [s.handler.FroniusSymoInverterHandler] - aqiResponse = {
   "Body" : {
      "Data" : {}
   },
   "Head" : {
      "RequestArguments" : {
         "DataCollection" : "CommonInverterData",
         "DeviceClass" : "Inverter",
         "DeviceId" : "1",
         "Scope" : "Device"
      },
      "Status" : {
         "Code" : 8,
         "Reason" : "Transfer timeout.",
         "UserMessage" : ""
      },
      "Timestamp" : "2018-07-19T23:14:32+02:00"
   }
}

```
