### PR TITLE
[Modbus] Add transport dependency, remove unused bundle properties

### DIFF
--- a/addons/binding/org.openhab.binding.modbus/pom.xml
+++ b/addons/binding/org.openhab.binding.modbus/pom.xml
@@ -14,4 +14,12 @@
   <name>Modbus Binding</name>
   <packaging>eclipse-plugin</packaging>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.io</groupId>
+      <artifactId>org.openhab.io.transport.modbus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/addons/io/org.openhab.io.transport.modbus/pom.xml
+++ b/addons/io/org.openhab.io.transport.modbus/pom.xml
@@ -9,11 +9,6 @@
 		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.transport.modbus</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.transport.modbus</bundle.namespace>
-	</properties>
-
 	<artifactId>org.openhab.io.transport.modbus</artifactId>
 
 	<name>openHAB Modbus Transport</name>


### PR DESCRIPTION
I think the missing transport dependency is causing the Jenkins PR builds to fail.