### PR TITLE
Streamline TTS service names

### DIFF
--- a/addons/voice/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
+++ b/addons/voice/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
@@ -47,7 +47,7 @@ public class GoogleTTSService implements TTSService {
     /**
      * Service name
      */
-    static final String SERVICE_NAME = "Google Cloud TTS Service";
+    static final String SERVICE_NAME = "Google Cloud";
 
     /**
      * Service id

--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
@@ -218,7 +218,7 @@ public class MaryTTSService implements TTSService {
 
     @Override
     public String getLabel(Locale locale) {
-        return "Mary Text-to-Speech Engine";
+        return "MaryTTS";
     }
 
 }

--- a/addons/voice/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSService.java
+++ b/addons/voice/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSService.java
@@ -226,6 +226,6 @@ public class VoiceRSSTTSService implements TTSService {
 
     @Override
     public String getLabel(Locale locale) {
-        return "VoiceRSS Text-to-Speech Engine";
+        return "VoiceRSS";
     }
 }


### PR DESCRIPTION
The TTS service names should be short because otherwise voice labels may get very long (https://github.com/eclipse/smarthome/pull/6031#issuecomment-412779924).