### PR TITLE
Add missing Automatic-Module-Name manifest entries

### DIFF
--- a/addons/binding/org.openhab.binding.airvisualnode/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.airvisualnode/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.airvisualnode
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  .,

--- a/addons/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.modbus.test
 Bundle-ManifestVersion: 2
 Bundle-Name: Modbus Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.modbus
 Bundle-ManifestVersion: 2
 Bundle-Name: Modbus Binding
 Bundle-SymbolicName: org.openhab.binding.modbus;singleton:=true

--- a/addons/binding/org.openhab.binding.neato/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.neato/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.neato
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Neato Binding

--- a/addons/binding/org.openhab.binding.neeo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.neeo/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.neeo
 Bundle-ManifestVersion: 2
 Bundle-Name: Neeo Binding
 Bundle-SymbolicName: org.openhab.binding.neeo;singleton:=true

--- a/addons/binding/org.openhab.binding.openuv/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.openuv/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.openuv
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2

--- a/addons/binding/org.openhab.binding.valloxmv/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.valloxmv/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.valloxmv
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2

--- a/addons/binding/org.openhab.binding.yamahareceiver.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.yamahareceiver.test/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.yamahareceiver.test
 Bundle-ManifestVersion: 2
 Bundle-Name: YamahaReceiver Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -29,4 +30,3 @@ Import-Package:
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
-

--- a/addons/io/org.openhab.io.neeo/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.neeo/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.neeo
 Bundle-ManifestVersion: 2
 Bundle-Name: Neeo Integration
 Bundle-SymbolicName: org.openhab.io.neeo;singleton:=true

--- a/addons/io/org.openhab.io.transport.modbus.test/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.transport.modbus.test/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.transport.modbus.test
 Bundle-ManifestVersion: 2
 Fragment-Host: org.openhab.io.transport.modbus
 Bundle-Name: Modbus Binding Tests

--- a/addons/io/org.openhab.io.transport.modbus/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.transport.modbus/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.transport.modbus
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB MODBUS Transport Bundle
 Bundle-SymbolicName:  org.openhab.io.transport.modbus

--- a/addons/voice/org.openhab.voice.picotts/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.picotts/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.voice.picotts
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
Hopefully we can test these with newer Java versions on the forthcoming Karaf 4.2.1.