### PR TITLE
[Modbus] Add transport dependency to test bundle

### DIFF
--- a/addons/binding/org.openhab.binding.modbus.test/pom.xml
+++ b/addons/binding/org.openhab.binding.modbus.test/pom.xml
@@ -14,6 +14,14 @@
 
   <name>modbus Binding Tests</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.io</groupId>
+      <artifactId>org.openhab.io.transport.modbus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Of course the modbus.test bundle also requires the transport dependency to fix the Jenkins PR build.