### PR TITLE
Revert "added Orbit repo so that it those dependencies are available in the build"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,6 @@
       <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/${ohdr.version}</url>
       <layout>p2</layout>
     </repository>
-    
-    <!-- Eclipse p2 repository -->
-    <repository>
-      <id>eclipse-oxygen</id>
-      <url>http://download.eclipse.org/releases/oxygen/201709271000</url>
-      <layout>p2</layout>
-    </repository>
 
   </repositories>
 


### PR DESCRIPTION
Reverts openhab/openhab2-addons#3800 as it didn't make any difference.