### PR TITLE
Fixed null exception error.

### DIFF
--- a/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/addons/io/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -583,10 +583,22 @@ public class CloudClient {
         public void onComplete(Result result) {
             // Remove this request from list of running requests
             runningRequests.remove(mRequestId);
-            if (result.isFailed() && result.getResponse().getStatus() != HttpStatus.OK_200) {
-                logger.warn("Jetty request {} failed: {}", mRequestId, result.getFailure().getMessage());
-                logger.warn("{}", result.getRequestFailure().getMessage());
-                logger.warn("{}", result.getResponseFailure().getMessage());
+            if (result != null) {
+                if (result.isFailed() && result.getResponse().getStatus() != HttpStatus.OK_200) {
+                    Throwable res;
+                    res = result.getFailure();
+                    if (res != null) {
+                        logger.warn("Jetty request {} failed: {}", mRequestId, res.getMessage());
+                    }
+                    res = result.getRequestFailure();
+                    if (res != null) {
+                        logger.warn("{}", res.getMessage());
+                    }
+                    res = result.getRequestFailure();
+                    if (res != null) {
+                        logger.warn("{}", res.getMessage());
+                    }
+                }
             }
 
             /**


### PR DESCRIPTION
- Check for null before calling a method on it.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

This PR is for fixing null pointer exception issues with openhabcloud.

`2018-08-06 18:24:30.961 [INFO ] [clipse.jetty.client.ResponseNotifier] - Exception while notifying listener org.openhab.io.openhabcloud.internal.CloudClient$ResponseListener@b43a01d
java.lang.NullPointerException: null
        at org.openhab.io.openhabcloud.internal.CloudClient$ResponseListener.onComplete(CloudClient.java:588) [223:org.openhab.io.openhabcloud:2.3.0]
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:193) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:185) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpReceiver.terminateResponse(HttpReceiver.java:458) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpReceiver.abort(HttpReceiver.java:539) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpChannel.abortResponse(HttpChannel.java:129) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpChannel.abort(HttpChannel.java:122) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpExchange.abort(HttpExchange.java:257) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpConversation.abort(HttpConversation.java:141) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.eclipse.jetty.client.HttpRequest.abort(HttpRequest.java:735) [72:org.eclipse.jetty.client:9.3.21.v20170918]
        at org.openhab.io.openhabcloud.internal.CloudClient.handleCancelEvent(CloudClient.java:403) [223:org.openhab.io.openhabcloud:2.3.0]
        at org.openhab.io.openhabcloud.internal.CloudClient.onEvent(CloudClient.java:298) [223:org.openhab.io.openhabcloud:2.3.0]
        at org.openhab.io.openhabcloud.internal.CloudClient$6.call(CloudClient.java:225) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.emitter.Emitter.emit(Emitter.java:117) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Socket.onevent(Socket.java:340) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Socket.onpacket(Socket.java:293) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Socket.access$100(Socket.java:19) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Socket$2$2.call(Socket.java:111) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.emitter.Emitter.emit(Emitter.java:117) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager.ondecoded(Manager.java:407) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager.access$1600(Manager.java:20) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager$7.call(Manager.java:383) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.emitter.Emitter.emit(Emitter.java:117) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.parser.Parser$Decoder.add(Parser.java:157) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager.ondata(Manager.java:399) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager.access$1000(Manager.java:20) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.client.Manager$2.call(Manager.java:350) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.emitter.Emitter.emit(Emitter.java:117) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.Socket.onPacket(Socket.java:511) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.Socket.access$1000(Socket.java:31) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.Socket$5.call(Socket.java:313) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.emitter.Emitter.emit(Emitter.java:117) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.Transport.onPacket(Transport.java:134) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.Transport.onData(Transport.java:126) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.transports.WebSocket.access$300(WebSocket.java:28) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.engineio.client.transports.WebSocket$2$3.run(WebSocket.java:122) [223:org.openhab.io.openhabcloud:2.3.0]
        at io.socket.thread.EventThread$2.run(EventThread.java:80) [223:org.openhab.io.openhabcloud:2.3.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
`