### PR TITLE
Streamline TTS/STT feature, bundle and POM names

### DIFF
--- a/addons/voice/org.openhab.voice.googletts/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.googletts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.openhab.voice.googletts
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-Name: Google Cloud TTS Service
+Bundle-Name: Google Cloud Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.voice.googletts;singleton:=true
 Bundle-Vendor: openHAB

--- a/addons/voice/org.openhab.voice.googletts/README.md
+++ b/addons/voice/org.openhab.voice.googletts/README.md
@@ -40,7 +40,7 @@ Before you can integrate this service with your Google Cloud Text-to-Speech, you
 
 ## Service Configuration
 
-Using your favourite configuration UI (e.g. PaperUI) edit **services/voice/Google Cloud TTS Service** settings and set 
+Using your favourite configuration UI (e.g. PaperUI) edit **Services/Voice/Google Cloud Text-to-Speech** settings and set 
 
 * **Service Account Key** - Copy-paste the content of the downloaded key file.
 * **Pitch** - The pitch of selected voice, up to 20 semitones
@@ -53,5 +53,5 @@ Using your favourite configuration UI
 
 * Edit **System** settings
 * Edit **Voice** settings
-* Set **Google Cloud TTS Service** as **Default Text-to-Speech**
+* Set **Google Cloud** as **Default Text-to-Speech**
 * Choose default voice for the setup.

--- a/addons/voice/org.openhab.voice.googletts/pom.xml
+++ b/addons/voice/org.openhab.voice.googletts/pom.xml
@@ -13,5 +13,5 @@
     <artifactId>org.openhab.voice.googletts</artifactId>
     <packaging>eclipse-plugin</packaging>
 
-    <name>Google Cloud TTS Service Integration</name>
+    <name>Google Cloud Text-to-Speech</name>
 </project>

--- a/addons/voice/org.openhab.voice.kaldi/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.kaldi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-ClassPath:
  .,
  lib/net-speech-api-0.2.0.jar
 Bundle-ManifestVersion: 2
-Bundle-Name: Kaldi Voice Integration
+Bundle-Name: Kaldi Speech-to-Text
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.voice.kaldi;singleton:=true
 Bundle-Vendor: openHAB

--- a/addons/voice/org.openhab.voice.kaldi/pom.xml
+++ b/addons/voice/org.openhab.voice.kaldi/pom.xml
@@ -12,6 +12,6 @@
   <artifactId>org.openhab.voice.kaldi</artifactId>
   <packaging>eclipse-plugin</packaging>
 
-  <name>Kaldi Voice Integration</name>
+  <name>Kaldi Speech-to-Text</name>
 
 </project>

--- a/addons/voice/org.openhab.voice.marytts/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.marytts/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Bundle-ClassPath:
  lib/voice-cmu-slt-hsmm-5.0.jar,
  lib/log4j-over-slf4j-1.7.21.jar
 Bundle-ManifestVersion: 2
-Bundle-Name: MaryTTS Voice Service
+Bundle-Name: Mary Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.voice.marytts;singleton:=true
 Bundle-Vendor: openHAB

--- a/addons/voice/org.openhab.voice.marytts/pom.xml
+++ b/addons/voice/org.openhab.voice.marytts/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>org.openhab.voice.marytts</artifactId>
   <packaging>eclipse-plugin</packaging>
 
-  <name>Mary TTS Integration</name>
+  <name>Mary Text-to-Speech</name>
 
   <build>
 

--- a/addons/voice/org.openhab.voice.picotts/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.picotts/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.openhab.voice.picotts
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: PicoTTS Service
+Bundle-Name: Pico Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.voice.picotts;singleton:=true
 Bundle-Vendor: openHAB

--- a/addons/voice/org.openhab.voice.picotts/pom.xml
+++ b/addons/voice/org.openhab.voice.picotts/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.openhab.voice</groupId>
   <artifactId>org.openhab.voice.picotts</artifactId>
 
-  <name>PicoTTS</name>
+  <name>Pico Text-to-Speech</name>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/addons/voice/org.openhab.voice.voicerss/META-INF/MANIFEST.MF
+++ b/addons/voice/org.openhab.voice.voicerss/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.openhab.voice.voicerss
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-Name: VoiceRSS TTS Voice Service
+Bundle-Name: VoiceRSS Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.voice.voicerss;singleton:=true
 Bundle-Vendor: openHAB

--- a/addons/voice/org.openhab.voice.voicerss/pom.xml
+++ b/addons/voice/org.openhab.voice.voicerss/pom.xml
@@ -12,6 +12,6 @@
   <artifactId>org.openhab.voice.voicerss</artifactId>
   <packaging>eclipse-plugin</packaging>
 
-  <name>VoiceRSS TTS Integration</name>
+  <name>VoiceRSS Text-to-Speech</name>
 
 </project>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -649,7 +649,7 @@
 
     <!-- voice -->
 
-    <feature name="openhab-voice-googletts" description="Google Cloud TTS Service" version="${project.version}">
+    <feature name="openhab-voice-googletts" description="Google Cloud Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.voice/org.openhab.voice.googletts/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
Consistently use the same name for a voice addon as:
* feature description
* bundle name
* POM project name

I.e. similar to what is also done for bindings. See also  https://github.com/openhab/openhab2-addons/pull/3836#issuecomment-413333008.