### PR TITLE
[Nest] Remove unused Number to QuantityType command conversion

### DIFF
--- a/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/handler/NestThermostatHandlerTest.java
+++ b/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/handler/NestThermostatHandlerTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
@@ -187,28 +186,10 @@ public class NestThermostatHandlerTest extends NestThingHandlerOSGiTest {
     }
 
     @Test
-    public void handleFanTimerDurationDecimalTypeCommands() throws IOException {
-        int[] durations = { 15, 30, 45, 60, 120, 240, 480, 960, 15 };
-        for (int duration : durations) {
-            handleCommand(CHANNEL_FAN_TIMER_DURATION, new DecimalType(duration));
-            assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, "fan_timer_duration", String.valueOf(duration));
-        }
-    }
-
-    @Test
-    public void handleFanTimerDurationQuantityTypeCommands() throws IOException {
+    public void handleFanTimerDurationCommands() throws IOException {
         int[] durations = { 15, 30, 45, 60, 120, 240, 480, 960, 15 };
         for (int duration : durations) {
             handleCommand(CHANNEL_FAN_TIMER_DURATION, new QuantityType<>(duration, SmartHomeUnits.MINUTE));
-            assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, "fan_timer_duration", String.valueOf(duration));
-        }
-    }
-
-    @Test
-    public void handleFanTimerDurationStringTypeCommands() throws IOException {
-        int[] durations = { 15, 30, 45, 60, 120, 240, 480, 960, 15 };
-        for (int duration : durations) {
-            handleCommand(CHANNEL_FAN_TIMER_DURATION, new StringType(String.valueOf(duration)));
             assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, "fan_timer_duration", String.valueOf(duration));
         }
     }
@@ -286,12 +267,6 @@ public class NestThermostatHandlerTest extends NestThingHandlerOSGiTest {
 
         handleCommand(channelId, new QuantityType<>(70, FAHRENHEIT));
         assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "21.0");
-
-        handleCommand(channelId, new StringType("21.5"));
-        assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "21.5");
-
-        handleCommand(channelId, new DecimalType(22.0));
-        assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "22.0");
     }
 
     private void fahrenheitCommandsTest(String channelId, String apiPropertyName) throws IOException {
@@ -316,12 +291,6 @@ public class NestThermostatHandlerTest extends NestThingHandlerOSGiTest {
 
         handleCommand(channelId, new QuantityType<>(21, CELSIUS));
         assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "70");
-
-        handleCommand(channelId, new StringType("71"));
-        assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "71");
-
-        handleCommand(channelId, new DecimalType(72.0));
-        assertNestApiPropertyState(THERMOSTAT1_DEVICE_ID, apiPropertyName, "72");
     }
 
 }

--- a/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
@@ -29,7 +29,6 @@ Import-Package:
  org.eclipse.jetty.util.ssl,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
- org.eclipse.smarthome.core.i18n,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.thing,

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestBaseHandler.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.binding.nest.handler;
 
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -36,7 +35,6 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
-import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.nest.internal.config.NestDeviceConfiguration;
@@ -119,14 +117,6 @@ abstract class NestBaseHandler<T> extends BaseThingHandler implements NestThingD
                 .build());
             // @formatter:on
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    protected <U extends Quantity<U>> QuantityType<U> commandToQuantityType(Command command, Unit<U> defaultUnit) {
-        if (command instanceof QuantityType) {
-            return (QuantityType<U>) command;
-        }
-        return new QuantityType<U>(new BigDecimal(command.toString()), defaultUnit);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestThermostatHandler.java
@@ -22,7 +22,6 @@ import javax.measure.quantity.Time;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.i18n.UnitProvider;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -49,11 +48,8 @@ import org.slf4j.LoggerFactory;
 public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
     private final Logger logger = LoggerFactory.getLogger(NestThermostatHandler.class);
 
-    private final UnitProvider unitProvider;
-
-    public NestThermostatHandler(Thing thing, UnitProvider unitProvider) {
+    public NestThermostatHandler(Thing thing) {
         super(thing, Thermostat.class);
-        this.unitProvider = unitProvider;
     }
 
     @Override
@@ -122,6 +118,7 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
      * value of a channel by sending the request to Nest.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (REFRESH.equals(command)) {
             Thermostat lastUpdate = getLastUpdate();
@@ -134,26 +131,36 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
                 addUpdateRequest("fan_timer_active", command == OnOffType.ON);
             }
         } else if (CHANNEL_FAN_TIMER_DURATION.equals(channelUID.getId())) {
-            // Update fan timer duration to the command value
-            QuantityType<Time> quantity = commandToQuantityType(command, SmartHomeUnits.MINUTE);
-            QuantityType<Time> minuteQuantity = quantity.toUnit(SmartHomeUnits.MINUTE);
-            if (minuteQuantity != null) {
-                addUpdateRequest("fan_timer_duration", minuteQuantity.intValue());
+            if (command instanceof QuantityType) {
+                // Update fan timer duration to the command value
+                QuantityType<Time> minuteQuantity = ((QuantityType<Time>) command).toUnit(SmartHomeUnits.MINUTE);
+                if (minuteQuantity != null) {
+                    addUpdateRequest("fan_timer_duration", minuteQuantity.intValue());
+                }
             }
         } else if (CHANNEL_MAX_SET_POINT.equals(channelUID.getId())) {
-            // Update maximum set point to the command value
-            addTemperatureUpdateRequest("target_temperature_high_c", "target_temperature_high_f", command);
+            if (command instanceof QuantityType) {
+                // Update maximum set point to the command value
+                addTemperatureUpdateRequest("target_temperature_high_c", "target_temperature_high_f",
+                        (QuantityType<Temperature>) command);
+            }
         } else if (CHANNEL_MIN_SET_POINT.equals(channelUID.getId())) {
-            // Update minimum set point to the command value
-            addTemperatureUpdateRequest("target_temperature_low_c", "target_temperature_low_f", command);
+            if (command instanceof QuantityType) {
+                // Update minimum set point to the command value
+                addTemperatureUpdateRequest("target_temperature_low_c", "target_temperature_low_f",
+                        (QuantityType<Temperature>) command);
+            }
         } else if (CHANNEL_MODE.equals(channelUID.getId())) {
             if (command instanceof StringType) {
                 // Update the HVAC mode to the command value
                 addUpdateRequest("hvac_mode", Mode.valueOf(((StringType) command).toString()));
             }
         } else if (CHANNEL_SET_POINT.equals(channelUID.getId())) {
-            // Update set point to the command value
-            addTemperatureUpdateRequest("target_temperature_c", "target_temperature_f", command);
+            if (command instanceof QuantityType) {
+                // Update set point to the command value
+                addTemperatureUpdateRequest("target_temperature_c", "target_temperature_f",
+                        (QuantityType<Temperature>) command);
+            }
         }
     }
 
@@ -161,27 +168,22 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
         addUpdateRequest(NEST_THERMOSTAT_UPDATE_PATH, field, value);
     }
 
-    private void addTemperatureUpdateRequest(String celsiusField, String fahrenheitField, Command command) {
-        Unit<Temperature> unit = getTemperatureUnit();
-        QuantityType<Temperature> quantity = commandToQuantityType(command, unit);
+    private void addTemperatureUpdateRequest(String celsiusField, String fahrenheitField,
+            QuantityType<Temperature> quantity) {
+        Unit<Temperature> unit = getTemperatureUnit(quantity.getUnit());
         BigDecimal value = quantityToRoundedTemperature(quantity, unit);
         if (value != null) {
             addUpdateRequest(NEST_THERMOSTAT_UPDATE_PATH, unit == CELSIUS ? celsiusField : fahrenheitField, value);
         }
     }
 
-    private Unit<Temperature> getTemperatureUnit() {
+    private Unit<Temperature> getTemperatureUnit(Unit<Temperature> fallbackUnit) {
         Thermostat lastUpdate = getLastUpdate();
         if (lastUpdate != null && lastUpdate.getTemperatureUnit() != null) {
             return lastUpdate.getTemperatureUnit();
         }
 
-        Unit<Temperature> systemTemperatureUnit = unitProvider.getUnit(Temperature.class);
-        if (systemTemperatureUnit != null) {
-            return systemTemperatureUnit;
-        }
-
-        return CELSIUS;
+        return fallbackUnit;
     }
 
     private @Nullable BigDecimal quantityToRoundedTemperature(QuantityType<Temperature> quantity,
@@ -209,7 +211,6 @@ public class NestThermostatHandler extends NestBaseHandler<Thermostat> {
         if (newStatus != thing.getStatus()) {
             updateStatus(newStatus);
         }
-
     }
 
 }

--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
@@ -20,7 +20,6 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
-import org.eclipse.smarthome.core.i18n.UnitProvider;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -36,7 +35,6 @@ import org.openhab.binding.nest.handler.NestThermostatHandler;
 import org.openhab.binding.nest.internal.discovery.NestDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link NestHandlerFactory} is responsible for creating things and thing
@@ -52,18 +50,6 @@ public class NestHandlerFactory extends BaseThingHandlerFactory {
             THING_TYPE_CAMERA, THING_TYPE_BRIDGE, THING_TYPE_STRUCTURE, THING_TYPE_SMOKE_DETECTOR).collect(toSet());
 
     private Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryService = new HashMap<>();
-
-    @NonNullByDefault({})
-    private UnitProvider unitProvider;
-
-    @Reference
-    protected void setUnitProvider(UnitProvider unitProvider) {
-        this.unitProvider = unitProvider;
-    }
-
-    protected void unsetUnitProvider(UnitProvider unitProvider) {
-        this.unitProvider = null;
-    }
 
     /**
      * The things this factory supports creating.
@@ -82,7 +68,7 @@ public class NestHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (THING_TYPE_THERMOSTAT.equals(thingTypeUID)) {
-            return new NestThermostatHandler(thing, unitProvider);
+            return new NestThermostatHandler(thing);
         }
 
         if (THING_TYPE_CAMERA.equals(thingTypeUID)) {


### PR DESCRIPTION
Removes the conversion to QuantityType values of commands with Number values in the Nest Binding (introduced in https://github.com/openhab/openhab2-addons/pull/3618). ESH will nowadays automatically do these conversions (see https://github.com/eclipse/smarthome/pull/5734).

See also the discussion in https://github.com/openhab/openhab2-addons/pull/3777.