### PR TITLE
[KNX2] some small fixes

### DIFF
--- a/addons/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTypeTest.java
+++ b/addons/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTypeTest.java
@@ -75,6 +75,22 @@ public class KNXChannelTypeTest {
         assertEquals(1, res.getReadGAs().size());
     }
 
+    @Test
+    public void testParse_twoLevel() {
+        ChannelConfiguration res = ct.parse("5.001:<3/1024+<4/1025");
+        assertEquals("3/1024", res.getMainGA().getGA());
+        assertEquals(2, res.getListenGAs().size());
+        assertEquals(2, res.getReadGAs().size());
+    }
+
+    @Test
+    public void testParse_freeLevel() {
+        ChannelConfiguration res = ct.parse("5.001:<4610+<4611");
+        assertEquals("4610", res.getMainGA().getGA());
+        assertEquals(2, res.getListenGAs().size());
+        assertEquals(2, res.getReadGAs().size());
+    }
+
     private static class MyKNXChannelType extends KNXChannelType {
         public MyKNXChannelType(String channelTypeID) {
             super(channelTypeID);

--- a/addons/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/addons/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.knx.internal.dpt;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+public class KNXCoreTypeMapperTest {
+
+    @Test
+    public void testToDPTValue_trailingZeroesStrippedOff() {
+        assertEquals("3", new KNXCoreTypeMapper().toDPTValue(new DecimalType("3"), "17.001"));
+        assertEquals("3", new KNXCoreTypeMapper().toDPTValue(new DecimalType("3.0"), "17.001"));
+    }
+
+}

--- a/addons/binding/org.openhab.binding.knx/README.md
+++ b/addons/binding/org.openhab.binding.knx/README.md
@@ -169,7 +169,7 @@ In contrast to the standard channels above, the control channel types are used f
 #### Group Address Notation
 
 ```
-<config>="[<][<dpt>:]<mainGA>[[+[<]<listeningGA>]+[<]<listeningGA>..]]"
+<config>="[<dpt>:][<]<mainGA>[[+[<]<listeningGA>]+[<]<listeningGA>..]]"
 ```
 
 where parts in brackets `[]` denote optional information.

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/handler/AbstractKNXThingHandler.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/handler/AbstractKNXThingHandler.java
@@ -205,9 +205,12 @@ public abstract class AbstractKNXThingHandler extends BaseThingHandler implement
             descriptionJob = null;
         }
         cancelReadFutures();
-        KNXBridgeBaseThingHandler handler = (KNXBridgeBaseThingHandler) getBridge().getHandler();
-        if (handler != null) {
-            handler.getClient().unregisterGroupAddressListener(this);
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            KNXBridgeBaseThingHandler handler = (KNXBridgeBaseThingHandler) bridge.getHandler();
+            if (handler != null) {
+                handler.getClient().unregisterGroupAddressListener(this);
+            }
         }
     }
 

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelType.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelType.java
@@ -43,10 +43,10 @@ import tuwien.auto.calimero.KNXFormatException;
 public abstract class KNXChannelType {
 
     private static final Pattern PATTERN = Pattern.compile(
-            "^((?<dpt>[0-9]{1,2}\\.[0-9]{3}):)?(?<read>\\<)?(?<mainGA>[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3})(?<listenGAs>(\\+(\\<?[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3}))*)$");
+            "^((?<dpt>[0-9]{1,2}\\.[0-9]{3}):)?(?<read>\\<)?(?<mainGA>[0-9]{1,5}(/[0-9]{1,4}){0,2})(?<listenGAs>(\\+(\\<?[0-9]{1,5}(/[0-9]{1,4}){0,2}))*)$");
 
     private static final Pattern PATTERN_LISTEN = Pattern
-            .compile("\\+((?<read>\\<)?(?<GA>[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3}))");
+            .compile("\\+((?<read>\\<)?(?<GA>[0-9]{1,5}(/[0-9]{1,4}){0,2}))");
 
     private final Logger logger = LoggerFactory.getLogger(KNXChannelType.class);
     private final Set<String> channelTypeIDs;

--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -595,7 +595,7 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
                             return "activate " + intVal;
                         }
                     default:
-                        return type.toString();
+                        return ((DecimalType) type).toBigDecimal().stripTrailingZeros().toPlainString();
                 }
             } else if (type instanceof StringType) {
                 return type.toString();


### PR DESCRIPTION
This PR contains a few minor fixes for the KNX2 binding:

* Avoid NPE in case bridge handler has been destroyed already
* added support for 2-level and free style GA notations
* Strip off trailing zeroes of DecimalTypes in order to gain compatibility with integer types in case any UI can't distinguish integers and floats coming from JS
* fixed < position in README.md  …

fixes #3609
fixes #3735
fixes #3686
fixes #3648
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>

