### PR TITLE
Remove outdated license header duplicates

### DIFF
--- a/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewHubHandler.java
+++ b/addons/binding/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/handler/HDPowerViewHubHandler.java
@@ -6,13 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-/**
-e * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 package org.openhab.binding.hdpowerview.handler;
 
 import java.io.IOException;

--- a/addons/binding/org.openhab.binding.miele/OSGI-INF/MieleMDNSDiscoveryParticipant.xml
+++ b/addons/binding/org.openhab.binding.miele/OSGI-INF/MieleMDNSDiscoveryParticipant.xml
@@ -9,9 +9,6 @@
 	http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<!-- Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others. All rights reserved. This program and the accompanying 
-	materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and 
-	is available at http://www.eclipse.org/legal/epl-v10.html -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true"
 	name="org.openhab.binding.miele.discovery.MieleMDNSDiscoveryParticipant">
 	<implementation class="org.openhab.binding.miele.internal.discovery.MieleMDNSDiscoveryParticipant" />

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedTransactionIdException.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedTransactionIdException.java
@@ -6,16 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
-/**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- */
 package org.openhab.io.transport.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/endpoint/ModbusTCPSlaveEndpoint.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/endpoint/ModbusTCPSlaveEndpoint.java
@@ -6,16 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
-/**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- */
 package org.openhab.io.transport.modbus.endpoint;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/endpoint/ModbusUDPSlaveEndpoint.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/endpoint/ModbusUDPSlaveEndpoint.java
@@ -6,16 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
-/**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- */
 package org.openhab.io.transport.modbus.endpoint;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
@@ -7,13 +7,6 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.voice.marytts.internal;
-/**
- * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 
 import java.io.IOException;
 import java.util.HashSet;


### PR DESCRIPTION
While looking at the MaryTTS code I stumbled upon a duplicate header. A grep showed there were a few more (outdated) duplicate license headers.