### PR TITLE
Fix null type mismatches due to annotated ESH types

### DIFF
--- a/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/handler/FeicanHandler.java
+++ b/addons/binding/org.openhab.binding.feican/src/main/java/org/openhab/binding/feican/handler/FeicanHandler.java
@@ -103,8 +103,10 @@ public class FeicanHandler extends BaseThingHandler {
      * @param onOff value to set: on or off
      * @throws IOException Connection to the bulb failed
      */
-    private void handleOnOff(OnOffType onOff) throws IOException {
-        connection.sendCommand(commands.switchOnOff(onOff));
+    private void handleOnOff(@Nullable OnOffType onOff) throws IOException {
+        if (onOff != null) {
+            connection.sendCommand(commands.switchOnOff(onOff));
+        }
     }
 
     /**
@@ -128,7 +130,7 @@ public class FeicanHandler extends BaseThingHandler {
             handleBrightness(command.getBrightness());
             connection.sendCommand(
                     commands.color(new HSBType(command.getHue(), command.getSaturation(), PercentType.HUNDRED)));
-            handleOnOff((OnOffType) command.as(OnOffType.class));
+            handleOnOff(command.as(OnOffType.class));
         }
     }
 
@@ -147,7 +149,7 @@ public class FeicanHandler extends BaseThingHandler {
         switch (id) {
             case CHANNEL_COLOR:
                 handleBrightness(command);
-                handleOnOff((OnOffType) command.as(OnOffType.class));
+                handleOnOff(command.as(OnOffType.class));
                 break;
             case CHANNEL_COLOR_TEMPERATURE:
                 handleColorTemperature(command);

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDevice.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDevice.java
@@ -31,8 +31,10 @@ import org.openhab.binding.tplinksmarthome.internal.model.HasErrorResponse;
 public class DimmerDevice extends SwitchDevice {
 
     @Override
-    protected @Nullable HasErrorResponse setOnOffState(Connection connection, OnOffType onOff) throws IOException {
-        return commands.setSwitchStateResponse(connection.sendCommand(commands.setSwitchState(onOff)));
+    protected @Nullable HasErrorResponse setOnOffState(Connection connection, @Nullable OnOffType onOff)
+            throws IOException {
+        return onOff != null ? commands.setSwitchStateResponse(connection.sendCommand(commands.setSwitchState(onOff)))
+                : null;
     }
 
     @Override
@@ -54,7 +56,7 @@ public class DimmerDevice extends SwitchDevice {
             response = commands.setDimmerBrightnessResponse(
                     connection.sendCommand(commands.setDimmerBrightness((decimalCommand).intValue())));
             checkErrors(response);
-            response = setOnOffState(connection, (OnOffType) decimalCommand.as(OnOffType.class));
+            response = setOnOffState(connection, decimalCommand.as(OnOffType.class));
         }
         checkErrors(response);
         return response != null;


### PR DESCRIPTION
Fixes the null type mismatches in the addons that are reported on error as a result of the annotations that were added to the types in https://github.com/eclipse/smarthome/pull/5901.