### PR TITLE
[MaryTTS] Cleanup and simplify code

### DIFF
--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
@@ -39,8 +39,8 @@ class MaryTTSAudioStream extends FixedLengthAudioStream {
      */
     private InputStream inputStream;
 
-    private byte[] rawAudio;
-    private int length;
+    private final byte[] rawAudio;
+    private final int length;
 
     /**
      * Constructs an instance with the passed properties
@@ -118,8 +118,8 @@ class MaryTTSAudioStream extends FixedLengthAudioStream {
         header[22] = channel;
         header[23] = 0;
         header[24] = (byte) (srate & 0xff);
-        header[25] = (byte) ((srate >> 8) & 0xff);
-        header[26] = (byte) ((srate >> 16) & 0xff);
+        header[25] = (byte) ((srate >> 8) & 0xff); 
+        header[26] = (byte) ((srate >> 16) & 0xff); 
         header[27] = (byte) ((srate >> 24) & 0xff);
         header[28] = (byte) ((bitrate / 8) & 0xff);
         header[29] = (byte) (((bitrate / 8) >> 8) & 0xff);

--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSService.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.voice.marytts.internal;
 
+import static javax.sound.sampled.AudioSystem.NOT_SPECIFIED;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
 
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioStream;
@@ -46,53 +45,47 @@ public class MaryTTSService implements TTSService {
     /**
      * Set of supported voices
      */
-    private HashSet<org.eclipse.smarthome.core.voice.Voice> voices;
+    private Set<org.eclipse.smarthome.core.voice.Voice> voices;
 
     /**
      * Set of supported audio formats
      */
-    private HashSet<AudioFormat> audioFormats;
+    private Set<AudioFormat> audioFormats;
 
     protected void activate() {
         try {
-            marytts = getMaryInterface();
+            marytts = new LocalMaryInterface();
             voices = initVoices();
             audioFormats = initAudioFormats();
-        } catch (Throwable t) {
-            logger.error("Failed to initialize MaryTTS: {}", t.getMessage(), t);
+        } catch (MaryConfigurationException e) {
+            logger.error("Failed to initialize MaryTTS: {}", e.getMessage(), e);
         }
     }
 
     @Override
     public Set<org.eclipse.smarthome.core.voice.Voice> getAvailableVoices() {
-        return this.voices;
+        return voices;
     }
 
     @Override
     public Set<AudioFormat> getSupportedFormats() {
-        return this.audioFormats;
+        return audioFormats;
     }
 
     @Override
     public AudioStream synthesize(String text, org.eclipse.smarthome.core.voice.Voice voice,
             AudioFormat requestedFormat) throws TTSException {
         // Validate arguments
-        if ((null == text) || text.isEmpty()) {
+        if (text == null || text.isEmpty()) {
             throw new TTSException("The passed text is null or empty");
         }
-        if (!this.voices.contains(voice)) {
+        if (!voices.contains(voice)) {
             throw new TTSException("The passed voice is unsupported");
         }
-        boolean isAudioFormatSupported = false;
-        for (AudioFormat currentAudioFormat : this.audioFormats) {
-            if (currentAudioFormat.isCompatible(requestedFormat)) {
-                isAudioFormatSupported = true;
-                break;
-            }
-        }
-        if (!isAudioFormatSupported) {
+        if (audioFormats.stream().noneMatch(f -> f.isCompatible(requestedFormat))) {
             throw new TTSException("The passed AudioFormat is unsupported");
         }
+
         /*
          * NOTE: For each MaryTTS voice only a single AudioFormat is supported
          * However, the TTSService interface allows the AudioFormat and
@@ -119,52 +112,42 @@ public class MaryTTSService implements TTSService {
 
         // Synchronize on marytts
         synchronized (marytts) {
-            // AudioStream to return
-            AudioStream audioStream = null;
-
-            // Set voice (Each voice supports onl a single AudioFormat)
+            // Set voice (Each voice supports only a single AudioFormat)
             marytts.setLocale(voice.getLocale());
             marytts.setVoice(voice.getLabel());
 
             try {
-                AudioInputStream audioInputStream = marytts.generateAudio(text);
-                audioStream = new MaryTTSAudioStream(audioInputStream, maryTTSVoiceAudioFormat);
+                return new MaryTTSAudioStream(marytts.generateAudio(text), maryTTSVoiceAudioFormat);
             } catch (SynthesisException | IOException e) {
                 throw new TTSException("Error generating an AudioStream", e);
             }
-
-            return audioStream;
         }
     }
 
     /**
-     * Initializes this.voices
+     * Initializes voices
      *
      * @return The voices of this instance
      */
-    private final HashSet<org.eclipse.smarthome.core.voice.Voice> initVoices() {
-        HashSet<org.eclipse.smarthome.core.voice.Voice> voices = new HashSet<org.eclipse.smarthome.core.voice.Voice>();
-        Set<Locale> locales = marytts.getAvailableLocales();
-        for (Locale local : locales) {
-            Set<String> voiceLabels = marytts.getAvailableVoices(local);
-            for (String voiceLabel : voiceLabels) {
-                voices.add(new MaryTTSVoice(local, voiceLabel));
+    private Set<org.eclipse.smarthome.core.voice.Voice> initVoices() {
+        Set<org.eclipse.smarthome.core.voice.Voice> voices = new HashSet<>();
+        for (Locale locale : marytts.getAvailableLocales()) {
+            for (String voiceLabel : marytts.getAvailableVoices(locale)) {
+                voices.add(new MaryTTSVoice(locale, voiceLabel));
             }
         }
         return voices;
     }
 
     /**
-     * Initializes this.audioFormats
+     * Initializes audioFormats
      *
      * @return The audio formats of this instance
      */
-    private final HashSet<AudioFormat> initAudioFormats() {
-        HashSet<AudioFormat> audioFormats = new HashSet<AudioFormat>();
-        Set<String> voiceLabels = marytts.getAvailableVoices();
-        for (String voiceLabel : voiceLabels) {
-            Voice voice = Voice.getVoice(voiceLabel);
-            audioFormats.add(getAudioFormat(voice.dbAudioFormat()));
+    private Set<AudioFormat> initAudioFormats() {
+        Set<AudioFormat> audioFormats = new HashSet<>();
+        for (String voiceLabel : marytts.getAvailableVoices()) {
+            audioFormats.add(getAudioFormat(Voice.getVoice(voiceLabel).dbAudioFormat()));
         }
         return audioFormats;
     }
@@ -175,40 +158,22 @@ public class MaryTTSService implements TTSService {
      * @param audioFormat The javax.sound.sampled.AudioFormat
      * @return The corresponding AudioFormat
      */
-    private final AudioFormat getAudioFormat(javax.sound.sampled.AudioFormat audioFormat) {
+    private AudioFormat getAudioFormat(javax.sound.sampled.AudioFormat audioFormat) {
         String container = AudioFormat.CONTAINER_WAVE;
-
         String codec = audioFormat.getEncoding().toString();
-
-        Boolean bigEndian = new Boolean(audioFormat.isBigEndian());
+        Boolean bigEndian = audioFormat.isBigEndian();
 
         int frameSize = audioFormat.getFrameSize(); // In bytes
         int bitsPerFrame = frameSize * 8;
-        Integer bitDepth = ((AudioSystem.NOT_SPECIFIED == frameSize) ? null : new Integer(bitsPerFrame));
+        Integer bitDepth = NOT_SPECIFIED == frameSize ? null : bitsPerFrame;
 
         float frameRate = audioFormat.getFrameRate();
-        Integer bitRate = ((AudioSystem.NOT_SPECIFIED == frameRate) ? null
-                : new Integer((int) (frameRate * bitsPerFrame)));
+        Integer bitRate = NOT_SPECIFIED == frameRate ? null : (int) frameRate * bitsPerFrame;
 
         float sampleRate = audioFormat.getSampleRate();
-        Long frequency = ((AudioSystem.NOT_SPECIFIED == sampleRate) ? null : new Long((long) sampleRate));
+        Long frequency = NOT_SPECIFIED == sampleRate ? null : (long) sampleRate;
 
         return new AudioFormat(container, codec, bigEndian, bitDepth, bitRate, frequency);
-    }
-
-    /**
-     * Create the MaryInterface
-     *
-     * @return The MaryInterface
-     */
-    private static final MaryInterface getMaryInterface() {
-        MaryInterface maryInterface = null;
-        try {
-            maryInterface = new LocalMaryInterface();
-        } catch (MaryConfigurationException e) {
-            throw new RuntimeException("Error creating MaryInterface", e);
-        }
-        return maryInterface;
     }
 
     @Override

--- a/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSVoice.java
+++ b/addons/voice/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSVoice.java
@@ -58,7 +58,7 @@ public class MaryTTSVoice implements Voice {
      */
     @Override
     public String getLabel() {
-        return this.label;
+        return label;
     }
 
     /**
@@ -66,6 +66,6 @@ public class MaryTTSVoice implements Voice {
      */
     @Override
     public Locale getLocale() {
-        return this.locale;
+        return locale;
     }
 }


### PR DESCRIPTION
* Fix SAT findings
* Add missing final modifiers to fields
* Use diamond operator
* Use autoboxing
* Use Set for variable types instead of HashSet
* Use stream to simplify AudioFormat supported check
* Remove unncessary variables, final, this declarations

Why is MaryTTS the only project that downloads some of its library JARs from an openHAB Bintray repo to the /lib directory during the build with maven-external-dependency-plugin (see [pom.xml](https://github.com/openhab/openhab2-addons/blob/871deb58a817fa1bc674773d61f626acab89c4a5/addons/voice/org.openhab.voice.marytts/pom.xml#L31))? Is that for space or licensing reasons? The downloaded content is 20MB.