### PR TITLE
[avmfritz] Added support for HAN-FUN devices

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzModelTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzModelTest.java
@@ -38,16 +38,22 @@ public class AVMFritzModelTest {
 
     @Before
     public void setUp() {
-        String xml = "<devicelist version=\"1\">"
-                + "<group identifier=\"F0:A3:7F-900\" id=\"20001\" functionbitmask=\"640\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>Schlafzimmer</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><groupinfo><masterdeviceid>1000</masterdeviceid><members>20000</members></groupinfo></group>"
-                + "<device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 200\"><present>1</present><name>FRITZ!DECT 200 #1</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device>"
-                + "<device identifier=\"08761 0000438\" id=\"18\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 210\"><present>1</present><name>FRITZ!DECT 210 #8</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device>"
-                + "<device identifier=\"08761 0000437\" id=\"20\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 300\"><present>0</present><name>FRITZ!DECT 300 #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>"
-                + "<device identifier=\"08761 0000436\" id=\"21\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 301\"><present>0</present><name>FRITZ!DECT 301 #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>"
-                + "<device identifier=\"08761 0000435\" id=\"22\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"Comet DECT\"><present>0</present><name>Comet DECT #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>"
-                + "<device identifier=\"5C:49:79:F0:A3:84\" id=\"30\" functionbitmask=\"640\" fwversion=\"06.92\" manufacturer=\"AVM\" productname=\"FRITZ!Powerline 546E\"><present>1</present><name>FRITZ!Powerline 546E #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter></device>"
-                + "<device identifier=\"08761 0954669\" id=\"40\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"FRITZ!DECT Repeater 100\"><present>1</present><name>FRITZ!DECT Repeater 100 #5</name><temperature><celsius>230</celsius><offset>0</offset></temperature></device>"
-                + "</devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<group identifier=\"F0:A3:7F-900\" id=\"20000\" functionbitmask=\"6784\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>Schlafzimmer</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><groupinfo><masterdeviceid>17</masterdeviceid><members>17,18</members></groupinfo></group>" +
+                    "<group identifier=\"F0:A3:7F-901\" id=\"20001\" functionbitmask=\"4160\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>Schlafzimmer</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr><groupinfo><masterdeviceid>0</masterdeviceid><members>20,21,22</members></groupinfo></group>" +
+                    "<device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 200\"><present>1</present><name>FRITZ!DECT 200 #1</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device>" +
+                    "<device identifier=\"08761 0000438\" id=\"18\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 210\"><present>1</present><name>FRITZ!DECT 210 #8</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device>" +
+                    "<device identifier=\"08761 0000437\" id=\"20\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 300\"><present>0</present><name>FRITZ!DECT 300 #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>" +
+                    "<device identifier=\"08761 0000436\" id=\"21\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 301\"><present>0</present><name>FRITZ!DECT 301 #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>" +
+                    "<device identifier=\"08761 0000435\" id=\"22\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"Comet DECT\"><present>0</present><name>Comet DECT #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>1</lock><devicelock>1</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><battery>100</battery><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device>" +
+                    "<device identifier=\"5C:49:79:F0:A3:84\" id=\"30\" functionbitmask=\"640\" fwversion=\"06.92\" manufacturer=\"AVM\" productname=\"FRITZ!Powerline 546E\"><present>1</present><name>FRITZ!Powerline 546E #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><voltage>230051</voltage><power>0</power><energy>2087</energy></powermeter></device>" +
+                    "<device identifier=\"08761 0000439\" id=\"40\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"FRITZ!DECT Repeater 100\"><present>1</present><name>FRITZ!DECT Repeater 100 #5</name><temperature><celsius>230</celsius><offset>0</offset></temperature></device>" +
+                    "<device identifier=\"11934 0059978-1\" id=\"2000\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\"><present>0</present><name>HAN-FUN #2: Unit #2</name><etsiunitinfo><etsideviceid>406</etsideviceid><unittype>514</unittype><interfaces>256</interfaces></etsiunitinfo><alert><state>1</state></alert></device>" +
+                    "<device identifier=\"11934 0059979-1\" id=\"2001\" functionbitmask=\"8200\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\"><present>0</present><name>HAN-FUN #2: Unit #2</name><etsiunitinfo><etsideviceid>412</etsideviceid><unittype>273</unittype><interfaces>772</interfaces></etsiunitinfo><button><lastpressedtimestamp>1529590797</lastpressedtimestamp></button></device>" +
+                "</devicelist>";
+        //@formatter:off
 
         try {
             Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
@@ -60,19 +66,19 @@ public class AVMFritzModelTest {
     @Test
     public void validateDevicelistModel() {
         assertNotNull(devices);
-        assertEquals(8, devices.getDevicelist().size());
+        assertEquals(11, devices.getDevicelist().size());
         assertEquals("1", devices.getXmlApiVersion());
     }
 
     @Test
     public void validateDECTRepeater100Model() {
-        Optional<AVMFritzBaseModel> optionalDevice = findModel("FRITZ!DECT Repeater 100");
+        Optional<AVMFritzBaseModel> optionalDevice = findModelByIdentifier("087610000439");
         assertTrue(optionalDevice.isPresent());
         assertTrue(optionalDevice.get() instanceof DeviceModel);
 
         DeviceModel device = (DeviceModel) optionalDevice.get();
         assertEquals("FRITZ!DECT Repeater 100", device.getProductName());
-        assertEquals("087610954669", device.getIdentifier());
+        assertEquals("087610000439", device.getIdentifier());
         assertEquals("40", device.getDeviceId());
         assertEquals("03.86", device.getFirmwareVersion());
         assertEquals("AVM", device.getManufacturer());
@@ -80,6 +86,8 @@ public class AVMFritzModelTest {
         assertEquals(1, device.getPresent());
         assertEquals("FRITZ!DECT Repeater 100 #5", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertTrue(device.isDectRepeater());
         assertFalse(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -113,6 +121,8 @@ public class AVMFritzModelTest {
         assertEquals(1, device.getPresent());
         assertEquals("FRITZ!DECT 200 #1", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertTrue(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -150,6 +160,8 @@ public class AVMFritzModelTest {
         assertEquals(1, device.getPresent());
         assertEquals("FRITZ!DECT 210 #8", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertTrue(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -187,6 +199,8 @@ public class AVMFritzModelTest {
         assertEquals(0, device.getPresent());
         assertEquals("FRITZ!DECT 300 #1", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertFalse(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -220,6 +234,8 @@ public class AVMFritzModelTest {
         assertEquals(0, device.getPresent());
         assertEquals("FRITZ!DECT 301 #1", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertFalse(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -253,6 +269,8 @@ public class AVMFritzModelTest {
         assertEquals(0, device.getPresent());
         assertEquals("Comet DECT #1", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertFalse(device.isSwitchableOutlet());
         assertTrue(device.isTempSensor());
@@ -286,6 +304,8 @@ public class AVMFritzModelTest {
         assertEquals(1, device.getPresent());
         assertEquals("FRITZ!Powerline 546E #1", device.getName());
 
+        assertFalse(device.isButton());
+        assertFalse(device.isAlarmSensor());
         assertFalse(device.isDectRepeater());
         assertTrue(device.isSwitchableOutlet());
         assertFalse(device.isTempSensor());
@@ -306,14 +326,90 @@ public class AVMFritzModelTest {
     }
 
     @Test
-    public void validateSwitchGroupModel() {
-        Optional<AVMFritzBaseModel> optionalGroup = findModel("");
+    public void validateHANFUNContactModel() {
+        Optional<AVMFritzBaseModel> optionalDevice = findModelByIdentifier("119340059978-1");
+        assertTrue(optionalDevice.isPresent());
+        assertTrue(optionalDevice.get() instanceof DeviceModel);
+
+        DeviceModel device = (DeviceModel) optionalDevice.get();
+        assertEquals("HAN-FUN", device.getProductName());
+        assertEquals("119340059978-1", device.getIdentifier());
+        assertEquals("2000", device.getDeviceId());
+        assertEquals("0.0", device.getFirmwareVersion());
+        assertEquals("0x0feb", device.getManufacturer());
+
+        assertEquals(0, device.getPresent());
+        assertEquals("HAN-FUN #2: Unit #2", device.getName());
+
+        assertFalse(device.isButton());
+        assertTrue(device.isAlarmSensor());
+        assertFalse(device.isDectRepeater());
+        assertFalse(device.isSwitchableOutlet());
+        assertFalse(device.isTempSensor());
+        assertFalse(device.isPowermeter());
+        assertFalse(device.isHeatingThermostat());
+
+        assertNull(device.getButton());
+
+        assertNotNull(device.getAlert());
+        assertEquals(BigDecimal.ONE, device.getAlert().getState());
+
+        assertNull(device.getSwitch());
+
+        assertNull(device.getTemperature());
+
+        assertNull(device.getPowermeter());
+
+        assertNull(device.getHkr());
+    }
+
+    @Test
+    public void validateHANFUNSwitchModel() {
+        Optional<AVMFritzBaseModel> optionalDevice = findModelByIdentifier("119340059979-1");
+        assertTrue(optionalDevice.isPresent());
+        assertTrue(optionalDevice.get() instanceof DeviceModel);
+
+        DeviceModel device = (DeviceModel) optionalDevice.get();
+        assertEquals("HAN-FUN", device.getProductName());
+        assertEquals("119340059979-1", device.getIdentifier());
+        assertEquals("2001", device.getDeviceId());
+        assertEquals("0.0", device.getFirmwareVersion());
+        assertEquals("0x0feb", device.getManufacturer());
+
+        assertEquals(0, device.getPresent());
+        assertEquals("HAN-FUN #2: Unit #2", device.getName());
+
+        assertTrue(device.isButton());
+        assertFalse(device.isAlarmSensor());
+        assertFalse(device.isDectRepeater());
+        assertFalse(device.isSwitchableOutlet());
+        assertFalse(device.isTempSensor());
+        assertFalse(device.isPowermeter());
+        assertFalse(device.isHeatingThermostat());
+
+        assertNotNull(device.getButton());
+        assertEquals(1529590797, device.getButton().getLastpressedtimestamp());
+
+        assertNull(device.getAlert());
+
+        assertNull(device.getSwitch());
+
+        assertNull(device.getTemperature());
+
+        assertNull(device.getPowermeter());
+
+        assertNull(device.getHkr());
+    }
+
+    @Test
+    public void validateHeatingGroupModel() {
+        Optional<AVMFritzBaseModel> optionalGroup = findModelByIdentifier("F0:A3:7F-901");
         assertTrue(optionalGroup.isPresent());
         assertTrue(optionalGroup.get() instanceof GroupModel);
 
         GroupModel group = (GroupModel) optionalGroup.get();
         assertEquals("", group.getProductName());
-        assertEquals("F0:A3:7F-900", group.getIdentifier());
+        assertEquals("F0:A3:7F-901", group.getIdentifier());
         assertEquals("20001", group.getDeviceId());
         assertEquals("1.0", group.getFirmwareVersion());
         assertEquals("AVM", group.getManufacturer());
@@ -321,6 +417,43 @@ public class AVMFritzModelTest {
         assertEquals(1, group.getPresent());
         assertEquals("Schlafzimmer", group.getName());
 
+        assertFalse(group.isButton());
+        assertFalse(group.isAlarmSensor());
+        assertFalse(group.isDectRepeater());
+        assertFalse(group.isSwitchableOutlet());
+        assertFalse(group.isTempSensor());
+        assertFalse(group.isPowermeter());
+        assertTrue(group.isHeatingThermostat());
+
+        assertNull(group.getSwitch());
+
+        assertNull(group.getPowermeter());
+
+        validateHeatingModel(group.getHkr());
+
+        assertNotNull(group.getGroupinfo());
+        assertEquals("0", group.getGroupinfo().getMasterdeviceid());
+        assertEquals("20,21,22", group.getGroupinfo().getMembers());
+    }
+
+    @Test
+    public void validateSwitchGroupModel() {
+        Optional<AVMFritzBaseModel> optionalGroup = findModelByIdentifier("F0:A3:7F-900");
+        assertTrue(optionalGroup.isPresent());
+        assertTrue(optionalGroup.get() instanceof GroupModel);
+
+        GroupModel group = (GroupModel) optionalGroup.get();
+        assertEquals("", group.getProductName());
+        assertEquals("F0:A3:7F-900", group.getIdentifier());
+        assertEquals("20000", group.getDeviceId());
+        assertEquals("1.0", group.getFirmwareVersion());
+        assertEquals("AVM", group.getManufacturer());
+
+        assertEquals(1, group.getPresent());
+        assertEquals("Schlafzimmer", group.getName());
+
+        assertFalse(group.isButton());
+        assertFalse(group.isAlarmSensor());
         assertFalse(group.isDectRepeater());
         assertTrue(group.isSwitchableOutlet());
         assertFalse(group.isTempSensor());
@@ -338,12 +471,17 @@ public class AVMFritzModelTest {
         assertNull(group.getHkr());
 
         assertNotNull(group.getGroupinfo());
-        assertEquals("1000", group.getGroupinfo().getMasterdeviceid());
-        assertEquals("20000", group.getGroupinfo().getMembers());
+        assertEquals("17", group.getGroupinfo().getMasterdeviceid());
+        assertEquals("17,18", group.getGroupinfo().getMembers());
     }
 
+    @Deprecated
     private Optional<AVMFritzBaseModel> findModel(@NonNull String name) {
         return devices.getDevicelist().stream().filter(it -> name.equals(it.getProductName())).findFirst();
+    }
+
+    private Optional<AVMFritzBaseModel> findModelByIdentifier(@NonNull String identifier) {
+        return devices.getDevicelist().stream().filter(it -> identifier.equals(it.getIdentifier())).findFirst();
     }
 
     private void validatePowerMeter(PowerMeterModel model) {

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -624,16 +624,16 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
         String xml =
                 "<devicelist version=\"1\">" +
                     "<device identifier=\"11324 0059952-1\" id=\"2003\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x2c3c\" productname=\"HAN-FUN\">" +
-                    "<present>1</present>" +
-                    "<name>HAN-FUN #4: Unit #4</name>" +
-                    "<etsiunitinfo>" +
-                        "<etsideviceid>407</etsideviceid>" +
-                        "<unittype>516</unittype>" +
-                        "<interfaces>256</interfaces>" +
-                    "</etsiunitinfo>" +
-                    "<alert>" +
-                        "<state>0</state>" +
-                    "</alert>" +
+                        "<present>1</present>" +
+                        "<name>HAN-FUN #4: Unit #4</name>" +
+                        "<etsiunitinfo>" +
+                            "<etsideviceid>407</etsideviceid>" +
+                            "<unittype>516</unittype>" +
+                            "<interfaces>256</interfaces>" +
+                        "</etsiunitinfo>" +
+                        "<alert>" +
+                            "<state>0</state>" +
+                        "</alert>" +
                     "</device>" +
                 "</devicelist>";
         //@formatter:on
@@ -670,9 +670,9 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
                         "<present>0</present>" +
                         "<name>HAN-FUN #2: Unit #2</name>" +
                         "<etsiunitinfo>" +
-                        "<etsideviceid>412</etsideviceid>" +
-                        "<unittype>273</unittype>" +
-                        "<interfaces>772</interfaces>" +
+                            "<etsideviceid>412</etsideviceid>" +
+                            "<unittype>273</unittype>" +
+                            "<interfaces>772</interfaces>" +
                         "</etsiunitinfo>" +
                         "<button>" +
                             "<lastpressedtimestamp>1529590797</lastpressedtimestamp>" +

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -490,13 +490,56 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
     }
 
     @Test
-    public void validHANFUNContactDiscoveryResult() throws JAXBException {
+    public void validHANFUNMagneticContactDiscoveryResult() throws JAXBException {
         //@formatter:off
         String xml =
                 "<devicelist version=\"1\">" +
                     "<device identifier=\"11934 0059578-1\" id=\"2000\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
                         "<present>0</present>" +
                         "<name>HAN-FUN #2: Unit #2</name>" +
+                        "<etsiunitinfo>" +
+                        "<etsideviceid>406</etsideviceid>" +
+                        "<unittype>513</unittype>" +
+                        "<interfaces>256</interfaces>" +
+                        "</etsiunitinfo>" +
+                        "<alert>" +
+                            "<state/>" +
+                        "</alert>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:HAN_FUN_CONTACT:1:119340059578_1"), discoveryResult.getThingUID());
+        assertEquals(HAN_FUN_CONTACT_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("2000", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validHANFUNOpticalContactDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11934 0059578-1\" id=\"2001\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
+                        "<present>0</present>" +
+                        "<name>HAN-FUN #3: Unit #3</name>" +
                         "<etsiunitinfo>" +
                         "<etsideviceid>406</etsideviceid>" +
                         "<unittype>514</unittype>" +
@@ -526,7 +569,7 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
         assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
         assertEquals("119340059578-1", discoveryResult.getProperties().get(CONFIG_AIN));
         assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
-        assertEquals("2000", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("2001", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
         assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
         assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
         assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -498,9 +498,9 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
                         "<present>0</present>" +
                         "<name>HAN-FUN #2: Unit #2</name>" +
                         "<etsiunitinfo>" +
-                        "<etsideviceid>406</etsideviceid>" +
-                        "<unittype>513</unittype>" +
-                        "<interfaces>256</interfaces>" +
+                            "<etsideviceid>406</etsideviceid>" +
+                            "<unittype>513</unittype>" +
+                            "<interfaces>256</interfaces>" +
                         "</etsiunitinfo>" +
                         "<alert>" +
                             "<state/>" +
@@ -541,9 +541,9 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
                         "<present>0</present>" +
                         "<name>HAN-FUN #3: Unit #3</name>" +
                         "<etsiunitinfo>" +
-                        "<etsideviceid>406</etsideviceid>" +
-                        "<unittype>514</unittype>" +
-                        "<interfaces>256</interfaces>" +
+                            "<etsideviceid>406</etsideviceid>" +
+                            "<unittype>514</unittype>" +
+                            "<interfaces>256</interfaces>" +
                         "</etsiunitinfo>" +
                         "<alert>" +
                             "<state/>" +
@@ -584,9 +584,9 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
                         "<present>0</present>" +
                         "<name>HAN-FUN #3: Unit #3</name>" +
                         "<etsiunitinfo>" +
-                        "<etsideviceid>408</etsideviceid>" +
-                        "<unittype>515</unittype>" +
-                        "<interfaces>32513,256</interfaces>" +
+                            "<etsideviceid>408</etsideviceid>" +
+                            "<unittype>515</unittype>" +
+                            "<interfaces>32513,256</interfaces>" +
                         "</etsiunitinfo>" +
                         "<alert>" +
                             "<state>0</state>" +
@@ -614,6 +614,49 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
         assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
         assertEquals("2002", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
         assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validHANFUNMSmokeDetectorDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11324 0059952-1\" id=\"2003\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x2c3c\" productname=\"HAN-FUN\">" +
+                    "<present>1</present>" +
+                    "<name>HAN-FUN #4: Unit #4</name>" +
+                    "<etsiunitinfo>" +
+                        "<etsideviceid>407</etsideviceid>" +
+                        "<unittype>516</unittype>" +
+                        "<interfaces>256</interfaces>" +
+                    "</etsiunitinfo>" +
+                    "<alert>" +
+                        "<state>0</state>" +
+                    "</alert>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:HAN_FUN_CONTACT:1:113240059952_1"), discoveryResult.getThingUID());
+        assertEquals(HAN_FUN_CONTACT_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("113240059952-1", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("0x2c3c", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("2003", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("113240059952-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
         assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
         assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
     }

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -78,7 +78,7 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void correctSupportedTypes() {
-        assertEquals(9, discovery.getSupportedThingTypes().size());
+        assertEquals(11, discovery.getSupportedThingTypes().size());
         assertTrue(discovery.getSupportedThingTypes().contains(DECT100_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(DECT200_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(DECT210_THING_TYPE));
@@ -86,6 +86,8 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
         assertTrue(discovery.getSupportedThingTypes().contains(DECT301_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(PL546E_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(COMETDECT_THING_TYPE));
+        assertTrue(discovery.getSupportedThingTypes().contains(HAN_FUN_CONTACT_THING_TYPE));
+        assertTrue(discovery.getSupportedThingTypes().contains(HAN_FUN_SWITCH_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(GROUP_HEATING_THING_TYPE));
         assertTrue(discovery.getSupportedThingTypes().contains(GROUP_SWITCH_THING_TYPE));
     }
@@ -93,7 +95,19 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
     @Test
     public void invalidDiscoveryResult() throws JAXBException {
         // attribute productname is important for a valid discovery result
-        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>FRITZ!DECT 210 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0954669\" id=\"20\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT Repeater 100 #5</name>" +
+                        "<temperature>" +
+                            "<celsius>230</celsius>" +
+                            "<offset>0</offset>" +
+                        "</temperature>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -109,7 +123,19 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void validDECTRepeater100Result() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0954669\" id=\"20\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"FRITZ!DECT Repeater 100\"><present>1</present><name>FRITZ!DECT Repeater 100 #5</name><temperature><celsius>230</celsius><offset>0</offset></temperature></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0954669\" id=\"20\" functionbitmask=\"1280\" fwversion=\"03.86\" manufacturer=\"AVM\" productname=\"FRITZ!DECT Repeater 100\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT Repeater 100 #5</name>" +
+                        "<temperature>" +
+                            "<celsius>230</celsius>" +
+                            "<offset>0</offset>" +
+                        "</temperature>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -136,7 +162,30 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void validDECT200DiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 200\"><present>1</present><name>FRITZ!DECT 200 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 200\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT 200 #1</name>" +
+                        "<switch>" +
+                            "<state>0</state>" +
+                            "<mode>manuell</mode>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>1</devicelock>" +
+                        "</switch>" +
+                        "<powermeter>" +
+                            "<voltage>232850</voltage>" +
+                            "<power>45</power>" +
+                            "<energy>166</energy>" +
+                        "</powermeter>" +
+                        "<temperature>" +
+                            "<celsius>255</celsius>" +
+                            "<offset>0</offset>" +
+                        "</temperature>" +
+                     "</device>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -163,7 +212,30 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void validDECT210DiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 210\"><present>1</present><name>FRITZ!DECT 210 #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>45</power><energy>166</energy></powermeter><temperature><celsius>255</celsius><offset>0</offset></temperature></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0000434\" id=\"17\" functionbitmask=\"2944\" fwversion=\"03.83\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 210\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT 210 #1</name>" +
+                        "<switch>" +
+                            "<state>0</state>" +
+                            "<mode>manuell</mode>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>1</devicelock>" +
+                        "</switch>" +
+                        "<powermeter>" +
+                            "<voltage>232850</voltage>" +
+                            "<power>45</power>" +
+                            "<energy>166</energy>" +
+                        "</powermeter>" +
+                        "<temperature>" +
+                            "<celsius>255</celsius>" +
+                            "<offset>0</offset>" +
+                        "</temperature>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -190,7 +262,33 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
 
     @Test
     public void validCometDECTDiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"08761 0000435\" id=\"18\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"Comet DECT\"><present>1</present><name>Comet DECT #1</name><temperature><celsius>220</celsius><offset>-10</offset></temperature><hkr><tist>44</tist><tsoll>42</tsoll><absenk>28</absenk><komfort>42</komfort><lock>0</lock><devicelock>0</devicelock><errorcode>0</errorcode><batterylow>0</batterylow><nextchange><endperiod>1484341200</endperiod><tchange>28</tchange></nextchange></hkr></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0000435\" id=\"18\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"Comet DECT\">" +
+                        "<present>1</present>" +
+                        "<name>Comet DECT #1</name>" +
+                        "<temperature>" +
+                            "<celsius>220</celsius>" +
+                            "<offset>-10</offset>" +
+                        "</temperature>" +
+                        "<hkr>" +
+                            "<tist>44</tist>" +
+                            "<tsoll>42</tsoll>" +
+                            "<absenk>28</absenk>" +
+                            "<komfort>42</komfort>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>0</devicelock>" +
+                            "<errorcode>0</errorcode>" +
+                            "<batterylow>0</batterylow>" +
+                            "<nextchange>" +
+                                "<endperiod>1484341200</endperiod>" +
+                                "<tchange>28</tchange>" +
+                            "</nextchange>" +
+                        "</hkr>" +
+                     "</device>" +
+                 "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -216,8 +314,133 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
     }
 
     @Test
+    public void validDECT300DiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0000435\" id=\"18\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 300\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT 300 #1</name>" +
+                        "<temperature>" +
+                            "<celsius>220</celsius>" +
+                            "<offset>-10</offset>" +
+                        "</temperature>" +
+                        "<hkr>" +
+                            "<tist>44</tist>" +
+                            "<tsoll>42</tsoll>" +
+                            "<absenk>28</absenk>" +
+                            "<komfort>42</komfort>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>0</devicelock>" +
+                            "<errorcode>0</errorcode>" +
+                            "<batterylow>0</batterylow>" +
+                            "<nextchange>" +
+                                "<endperiod>1484341200</endperiod>" +
+                                "<tchange>28</tchange>" +
+                            "</nextchange>" +
+                        "</hkr>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:FRITZ_DECT_300:1:087610000435"), discoveryResult.getThingUID());
+        assertEquals(DECT300_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("087610000435", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("AVM", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("18", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("087610000435", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("03.50", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validDECT301DiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"08761 0000435\" id=\"18\" functionbitmask=\"320\" fwversion=\"03.50\" manufacturer=\"AVM\" productname=\"FRITZ!DECT 301\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!DECT 301 #1</name>" +
+                        "<temperature>" +
+                        "<celsius>220</celsius>" +
+                        "<offset>-10</offset>" +
+                    "</temperature>" +
+                    "<hkr>" +
+                        "<tist>44</tist>" +
+                        "<tsoll>42</tsoll>" +
+                        "<absenk>28</absenk>" +
+                        "<komfort>42</komfort>" +
+                        "<lock>0</lock>" +
+                        "<devicelock>0</devicelock>" +
+                        "<errorcode>0</errorcode>" +
+                        "<batterylow>0</batterylow>" +
+                        "<nextchange>" +
+                            "<endperiod>1484341200</endperiod>" +
+                            "<tchange>28</tchange>" +
+                        "</nextchange>" +
+                    "</hkr>" +
+                "</device>" +
+            "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:FRITZ_DECT_301:1:087610000435"), discoveryResult.getThingUID());
+        assertEquals(DECT301_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("087610000435", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("AVM", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("18", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("087610000435", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("03.50", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
     public void validPowerline546EDiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><device identifier=\"5C:49:79:F0:A3:84\" id=\"19\" functionbitmask=\"640\" fwversion=\"06.92\" manufacturer=\"AVM\" productname=\"FRITZ!Powerline 546E\"><present>1</present><name>FRITZ!Powerline 546E #1</name><switch><state>0</state><mode>manuell</mode><lock>0</lock><devicelock>1</devicelock></switch><powermeter><power>0</power><energy>2087</energy></powermeter></device></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"5C:49:79:F0:A3:84\" id=\"19\" functionbitmask=\"640\" fwversion=\"06.92\" manufacturer=\"AVM\" productname=\"FRITZ!Powerline 546E\">" +
+                        "<present>1</present>" +
+                        "<name>FRITZ!Powerline 546E #1</name>" +
+                        "<switch>" +
+                            "<state>0</state>" +
+                            "<mode>manuell</mode>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>1</devicelock>" +
+                        "</switch>" +
+                        "<powermeter>" +
+                            "<voltage>232850</voltage>" +
+                            "<power>0</power>" +
+                            "<energy>2087</energy>" +
+                        "</powermeter>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
@@ -243,8 +466,200 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
     }
 
     @Test
+    public void invalidHANFUNContactDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11934 0059578\" id=\"406\" functionbitmask=\"1\" fwversion=\"00.00\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
+                        "<present>0</present>" +
+                        "<name>HAN-FUN #2</name>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNull(discoveryResult);
+    }
+
+    @Test
+    public void validHANFUNContactDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11934 0059578-1\" id=\"2000\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
+                        "<present>0</present>" +
+                        "<name>HAN-FUN #2: Unit #2</name>" +
+                        "<etsiunitinfo>" +
+                        "<etsideviceid>406</etsideviceid>" +
+                        "<unittype>514</unittype>" +
+                        "<interfaces>256</interfaces>" +
+                        "</etsiunitinfo>" +
+                        "<alert>" +
+                            "<state/>" +
+                        "</alert>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:HAN_FUN_CONTACT:1:119340059578_1"), discoveryResult.getThingUID());
+        assertEquals(HAN_FUN_CONTACT_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("2000", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validHANFUNSwitchtDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11934 0059578-1\" id=\"2001\" functionbitmask=\"8200\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
+                        "<present>0</present>" +
+                        "<name>HAN-FUN #2: Unit #2</name>" +
+                        "<etsiunitinfo>" +
+                        "<etsideviceid>412</etsideviceid>" +
+                        "<unittype>273</unittype>" +
+                        "<interfaces>772</interfaces>" +
+                        "</etsiunitinfo>" +
+                        "<button>" +
+                            "<lastpressedtimestamp>1529590797</lastpressedtimestamp>" +
+                        "</button>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:HAN_FUN_SWITCH:1:119340059578_1"), discoveryResult.getThingUID());
+        assertEquals(HAN_FUN_SWITCH_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("2001", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
+    public void validHeatingGroupDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<group identifier=\"F0:A3:7F-900\" id=\"20000\" functionbitmask=\"4160\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\">" +
+                        "<present>1</present>" +
+                        "<name>Schlafzimmer</name>" +
+                        "<hkr>" +
+                            "<tist>0</tist>" +
+                            "<tsoll>253</tsoll>" +
+                            "<absenk>33</absenk>" +
+                            "<komfort>40</komfort>" +
+                            "<lock>1</lock>" +
+                            "<devicelock>0</devicelock>" +
+                            "<errorcode>0</errorcode>" +
+                            "<batterylow>0</batterylow>" +
+                            "<windowopenactiv>0</windowopenactiv>" +
+                            "<battery>1</battery>" +
+                            "<nextchange>" +
+                                "<endperiod>1546293600</endperiod>" +
+                                "<tchange>33</tchange>" +
+                            "</nextchange>" +
+                            "<summeractive>1</summeractive>" +
+                            "<holidayactive>0</holidayactive>" +
+                        "</hkr>" +
+                        "<groupinfo>" +
+                            "<masterdeviceid>1000</masterdeviceid>" +
+                            "<members>20000</members>" +
+                        "</groupinfo>" +
+                    "</group>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:FRITZ_GROUP_HEATING:1:F0_A3_7F_900"), discoveryResult.getThingUID());
+        assertEquals(GROUP_HEATING_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("F0:A3:7F-900", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("AVM", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("20000", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("F0:A3:7F-900", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("1.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals("1000", discoveryResult.getProperties().get(PROPERTY_MASTER));
+        assertEquals("20000", discoveryResult.getProperties().get(PROPERTY_MEMBERS));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
     public void validSwitchGroupDiscoveryResult() throws JAXBException {
-        String xml = "<devicelist version=\"1\"><group identifier=\"F0:A3:7F-900\" id=\"20001\" functionbitmask=\"640\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\"><present>1</present><name>Schlafzimmer</name><switch><state>1</state><mode>manuell</mode><lock>0</lock><devicelock>0</devicelock></switch><powermeter><power>0</power><energy>2087</energy></powermeter><groupinfo><masterdeviceid>1000</masterdeviceid><members>20000</members></groupinfo></group></devicelist>";
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<group identifier=\"F0:A3:7F-900\" id=\"20001\" functionbitmask=\"6784\" fwversion=\"1.0\" manufacturer=\"AVM\" productname=\"\">" +
+                        "<present>1</present>" +
+                        "<name>Schlafzimmer</name>" +
+                        "<switch>" +
+                            "<state>1</state>" +
+                            "<mode>manuell</mode>" +
+                            "<lock>0</lock>" +
+                            "<devicelock>0</devicelock>" +
+                        "</switch>" +
+                        "<powermeter>" +
+                            "<voltage>232850</voltage>" +
+                            "<power>0</power>" +
+                            "<energy>2087</energy>" +
+                        "</powermeter>" +
+                        "<groupinfo>" +
+                            "<masterdeviceid>1000</masterdeviceid>" +
+                            "<members>20000</members>" +
+                        "</groupinfo>" +
+                    "</group>" +
+                "</devicelist>";
+        //@formatter:on
 
         Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
         DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));

--- a/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
+++ b/addons/binding/org.openhab.binding.avmfritz.test/src/test/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceTest.java
@@ -533,6 +533,49 @@ public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
     }
 
     @Test
+    public void validHANFUNMotionSensorDiscoveryResult() throws JAXBException {
+        //@formatter:off
+        String xml =
+                "<devicelist version=\"1\">" +
+                    "<device identifier=\"11934 0059578-1\" id=\"2002\" functionbitmask=\"8208\" fwversion=\"0.0\" manufacturer=\"0x0feb\" productname=\"HAN-FUN\">" +
+                        "<present>0</present>" +
+                        "<name>HAN-FUN #3: Unit #3</name>" +
+                        "<etsiunitinfo>" +
+                        "<etsideviceid>408</etsideviceid>" +
+                        "<unittype>515</unittype>" +
+                        "<interfaces>32513,256</interfaces>" +
+                        "</etsiunitinfo>" +
+                        "<alert>" +
+                            "<state>0</state>" +
+                        "</alert>" +
+                    "</device>" +
+                "</devicelist>";
+        //@formatter:on
+
+        Unmarshaller u = JAXBUtils.JAXBCONTEXT.createUnmarshaller();
+        DevicelistModel devices = (DevicelistModel) u.unmarshal(new StringReader(xml));
+        assertNotNull(devices);
+        assertEquals(1, devices.getDevicelist().size());
+
+        AVMFritzBaseModel device = devices.getDevicelist().get(0);
+        assertNotNull(device);
+
+        discovery.onDeviceAddedInternal(device);
+        assertNotNull(discoveryResult);
+
+        assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
+        assertEquals(new ThingUID("avmfritz:HAN_FUN_CONTACT:1:119340059578_1"), discoveryResult.getThingUID());
+        assertEquals(HAN_FUN_CONTACT_THING_TYPE, discoveryResult.getThingTypeUID());
+        assertEquals(BRIGE_THING_ID, discoveryResult.getBridgeUID());
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(CONFIG_AIN));
+        assertEquals("0x0feb", discoveryResult.getProperties().get(PROPERTY_VENDOR));
+        assertEquals("2002", discoveryResult.getProperties().get(PROPERTY_MODEL_ID));
+        assertEquals("119340059578-1", discoveryResult.getProperties().get(PROPERTY_SERIAL_NUMBER));
+        assertEquals("0.0", discoveryResult.getProperties().get(PROPERTY_FIRMWARE_VERSION));
+        assertEquals(CONFIG_AIN, discoveryResult.getRepresentationProperty());
+    }
+
+    @Test
     public void validHANFUNSwitchtDiscoveryResult() throws JAXBException {
         //@formatter:off
         String xml =

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de.properties
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/i18n/avmfritz_de.properties
@@ -7,6 +7,12 @@ thing-type.avmfritz.fritzbox.description = FRITZ!Box
 
 thing-type.avmfritz.FRITZ_Powerline_546E_Solo.description = FRITZ!Powerline 546E schaltbare Steckdose im stand-alone Modus. Dient zur Steuerung der integrierten Steckdose und liefert Daten wie z.B. Temperatur.
 
+thing-type.avmfritz.HAN_FUN_CONTACT.label = HAN-FUN Kontakt
+thing-type.avmfritz.HAN_FUN_CONTACT.description = HAN-FUN Kontakt (e.g. SmartHome Tür-/Fensterkontakt or SmartHome Bewegungsmelder).
+
+thing-type.avmfritz.HAN_FUN_SWITCH.label = HAN-FUN Schalter
+thing-type.avmfritz.HAN_FUN_SWITCH.description = HAN-FUN Schalter (e.g. SmartHome Wandtaster).
+
 # bridge types config groups
 bridge-type.config.avmfritz.fritzbox.group.network.label = Netzwerk
 bridge-type.config.avmfritz.fritzbox.group.network.description = Einstellungen für das Netzwerk.
@@ -154,6 +160,16 @@ channel-type.avmfritz.next_change.pattern = pattern = %1$td.%1$tm.%1$tY %1$tH:%1
 
 channel-type.avmfritz.next_temp.label = Nächste Solltemperatur
 channel-type.avmfritz.next_temp.description = Zeigt die nächste Solltemperatur des Heizkörperreglers an.
+
+channel-type.avmfritz.contact_state.label = Tür-/Fenster-Zustand
+channel-type.avmfritz.contact_state.description = Zeigt an, ob die Tür oder das Fester offen oder geschlossen ist (OPEN/CLOSED).
+
+thing-type.avmfritz.HAN_FUN_SWITCH.channel.press.label = Tastendruck
+thing-type.avmfritz.HAN_FUN_SWITCH.channel.press.description = Wird ausgelöst, wenn eine Taste gedrückt wird.
+
+channel-type.avmfritz.last_change.label = Letzte Änderung
+channel-type.avmfritz.last_change.description = Zeigt an, wann der Schalter zuletzt gedrückt wurde.
+channel-type.avmfritz.last_change.pattern = %1$td.%1$tm.%1$tY %1$tH:%1$tM:%1$tS
 
 # channel types config
 channel-type.config.avmfritz.temperature.offset.label = Temperatur-Offset

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/channel-types.xml
@@ -128,6 +128,7 @@
 		<item-type>DateTime</item-type>
 		<label>Next Setpoint Change</label>
 		<description>Next change of Setpoint Temperature.</description>
+		<category>Time</category>
 		<state readOnly="true" />
 	</channel-type>
 
@@ -137,5 +138,21 @@
 		<description>Next Setpoint Temperature.</description>
 		<category>Temperature</category>
 		<state pattern="%.1f %unit%" readOnly="true" />
+	</channel-type>
+
+	<channel-type id="contact_state">
+		<item-type>Contact</item-type>
+		<label>Contact State</label>
+		<description>Contact state information (OPEN/CLOSED).</description>
+		<category>Contact</category>
+		<state pattern="%s" readOnly="true" />
+	</channel-type>
+
+	<channel-type id="last_change">
+		<item-type>DateTime</item-type>
+		<label>Last Change</label>
+		<description>States the last time the button was pressed.</description>
+		<category>Time</category>
+		<state readOnly="true" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -182,6 +182,46 @@
 		<config-description-ref uri="thing-type:avmfritz:fritzdevice" />
 	</thing-type>
 
+	<thing-type id="HAN_FUN_CONTACT">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+			<bridge-type-ref id="FRITZ_Powerline_546E_Solo" />
+		</supported-bridge-type-refs>
+
+		<label>HAN-FUN contact</label>
+		<description>HAN-FUN contact (e.g. SmartHome Tür-/Fensterkontakt or SmartHome Bewegungsmelder).</description>
+
+		<channels>
+			<channel typeId="contact_state" id="contact_state" />
+		</channels>
+
+		<representation-property>ain</representation-property>
+
+		<config-description-ref uri="thing-type:avmfritz:fritzdevice" />
+	</thing-type>
+
+	<thing-type id="HAN_FUN_SWITCH">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="fritzbox" />
+			<bridge-type-ref id="FRITZ_Powerline_546E_Solo" />
+		</supported-bridge-type-refs>
+
+		<label>HAN-FUN switch</label>
+		<description>HAN-FUN switch (e.g. SmartHome Wandtaster).</description>
+
+		<channels>
+			<channel id="press" typeId="system.trigger">
+				<label>Button press</label>
+				<description>Triggered when a button was pressed.</description>
+			</channel>
+			<channel typeId="last_change" id="last_change" />
+		</channels>
+
+		<representation-property>ain</representation-property>
+
+		<config-description-ref uri="thing-type:avmfritz:fritzdevice" />
+	</thing-type>
+
 	<!-- Supported FRITZ! groups and features -->
 	<thing-type id="FRITZ_GROUP_HEATING">
 		<supported-bridge-type-refs>

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -37,6 +37,18 @@ Additionally you can check the eco temperature, the comfort temperature and the 
 The FRITZ!Box has to run at least on firmware FRITZ!OS 6.35.
 **NOTE:** The `battery_level` channel will be added to the thing during runtime - if the interface supports it (FRITZ!OS 7 or higher).
 
+### DECT-ULE / HAN-FUN devices
+
+The following sensors have been successfully tested using FRITZ!OS 7 for FRITZ!Box 7490 / 7590:
+
+- [SmartHome Tür-/Fensterkontakt](https://www.smarthome.de/geraete/eurotronic-smarthome-tuer-fensterkontakt-optisch) - a door/window contact
+- [SmartHome Bewegungsmelder](https://www.smarthome.de/geraete/telekom-smarthome-bewegungsmelder-innen) - a motion sensor
+- [SmartHome Wandtaster](https://www.smarthome.de/geraete/telekom-smarthome-wandtaster) - a switch with two buttons
+
+The use of other Sensors should be possible, if these are compatible with DECT-ULE / HAN-FUN standards.
+
+The FRITZ!Box has to run at least on firmware FRITZ!OS 7.
+
 ### FRITZ! groups 
 
 The FRITZ!OS supports two different types of groups.
@@ -93,12 +105,12 @@ If correct credentials are set in the bridge configuration, connected AHA device
 | mode            | String                   | States the mode of the device (MANUAL/AUTOMATIC/VACATION)                                              | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
 | locked          | Contact                  | Device is locked for switching over external sources (OPEN/CLOSE)                                      | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
 | device_locked   | Contact                  | Device is locked for switching manually (OPEN/CLOSE) - FRITZ!OS 6.90                                   | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT    |
-| temperature     | Number:Temperature       | Current measured temperature                                                                            | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!DECT Repeater 100, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT |
+| temperature     | Number:Temperature       | Current measured temperature                                                                           | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!DECT Repeater 100, FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT |
 | energy          | Number:Energy            | Accumulated energy consumption                                                                         | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
 | power           | Number:Power             | Current power consumption                                                                              | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
 | voltage         | Number:ElectricPotential | Current voltage - FRITZ!OS 7                                                                           | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
 | outlet          | Switch                   | Switchable outlet (ON/OFF)                                                                             | FRITZ!DECT 210, FRITZ!DECT 200, FRITZ!Powerline 546E                                                |
-| actual_temp     | Number:Temperature       | Current temperature of heating thermostat                                                               | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| actual_temp     | Number:Temperature       | Current temperature of heating thermostat                                                              | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 | set_temp        | Number:Temperature       | Set Temperature of heating thermostat                                                                  | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 | eco_temp        | Number:Temperature       | Eco Temperature of heating thermostat                                                                  | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 | comfort_temp    | Number:Temperature       | Comfort Temperature of heating thermostat                                                              | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
@@ -107,18 +119,28 @@ If correct credentials are set in the bridge configuration, connected AHA device
 | next_temp       | Number:Temperature       | Next Set Temperature if scheduler is activated in the FRITZ!Box settings - FRITZ!OS 6.80               | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 | battery_level   | Number                   | Battery level (in %) - FRITZ!OS 7                                                                      | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
 | battery_low     | Switch                   | Battery level low (ON/OFF) - FRITZ!OS 6.80                                                             | FRITZ!DECT 301, FRITZ!DECT 300, Comet DECT                                                          |
+| contact_state   | Contact                  | Contact state information (OPEN/CLOSED).                                                               | HAN-FUN contact (e.g. SmartHome Tür-/Fensterkontakt or SmartHome Bewegungsmelder)- FRITZ!OS 7       |
+| last_change     | DateTime                 | States the last time the button was pressed.                                                           | HAN-FUN switch (e.g. SmartHome Wandtaster) - FRITZ!OS 7                                             |
+
+### Triggers
+
+| Channel Type ID | Item Type | Description                          | Available on thing                                      |
+|-----------------|-----------|--------------------------------------|---------------------------------------------------------|
+| press           | Trigger   | Dispatched when a button is pressed. | HAN-FUN switch (e.g. SmartHome Wandtaster) - FRITZ!OS 7 |
 
 ## Full Example
 
 demo.things:
 
 ```java
-Bridge avmfritz:fritzbox:1 @ "Office" [ ipAddress="192.168.x.x", password="xxx", user="xxx" ] {
-    Thing FRITZ_DECT_200 xxxxxxxxxxxx "FRITZ!DECT 200 #1" @ "Living Room" [ ain="xxxxxxxxxxxx" ]
-    Thing FRITZ_Powerline_546E yy_yy_yy_yy_yy_yy "FRITZ!Powerline 546E #2" @ "Office" [ ain="yy:yy:yy:yy:yy:yy" ]
-    Thing Comet_DECT aaaaaabbbbbb "Comet DECT #3" @ "Office" [ ain="aaaaaabbbbbb" ]
-    Thing FRITZ_GROUP_HEATING AA_AA_AA_900 "Heating group" @ "Office" [ ain="AA:AA:AA-900" ]
-    Thing FRITZ_GROUP_SWITCH BB_BB_BB_900 "Switch group" @ "Living Room" [ ain="BB:BB:BB-900" ]
+Bridge avmfritz:fritzbox:1 "FRITZ!Box" [ ipAddress="192.168.x.x", password="xxx", user="xxx" ] {
+    Thing FRITZ_DECT_200 xxxxxxxxxxxx "FRITZ!DECT 200 #1" [ ain="xxxxxxxxxxxx" ]
+    Thing FRITZ_Powerline_546E yy_yy_yy_yy_yy_yy "FRITZ!Powerline 546E #2" [ ain="yy:yy:yy:yy:yy:yy" ]
+    Thing Comet_DECT aaaaaabbbbbb "Comet DECT #3" [ ain="aaaaaabbbbbb" ]
+    Thing HANFUNContact zzzzzzzzzzzz_1 "HAN-FUN Contact #4" [ ain="zzzzzzzzzzzz-1" ]
+    Thing HANFUNSwitch zzzzzzzzzzzz_2 "HAN-FUN Switch #5" [ ain=zzzzzzzzzzzz-2" ]
+    Thing FRITZ_GROUP_HEATING AA_AA_AA_900 "Heating group" [ ain="AA:AA:AA-900" ]
+    Thing FRITZ_GROUP_SWITCH BB_BB_BB_900 "Switch group" [ ain="BB:BB:BB-900" ]
 }
 ```
 
@@ -139,6 +161,10 @@ String COMETDECTRadiatorMode "Radiator mode [%s]" { channel="avmfritz:Comet_DECT
 Number COMETDECTBattery "Battery level" { channel="avmfritz:Comet_DECT:1:aaaaaabbbbbb:battery_level" }
 Switch COMETDECTBatteryLow "Battery low" { channel="avmfritz:Comet_DECT:1:aaaaaabbbbbb:battery_low" }
 
+Contact HANFUNContactState "Status [%s]" { channel="avmfritz:HAN_FUN_CONTACT:1:zzzzzzzzzzzz_1:contact_state" }
+
+DateTime HANFUNSwitchLastChanged "Last change" { channel="avmfritz:HAN_FUN_SWITCH:1:zzzzzzzzzzzz_2:last_change" }
+
 Number:Temperature FRITZ_GROUP_HEATINGSetTemperature "Group temperature set point [%.1f %unit%]" { channel="avmfritz:FRITZ_GROUP_HEATING:1:AA_AA_AA_900:set_temp" }
 
 Switch Outlet3 "Group switch" { channel="avmfritz:FRITZ_GROUP_SWITCH:1:BB_BB_BB_900:outlet" }
@@ -146,7 +172,7 @@ Switch Outlet3 "Group switch" { channel="avmfritz:FRITZ_GROUP_SWITCH:1:BB_BB_BB_
 
 demo.sitemap:
 
-```perl
+```java
 sitemap demo label="Main Menu" {
 
 	Frame label="FRITZ!DECT 200 switchable outlet" {
@@ -161,12 +187,31 @@ sitemap demo label="Main Menu" {
 		Switch item=Outlet2 icon="poweroutlet"
 	}
 
-	Frame "Comet DECT heating thermostat" {
+	Frame label="Comet DECT heating thermostat" {
 		Text item=COMETDECTTemperature icon="temperature"
 		Setpoint item=COMETDECTSetTemperature minValue=8.0 maxValue=28.0 step=0.5 icon="temperature"
 		Selection item=COMETDECTRadiatorMode mappings=["ON"="ON", "OFF"="OFF", "COMFORT"="COMFORT", "ECO"="ECO", "BOOST"="BOOST"] icon="heating"
 		Text item=COMETDECTBattery icon="battery"
 		Switch item=COMETDECTBatteryLow icon="lowbattery"
 	}
+	 
+    Frame label="HAN-FUN Contact" {
+        Text item=HANFUNContactState
+    }
+	
+	Frame label="HAN-FUN Switch" {
+	    Text item=HANFUNSwitchLastChanged
+	}
 }
+```
+
+demo.rule:
+
+```java
+rule "HAN-FUN Button pressed"
+when
+    Channel "avmfritz:HAN_FUN_SWITCH:1:zzzzzzzzzzzz_2:press" triggered
+then
+    logInfo("demo", "Button pressed")
+end
 ```

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -44,6 +44,7 @@ The following sensors have been successfully tested using FRITZ!OS 7 for FRITZ!B
 - [SmartHome Tür-/Fensterkontakt (optisch)](https://www.smarthome.de/geraete/eurotronic-smarthome-tuer-fensterkontakt-optisch) - an optical door/window contact
 - SmartHome Tür-/Fensterkontakt (magnetisch) - a magnetic door/window contact
 - [SmartHome Bewegungsmelder](https://www.smarthome.de/geraete/telekom-smarthome-bewegungsmelder-innen) - a motion sensor
+- [SmartHome Rauchmelder](https://www.smarthome.de/geraete/smarthome-rauchmelder-weiss) - a smoke detector
 - [SmartHome Wandtaster](https://www.smarthome.de/geraete/telekom-smarthome-wandtaster) - a switch with two buttons
 
 The use of other Sensors should be possible, if these are compatible with DECT-ULE / HAN-FUN standards.

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -137,8 +137,8 @@ Bridge avmfritz:fritzbox:1 "FRITZ!Box" [ ipAddress="192.168.x.x", password="xxx"
     Thing FRITZ_DECT_200 xxxxxxxxxxxx "FRITZ!DECT 200 #1" [ ain="xxxxxxxxxxxx" ]
     Thing FRITZ_Powerline_546E yy_yy_yy_yy_yy_yy "FRITZ!Powerline 546E #2" [ ain="yy:yy:yy:yy:yy:yy" ]
     Thing Comet_DECT aaaaaabbbbbb "Comet DECT #3" [ ain="aaaaaabbbbbb" ]
-    Thing HANFUNContact zzzzzzzzzzzz_1 "HAN-FUN Contact #4" [ ain="zzzzzzzzzzzz-1" ]
-    Thing HANFUNSwitch zzzzzzzzzzzz_2 "HAN-FUN Switch #5" [ ain=zzzzzzzzzzzz-2" ]
+    Thing HAN_FUN_CONTACT zzzzzzzzzzzz_1 "HAN-FUN Contact #4" [ ain="zzzzzzzzzzzz-1" ]
+    Thing HAN_FUN_SWITCH zzzzzzzzzzzz_2 "HAN-FUN Switch #5" [ ain=zzzzzzzzzzzz-2" ]
     Thing FRITZ_GROUP_HEATING AA_AA_AA_900 "Heating group" [ ain="AA:AA:AA-900" ]
     Thing FRITZ_GROUP_SWITCH BB_BB_BB_900 "Switch group" [ ain="BB:BB:BB-900" ]
 }

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -41,7 +41,8 @@ The FRITZ!Box has to run at least on firmware FRITZ!OS 6.35.
 
 The following sensors have been successfully tested using FRITZ!OS 7 for FRITZ!Box 7490 / 7590:
 
-- [SmartHome Tür-/Fensterkontakt](https://www.smarthome.de/geraete/eurotronic-smarthome-tuer-fensterkontakt-optisch) - a door/window contact
+- [SmartHome Tür-/Fensterkontakt (optisch)](https://www.smarthome.de/geraete/eurotronic-smarthome-tuer-fensterkontakt-optisch) - an optical door/window contact
+- SmartHome Tür-/Fensterkontakt (magnetisch) - a magnetic door/window contact
 - [SmartHome Bewegungsmelder](https://www.smarthome.de/geraete/telekom-smarthome-bewegungsmelder-innen) - a motion sensor
 - [SmartHome Wandtaster](https://www.smarthome.de/geraete/telekom-smarthome-wandtaster) - a switch with two buttons
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/BindingConstants.java
@@ -43,6 +43,8 @@ public class BindingConstants {
     public static final String DEVICE_PL546E = "FRITZ_Powerline_546E";
     public static final String DEVICE_PL546E_STANDALONE = "FRITZ_Powerline_546E_Solo";
     public static final String DEVICE_COMETDECT = "Comet_DECT";
+    public static final String DEVICE_HAN_FUN_CONTACT = "HAN_FUN_CONTACT";
+    public static final String DEVICE_HAN_FUN_SWITCH = "HAN_FUN_SWITCH";
 
     // List of main group types
     public static final String GROUP_HEATING = "FRITZ_GROUP_HEATING";
@@ -59,6 +61,8 @@ public class BindingConstants {
     public static final ThingTypeUID PL546E_STANDALONE_THING_TYPE = new ThingTypeUID(BINDING_ID,
             DEVICE_PL546E_STANDALONE);
     public static final ThingTypeUID COMETDECT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_COMETDECT);
+    public static final ThingTypeUID HAN_FUN_CONTACT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_HAN_FUN_CONTACT);
+    public static final ThingTypeUID HAN_FUN_SWITCH_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_HAN_FUN_SWITCH);
     public static final ThingTypeUID GROUP_HEATING_THING_TYPE = new ThingTypeUID(BINDING_ID, GROUP_HEATING);
     public static final ThingTypeUID GROUP_SWITCH_THING_TYPE = new ThingTypeUID(BINDING_ID, GROUP_SWITCH);
 
@@ -89,10 +93,13 @@ public class BindingConstants {
     public static final String CHANNEL_ECOTEMP = "eco_temp";
     public static final String CHANNEL_COMFORTTEMP = "comfort_temp";
     public static final String CHANNEL_RADIATOR_MODE = "radiator_mode";
-    public static final String CHANNEL_NEXTCHANGE = "next_change";
+    public static final String CHANNEL_NEXT_CHANGE = "next_change";
     public static final String CHANNEL_NEXTTEMP = "next_temp";
     public static final String CHANNEL_BATTERY_LOW = "battery_low";
     public static final String CHANNEL_BATTERY = "battery_level";
+    public static final String CHANNEL_CONTACT_STATE = "contact_state";
+    public static final String CHANNEL_PRESS = "press";
+    public static final String CHANNEL_LAST_CHANGE = "last_change";
 
     // List of all Channel config ids
     public static final String CONFIG_CHANNEL_TEMP_OFFSET = "offset";
@@ -119,9 +126,10 @@ public class BindingConstants {
     public static final String MODE_WINDOW_OPEN = "WINDOW_OPEN";
     public static final String MODE_UNKNOWN = "UNKNOWN";
 
-    public static final Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = Collections
-            .unmodifiableSet(Stream.of(DECT100_THING_TYPE, DECT200_THING_TYPE, DECT210_THING_TYPE, DECT300_THING_TYPE,
-                    DECT301_THING_TYPE, PL546E_THING_TYPE, COMETDECT_THING_TYPE).collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
+            .of(DECT100_THING_TYPE, DECT200_THING_TYPE, DECT210_THING_TYPE, DECT300_THING_TYPE, DECT301_THING_TYPE,
+                    PL546E_THING_TYPE, COMETDECT_THING_TYPE, HAN_FUN_CONTACT_THING_TYPE, HAN_FUN_SWITCH_THING_TYPE)
+            .collect(Collectors.toSet()));
 
     public static final Set<ThingTypeUID> SUPPORTED_GROUP_THING_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(GROUP_HEATING_THING_TYPE, GROUP_SWITCH_THING_TYPE).collect(Collectors.toSet()));

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzBaseModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzBaseModel.java
@@ -19,12 +19,16 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * In the functionbitmask element value the following bits are used:
  *
  * <ol>
- * <li>Bit 4: Alarm-Sensor</li>
- * <li>Bit 6: Comet DECT, Heizkostenregler</li>
- * <li>Bit 7: Energie Messgerät</li>
- * <li>Bit 8: Temperatursensor</li>
- * <li>Bit 9: Schaltsteckdose</li>
- * <li>Bit 10: AVM DECT Repeater</li>
+ *     <li>Bit 0: HAN-FUN Gerät</li>
+ *     <li>Bit 3: Button</li>
+ *     <li>Bit 4: Alarm-Sensor</li>
+ *     <li>Bit 6: Comet DECT, Heizkostenregler</li>
+ *     <li>Bit 7: Energie Messgerät</li>
+ *     <li>Bit 8: Temperatursensor</li>
+ *     <li>Bit 9: Schaltsteckdose</li>
+ *     <li>Bit 10: AVM DECT Repeater</li>
+ *     <li>Bit 11: Mikrofon</li>
+ *     <li>Bit 13: HAN-FUN Unit</li>
  * </ol>
  *
  * @author Robert Bausdorf - Initial contribution
@@ -32,13 +36,16 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * @author Christoph Weitkamp - Added support for groups
  */
 public abstract class AVMFritzBaseModel {
-    protected static final int BUTTON_BIT = 8;
-    protected static final int ALARM_SENSOR_BIT = 16;
+    protected static final int HAN_FUN_DEVICE_BIT = 1;
+    protected static final int HAN_FUN_BUTTON_BIT = 8;
+    protected static final int HAN_FUN_ALARM_SENSOR_BIT = 16;
     protected static final int HEATING_THERMOSTAT_BIT = 64;
     protected static final int POWERMETER_BIT = 128;
     protected static final int TEMPSENSOR_BIT = 256;
     protected static final int OUTLET_BIT = 512;
     protected static final int DECT_REPEATER_BIT = 1024;
+    protected static final int MICROPHONE_BIT = 2048;
+    protected static final int HAN_FUN_UNIT_BIT = 8192;
 
     @XmlAttribute(name = "identifier")
     private String ident;
@@ -109,12 +116,16 @@ public abstract class AVMFritzBaseModel {
         return deviceId;
     }
 
+    public boolean isHANFUNDevice() {
+        return (bitmask & HAN_FUN_DEVICE_BIT) > 0;
+    }
+
     public boolean isButton() {
-        return (bitmask & BUTTON_BIT) > 0;
+        return (bitmask & HAN_FUN_BUTTON_BIT) > 0;
     }
 
     public boolean isAlarmSensor() {
-        return (bitmask & ALARM_SENSOR_BIT) > 0;
+        return (bitmask & HAN_FUN_ALARM_SENSOR_BIT) > 0;
     }
 
     public boolean isSwitchableOutlet() {
@@ -135,6 +146,14 @@ public abstract class AVMFritzBaseModel {
 
     public boolean isHeatingThermostat() {
         return (bitmask & HEATING_THERMOSTAT_BIT) > 0;
+    }
+
+    public boolean isMicrophone() {
+        return (bitmask & MICROPHONE_BIT) > 0;
+    }
+
+    public boolean isHANFUNUnit() {
+        return (bitmask & HAN_FUN_UNIT_BIT) > 0;
     }
 
     public String getFirmwareVersion() {
@@ -160,12 +179,14 @@ public abstract class AVMFritzBaseModel {
     @Override
     public String toString() {
         return new ToStringBuilder(this).append("ain", getIdentifier()).append("bitmask", bitmask)
-                .append("isButton", isButton()).append("isAlarmSensor", isAlarmSensor())
-                .append("isSwitchableOutlet", isSwitchableOutlet()).append("isTempSensor", isTempSensor())
-                .append("isPowermeter", isPowermeter()).append("isDectRepeater", isDectRepeater())
-                .append("isHeatingThermostat", isHeatingThermostat()).append("id", getDeviceId())
-                .append("manufacturer", getManufacturer()).append("productname", getProductName())
-                .append("fwversion", getFirmwareVersion()).append("present", getPresent()).append("name", getName())
-                .append(getSwitch()).append(getPowermeter()).append(getHkr()).toString();
+                .append("isHANFUNDevice", isHANFUNDevice()).append("isButton", isButton())
+                .append("isAlarmSensor", isAlarmSensor()).append("isSwitchableOutlet", isSwitchableOutlet())
+                .append("isTempSensor", isTempSensor()).append("isPowermeter", isPowermeter())
+                .append("isDectRepeater", isDectRepeater()).append("isHeatingThermostat", isHeatingThermostat())
+                .append("isMicrophone", isMicrophone()).append("isHANFUNUnit", isHANFUNUnit())
+                .append("id", getDeviceId()).append("manufacturer", getManufacturer())
+                .append("productname", getProductName()).append("fwversion", getFirmwareVersion())
+                .append("present", getPresent()).append("name", getName()).append(getSwitch()).append(getPowermeter())
+                .append(getHkr()).toString();
     }
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzBaseModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AVMFritzBaseModel.java
@@ -28,18 +28,17 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * </ol>
  *
  * @author Robert Bausdorf - Initial contribution
- * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet
- *         DECT
+ * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet DECT
  * @author Christoph Weitkamp - Added support for groups
  */
 public abstract class AVMFritzBaseModel {
-
-    public static final int ALARM_SENSOR_BIT = 16;
-    public static final int HEATING_THERMOSTAT_BIT = 64;
-    public static final int POWERMETER_BIT = 128;
-    public static final int TEMPSENSOR_BIT = 256;
-    public static final int SWITCH_BIT = 512;
-    public static final int DECT_REPEATER_BIT = 1024;
+    protected static final int BUTTON_BIT = 8;
+    protected static final int ALARM_SENSOR_BIT = 16;
+    protected static final int HEATING_THERMOSTAT_BIT = 64;
+    protected static final int POWERMETER_BIT = 128;
+    protected static final int TEMPSENSOR_BIT = 256;
+    protected static final int OUTLET_BIT = 512;
+    protected static final int DECT_REPEATER_BIT = 1024;
 
     @XmlAttribute(name = "identifier")
     private String ident;
@@ -86,8 +85,8 @@ public abstract class AVMFritzBaseModel {
         return heatingModel;
     }
 
-    public void setHkr(HeatingModel heating) {
-        this.heatingModel = heating;
+    public void setHkr(HeatingModel heatingModel) {
+        this.heatingModel = heatingModel;
     }
 
     public SwitchModel getSwitch() {
@@ -110,24 +109,32 @@ public abstract class AVMFritzBaseModel {
         return deviceId;
     }
 
+    public boolean isButton() {
+        return (bitmask & BUTTON_BIT) > 0;
+    }
+
+    public boolean isAlarmSensor() {
+        return (bitmask & ALARM_SENSOR_BIT) > 0;
+    }
+
     public boolean isSwitchableOutlet() {
-        return (bitmask & DeviceModel.SWITCH_BIT) > 0;
+        return (bitmask & OUTLET_BIT) > 0;
     }
 
     public boolean isTempSensor() {
-        return (bitmask & DeviceModel.TEMPSENSOR_BIT) > 0;
+        return (bitmask & TEMPSENSOR_BIT) > 0;
     }
 
     public boolean isPowermeter() {
-        return (bitmask & DeviceModel.POWERMETER_BIT) > 0;
+        return (bitmask & POWERMETER_BIT) > 0;
     }
 
     public boolean isDectRepeater() {
-        return (bitmask & DeviceModel.DECT_REPEATER_BIT) > 0;
+        return (bitmask & DECT_REPEATER_BIT) > 0;
     }
 
     public boolean isHeatingThermostat() {
-        return (bitmask & DeviceModel.HEATING_THERMOSTAT_BIT) > 0;
+        return (bitmask & HEATING_THERMOSTAT_BIT) > 0;
     }
 
     public String getFirmwareVersion() {
@@ -153,8 +160,9 @@ public abstract class AVMFritzBaseModel {
     @Override
     public String toString() {
         return new ToStringBuilder(this).append("ain", getIdentifier()).append("bitmask", bitmask)
-                .append("isDectRepeater", isDectRepeater()).append("isPowermeter", isPowermeter())
-                .append("isTempSensor", isTempSensor()).append("isSwitchableOutlet", isSwitchableOutlet())
+                .append("isButton", isButton()).append("isAlarmSensor", isAlarmSensor())
+                .append("isSwitchableOutlet", isSwitchableOutlet()).append("isTempSensor", isTempSensor())
+                .append("isPowermeter", isPowermeter()).append("isDectRepeater", isDectRepeater())
                 .append("isHeatingThermostat", isHeatingThermostat()).append("id", getDeviceId())
                 .append("manufacturer", getManufacturer()).append("productname", getProductName())
                 .append("fwversion", getFirmwareVersion()).append("present", getPresent()).append("name", getName())

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AlertModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/AlertModel.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.avmfritz.internal.ahamodel;
+
+import java.math.BigDecimal;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ * See {@link DevicelistModel}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@XmlRootElement(name = "alert")
+@XmlType(propOrder = { "state" })
+public class AlertModel {
+    public static final BigDecimal ON = BigDecimal.ONE;
+    public static final BigDecimal OFF = BigDecimal.ZERO;
+
+    private BigDecimal state;
+
+    public BigDecimal getState() {
+        return state;
+    }
+
+    public void setState(BigDecimal state) {
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("state", getState()).toString();
+    }
+}

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/ButtonModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/ButtonModel.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.avmfritz.internal.ahamodel;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ * See {@link DevicelistModel}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@XmlRootElement(name = "button")
+@XmlType(propOrder = { "lastpressedtimestamp" })
+public class ButtonModel {
+
+    private int lastpressedtimestamp;
+
+    public int getLastpressedtimestamp() {
+        return lastpressedtimestamp;
+    }
+
+    public void setLastpressedtimestamp(int lastpressedtimestamp) {
+        this.lastpressedtimestamp = lastpressedtimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("lastpressedtimestamp", getLastpressedtimestamp()).toString();
+    }
+}

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -22,17 +22,85 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 public class DeviceModel extends AVMFritzBaseModel {
 
     private TemperatureModel temperature;
+    private AlertModel alert;
+    private ButtonModel button;
+    private Etsiunitinfo etsiunitinfo;
 
     public TemperatureModel getTemperature() {
         return temperature;
     }
 
-    public void setTemperature(TemperatureModel temperature) {
-        this.temperature = temperature;
+    public void setTemperature(TemperatureModel temperatureModel) {
+        this.temperature = temperatureModel;
+    }
+
+    public AlertModel getAlert() {
+        return alert;
+    }
+
+    public void setAlert(AlertModel alertModel) {
+        this.alert = alertModel;
+    }
+
+    public ButtonModel getButton() {
+        return button;
+    }
+
+    public void setButton(ButtonModel buttonModel) {
+        this.button = buttonModel;
+    }
+
+    public Etsiunitinfo getEtsiunitinfo() {
+        return etsiunitinfo;
+    }
+
+    public void setEtsiunitinfo(Etsiunitinfo etsiunitinfo) {
+        this.etsiunitinfo = etsiunitinfo;
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append(super.toString()).append(getTemperature()).toString();
+        return new ToStringBuilder(this).append(super.toString()).append(getTemperature()).append(getAlert())
+                .append(getButton()).append(getEtsiunitinfo()).toString();
+    }
+
+    @XmlType(propOrder = { "etsideviceid", "unittype", "interfaces" })
+    public static class Etsiunitinfo {
+        public static final String HAN_FUN_CONTACT_UNITTYPE = "514";
+        public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
+
+        private String etsideviceid;
+        private String unittype;
+        private String interfaces;
+
+        public String getEtsideviceid() {
+            return etsideviceid;
+        }
+
+        public void setEtsideviceid(String etsideviceid) {
+            this.etsideviceid = etsideviceid;
+        }
+
+        public String getUnittype() {
+            return unittype;
+        }
+
+        public void setUnittype(String unittype) {
+            this.unittype = unittype;
+        }
+
+        public String getInterfaces() {
+            return interfaces;
+        }
+
+        public void setInterfaces(String interfaces) {
+            this.interfaces = interfaces;
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this).append("etsideviceid", getEtsideviceid()).append("unittype", getUnittype())
+                    .append("interfaces", getInterfaces()).toString();
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -72,6 +72,9 @@ public class DeviceModel extends AVMFritzBaseModel {
         public static final String HAN_FUN_SMOKE_DETECTOR_UNITTYPE = "516";
         public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
 
+        public static final String HAN_FUN_ALERT_INTERFACE = "256";
+        public static final String HAN_FUN_BUTTON_INTERFACE = "772";
+
         private String etsideviceid;
         private String unittype;
         private String interfaces;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -69,6 +69,7 @@ public class DeviceModel extends AVMFritzBaseModel {
         public static final String HAN_FUN_MAGNETIC_CONTACT_UNITTYPE = "513";
         public static final String HAN_FUN_OPTICAL_CONTACT_UNITTYPE = "514";
         public static final String HAN_FUN_MOTION_SENSOR_UNITTYPE = "515";
+        public static final String HAN_FUN_SMOKE_DETECTOR_UNITTYPE = "516";
         public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
 
         private String etsideviceid;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -67,6 +67,7 @@ public class DeviceModel extends AVMFritzBaseModel {
     @XmlType(propOrder = { "etsideviceid", "unittype", "interfaces" })
     public static class Etsiunitinfo {
         public static final String HAN_FUN_CONTACT_UNITTYPE = "514";
+        public static final String HAN_FUN_MOTION_SENSOR_UNITTYPE = "515";
         public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
 
         private String etsideviceid;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -66,14 +66,19 @@ public class DeviceModel extends AVMFritzBaseModel {
 
     @XmlType(propOrder = { "etsideviceid", "unittype", "interfaces" })
     public static class Etsiunitinfo {
-        public static final String HAN_FUN_MAGNETIC_CONTACT_UNITTYPE = "513";
-        public static final String HAN_FUN_OPTICAL_CONTACT_UNITTYPE = "514";
-        public static final String HAN_FUN_MOTION_SENSOR_UNITTYPE = "515";
-        public static final String HAN_FUN_SMOKE_DETECTOR_UNITTYPE = "516";
-        public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
+        public static final String HAN_FUN_UNITTYPE_SIMPLE_BUTTON = "273";
+        public static final String HAN_FUN_UNITTYPE_SIMPLE_DETECTOR = "512";
+        public static final String HAN_FUN_UNITTYPE_MAGNETIC_CONTACT = "513";
+        public static final String HAN_FUN_UNITTYPE_OPTICAL_CONTACT = "514";
+        public static final String HAN_FUN_UNITTYPE_MOTION_DETECTOR = "515";
+        public static final String HAN_FUN_UNITTYPE_SMOKE_DETECTOR = "516";
+        public static final String HAN_FUN_UNITTYPE_FLOOD_DETECTOR = "518";
+        public static final String HAN_FUN_UNITTYPE_GLAS_BREAK_DETECTOR = "519";
+        public static final String HAN_FUN_UNITTYPE_VIBRATION_DETECTOR = "520";
 
-        public static final String HAN_FUN_ALERT_INTERFACE = "256";
-        public static final String HAN_FUN_BUTTON_INTERFACE = "772";
+        public static final String HAN_FUN_INTERFACE_ALERT = "256";
+        public static final String HAN_FUN_INTERFACE_KEEP_ALIVE = "277";
+        public static final String HAN_FUN_INTERFACE_SIMPLE_BUTTON = "772";
 
         private String etsideviceid;
         private String unittype;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -66,7 +66,8 @@ public class DeviceModel extends AVMFritzBaseModel {
 
     @XmlType(propOrder = { "etsideviceid", "unittype", "interfaces" })
     public static class Etsiunitinfo {
-        public static final String HAN_FUN_CONTACT_UNITTYPE = "514";
+        public static final String HAN_FUN_MAGNETIC_CONTACT_UNITTYPE = "513";
+        public static final String HAN_FUN_OPTICAL_CONTACT_UNITTYPE = "514";
         public static final String HAN_FUN_MOTION_SENSOR_UNITTYPE = "515";
         public static final String HAN_FUN_SWITCH_UNITTYPE = "273";
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/ahamodel/DeviceModel.java
@@ -24,7 +24,7 @@ public class DeviceModel extends AVMFritzBaseModel {
     private TemperatureModel temperature;
     private AlertModel alert;
     private ButtonModel button;
-    private Etsiunitinfo etsiunitinfo;
+    private ETSUnitInfo etsiunitinfo;
 
     public TemperatureModel getTemperature() {
         return temperature;
@@ -50,11 +50,11 @@ public class DeviceModel extends AVMFritzBaseModel {
         this.button = buttonModel;
     }
 
-    public Etsiunitinfo getEtsiunitinfo() {
+    public ETSUnitInfo getEtsiunitinfo() {
         return etsiunitinfo;
     }
 
-    public void setEtsiunitinfo(Etsiunitinfo etsiunitinfo) {
+    public void setEtsiunitinfo(ETSUnitInfo etsiunitinfo) {
         this.etsiunitinfo = etsiunitinfo;
     }
 
@@ -65,7 +65,7 @@ public class DeviceModel extends AVMFritzBaseModel {
     }
 
     @XmlType(propOrder = { "etsideviceid", "unittype", "interfaces" })
-    public static class Etsiunitinfo {
+    public static class ETSUnitInfo {
         public static final String HAN_FUN_UNITTYPE_SIMPLE_BUTTON = "273";
         public static final String HAN_FUN_UNITTYPE_SIMPLE_DETECTOR = "512";
         public static final String HAN_FUN_UNITTYPE_MAGNETIC_CONTACT = "513";

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -12,6 +12,7 @@ import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
 import static org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.Etsiunitinfo.*;
+import static org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel.*;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -51,9 +52,7 @@ import org.openhab.binding.avmfritz.internal.BindingConstants;
 import org.openhab.binding.avmfritz.internal.ahamodel.AVMFritzBaseModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.AlertModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel;
-import org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.Etsiunitinfo;
 import org.openhab.binding.avmfritz.internal.ahamodel.GroupModel;
-import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
 import org.openhab.binding.avmfritz.internal.config.AVMFritzConfiguration;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
@@ -255,13 +254,13 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                     BigDecimal.ZERO.equals(device.getHkr().getDevicelock()) ? OpenClosedType.OPEN
                             : OpenClosedType.CLOSED);
             updateThingChannelState(thing, CHANNEL_ACTUALTEMP,
-                    new QuantityType<>(HeatingModel.toCelsius(device.getHkr().getTist()), CELSIUS));
+                    new QuantityType<>(toCelsius(device.getHkr().getTist()), CELSIUS));
             updateThingChannelState(thing, CHANNEL_SETTEMP,
-                    new QuantityType<>(HeatingModel.toCelsius(device.getHkr().getTsoll()), CELSIUS));
+                    new QuantityType<>(toCelsius(device.getHkr().getTsoll()), CELSIUS));
             updateThingChannelState(thing, CHANNEL_ECOTEMP,
-                    new QuantityType<>(HeatingModel.toCelsius(device.getHkr().getAbsenk()), CELSIUS));
+                    new QuantityType<>(toCelsius(device.getHkr().getAbsenk()), CELSIUS));
             updateThingChannelState(thing, CHANNEL_COMFORTTEMP,
-                    new QuantityType<>(HeatingModel.toCelsius(device.getHkr().getKomfort()), CELSIUS));
+                    new QuantityType<>(toCelsius(device.getHkr().getKomfort()), CELSIUS));
             updateThingChannelState(thing, CHANNEL_RADIATOR_MODE, new StringType(device.getHkr().getRadiatorMode()));
             if (device.getHkr().getNextchange() != null) {
                 if (device.getHkr().getNextchange().getEndperiod() == 0) {
@@ -272,11 +271,11 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                                     Instant.ofEpochSecond(device.getHkr().getNextchange().getEndperiod()),
                                     ZoneId.systemDefault())));
                 }
-                if (HeatingModel.TEMP_FRITZ_UNDEFINED.equals(device.getHkr().getNextchange().getTchange())) {
+                if (TEMP_FRITZ_UNDEFINED.equals(device.getHkr().getNextchange().getTchange())) {
                     updateThingChannelState(thing, CHANNEL_NEXTTEMP, UnDefType.UNDEF);
                 } else {
-                    updateThingChannelState(thing, CHANNEL_NEXTTEMP, new QuantityType<>(
-                            HeatingModel.toCelsius(device.getHkr().getNextchange().getTchange()), CELSIUS));
+                    updateThingChannelState(thing, CHANNEL_NEXTTEMP,
+                            new QuantityType<>(toCelsius(device.getHkr().getNextchange().getTchange()), CELSIUS));
                 }
             }
             if (device.getHkr().getBattery() == null) {
@@ -288,7 +287,7 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                 updateThingChannelState(thing, CHANNEL_BATTERY_LOW, UnDefType.UNDEF);
             } else {
                 updateThingChannelState(thing, CHANNEL_BATTERY_LOW,
-                        HeatingModel.BATTERY_ON.equals(device.getHkr().getBatterylow()) ? OnOffType.ON : OnOffType.OFF);
+                        BATTERY_ON.equals(device.getHkr().getBatterylow()) ? OnOffType.ON : OnOffType.OFF);
             }
         }
         if (device instanceof DeviceModel && device.isAlarmSensor() && ((DeviceModel) device).getAlert() != null) {
@@ -426,8 +425,6 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                     return DEVICE_HAN_FUN_CONTACT;
                 case HAN_FUN_SWITCH_UNITTYPE:
                     return DEVICE_HAN_FUN_SWITCH;
-                case Etsiunitinfo.HAN_FUN_CONTACT_UNITTYPE:
-                    return DEVICE_HAN_FUN_CONTACT;
             }
         }
         return device.getProductName().replaceAll(INVALID_PATTERN, "_");

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -416,11 +416,13 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
             }
         }
         if (device instanceof DeviceModel && ((DeviceModel) device).getEtsiunitinfo() != null) {
+            // TODO: change to HAN_FUN_INTERFACES ... (z.b. 256 or 772)
             String unittype = ((DeviceModel) device).getEtsiunitinfo().getUnittype();
             switch (unittype) {
                 case HAN_FUN_MAGNETIC_CONTACT_UNITTYPE:
                 case HAN_FUN_OPTICAL_CONTACT_UNITTYPE:
                 case HAN_FUN_MOTION_SENSOR_UNITTYPE:
+                case HAN_FUN_SMOKE_DETECTOR_UNITTYPE:
                     return DEVICE_HAN_FUN_CONTACT;
                 case HAN_FUN_SWITCH_UNITTYPE:
                     return DEVICE_HAN_FUN_SWITCH;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -418,7 +418,8 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
         if (device instanceof DeviceModel && ((DeviceModel) device).getEtsiunitinfo() != null) {
             String unittype = ((DeviceModel) device).getEtsiunitinfo().getUnittype();
             switch (unittype) {
-                case HAN_FUN_CONTACT_UNITTYPE:
+                case HAN_FUN_MAGNETIC_CONTACT_UNITTYPE:
+                case HAN_FUN_OPTICAL_CONTACT_UNITTYPE:
                 case HAN_FUN_MOTION_SENSOR_UNITTYPE:
                     return DEVICE_HAN_FUN_CONTACT;
                 case HAN_FUN_SWITCH_UNITTYPE:

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -11,6 +11,7 @@ package org.openhab.binding.avmfritz.internal.handler;
 import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
+import static org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.Etsiunitinfo.*;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -336,7 +337,7 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
     /**
      * Triggers thing channels.
      *
-     * @param thing     Thing which channels should be triggered.
+     * @param thing Thing which channels should be triggered.
      * @param channelId ID of the channel to be triggered.
      */
     private void triggerThingChannel(Thing thing, String channelId) {
@@ -417,7 +418,10 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
         if (device instanceof DeviceModel && ((DeviceModel) device).getEtsiunitinfo() != null) {
             String unittype = ((DeviceModel) device).getEtsiunitinfo().getUnittype();
             switch (unittype) {
-                case Etsiunitinfo.HAN_FUN_SWITCH_UNITTYPE:
+                case HAN_FUN_CONTACT_UNITTYPE:
+                case HAN_FUN_MOTION_SENSOR_UNITTYPE:
+                    return DEVICE_HAN_FUN_CONTACT;
+                case HAN_FUN_SWITCH_UNITTYPE:
                     return DEVICE_HAN_FUN_SWITCH;
                 case Etsiunitinfo.HAN_FUN_CONTACT_UNITTYPE:
                     return DEVICE_HAN_FUN_CONTACT;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -11,7 +11,7 @@ package org.openhab.binding.avmfritz.internal.handler;
 import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
-import static org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.Etsiunitinfo.*;
+import static org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.ETSUnitInfo.*;
 import static org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel.*;
 
 import java.math.BigDecimal;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -45,8 +45,7 @@ import org.slf4j.LoggerFactory;
  * Abstract handler for a FRITZ! thing. Handles commands, which are sent to one of the channels.
  *
  * @author Robert Bausdorf - Initial contribution
- * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet
- *         DECT
+ * @author Christoph Weitkamp - Added support for AVM FRITZ!DECT 300 and Comet DECT
  * @author Christoph Weitkamp - Added support for groups
  */
 @NonNullByDefault
@@ -120,10 +119,12 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
             case CHANNEL_ACTUALTEMP:
             case CHANNEL_ECOTEMP:
             case CHANNEL_COMFORTTEMP:
-            case CHANNEL_NEXTCHANGE:
+            case CHANNEL_NEXT_CHANGE:
             case CHANNEL_NEXTTEMP:
             case CHANNEL_BATTERY:
             case CHANNEL_BATTERY_LOW:
+            case CHANNEL_CONTACT_STATE:
+            case CHANNEL_LAST_CHANGE:
                 logger.debug("Channel {} is a read-only channel and cannot handle command '{}'", channelId, command);
                 break;
             case CHANNEL_OUTLET:
@@ -237,8 +238,8 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
         Bridge bridge = getBridge();
         if (bridge != null) {
             BridgeHandler handler = bridge.getHandler();
-            if (handler != null && handler instanceof AVMFritzBaseBridgeHandler) {
-                return ((AVMFritzBaseBridgeHandler) handler).getWebInterface();
+            if (handler != null && handler instanceof BoxHandler) {
+                return ((BoxHandler) handler).getWebInterface();
             }
         }
         return null;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -232,8 +232,8 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
         Bridge bridge = getBridge();
         if (bridge != null) {
             BridgeHandler handler = bridge.getHandler();
-            if (handler != null && handler instanceof BoxHandler) {
-                return ((BoxHandler) handler).getWebInterface();
+            if (handler != null && handler instanceof AVMFritzBaseBridgeHandler) {
+                return ((AVMFritzBaseBridgeHandler) handler).getWebInterface();
             }
         }
         return null;

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -10,6 +10,7 @@ package org.openhab.binding.avmfritz.internal.handler;
 
 import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
+import static org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel.*;
 
 import java.math.BigDecimal;
 
@@ -35,7 +36,6 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.avmfritz.internal.ahamodel.AVMFritzBaseModel;
-import org.openhab.binding.avmfritz.internal.ahamodel.HeatingModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.SwitchModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
 import org.slf4j.Logger;
@@ -135,15 +135,15 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
                 break;
             case CHANNEL_SETTEMP:
                 if (command instanceof DecimalType) {
-                    BigDecimal temperature = HeatingModel.normalizeCelsius(((DecimalType) command).toBigDecimal());
+                    BigDecimal temperature = normalizeCelsius(((DecimalType) command).toBigDecimal());
                     state.getHkr().setTsoll(temperature);
-                    fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(temperature));
+                    fritzBox.setSetTemp(ain, fromCelsius(temperature));
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else if (command instanceof QuantityType) {
-                    BigDecimal temperature = HeatingModel
-                            .normalizeCelsius(((QuantityType<Temperature>) command).toUnit(CELSIUS).toBigDecimal());
+                    BigDecimal temperature = normalizeCelsius(
+                            ((QuantityType<Temperature>) command).toUnit(CELSIUS).toBigDecimal());
                     state.getHkr().setTsoll(temperature);
-                    fritzBox.setSetTemp(ain, HeatingModel.fromCelsius(temperature));
+                    fritzBox.setSetTemp(ain, fromCelsius(temperature));
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else if (command instanceof IncreaseDecreaseType) {
                     BigDecimal temperature = state.getHkr().getTsoll();
@@ -156,8 +156,7 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
                     fritzBox.setSetTemp(ain, temperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
                 } else if (command instanceof OnOffType) {
-                    BigDecimal temperature = OnOffType.ON.equals(command) ? HeatingModel.TEMP_FRITZ_ON
-                            : HeatingModel.TEMP_FRITZ_OFF;
+                    BigDecimal temperature = OnOffType.ON.equals(command) ? TEMP_FRITZ_ON : TEMP_FRITZ_OFF;
                     state.getHkr().setTsoll(temperature);
                     fritzBox.setSetTemp(ain, temperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(state.getHkr().getRadiatorMode()));
@@ -167,36 +166,31 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler {
                 if (command instanceof StringType) {
                     switch (command.toString()) {
                         case MODE_ON:
-                            state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_ON);
-                            fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_ON);
-                            updateState(CHANNEL_SETTEMP,
-                                    new QuantityType<>(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_ON), CELSIUS));
+                            state.getHkr().setTsoll(TEMP_FRITZ_ON);
+                            fritzBox.setSetTemp(ain, TEMP_FRITZ_ON);
+                            updateState(CHANNEL_SETTEMP, new QuantityType<>(toCelsius(TEMP_FRITZ_ON), CELSIUS));
                             break;
                         case MODE_OFF:
-                            state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_OFF);
-                            fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_OFF);
-                            updateState(CHANNEL_SETTEMP,
-                                    new QuantityType<>(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_OFF), CELSIUS));
+                            state.getHkr().setTsoll(TEMP_FRITZ_OFF);
+                            fritzBox.setSetTemp(ain, TEMP_FRITZ_OFF);
+                            updateState(CHANNEL_SETTEMP, new QuantityType<>(toCelsius(TEMP_FRITZ_OFF), CELSIUS));
                             break;
                         case MODE_COMFORT:
                             BigDecimal comfortTemperature = state.getHkr().getKomfort();
                             state.getHkr().setTsoll(comfortTemperature);
                             fritzBox.setSetTemp(ain, comfortTemperature);
-                            updateState(CHANNEL_SETTEMP,
-                                    new QuantityType<>(HeatingModel.toCelsius(comfortTemperature), CELSIUS));
+                            updateState(CHANNEL_SETTEMP, new QuantityType<>(toCelsius(comfortTemperature), CELSIUS));
                             break;
                         case MODE_ECO:
                             BigDecimal ecoTemperature = state.getHkr().getAbsenk();
                             state.getHkr().setTsoll(ecoTemperature);
                             fritzBox.setSetTemp(ain, ecoTemperature);
-                            updateState(CHANNEL_SETTEMP,
-                                    new QuantityType<>(HeatingModel.toCelsius(ecoTemperature), CELSIUS));
+                            updateState(CHANNEL_SETTEMP, new QuantityType<>(toCelsius(ecoTemperature), CELSIUS));
                             break;
                         case MODE_BOOST:
-                            state.getHkr().setTsoll(HeatingModel.TEMP_FRITZ_MAX);
-                            fritzBox.setSetTemp(ain, HeatingModel.TEMP_FRITZ_MAX);
-                            updateState(CHANNEL_SETTEMP,
-                                    new QuantityType<>(HeatingModel.toCelsius(HeatingModel.TEMP_FRITZ_MAX), CELSIUS));
+                            state.getHkr().setTsoll(TEMP_FRITZ_MAX);
+                            fritzBox.setSetTemp(ain, TEMP_FRITZ_MAX);
+                            updateState(CHANNEL_SETTEMP, new QuantityType<>(toCelsius(TEMP_FRITZ_MAX), CELSIUS));
                             break;
                         case MODE_UNKNOWN:
                         case MODE_WINDOW_OPEN:

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
@@ -70,7 +70,7 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
         if (optionalDevice.isPresent()) {
             AVMFritzBaseModel device = optionalDevice.get();
             devicelist.remove(device);
-            logger.debug("update self {} with device model: {}", getThing().getUID(), device);
+            logger.debug("update self '{}' with device model: {}", getThing().getUID(), device);
             setState(device);
             if (device.getPresent() == 1) {
                 setStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);


### PR DESCRIPTION
- Added support for HAN-FUN devices

Beta version: [org.openhab.binding.avmfritz-2.4.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab2-addons/files/2490418/org.openhab.binding.avmfritz-2.4.0-SNAPSHOT.jar.zip)

See https://community.openhab.org/t/avmfritz-support-for-han-fun-dect-ule-devices/38950

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>