### PR TITLE
added Orbit repo so that it those dependencies are available in the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
       <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/${ohdr.version}</url>
       <layout>p2</layout>
     </repository>
+    
+    <!-- Eclipse p2 repository -->
+    <repository>
+      <id>eclipse-oxygen</id>
+      <url>http://download.eclipse.org/releases/oxygen/201709271000</url>
+      <layout>p2</layout>
+    </repository>
 
   </repositories>
 


### PR DESCRIPTION
I am not completely sure that this is required, but it is an attempt to solve the build issues that we have at https://openhab.ci.cloudbees.com/view/Sandbox/job/sandbox-openhab2-release/658/

Signed-off-by: Kai Kreuzer <kai@openhab.org>
