### PR TITLE
Re-add missing version parameter that was deleted on a POM refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
   <groupId>org.openhab</groupId>
   <artifactId>pom-addons2</artifactId>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>openHAB 2 Add-ons</name>
 


### PR DESCRIPTION
fixes a build issue within the release automation: `Missing requirement: org.openhab.binding.airquality 2.4.0.qualifier requires 'package com.google.gson 0.0.0' but it could not be found`

Signed-off-by: Patrick Fink <mail@pfink.de>