### PR TITLE
Use ChannelTypeBuilder instead of deprecated ChannelType constructors

### DIFF
--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyDeviceHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -181,9 +182,9 @@ public class HarmonyDeviceHandler extends BaseThingHandler {
 
         List<StateOption> states = getButtonStateOptions(harmonyConfig);
 
-        ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Send Button Press",
-                "Send a button press to device " + getThing().getLabel(), null, null,
-                new StateDescription(null, null, null, null, false, states), null);
+        ChannelType channelType = ChannelTypeBuilder.state(channelTypeUID, "Send Button Press", "String")
+                .withDescription("Send a button press to device " + getThing().getLabel())
+                .withStateDescription(new StateDescription(null, null, null, null, false, states)).build();
 
         factory.addChannelType(channelType);
 

--- a/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
+++ b/addons/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/handler/HarmonyHubHandler.java
@@ -41,6 +41,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -355,9 +356,9 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyHubLi
             states.add(new StateOption(activity.getLabel(), activity.getLabel()));
         }
 
-        ChannelType channelType = new ChannelType(channelTypeUID, false, "String", "Current Activity",
-                "Current activity for " + getThing().getLabel(), null, null,
-                new StateDescription(null, null, null, "%s", false, states), null);
+        ChannelType channelType = ChannelTypeBuilder.state(channelTypeUID, "Current Activity", "String")
+                .withDescription("Current activity for " + getThing().getLabel())
+                .withStateDescription(new StateDescription(null, null, null, "%s", false, states)).build();
 
         factory.addChannelType(channelType);
 

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/ChannelsTypeProviderAvailableInputs.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/ChannelsTypeProviderAvailableInputs.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.yamahareceiver.internal;
 
+import static org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants.Inputs.*;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,15 +21,13 @@ import java.util.Map.Entry;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
-import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants;
-
-import static org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants.Inputs.*;
 
 /**
  * Provide a custom channel type for available inputs
@@ -75,8 +75,8 @@ public class ChannelsTypeProviderAvailableInputs implements ChannelTypeProvider 
     }
 
     private void createChannelType(StateDescription state) {
-        channelType = new ChannelType(channelTypeUID, false, "String", ChannelKind.STATE, "Input source",
-                "Select the input source of the AVR", null, null, state, null, null);
+        channelType = ChannelTypeBuilder.state(channelTypeUID, "Input source", "String")
+                .withDescription("Select the input source of the AVR").withStateDescription(state).build();
     }
 
     private StateDescription getDefaultStateDescription() {

--- a/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/ChannelsTypeProviderPreset.java
+++ b/addons/binding/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/ChannelsTypeProviderPreset.java
@@ -8,24 +8,25 @@
  */
 package org.openhab.binding.yamahareceiver.internal;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toList;
+import static org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.IntStream;
 
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
-import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.openhab.binding.yamahareceiver.internal.state.PresetInfoState;
-
-import static java.util.stream.Collectors.*;
-import static org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants.BINDING_ID;
-import static org.openhab.binding.yamahareceiver.YamahaReceiverBindingConstants.CHANNEL_PLAYBACK_PRESET_TYPE_NAMED;
 
 /**
  * Provide a custom channel type for the preset channel
@@ -94,8 +95,8 @@ public class ChannelsTypeProviderPreset implements ChannelTypeProvider {
     }
 
     private void createChannelType(StateDescription state) {
-        channelType = new ChannelType(channelTypeUID, false, "Number", ChannelKind.STATE, "Preset",
-                "Select a saved channel by its preset number", null, null, state, null, null);
+        channelType = ChannelTypeBuilder.state(channelTypeUID, "Preset", "Number")
+                .withDescription("Select a saved channel by its preset number").withStateDescription(state).build();
     }
 
 }


### PR DESCRIPTION
Uses the ChannelTypeBuilder instead of the deprecated ChannelType constructors in all bindings (Harmony Hub, Yamaha Receiver).