### PR TITLE
[mcp23017] Workaround for input pins not being initialized

### DIFF
--- a/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/handler/Mcp23017Handler.java
+++ b/addons/binding/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/handler/Mcp23017Handler.java
@@ -58,9 +58,6 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
 
     public Mcp23017Handler(Thing thing) {
         super(thing);
-        checkConfiguration();
-        mcpProvider = initializeMcpProvider();
-        pinStateHolder = new Mcp23017PinStateHolder(mcpProvider, this.thing);
 
     }
 
@@ -88,16 +85,14 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
 
     @Override
     public void initialize() {
-        super.initialize();
-
-        for (Channel channel : this.thing.getChannels()) {
-            if (isLinked(channel.getUID())) {
-                String channelGroup = channel.getUID().getGroupId();
-
-                if (channelGroup.equals(CHANNEL_GROUP_INPUT)) {
-                    channelLinked(channel.getUID());
-                }
-            }
+        try {
+            checkConfiguration();
+            mcpProvider = initializeMcpProvider();
+            pinStateHolder = new Mcp23017PinStateHolder(mcpProvider, this.thing);
+            updateStatus(ThingStatus.ONLINE);
+        } catch (IllegalArgumentException | SecurityException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "An exception occurred while adding pin. Check pin configuration. Exception: " + e.getMessage());
         }
     }
 
@@ -144,12 +139,6 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
         Configuration configuration = getConfig();
         address = Integer.parseInt((configuration.get(ADDRESS)).toString(), 16);
         busNumber = Integer.parseInt((configuration.get(BUS_NUMBER)).toString());
-        try {
-            updateStatus(ThingStatus.ONLINE);
-        } catch (IllegalArgumentException | SecurityException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "An exception occurred while adding pin. Check pin configuration. Exception: " + e.getMessage());
-        }
     }
 
     private MCP23017GpioProvider initializeMcpProvider() {


### PR DESCRIPTION
Fixed INPUT PIN support after changes in 2.3.0.1

After upgrade to OH2 ver 2.3.0.0 INPUT pins in [mcp23017] binding stopped to work.
I investigated a little, and it turned out, that "channelLinked" method is not called at all, so input pins cannot be initialized.
First I suspected that it is due to wrong order of loading configuration files - items are loaded before things - but in ThingLinkManager there is method receiveTypedEvent which should be called after ThingStatusInfoChangedEvent (INITIALIZING -> ONLINE).

The problem is - it is not called for my binding and I really do not know why. I changed log level to TRACE and noticed that event itself is generated, but this handler is not called - so channelLinked is not called - so input pins are not initialized - so binding is not working.
I've been searching through git history and I've noticed that there were some quite big changes in thing initialization - now it is asynchronous - if I understood changes correctly, and I suspect that somewhere there is a reason. There might be something with threads synchronization, but I'm not sure.

So, I created some fix. I am aware that is quite dirty workaround of a problem, but it works well form me and is confirmed working by other user here:
https://community.openhab.org/t/problem-with-new-mcp23017-binding-in-openhab-2-3/49270/10

I also started a thread here:
https://community.openhab.org/t/invalid-load-order-of-configuration-file-not-calling-channellinked/49269/2

@kaikreuzer I know You are quite busy now, but I think You may know a lot more about recent changes in thing intialization, so please take a look at this in a free moment.

I suggest to temporarily add this change to repository, because now INPUT pins mostly doesn't work.
If main problem will be found I'll restore previous version.







<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
