### PR TITLE
[Nest] Prevent race conditions when NestStreamingRestClient reconnects

### DIFF
--- a/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
+++ b/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRestClient.java
@@ -57,11 +57,11 @@ public class NestStreamingRestClient {
 
     private final List<NestStreamingDataListener> listeners = new CopyOnWriteArrayList<>();
     private final ScheduledExecutorService scheduler;
+    private final Object startStopLock = new Object();
 
     private String accessToken;
     private @Nullable ScheduledFuture<?> checkConnectionJob;
     private boolean connected;
-    private boolean openingEventSource;
     private @Nullable EventSource eventSource;
     private long lastEventTimestamp;
     private @Nullable TopLevelData lastReceivedTopLevelData;
@@ -87,12 +87,16 @@ public class NestStreamingRestClient {
         long millisSinceLastEvent = System.currentTimeMillis() - lastEventTimestamp;
         if (millisSinceLastEvent > CONNECTION_TIMEOUT_MILLIS) {
             logger.debug("Check: Disconnected from streaming events, millisSinceLastEvent={}", millisSinceLastEvent);
-            if (connected) {
-                connected = false;
-                listeners.forEach(listener -> listener.onDisconnected());
+            synchronized (startStopLock) {
+                stopCheckConnectionJob(false);
+                if (connected) {
+                    connected = false;
+                    listeners.forEach(listener -> listener.onDisconnected());
+                }
+                redirectUrlSupplier.resetCache();
+                reopenEventSource();
+                startCheckConnectionJob();
             }
-            redirectUrlSupplier.resetCache();
-            reopenEventSource();
         } else {
             logger.debug("Check: Receiving streaming events, millisSinceLastEvent={}", millisSinceLastEvent);
         }
@@ -103,73 +107,65 @@ public class NestStreamingRestClient {
      * itself.
      */
     private void reopenEventSource() {
-        if (openingEventSource) {
-            logger.debug("EventSource is currently being opened");
-            return;
-        }
+        try {
+            logger.debug("Reopening EventSource");
+            closeEventSource(10, TimeUnit.SECONDS);
 
-        synchronized (this) {
-            try {
-                logger.debug("Reopening EventSource");
-                openingEventSource = true;
+            logger.debug("Opening new EventSource");
+            EventSource localEventSource = createEventSource();
+            localEventSource.open();
 
-                EventSource localEventSource = eventSource;
-                if (localEventSource != null) {
-                    if (!localEventSource.isOpen()) {
-                        logger.debug("Existing EventSource is already closed");
-                    } else if (localEventSource.close(10, TimeUnit.SECONDS)) {
-                        logger.debug("Succesfully closed existing EventSource");
-                    } else {
-                        logger.debug("Failed to close existing EventSource");
-                    }
-                    eventSource = null;
-                }
-
-                logger.debug("Opening new EventSource");
-                localEventSource = createEventSource();
-                localEventSource.open();
-
-                eventSource = localEventSource;
-            } catch (FailedResolvingNestUrlException e) {
-                logger.debug("Failed to resolve Nest redirect URL while opening new EventSource");
-            } finally {
-                openingEventSource = false;
-            }
+            eventSource = localEventSource;
+        } catch (FailedResolvingNestUrlException e) {
+            logger.debug("Failed to resolve Nest redirect URL while opening new EventSource");
         }
     }
 
     public void start() {
-        synchronized (this) {
+        synchronized (startStopLock) {
             logger.debug("Opening EventSource and starting checkConnection job");
             reopenEventSource();
-
-            ScheduledFuture<?> localCheckConnectionJob = checkConnectionJob;
-            if (localCheckConnectionJob == null || localCheckConnectionJob.isCancelled()) {
-                checkConnectionJob = scheduler.scheduleWithFixedDelay(this::checkConnection, KEEP_ALIVE_MILLIS,
-                        KEEP_ALIVE_MILLIS, TimeUnit.MILLISECONDS);
-            }
-
+            startCheckConnectionJob();
             logger.debug("Started");
         }
     }
 
     public void stop() {
-        synchronized (this) {
+        synchronized (startStopLock) {
             logger.debug("Closing EventSource and stopping checkConnection job");
-
-            EventSource localEventSource = eventSource;
-            if (localEventSource != null) {
-                localEventSource.close(0, TimeUnit.SECONDS);
-                eventSource = null;
-            }
-
-            ScheduledFuture<?> localCheckConnectionJob = checkConnectionJob;
-            if (localCheckConnectionJob != null && !localCheckConnectionJob.isCancelled()) {
-                localCheckConnectionJob.cancel(true);
-                checkConnectionJob = null;
-            }
-
+            stopCheckConnectionJob(true);
+            closeEventSource(0, TimeUnit.SECONDS);
             logger.debug("Stopped");
+        }
+    }
+
+    private void closeEventSource(long timeout, TimeUnit timeoutUnit) {
+        EventSource localEventSource = eventSource;
+        if (localEventSource != null) {
+            if (!localEventSource.isOpen()) {
+                logger.debug("Existing EventSource is already closed");
+            } else if (localEventSource.close(timeout, timeoutUnit)) {
+                logger.debug("Succesfully closed existing EventSource");
+            } else {
+                logger.debug("Failed to close existing EventSource");
+            }
+            eventSource = null;
+        }
+    }
+
+    private void startCheckConnectionJob() {
+        ScheduledFuture<?> localCheckConnectionJob = checkConnectionJob;
+        if (localCheckConnectionJob == null || localCheckConnectionJob.isCancelled()) {
+            checkConnectionJob = scheduler.scheduleWithFixedDelay(this::checkConnection, CONNECTION_TIMEOUT_MILLIS,
+                    KEEP_ALIVE_MILLIS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void stopCheckConnectionJob(boolean mayInterruptIfRunning) {
+        ScheduledFuture<?> localCheckConnectionJob = checkConnectionJob;
+        if (localCheckConnectionJob != null && !localCheckConnectionJob.isCancelled()) {
+            localCheckConnectionJob.cancel(mayInterruptIfRunning);
+            checkConnectionJob = null;
         }
     }
 


### PR DESCRIPTION
* Stop and restart checkConnectionJob when reconnecting
* Use CONNECTION_TIMEOUT_MILLIS for checkConnectionJob as initial delay