### PR TITLE
removed usage of Guava from MAX binding

### DIFF
--- a/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Export-Package: org.openhab.binding.max
 Import-Package: 
  com.google.common.collect,
  org.apache.commons.lang,
- org.apache.commons.lang.builder;version="2.6.0",
+ org.apache.commons.lang.builder,
  org.apache.commons.net.util,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.max/META-INF/MANIFEST.MF
@@ -9,9 +9,9 @@ Bundle-Vendor: openHAB
 Bundle-Version: 2.4.0.qualifier
 Export-Package: org.openhab.binding.max
 Import-Package: 
- com.google.common.base,
  com.google.common.collect,
  org.apache.commons.lang,
+ org.apache.commons.lang.builder;version="2.6.0",
  org.apache.commons.net.util,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
@@ -24,8 +24,6 @@ import org.openhab.binding.max.internal.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-
 /**
  * The {@link UdpCubeCommand} is responsible for sending UDP commands to the MAX!
  * Cube LAN gateway.
@@ -146,8 +144,7 @@ public class UdpCubeCommand {
                     if (logger.isDebugEnabled()) {
                         final StringBuilder builder = new StringBuilder();
                         for (final Map.Entry<String, String> entry : commandResponse.entrySet()) {
-                            builder.append(String.format("%s:%s%s\n", entry.getKey(),
-                                    Strings.repeat(" ", 25 - entry.getKey().length()), entry.getValue()));
+                            builder.append(String.format("%s: %s\n", entry.getKey(), entry.getValue()));
                         }
                         logger.debug("MAX! UDP response {}", builder);
                     }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/SendCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/SendCommand.java
@@ -8,11 +8,10 @@
  */
 package org.openhab.binding.max.internal.handler;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.max.internal.command.CubeCommand;
-
-import com.google.common.base.Objects;
 
 /**
  * Class for sending a command.
@@ -120,9 +119,9 @@ public final class SendCommand {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(SendCommand.class).add("id", id).add("channelUID", channelUID)
-                .add("command", command).add("cubeCommand", cubeCommand).add("serialNumber", serialNumber)
-                .add("key", key).add("commandText", commandText).toString();
+        return new ToStringBuilder(this).append("id", id).append("channelUID", channelUID).append("command", command)
+                .append("cubeCommand", cubeCommand).append("serialNumber", serialNumber).append("key", key)
+                .append("commandText", commandText).toString();
     }
 
 }

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/C_Message.java
@@ -27,8 +27,6 @@ import org.openhab.binding.max.internal.device.DeviceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-
 /**
  * The {@link C_Message} contains configuration about a MAX! device.
  *
@@ -281,10 +279,9 @@ public final class C_Message extends Message {
         for (String key : properties.keySet()) {
             if (!key.startsWith("Unknown")) {
                 String propertyName = StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(key), ' ');
-                logger.debug("{}:{}{}", propertyName, Strings.repeat(" ", 25 - propertyName.length()),
-                        properties.get(key));
+                logger.debug("{}: {}", propertyName, properties.get(key));
             } else {
-                logger.debug("{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
+                logger.debug("{}: {}", key, properties.get(key));
             }
         }
         if (programData != null) {

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/H_Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/H_Message.java
@@ -15,8 +15,6 @@ import java.util.Map;
 import org.openhab.binding.max.internal.Utils;
 import org.slf4j.Logger;
 
-import com.google.common.base.Strings;
-
 /**
  * The H message contains information about the MAX! Cube.
  *
@@ -123,7 +121,7 @@ public final class H_Message extends Message {
         logger.trace("\tRAW:            : {}", this.getPayload());
         logger.trace("\tReading Time    : {}", cal.getTime());
         for (String key : properties.keySet()) {
-            logger.debug("\t{}:{}{}", key, Strings.repeat(" ", 25 - key.length()), properties.get(key));
+            logger.debug("\t{}: {}", key, properties.get(key));
         }
     }
 


### PR DESCRIPTION
As can be [seen on the current build](https://openhab.ci.cloudbees.com/job/openHAB2-Bundles/375/console), the MAX binding makes use of Guava methods that are not available in the different versions of Guava, so we have a mismatch between IDE and Maven build here.
As the use of Guava is not anymore recommended for these reasons, this PR removes the dependency with the imho acceptable impact of having a few less tabular trace/debug log messages.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
