### PR TITLE
[avmfritz] Added deactivation of background discovery

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -47,9 +47,15 @@ The FRITZ!Box has to run at least on firmware FRITZ!OS 6.69.
 
 ## Discovery
 
-The FRITZ!Box and the powerline adapter are discovered through UPNP in the local network.
+The FRITZ!Box and the powerline adapter are discovered through UPnP in the local network.
+Auto-discovery is enabled by default.
 When added as things, a username/password has eventually to be set depending on your Box/Powerline security configuration.
 The credentials given in the settings must have HomeAuto permissions.
+To disable it, you can add the following line to `<openHAB-conf>/services/runtime.cfg`:
+
+```
+discovery.avmfritz:background=false
+```
 
 If correct credentials are set in the bridge configuration, connected AHA devices are discovered automatically (may last up to 3 minutes).
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant;
@@ -41,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Use "discovery.avmfritz:background=false" to disable discovery service
  */
 @Component(service = UpnpDiscoveryParticipant.class, immediate = true, configurationPid = "discovery.avmfritz")
+@NonNullByDefault
 public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     private final Logger logger = LoggerFactory.getLogger(AVMFritzUpnpDiscoveryParticipant.class);
@@ -59,7 +62,7 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
     }
 
     private void activateOrModifyService(ComponentContext componentContext) {
-        Dictionary<String, Object> properties = componentContext.getProperties();
+        Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
         String autoDiscoveryPropertyValue = (String) properties.get("background");
         if (autoDiscoveryPropertyValue != null && autoDiscoveryPropertyValue.length() != 0) {
             isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
@@ -73,7 +76,7 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
     }
 
     @Override
-    public DiscoveryResult createResult(RemoteDevice device) {
+    public @Nullable DiscoveryResult createResult(RemoteDevice device) {
         ThingUID uid = getThingUID(device);
         if (uid != null) {
             logger.debug("discovered: {} ({}) at {}", device.getDisplayString(), device.getDetails().getFriendlyName(),
@@ -93,7 +96,7 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
     }
 
     @Override
-    public ThingUID getThingUID(RemoteDevice device) {
+    public @Nullable ThingUID getThingUID(RemoteDevice device) {
         if (isAutoDiscoveryEnabled) {
             // newer FRITZ!OS versions return several upnp services (e.g. Mediaserver)
             if (device.getType().getType().equals(BRIDGE_FRITZBOX)) {


### PR DESCRIPTION
- Added null annotations to discovery service
- Use `discovery.avmfritz:background=false` to disable discovery service

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>