### PR TITLE
Remove @since tags from JavaDocs

### DIFF
--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/IRtransBindingConstants.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/IRtransBindingConstants.java
@@ -15,7 +15,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * handler classes
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  **/
 public class IRtransBindingConstants {

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/IrCommand.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/IrCommand.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
  * in various formats
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  */
 public class IrCommand {

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/BlasterHandler.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/BlasterHandler.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  */
 public class BlasterHandler extends BaseThingHandler implements TransceiverStatusListener {

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/EthernetBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/EthernetBridgeHandler.java
@@ -55,7 +55,6 @@ import org.slf4j.LoggerFactory;
  * are sent to one of the channels.
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  */
 public class EthernetBridgeHandler extends BaseBridgeHandler implements TransceiverStatusListener {

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/TransceiverStatusListener.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/handler/TransceiverStatusListener.java
@@ -16,7 +16,6 @@ import org.openhab.binding.irtrans.IrCommand;
  * transceiver
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  */
 public interface TransceiverStatusListener {

--- a/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/IRtransHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/IRtransHandlerFactory.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Lists;
  * thing handlers.
  *
  * @author Karel Goderis - Initial contribution
- * @since 2.3.0
  *
  */
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.irtrans")

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/command/SConfigCommandTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/command/SConfigCommandTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.max.internal.command.SConfigCommand.ConfigCommandType
  * Tests cases for {@link SConfigCommand}.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class SConfigCommandTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/CMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/CMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.max.internal.device.DeviceType;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 Version and updates
- * @since 1.4.0
  */
 public class CMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/ConfigurationTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/ConfigurationTest.java
@@ -20,7 +20,6 @@ import org.openhab.binding.max.internal.device.DeviceType;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 Version and updates
- * @since 1.4.0
  */
 public class ConfigurationTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/FMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/FMessageTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
  * Tests cases for {@link FMessage}.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class FMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/HMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/HMessageTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.max.internal.Utils;
  * Tests cases for {@link HMessage}.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class HMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MMessageTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.max.internal.device.RoomInformation;
  * Tests cases for {@link MMessage}.
  *
  * @author Marcel Verpaalen - Initial version
- * @since 2.0
  */
 public class MMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
@@ -20,7 +20,6 @@ import org.openhab.binding.max.internal.exceptions.UnsupportedMessageTypeExcepti
 
 /**
  * @author Christian Rockrohr <christian@rockrohr.de>
- * @since 1.7.0
  */
 public class MessageProcessorTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/NMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/NMessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.max.internal.device.DeviceType;
  * Tests cases for {@link NMessage}.
  *
  * @author Marcel Verpaalen - Initial Version
- * @since 2.0
  */
 public class NMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/SMessageTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/SMessageTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
  * Tests cases for {@link FMessage}.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class SMessageTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/UtilsTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/internal/message/UtilsTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.max.internal.Utils;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 Version and updates
- * @since 1.4.0
  */
 public class UtilsTest {
 

--- a/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/test/MaxCubeBridgeHandlerOSGiTest.java
+++ b/addons/binding/org.openhab.binding.max.test/src/test/java/org/openhab/binding/max/test/MaxCubeBridgeHandlerOSGiTest.java
@@ -33,7 +33,6 @@ import org.openhab.binding.max.internal.handler.MaxCubeBridgeHandler;
  *
  * @author Marcel Verpaalen - Initial contribution
  * @author Wouter Born - Migrate Groovy to Java tests
- * @since 2.0
  */
 public class MaxCubeBridgeHandlerOSGiTest extends JavaOSGiTest {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/Utils.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/Utils.java
@@ -16,7 +16,6 @@ import java.util.Date;
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
  *
- * @since 1.4.0
  */
 public final class Utils {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ACommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ACommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link ACommand} deletes the device and room configuration from the Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class ACommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link C_CubeCommand} to request configuration of a new MAX! device after inclusion.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class CCommand extends CubeCommand {
     private final String rfAddress;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * {@link CubeCommand} is the base class for commands to be send to the MAX! Cube.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  *
  */
 public abstract class CubeCommand {

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/FCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/FCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link F_CubeCommand} is used to query and update the NTP servers used by the Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class FCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/LCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/LCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link LCommand} request a status update for MAX! devices.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class LCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * The {@link MCommand} Creates the MAX! Cube the room & device name information update message.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class MCommand extends CubeCommand {
     private final Logger logger = LoggerFactory.getLogger(MCommand.class);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/NCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/NCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link N_CubeCommand} starts the inclusion mode for new MAX! devices.
  * 
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class NCommand extends CubeCommand {
     // Example n:003c = start inclusion, timeout 003c = 60 sec

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/QCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/QCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.command;
  * The {@link QCommand} Quits the connection to the MAX! Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class QCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
@@ -17,7 +17,6 @@ import org.openhab.binding.max.internal.device.ThermostatModeType;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update + simplification
- * @since 1.4.0
  */
 public class SCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * The {@link SConfigCommand} for setting MAX! thermostat configuration.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class SConfigCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
@@ -19,7 +19,6 @@ import org.openhab.binding.max.internal.Utils;
  * The {@link T_CubeCommand} is used to unlink MAX! devices from the Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class TCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * Cube LAN gateway.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0
  */
 public class UdpCubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ZCommand.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ZCommand.java
@@ -14,7 +14,6 @@ import org.openhab.binding.max.internal.Utils;
  * The {@link ZCommand} send a wakeup request to MAX! devices.
  *
  * @author Marcel Verpaalen - Initial Contribution
- * @since 2.0
  */
 public class ZCommand extends CubeCommand {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Cube.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Cube.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.device;
  * Cube Lan Gateway.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0.0
  */
 public class Cube extends Device {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Device.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/Device.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update + enhancements
- * @since 1.4.0
  */
 public abstract class Device {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceConfiguration.java
@@ -18,7 +18,6 @@ import org.openhab.binding.max.internal.message.Message;
  * Base class for configuration provided by the MAX! Cube C Message.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public final class DeviceConfiguration {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceInformation.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceInformation.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.device;
  * Device information provided by the M message meta information.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public class DeviceInformation {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceType.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/DeviceType.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.device;
  * This enumeration represents the different message types provided by the MAX! Cube protocol.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public enum DeviceType {
     Invalid(256),

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/EcoSwitch.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/EcoSwitch.java
@@ -14,7 +14,6 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
  * MAX! EcoSwitch.
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 1.6.0
  */
 public class EcoSwitch extends ShutterContact {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/HeatingThermostat.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/HeatingThermostat.java
@@ -18,7 +18,6 @@ import java.util.Date;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
- * @since 1.4.0
  */
 public class HeatingThermostat extends Device {
     private ThermostatModeType mode;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/RoomInformation.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/RoomInformation.java
@@ -13,7 +13,6 @@ package org.openhab.binding.max.internal.device;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen (marcel@verpaalen.com) - OH2 update
- * @since 1.4.0
  */
 public class RoomInformation {
     private int position;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/ShutterContact.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/ShutterContact.java
@@ -15,7 +15,6 @@ import org.eclipse.smarthome.core.library.types.OpenClosedType;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
- * @since 1.4.0
  */
 public class ShutterContact extends Device {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/ThermostatModeType.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/ThermostatModeType.java
@@ -17,7 +17,6 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
- * @since 1.4.0
  */
 public enum ThermostatModeType implements PrimitiveType, State, Command {
     AUTOMATIC,

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/UnsupportedDevice.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/UnsupportedDevice.java
@@ -13,7 +13,6 @@ package org.openhab.binding.max.internal.device;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
- * @since 1.4.0
  */
 
 public class UnsupportedDevice extends Device {

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/WallMountedThermostat.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/device/WallMountedThermostat.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.device;
  * MAX! wall mounted thermostat.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public class WallMountedThermostat extends HeatingThermostat {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/AMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/AMessage.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
  * The {@link AMessage} Acknowledge the execution of a command
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0.0
  */
 public final class AMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/CMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/CMessage.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - Detailed parsing, OH2 Update
- * @since 1.4.0
  */
 public final class CMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/FMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/FMessage.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
  * This is the response to a f: command
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0.0
  */
 public final class FMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/HMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/HMessage.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - Details parsing, OH2 version
- * @since 1.4.0
  */
 public final class HMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/LMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/LMessage.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update
  *
- * @since 1.4.0
  */
 public final class LMessage extends Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MMessage.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andreas Heil (info@aheil.de) - Initial Contribution
  * @author Marcel Verpaalen - Room details parse
- * @since 1.4.0
  */
 public final class MMessage extends Message {
     private final Logger logger = LoggerFactory.getLogger(MMessage.class);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MaxTokenizer.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MaxTokenizer.java
@@ -19,7 +19,6 @@ import java.util.Enumeration;
  * tokens length.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public final class MaxTokenizer implements Enumeration<byte[]> {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/Message.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/Message.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
  * Base message for the messages received from the MAX! Cube.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public abstract class Message {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageProcessor.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageProcessor.java
@@ -28,7 +28,6 @@ import org.openhab.binding.max.internal.exceptions.UnsupportedMessageTypeExcepti
  * processed.
  *
  * @author Christian Rockrohr <christian@rockrohr.de> - Initial contribution
- * @since 1.7.0
  */
 public class MessageProcessor {
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageType.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MessageType.java
@@ -12,7 +12,6 @@ package org.openhab.binding.max.internal.message;
  * This enumeration represents the different message types provided by the MAX! Cube protocol.
  *
  * @author Andreas Heil (info@aheil.de) - Initial contribution
- * @since 1.4.0
  */
 public enum MessageType {
     H,

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/NMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/NMessage.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
  * This is the response to a n: command
  *
  * @author Marcel Verpaalen - Initial contribution
- * @since 2.0.0
  */
 public final class NMessage extends Message {
     private final Logger logger = LoggerFactory.getLogger(NMessage.class);

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/SMessage.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/SMessage.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bernd Michael Helm (bernd.helm at helmundwalter.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 version + parsing of the message
- * @since 1.6.0
  */
 public final class SMessage extends Message {
     private final Logger logger = LoggerFactory.getLogger(SMessage.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/AbstractBulbInterface.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/AbstractBulbInterface.java
@@ -16,7 +16,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * Implement this bulb interface for each new bulb type. It is used by {@see MilightLedHandler} to handle commands.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public abstract class AbstractBulbInterface {
     /**

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV2RGB.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV2RGB.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * and can only be add manually in the things file.
  *
  * @author David Graeff - Initial contribution
- * @since 2.0
  */
 public class MilightV2RGB extends AbstractBulbInterface {
     protected final Logger logger = LoggerFactory.getLogger(MilightV2RGB.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * The class is state-less, use {@link MilightThingState} instead.
  *
  * @author David Graeff - Initial contribution
- * @since 2.0
  */
 public abstract class MilightV3 extends AbstractBulbInterface {
     public static final int MAX_ANIM_MODES = 10;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3RGBW.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3RGBW.java
@@ -15,7 +15,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * Color temperature and saturation are not supported for this type of bulbs.
  *
  * @author David Graeff - Initial contribution
- * @since 2.0
  */
 public class MilightV3RGBW extends MilightV3 {
     protected static final int BRIGHTNESS_LEVELS = 26;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3White.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV3White.java
@@ -15,7 +15,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * Color temperature is supported for this type of bulbs.
  *
  * @author David Graeff - Initial contribution
- * @since 2.0
  */
 public class MilightV3White extends MilightV3 {
     protected static final int BRIGHTNESS_LEVELS = 11;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * done in subclasses.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public abstract class MilightV6 extends AbstractBulbInterface {
     protected final Logger logger = LoggerFactory.getLogger(MilightV6.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBCWWW.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBCWWW.java
@@ -14,7 +14,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * Implements the RGB cold white / warm white bulb. It is the most feature rich bulb.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class MilightV6RGBCWWW extends MilightV6 {
     private static final int ADDR = 0x08;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBIBOX.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBIBOX.java
@@ -15,7 +15,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * saturation or colour temperature available.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class MilightV6RGBIBOX extends MilightV6 {
     private static final byte ADDR = 0x00;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBW.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6RGBW.java
@@ -15,7 +15,6 @@ import org.openhab.binding.milight.internal.MilightThingState;
  * control. It still allows more colours than the old v3 rgbw bulb (16320 (255*64) vs 4080 (255*16) colors).
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class MilightV6RGBW extends MilightV6 {
     private static final int ADDR = 0x07;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
  * our session is still valid and can redo the session handshake if necessary.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class MilightV6SessionManager implements Runnable {
     protected final Logger logger = LoggerFactory.getLogger(MilightV6SessionManager.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * want to just queue up those commands but apply the newest command only.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class QueuedSend implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(QueuedSend.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/test/EmulatedV6Bridge.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/test/EmulatedV6Bridge.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  * as well as test the binding to be conformant to the protocol.
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 public class EmulatedV6Bridge {
     protected final Logger logger = LoggerFactory.getLogger(EmulatedV6Bridge.class);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/test/TestDiscovery.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/test/TestDiscovery.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
  * Enable this in OSGI-INF/TestDiscovery.xml with enabled="true".
  *
  * @author David Graeff - Initial contribution
- * @since 2.1
  */
 @Component(service = DiscoveryService.class, immediate = true, enabled = false)
 public class TestDiscovery extends AbstractDiscoveryService {

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * On the pulseaudio server the module-cli-protocol-tcp has to be loaded.
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class PulseaudioClient {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * Parsers for the pulseaudio return strings
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(Parser.class);

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/AbstractAudioDeviceConfig.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/AbstractAudioDeviceConfig.java
@@ -13,7 +13,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * muted or their volume can be changed.
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public abstract class AbstractAudioDeviceConfig extends AbstractDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/AbstractDeviceConfig.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/AbstractDeviceConfig.java
@@ -14,7 +14,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * class.
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public abstract class AbstractDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Module.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Module.java
@@ -14,7 +14,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * be able to remove sinks from the pulseaudio server.
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class Module extends AbstractDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Sink.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Sink.java
@@ -17,7 +17,6 @@ import java.util.List;
  * combined to one playback device
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class Sink extends AbstractAudioDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/SinkInput.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/SinkInput.java
@@ -12,7 +12,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * A SinkInput is an audio stream which can be routed to a {@link Sink}
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class SinkInput extends AbstractAudioDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Source.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Source.java
@@ -13,7 +13,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * device) For example microphones or line-in jacks.
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class Source extends AbstractAudioDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/SourceOutput.java
+++ b/addons/binding/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/SourceOutput.java
@@ -12,7 +12,6 @@ package org.openhab.binding.pulseaudio.internal.items;
  * A SourceOutput is the audio stream which is produced by a (@link Source}
  *
  * @author Tobias Bräutigam - Initial contribution
- * @since 1.2.0
  */
 public class SourceOutput extends AbstractAudioDeviceConfig {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/config/RFXComDeviceConfigurationBuilder.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/config/RFXComDeviceConfigurationBuilder.java
@@ -12,7 +12,6 @@ package org.openhab.binding.rfxcom.internal.config;
  * Test helper for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 2.1.0
  */
 public class RFXComDeviceConfigurationBuilder {
     private final RFXComDeviceConfiguration config;

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQTemperatureMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQTemperatureMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Mike Jagdis
- * @since 2.2.0
  */
 public class RFXComBBQTemperatureMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBarometricMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBarometricMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComBarometricMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
@@ -20,7 +20,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.SubType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComBlinds1MessageTest {
     private void testMessage(String hexMsg, SubType subType, int seqNbr, String deviceId, int signalLevel,

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComCamera1MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
@@ -21,7 +21,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComChimeMessage.SubType;
  *
  * @author Mike Jagdis
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComChimeMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComCurrentEnergyMessageTest {
     private void testMessage(String hexMsg, RFXComCurrentEnergyMessage.SubType subType, int seqNbr, String deviceId,

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
@@ -17,7 +17,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComCurtain1MessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
@@ -20,7 +20,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComDateTimeMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
@@ -17,7 +17,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 2.0.0
  */
 public class RFXComEdisioTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComEnergyMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComFS20MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComFanMessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComGasMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
@@ -23,7 +23,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.Sub
  *
  * @author Martin van Wingerden - Initial contribution of empty test
  * @author Mike Jagdis - added message handling and real test
- * @since 2.0.0
  */
 public class RFXComHomeConfortTest {
     private void testMessage(SubType subType, Commands command, String deviceId, String data)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComHumidityMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComIOLinesMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
@@ -21,7 +21,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Mike Jagdis
- * @since 2.1.0
  */
 public class RFXComInterfaceControlMessageTest {
     private RFXComBridgeConfiguration configuration = new RFXComBridgeConfiguration();

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
@@ -24,7 +24,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubTy
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 2.0.0
  */
 public class RFXComInterfaceMessageTest {
     private RFXComInterfaceMessage testMessage(String hexMsg, SubType subType, int seqNbr, Commands command,

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
@@ -17,7 +17,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  * Test for RFXCom-binding
  *
  * @author James Hewitt-Thomas
- * @since 1.9.0
  */
 public class RFXComInvalidMessageTypeTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComLighting1Message.Comma
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting1MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting2MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting3MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
@@ -28,7 +28,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting4MessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
@@ -23,7 +23,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting5MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComLighting6MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
@@ -15,7 +15,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComPowerMessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComRFXMeterMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComRFXSensorMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
@@ -17,7 +17,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 2.0.0
  */
 public class RFXComRadiator1MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComRainMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComRemoteControlMessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
@@ -21,7 +21,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComRfyMessage.SubType;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComRfyMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
@@ -23,7 +23,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.Statu
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComSecurity1MessageTest {
     private void testSomeMessages(String hexMessage, RFXComSecurity1Message.SubType subType, int sequenceNumber,

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
@@ -20,7 +20,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity2Message.SubTy
  *
  * @author Martin van Wingerden - Initial contribution of empty test
  * @author Mike Jagdis - added message handling and real test
- * @since 2.0.0
  */
 public class RFXComSecurity2MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTemperatureHumidityBarometricMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMes
  *
  * @author Ivan F. Martinez
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTemperatureHumidityMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTemperatureMessageTest {
     private void testMessage(String hexMsg, RFXComTemperatureMessage.SubType subType, int seqNbr, String deviceId,

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTemperatureRainMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Helper class for testing the RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTestHelper {
     static void basicBoundaryCheck(PacketType packetType, RFXComMessage message) throws RFXComException {

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
@@ -18,7 +18,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComThermostat1MessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComThermostat2MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
@@ -17,7 +17,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComThermostat4MessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.Sub
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComTransmitterMessageTest {
     private void testMessage(String hexMsg, Response response, SubType subType, int seqNbr) throws RFXComException {

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  *
  * @author Martin van Wingerden
  * @author Mike Jagdis
- * @since 1.9.0
  */
 public class RFXComUVMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
@@ -21,7 +21,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  *
  * @author Martin van Wingerden
  * @author James Hewitt-Thomas
- * @since 1.9.0
  */
 public class RFXComUndecodedRFMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComWaterMessageTest {
 

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
@@ -16,7 +16,6 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComWeightMessageTest {
     @Test(expected = RFXComMessageNotImplementedException.class)

--- a/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
+++ b/addons/binding/org.openhab.binding.rfxcom.test/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
@@ -19,7 +19,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
  * Test for RFXCom-binding
  *
  * @author Martin van Wingerden
- * @since 1.9.0
  */
 public class RFXComWindMessageTest {
     @Test

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  * RFXCOM data class for Current and Energy message.
  *
  * @author Damien Servant
- * @since 1.9.0
  */
 public class RFXComCurrentEnergyMessage extends RFXComBatteryDeviceMessage<RFXComCurrentEnergyMessage.SubType> {
     private static final float TOTAL_USAGE_CONVERSION_FACTOR = 223.666F;

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
@@ -22,7 +22,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  * RFXCOM data class for Date and Time message.
  *
  * @author Damien Servant
- * @since 1.9.0
  */
 public class RFXComDateTimeMessage extends RFXComBatteryDeviceMessage<RFXComDateTimeMessage.SubType> {
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessage.java
@@ -24,7 +24,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  *
  * @author Damien Servant
  * @author Martin van Wingerden - ported to openHAB 2.0
- * @since 1.9.0
  */
 public class RFXComTemperatureHumidityBarometricMessage
         extends RFXComBatteryDeviceMessage<RFXComTemperatureHumidityBarometricMessage.SubType> {

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
@@ -23,7 +23,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  *
  * @author Damien Servant
  * @author Martin van Wingerden - ported to openHAB 2.0
- * @since 1.9.0
  */
 public class RFXComTemperatureRainMessage extends RFXComBatteryDeviceMessage<RFXComTemperatureRainMessage.SubType> {
 

--- a/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
+++ b/addons/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
@@ -27,7 +27,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueExce
  *
  * @author Ivan Martinez
  * @author James Hewitt-Thomas
- * @since 1.9.0
  */
 public class RFXComUndecodedRFMessage extends RFXComDeviceMessageImpl<RFXComUndecodedRFMessage.SubType> {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ClearTroublesCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ClearTroublesCommand.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.command;
  * Command class for command that clear troubles memory.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class ClearTroublesCommand extends ControlCommand {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ControlCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ControlCommand.java
@@ -15,7 +15,6 @@ import org.openhab.binding.satel.internal.protocol.SatelMessage;
  * Base class for all commands that return result code in the response.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public abstract class ControlCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ControlObjectCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ControlObjectCommand.java
@@ -24,7 +24,6 @@ import org.openhab.binding.satel.internal.types.ControlType;
  * switch), etc.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class ControlObjectCommand extends ControlCommand {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStateCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStateCommand.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
  * outputs and doors (opened, opened long).
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraStateCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStatusCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStatusCommand.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
  * Command class for command that returns Integra RTC and basic status.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraStatusCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraVersionCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraVersionCommand.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * Command class for command that returns Integra version and type.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraVersionCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/NewStatesCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/NewStatesCommand.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * state read.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class NewStatesCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadDeviceInfoCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadDeviceInfoCommand.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * (partition, zone, user, etc).
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public class ReadDeviceInfoCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadEventCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadEventCommand.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * Command class for command that reads one record from the event log.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public class ReadEventCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadEventDescCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ReadEventDescCommand.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * code.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public class ReadEventDescCommand extends SatelCommandBase {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommand.java
@@ -15,7 +15,6 @@ import org.openhab.binding.satel.internal.protocol.SatelMessage;
  * Interface for commands sent to communication module.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public interface SatelCommand {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommandBase.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommandBase.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * Base class for all command classes.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public abstract class SatelCommandBase extends SatelMessage implements SatelCommand {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SetClockCommand.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SetClockCommand.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang.ArrayUtils;
  * Command class for command to set RTC clock.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class SetClockCommand extends ControlCommand {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ConnectionStatusEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ConnectionStatusEvent.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.event;
  * Event class describing connection status to Satel module.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class ConnectionStatusEvent implements SatelEvent {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/EventDispatcher.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/EventDispatcher.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * must implement {@link SatelEventListener} interface.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class EventDispatcher {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStateEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStateEvent.java
@@ -18,7 +18,6 @@ import org.openhab.binding.satel.internal.types.StateType;
  * Event class describing current state of zones/partitions/outputs/doors/troubles.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraStateEvent implements SatelEvent {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStatusEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStatusEvent.java
@@ -14,7 +14,6 @@ import java.util.Calendar;
  * Event class describing basic status bits and current time.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraStatusEvent implements SatelEvent {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraVersionEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraVersionEvent.java
@@ -14,7 +14,6 @@ import org.openhab.binding.satel.internal.types.IntegraType;
  * Event class describing type and version of connected Integra system.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntegraVersionEvent implements SatelEvent {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/NewStatesEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/NewStatesEvent.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Event class describing changes in Integra state since last state read.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class NewStatesEvent implements SatelEvent {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/SatelEvent.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/SatelEvent.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.event;
  * Simple interface that all event classes must implement.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public interface SatelEvent {
 }

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/SatelEventListener.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/SatelEventListener.java
@@ -13,7 +13,6 @@ package org.openhab.binding.satel.internal.event;
  * implement this interface.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public interface SatelEventListener {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/EncryptionHelper.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/EncryptionHelper.java
@@ -18,7 +18,6 @@ import javax.crypto.spec.SecretKeySpec;
  * Helper class for encrypting ETHM-1 messages.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class EncryptionHelper {
     private Key key;

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/Ethm1Module.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/Ethm1Module.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * integration protocol enable in DLOADX configuration options.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class Ethm1Module extends SatelModule {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/IntRSModule.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/IntRSModule.java
@@ -31,7 +31,6 @@ import gnu.io.UnsupportedCommOperationException;
  * communicate with that module over serial protocol.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class IntRSModule extends SatelModule {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/SatelMessage.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/SatelMessage.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
  * message checksum.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public class SatelMessage {
     private static final Logger LOGGER = LoggerFactory.getLogger(SatelMessage.class);

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/SatelModule.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/SatelModule.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
  * module. Each command class must extend {@link SatelCommand}.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public abstract class SatelModule extends EventDispatcher implements SatelEventListener {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ControlType.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ControlType.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Interface for all types of control.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public interface ControlType {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/DoorControl.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/DoorControl.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Available door control types.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public enum DoorControl implements ControlType {
     OPEN(0x8A, DoorState.OPENED);

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/DoorState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/DoorState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Available door states.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum DoorState implements StateType {
     OPENED(0x18),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Available Integra types.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum IntegraType {
     UNKNOWN(-1, "Unknown", 0, 0),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ObjectType.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ObjectType.java
@@ -20,7 +20,6 @@ package org.openhab.binding.satel.internal.types;
  * </ul>
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum ObjectType {
     ZONE,

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/OutputControl.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/OutputControl.java
@@ -19,7 +19,6 @@ import java.util.BitSet;
  * </ul>
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum OutputControl implements ControlType {
     ON(0x88),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/OutputState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/OutputState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Available output states.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum OutputState implements StateType {
     STATE(0x17);

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/PartitionControl.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/PartitionControl.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Available partition control types.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum PartitionControl implements ControlType {
     ARM_MODE_0(0x80),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/PartitionState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/PartitionState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Available partition states.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum PartitionState implements StateType {
     ARMED(0x09),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/StateType.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/StateType.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Base of all kinds of Integra state.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public interface StateType {
 

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/TroubleMemoryState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/TroubleMemoryState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Supported memory of troubles.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.10.0
  */
 public enum TroubleMemoryState implements StateType {
     // part 1

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/TroubleState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/TroubleState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Supported troubles.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.10.0
  */
 public enum TroubleState implements StateType {
     // part 1

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ZoneControl.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ZoneControl.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
  * Available zone control types.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.9.0
  */
 public enum ZoneControl implements ControlType {
     BYPASS(0x86, ZoneState.BYPASS),

--- a/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ZoneState.java
+++ b/addons/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/ZoneState.java
@@ -12,7 +12,6 @@ package org.openhab.binding.satel.internal.types;
  * Available zone states.
  *
  * @author Krzysztof Goworek - Initial contribution
- * @since 1.7.0
  */
 public enum ZoneState implements StateType {
     VIOLATION(0x00),

--- a/addons/ui/org.openhab.ui.cometvisu/src/gen/java/org/openhab/ui/cometvisu/internal/config/beans/LibVersion.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/gen/java/org/openhab/ui/cometvisu/internal/config/beans/LibVersion.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.config.beans;
  * this must be changed manually, everytime the cometvisu´s libVersion changes after JAXB generation
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class LibVersion {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/StateBeanMessageBodyWriter.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/StateBeanMessageBodyWriter.java
@@ -31,7 +31,6 @@ import org.openhab.ui.cometvisu.internal.backend.beans.StateBean;
  * for the CometVisu client
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 @Provider
 @Produces(MediaType.APPLICATION_JSON)

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ChartResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ChartResource.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
  * used by the diagram plugin
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_CHART_ALIAS)

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ConfigResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ConfigResource.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
  * Allows certain actions to configure the CometVisu backend through the REST api.
  *
  * @author Tobias Bräutigam
- * @since 2.2.0
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_CONFIG_ALIAS)
 public class ConfigResource implements RESTResource {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/EventBroadcaster.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/EventBroadcaster.java
@@ -17,7 +17,6 @@ import org.eclipse.smarthome.core.types.State;
  * Broadcast state change events of items to listening clients
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public interface EventBroadcaster {
     /**

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/LoginResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/LoginResource.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * currently this is just a placeholder and does no real authentification
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_LOGIN_ALIAS)
 public class LoginResource implements RESTResource {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ReadResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/ReadResource.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * SSE communication
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_READ_ALIAS)
 public class ReadResource implements EventBroadcaster, RESTResource {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/WriteResource.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/WriteResource.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * handles state updates send by the CometVisu client and forwars them to the EventPublisher
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_WRITE_ALIAS)
 public class WriteResource implements RESTResource {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/ConfigBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/ConfigBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.backend.beans;
  * Cometvisu client.
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class ConfigBean {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/LoginBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/LoginBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.backend.beans;
  * page of the Cometvisu interface.
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class LoginBean {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/ResourcesBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/ResourcesBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.backend.beans;
  * Cometvisu client.
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class ResourcesBean {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/StateBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/StateBean.java
@@ -12,7 +12,6 @@ package org.openhab.ui.cometvisu.internal.backend.beans;
  * Item bean for broadcasted item states.
  * 
  * @author Tobias Bräutigam - Initial Contribution and API
- * @since 2.0.0
  */
 public class StateBean {
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/SuccessBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/beans/SuccessBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.backend.beans;
  * page of the Cometvisu interface.
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class SuccessBean {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/ConfigHelper.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/ConfigHelper.java
@@ -70,7 +70,6 @@ import org.slf4j.LoggerFactory;
  * XML file.
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class ConfigHelper {
     public enum Transform {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/VisuConfig.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/VisuConfig.java
@@ -73,7 +73,6 @@ import org.xml.sax.SAXException;
  * multi-column-layouts)
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  *
  */
 public class VisuConfig {

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/DataBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/DataBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.editor.dataprovider.beans;
  * which delivers some additional data for the CometVisu-Editor
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class DataBean {
     public String value;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/ItemBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/ItemBean.java
@@ -16,7 +16,6 @@ import java.util.Map;
  * which delivers some additional data for the CometVisu-Editor
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class ItemBean extends DataBean {
     public Map<String, String> hints = new HashMap<String, String>();

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/TransformBean.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/editor/dataprovider/beans/TransformBean.java
@@ -13,7 +13,6 @@ package org.openhab.ui.cometvisu.internal.editor.dataprovider.beans;
  * which delivers some additional data for the CometVisu-Editor
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class TransformBean {
     public String value;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/ItemRegistryEventListener.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/ItemRegistryEventListener.java
@@ -20,7 +20,6 @@ import org.openhab.ui.cometvisu.internal.backend.EventBroadcaster;
  * in the ItemRegistry
  * 
  * @author Tobias Bräutigam - Initial Contribution and API
- * @since 2.0.0
  */
 public class ItemRegistryEventListener implements ItemRegistryChangeListener {
     private ItemRegistry itemRegistry;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/StateEventListener.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/StateEventListener.java
@@ -21,7 +21,6 @@ import org.openhab.ui.cometvisu.internal.backend.beans.StateBean;
  * listens to state changes on items and send them to an EventBroadcaster
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class StateEventListener implements StateChangeListener {
 

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/Entry.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/Entry.java
@@ -15,7 +15,6 @@ import java.util.List;
  * {@link Entry} is used by the CometVisu rss-plugin
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class Entry {
     public String id;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/Feed.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/Feed.java
@@ -15,7 +15,6 @@ import java.util.List;
  * {@link Feed} is used by the CometVisu rss-plugin
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class Feed {
     public String feedUrl;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/ResponseData.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/rss/beans/ResponseData.java
@@ -12,7 +12,6 @@ package org.openhab.ui.cometvisu.internal.rss.beans;
  * {@link ResponseData} is used by the CometVisu rss-plugin
  * 
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class ResponseData {
     public Feed feed;

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuApp.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuApp.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
  * registers the CometVisuServlet-Service
  *
  * @author Tobias Bräutigam
- * @since 2.0.0
  */
 public class CometVisuApp {
 


### PR DESCRIPTION
The `@since` tags are no longer used and part of the openHAB coding guidelines.

Fixes #3815 
