### PR TITLE
[Nest] Small change acc. to review comment to #2990 (ValloxMV)

### DIFF
--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.binding.nest.handler;
 
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -122,11 +121,15 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestThingD
     }
 
     @SuppressWarnings("unchecked")
-    protected <U extends Quantity<U>> QuantityType<U> commandToQuantityType(Command command, Unit<U> defaultUnit) {
+    protected @Nullable <U extends Quantity<U>> QuantityType<U> commandToQuantityType(Command command,
+            Unit<U> defaultUnit) {
         if (command instanceof QuantityType) {
             return (QuantityType<U>) command;
+        } else if (command instanceof Number) {
+            return new QuantityType<U>((Number) command, defaultUnit);
+        } else {
+            return null;
         }
-        return new QuantityType<U>(new BigDecimal(command.toString()), defaultUnit);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
@@ -164,6 +164,9 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
     private void addTemperatureUpdateRequest(String celsiusField, String fahrenheitField, Command command) {
         Unit<Temperature> unit = getTemperatureUnit();
         QuantityType<Temperature> quantity = commandToQuantityType(command, unit);
+        if (quantity == null) {
+            return;
+        }
         BigDecimal value = quantityToRoundedTemperature(quantity, unit);
         if (value != null) {
             addUpdateRequest(NEST_THERMOSTAT_UPDATE_PATH, unit == CELSIUS ? celsiusField : fahrenheitField, value);


### PR DESCRIPTION
Signed-off-by: Björn Brings <bjoernbrings@web.de>

Review comment bei @kaikreuzer at #2990 
> Serialising to String is ugly. You should in any case be sure that command is an instance of DecimalType, so you can actually use the new QuantityType<U>((Number) command, defaultUnit) constructor.

As I took the code from the Nest binding => adapted here as well