### PR TITLE
[Fronius] Fixed the NullPointerException if timeout by evaluate the status

### DIFF
--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/handler/FroniusSymoInverterHandler.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/handler/FroniusSymoInverterHandler.java
@@ -74,11 +74,6 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
     protected Object getValue(String channelId) {
         String[] fields = StringUtils.split(channelId, "#");
 
-        if (inverterRealtimeResponse == null || inverterRealtimeResponse.getBody() == null
-                || inverterRealtimeResponse.getBody().getData() == null) {
-            return null;
-        }
-
         String fieldName = fields[0];
 
         switch (fieldName) {
@@ -108,11 +103,6 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
                 return inverterRealtimeResponse.getBody().getData().getUdc();
         }
 
-        if (powerFlowResponse == null || powerFlowResponse.getBody() == null
-                || powerFlowResponse.getBody().getData() == null
-                || powerFlowResponse.getBody().getData().getSite() == null) {
-            return null;
-        }
         switch (fieldName) {
             case FroniusBindingConstants.PowerFlowpGrid:
                 return powerFlowResponse.getBody().getData().getSite().getPgrid();
@@ -201,7 +191,15 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
             if (result == null) {
                 errorMsg = "no data returned";
             } else if (result.getBody() != null) {
-                resultOk = true;
+                if (result.getHead() == null) {
+                    errorMsg = "no header";
+                } else {
+                    if (result.getHead().getStatus().getCode() == 0) {
+                        resultOk = true;
+                    } else {
+                        errorMsg = result.getHead().getStatus().getReason();
+                    }
+                }
             } else {
                 errorMsg = "missing data sub-object";
             }

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/Head.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/Head.java
@@ -28,6 +28,9 @@ public class Head {
     private String timestamp;
 
     public HeadRequestArguments getRequestArguments() {
+        if (requestArguments == null) {
+            requestArguments = new HeadRequestArguments();
+        }
         return requestArguments;
     }
 
@@ -36,6 +39,11 @@ public class Head {
     }
 
     public HeadStatus getStatus() {
+        if (status == null) {
+            status = new HeadStatus();
+            status.setCode(255);
+            status.setReason("undefined runtime error");
+        }
         return status;
     }
 
@@ -44,6 +52,9 @@ public class Head {
     }
 
     public String getTimestamp() {
+        if (timestamp == null) {
+            timestamp = "";
+        }
         return timestamp;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/HeadRequestArguments.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/HeadRequestArguments.java
@@ -27,6 +27,9 @@ public class HeadRequestArguments {
     private String scope;
 
     public String getDataCollection() {
+        if (null == dataCollection) {
+            dataCollection = "";
+        }
         return dataCollection;
     }
 
@@ -35,6 +38,9 @@ public class HeadRequestArguments {
     }
 
     public String getDeviceClass() {
+        if (null == deviceClass) {
+            deviceClass = "";
+        }
         return deviceClass;
     }
 
@@ -43,6 +49,9 @@ public class HeadRequestArguments {
     }
 
     public String getDeviceId() {
+        if (null == deviceId) {
+            deviceId = "";
+        }
         return deviceId;
     }
 
@@ -51,6 +60,9 @@ public class HeadRequestArguments {
     }
 
     public String getScope() {
+        if (null == scope) {
+            scope = "";
+        }
         return scope;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/HeadStatus.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/HeadStatus.java
@@ -33,6 +33,9 @@ public class HeadStatus {
     }
 
     public String getReason() {
+        if (reason == null) {
+            reason = "";
+        }
         return reason;
     }
 
@@ -41,6 +44,9 @@ public class HeadStatus {
     }
 
     public String getUserMessage() {
+        if (userMessage == null) {
+            userMessage = "";
+        }
         return userMessage;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeBody.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeBody.java
@@ -21,6 +21,9 @@ public class InverterRealtimeBody {
     private InverterRealtimeBodyData data;
 
     public InverterRealtimeBodyData getData() {
+        if (data == null) {
+            data = new InverterRealtimeBodyData();
+        }
         return data;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeBodyData.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeBodyData.java
@@ -40,6 +40,9 @@ public class InverterRealtimeBodyData {
     private DeviceStatus deviceStatus;
 
     public ValueUnit getDayEnergy() {
+        if (dayEnergy == null) {
+            dayEnergy = new ValueUnit();
+        }
         return dayEnergy;
     }
 
@@ -48,6 +51,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getPac() {
+        if (pac == null) {
+            pac = new ValueUnit();
+        }
         return pac;
     }
 
@@ -56,6 +62,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getTotalEnergy() {
+        if (totalEnergy == null) {
+            totalEnergy = new ValueUnit();
+        }
         return totalEnergy;
     }
 
@@ -64,6 +73,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getYearEnergy() {
+        if (yearEnergy == null) {
+            yearEnergy = new ValueUnit();
+        }
         return yearEnergy;
     }
 
@@ -72,6 +84,9 @@ public class InverterRealtimeBodyData {
     }
 
     public DeviceStatus getDeviceStatus() {
+        if (deviceStatus == null) {
+            deviceStatus = new DeviceStatus();
+        }
         return deviceStatus;
     }
 
@@ -80,6 +95,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getFac() {
+        if (fac == null) {
+            fac = new ValueUnit();
+        }
         return fac;
     }
 
@@ -88,6 +106,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getIac() {
+        if (iac == null) {
+            iac = new ValueUnit();
+        }
         return iac;
     }
 
@@ -96,6 +117,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getIdc() {
+        if (idc == null) {
+            idc = new ValueUnit();
+        }
         return idc;
     }
 
@@ -104,6 +128,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getUac() {
+        if (uac == null) {
+            uac = new ValueUnit();
+        }
         return uac;
     }
 
@@ -112,6 +139,9 @@ public class InverterRealtimeBodyData {
     }
 
     public ValueUnit getUdc() {
+        if (udc == null) {
+            udc = new ValueUnit();
+        }
         return udc;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeResponse.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/InverterRealtimeResponse.java
@@ -23,6 +23,9 @@ public class InverterRealtimeResponse {
     private InverterRealtimeBody body;
 
     public Head getHead() {
+        if (head == null) {
+            head = new Head();
+        }
         return head;
     }
 
@@ -31,6 +34,9 @@ public class InverterRealtimeResponse {
     }
 
     public InverterRealtimeBody getBody() {
+        if (body == null) {
+            body = new InverterRealtimeBody();
+        }
         return body;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeBody.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeBody.java
@@ -21,6 +21,9 @@ public class PowerFlowRealtimeBody {
     private PowerFlowRealtimeBodyData data;
 
     public PowerFlowRealtimeBodyData getData() {
+        if (data == null) {
+            data = new PowerFlowRealtimeBodyData();
+        }
         return data;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeBodyData.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeBodyData.java
@@ -27,6 +27,9 @@ public class PowerFlowRealtimeBodyData {
     private HashMap<String, PowerFlowRealtimeInverter> inverters;
 
     public HashMap<String, PowerFlowRealtimeInverter> getInverters() {
+        if (inverters == null) {
+            inverters = new HashMap<String, PowerFlowRealtimeInverter>();
+        }
         return inverters;
     }
 
@@ -35,6 +38,9 @@ public class PowerFlowRealtimeBodyData {
     }
 
     public PowerFlowRealtimeSite getSite() {
+        if (site == null) {
+            site = new PowerFlowRealtimeSite();
+        }
         return site;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeResponse.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeResponse.java
@@ -24,6 +24,9 @@ public class PowerFlowRealtimeResponse {
     private PowerFlowRealtimeBody body;
 
     public Head getHead() {
+        if (head == null) {
+            head = new Head();
+        }
         return head;
     }
 
@@ -32,6 +35,9 @@ public class PowerFlowRealtimeResponse {
     }
 
     public PowerFlowRealtimeBody getBody() {
+        if (body == null) {
+            body = new PowerFlowRealtimeBody();
+        }
         return body;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeSite.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/PowerFlowRealtimeSite.java
@@ -42,6 +42,9 @@ public class PowerFlowRealtimeSite {
     private String meterLocation;
 
     public String getMode() {
+        if (mode == null) {
+            mode = new String();
+        }
         return mode;
     }
 

--- a/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/ValueUnit.java
+++ b/addons/binding/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/ValueUnit.java
@@ -33,6 +33,9 @@ public class ValueUnit {
     }
 
     public String getUnit() {
+        if (unit == null) {
+            unit = new String();
+        }
         return unit;
     }
 


### PR DESCRIPTION
Signed-off-by: Thomas Rokohl <thomas.rokohl@codemacher.de>

The NullPointerException (#3749, #3725) has been fixed by checking the status of the device and also creating empty objects if the API does not respond correctly.

I have also removed the changes and checks to null from PR #3749 as they are no longer necessary.