### PR TITLE
[jeelink] Add units of measurement

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
@@ -54,16 +54,16 @@ parameter.sendCount.label = Switching Command Count
 parameter.sendCount.description = The number of times a switching command will be sent (every 2 seconds) to the socket until giving up. 
 
 # channel types
-channel-type.current-watt.label = Current Watt
-channel-type.current-watt.description = The current consumption of the appliance in W.
-channel-type.max-watt.label = Max Watt
-channel-type.max-watt.description = The maximum consumption of the appliance in W.
+channel-type.current-power.label = Current Power
+channel-type.current-power.description = The current power draw of the appliance.
+channel-type.max-power.label = Max Power
+channel-type.max-power.description = The maximum power draw of the appliance.
 channel-type.consumption-total.label = Total Consumption
 channel-type.consumption-total.description = The total consumption of the connected appliance.
 channel-type.appliance-time.label = Appliance On Time
-channel-type.appliance-time.description = The number of hours the appliance was turned on.
+channel-type.appliance-time.description = The time the appliance was turned on.
 channel-type.sensor-time.label = Sensor On Time
-channel-type.sensor-time.description = The number of hours the EC3000 was connected to an outlet.
+channel-type.sensor-time.description = The time the EC3000 was connected to an outlet.
 channel-type.resets.label = Resets
 channel-type.resets.description = Number of resets performed by the sensor.
 channel-type.temperature.label = Temperature

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
@@ -54,16 +54,16 @@ parameter.sendCount.label = Anzahl der Schaltversuche
 parameter.sendCount.description = Die Anzahl der Versuche eine Steckdose zu schalten (alle 2 Sekunden) bevor aufgegeben wird. 
 
 # channel types
-channel-type.current-watt.label = Momentaner Verbrauch
-channel-type.current-watt.description = Der momentane Verbrauch des angeschlossenen Gerätes in W.
-channel-type.max-watt.label = Höchster Verbrauch
-channel-type.max-watt.description = Der höchste Verbrauch des angeschlossenen Gerätes in W.
+channel-type.current-power.label = Momentaner Verbrauch
+channel-type.current-power.description = Der momentane Verbrauch des angeschlossenen Gerätes.
+channel-type.max-power.label = Höchster Verbrauch
+channel-type.max-power.description = Der höchste Verbrauch des angeschlossenen Gerätes.
 channel-type.consumption-total.label = Absoluter Verbrauch
-channel-type.consumption-total.description = Der absdolute Verbrauch des angeschlossenen Gerätes in W.
+channel-type.consumption-total.description = Der absolute Verbrauch des angeschlossenen Gerätes.
 channel-type.appliance-time.label = Einschaltzeit des Gerätes
-channel-type.appliance-time.description = Die Anzahl der Sekunden während deren das angeschlossene Gerät eingeschaltet war.
+channel-type.appliance-time.description = Die Zeit während derer das angeschlossene Gerät eingeschaltet war.
 channel-type.sensor-time.label = Einschaltzeit des Sensoren
-channel-type.sensor-time.description = Die Anzahl der Sekunden während deren der Sensor eingeschaltet war.
+channel-type.sensor-time.description = Die Zeit während derer der Sensor eingeschaltet war.
 channel-type.resets.label = Resets
 channel-type.resets.description = Anzahl der Resets dieses Sensors.
 channel-type.temperature.label = Temperatur

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
@@ -315,11 +315,11 @@
 
 	<!-- Temperature Channel Type -->
 	<channel-type id="temperature">
-		<item-type>Number</item-type>
+		<item-type>Number:Temperature</item-type>
 		<label>@text/channel-type.temperature.label</label>
 		<description>@text/channel-type.temperature.description</description>
 		<category>Temperature</category>
-		<state readOnly="true" pattern="%.1f °C" />
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<!-- Humidity Channel Type -->

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
@@ -323,11 +323,11 @@
 
 	<!-- Humidity Channel Type -->
 	<channel-type id="humidity">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>@text/channel-type.humidity.label</label>
 		<description>@text/channel-type.humidity.description</description>
 		<category>Humidity</category>
-		<state readOnly="true" pattern="%.1f" />
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<!-- Battery New Channel Type -->

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
@@ -196,8 +196,8 @@
 		<description>@text/thing-type.ec3k.description</description>
 
 		<channels>
-			<channel id="currentWatt" typeId="current-watt" />
-			<channel id="maxWatt" typeId="max-watt" />
+			<channel id="currentPower" typeId="current-power" />
+			<channel id="maxPower" typeId="max-power" />
 			<channel id="consumptionTotal" typeId="consumption-total" />
 			<channel id="applianceTime" typeId="appliance-time" />
 			<channel id="sensorTime" typeId="sensor-time" />
@@ -242,7 +242,7 @@
 
 		<channels>
 			<channel id="switchingState" typeId="switching-state" />
-			<channel id="currentWatt" typeId="current-watt" />
+			<channel id="currentPower" typeId="current-power" />
 			<channel id="consumptionTotal" typeId="consumption-total" />
 		</channels>
 
@@ -264,45 +264,44 @@
 		</config-description>
 	</thing-type>
 
-	<!-- Current Watt Channel Type -->
-	<channel-type id="current-watt">
-		<item-type>Number</item-type>
-		<label>@text/channel-type.current-watt.label</label>
-		<description>@text/channel-type.current-watt.description</description>
-		<state readOnly="true" pattern="%.1f W" />
+	<!-- Current Power Channel Type -->
+	<channel-type id="current-power">
+		<item-type>Number:Power</item-type>
+		<label>@text/channel-type.current-power.label</label>
+		<description>@text/channel-type.current-power.description</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
-	<!-- Max Watt Channel Type -->
-	<channel-type id="max-watt">
-		<item-type>Number</item-type>
-		<label>@text/channel-type.max-watt.label</label>
-		<description>@text/channel-type.max-watt.description</description>
-		<state readOnly="true" pattern="%.1f W" />
+	<!-- Max Power Channel Type -->
+	<channel-type id="max-power">
+		<item-type>Number:Power</item-type>
+		<label>@text/channel-type.max-power.label</label>
+		<description>@text/channel-type.max-power.description</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
-	<!-- Total Consumption Channel Type -->
+	<!-- Total Energy Consumption Channel Type -->
 	<channel-type id="consumption-total">
-		<item-type>Number</item-type>
+		<item-type>Number:Energy</item-type>
 		<label>@text/channel-type.consumption-total.label</label>
 		<description>@text/channel-type.consumption-total.description</description>
-		<state readOnly="true" pattern="%d Wh" />
+		<state readOnly="true" pattern="%d %unit%" />
 	</channel-type>
 
 	<!-- Appliance On Time Channel Type -->
 	<channel-type id="appliance-time" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:Time</item-type>
 		<label>@text/channel-type.appliance-time.label</label>
 		<description>@text/channel-type.appliance-time.description</description>
-		<state readOnly="true" pattern="%d h" />
-
+		<state readOnly="true" pattern="%d %unit%" />
 	</channel-type>
 
 	<!-- Sensor On Time Channel Type -->
 	<channel-type id="sensor-time" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:Time</item-type>
 		<label>@text/channel-type.sensor-time.label</label>
 		<description>@text/channel-type.sensor-time.description</description>
-		<state readOnly="true" pattern="%d h" />
+		<state readOnly="true" pattern="%d %unit%" />
 	</channel-type>
 
 	<!-- Resets Channel Type -->

--- a/addons/binding/org.openhab.binding.jeelink/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.jeelink/META-INF/MANIFEST.MF
@@ -11,12 +11,14 @@ Bundle-Version: 2.4.0.qualifier
 Export-Package: org.openhab.binding.jeelink
 Import-Package: 
  gnu.io,
+ javax.measure.quantity,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.core.i18n,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,

--- a/addons/binding/org.openhab.binding.jeelink/README.md
+++ b/addons/binding/org.openhab.binding.jeelink/README.md
@@ -98,22 +98,22 @@ The available init commands depend on the sketch that is running on the USB stic
 
 #### EC3000 power monitors
 
-| Channel Type ID  | Item Type | Description                                        |
-|------------------|-----------|----------------------------------------------------|
-| currentWatt      | Number    | Instantaneous power in Watt                        |
-| maxWatt          | Number    | Maximum load power in Watt                         |
-| consumptionTotal | Number    | Total energy  consumption                          |
-| applianceTime    | Number    | Total electrical appliance operating time in hours |
-| sensorTime       | Number    | Total turn on time of power monitor in hours       |
-| resets           | Number    | Number of resets                                   |
+| Channel Type ID  | Item Type     | Description                               |
+|------------------|---------------|-------------------------------------------|
+| currentPower     | Number:Power  | Current power draw                        |
+| maxPower         | Number:Power  | Maximum power draw                        |
+| consumptionTotal | Number:Energy | Total energy consumption                  |
+| applianceTime    | Number:Time   | Total electrical appliance operating time |
+| sensorTime       | Number:Time   | Total turn on time of power monitor       |
+| resets           | Number        | Number of resets                          |
 
 #### PCA301 power monitoring wireless sockets
 
-| Channel Type ID         | Item Type    | Description                                          |
-|-------------------------|--------------|------------------------------------------------------|
-| switchingState          | Switch       | Whether the sockets are currently switched on or off |
-| currentWatt             | Number       | Instantaneous power in Watt                          |
-| consumptionTotal        | Number       | Total energy consumption                             |
+| Channel Type ID         | Item Type     | Description                                          |
+|-------------------------|---------------|------------------------------------------------------|
+| switchingState          | Switch        | Whether the sockets are currently switched on or off |
+| currentPower            | Number:Power  | Current power draw                                   |
+| consumptionTotal        | Number:Energy | Total energy consumption                             |
 
 ## Commands
 
@@ -161,6 +161,6 @@ A typical item configuration for a PCA301 power monitoring wireless sockets look
 
 ```
 Switch SocketSwitch {channel="jeelink:pca301:1-160-236:switchingState"}
-Number SocketWattage {channel="jeelink:pca301:1-160-236:currentWatt"}
-Number SocketConsumption {channel="jeelink:pca301:1-160-236:consumptionTotal"}
+Number:Power SocketWattage {channel="jeelink:pca301:1-160-236:currentPower"}
+Number:Energy SocketConsumption {channel="jeelink:pca301:1-160-236:consumptionTotal"}
 ```

--- a/addons/binding/org.openhab.binding.jeelink/README.md
+++ b/addons/binding/org.openhab.binding.jeelink/README.md
@@ -92,7 +92,7 @@ The available init commands depend on the sketch that is running on the USB stic
 | Channel Type ID | Item Type             | Description                                       |
 |-----------------|-----------------------|---------------------------------------------------|
 | temperature     | Number:Temperature    | Temperature reading                               |
-| humidity        | Number                | Humidity reading                                  |
+| humidity        | Number:Dimensionless  | Humidity reading                                  |
 | batteryNew      | Contact               | Whether the battery is new (CLOSED) or not (OPEN) |
 | batteryLow      | Contact               | Whether the battery is low (CLOSED) or not (OPEN) |
 
@@ -151,7 +151,7 @@ Thing jeelink:lacrosse:sensor2 "Jeelink lacrosse 2" (jeelink:jeelinkUsb:lacrosse
 A typical item configuration for a LaCrosse temperature sensor looks like this:
 
 ```
-Number Humidty_LR "Living Room" <humidity> {channel="jeelink:lacrosse:42:humidity"}
+Number:Dimensionless Humidty_LR "Living Room [%.1f %unit%]" <humidity> {channel="jeelink:lacrosse:42:humidity"}
 Number:Temperature Temperature_LR "Living Room [%.1f %unit%]" <temperature> {channel="jeelink:lacrosse:42:temperature"}
 Contact Battery_Low_LR "Battery Low Living Room" {channel="jeelink:lacrosse:42:batteryLow"}
 Contact Battery_New_LR "Battery New Living Room" {channel="jeelink:lacrosse:42:batteryLow"}

--- a/addons/binding/org.openhab.binding.jeelink/README.md
+++ b/addons/binding/org.openhab.binding.jeelink/README.md
@@ -89,12 +89,12 @@ The available init commands depend on the sketch that is running on the USB stic
 
 #### LaCrosse temperature sensors
 
-| Channel Type ID | Item Type | Description                                       |
-|-----------------|-----------|---------------------------------------------------|
-| temperature     | Number    | Temperature reading                               |
-| humidity        | Number    | Humidity reading                                  |
-| batteryNew      | Contact   | Whether the battery is new (CLOSED) or not (OPEN) |
-| batteryLow      | Contact   | Whether the battery is low (CLOSED) or not (OPEN) |
+| Channel Type ID | Item Type             | Description                                       |
+|-----------------|-----------------------|---------------------------------------------------|
+| temperature     | Number:Temperature    | Temperature reading                               |
+| humidity        | Number                | Humidity reading                                  |
+| batteryNew      | Contact               | Whether the battery is new (CLOSED) or not (OPEN) |
+| batteryLow      | Contact               | Whether the battery is low (CLOSED) or not (OPEN) |
 
 #### EC3000 power monitors
 
@@ -152,7 +152,7 @@ A typical item configuration for a LaCrosse temperature sensor looks like this:
 
 ```
 Number Humidty_LR "Living Room" <humidity> {channel="jeelink:lacrosse:42:humidity"}
-Number Temperature_LR "Living Room" <temperature> {channel="jeelink:lacrosse:42:temperature"}
+Number:Temperature Temperature_LR "Living Room [%.1f %unit%]" <temperature> {channel="jeelink:lacrosse:42:temperature"}
 Contact Battery_Low_LR "Battery Low Living Room" {channel="jeelink:lacrosse:42:batteryLow"}
 Contact Battery_New_LR "Battery New Living Room" {channel="jeelink:lacrosse:42:batteryLow"}
 ```

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
@@ -49,8 +49,8 @@ public class JeeLinkBindingConstants {
     public static final String PROPERTY_SENSOR_ID = "sensorId";
 
     // List of all additional channel ids for ec3k sensor things
-    public static final String CURRENT_WATT_CHANNEL = "currentWatt";
-    public static final String MAX_WATT_CHANNEL = "maxWatt";
+    public static final String CURRENT_POWER_CHANNEL = "currentPower";
+    public static final String MAX_POWER_CHANNEL = "maxPower";
     public static final String CONSUMPTION_CHANNEL = "consumptionTotal";
     public static final String APPLIANCE_TIME_CHANNEL = "applianceTime";
     public static final String SENSOR_TIME_CHANNEL = "sensorTime";

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
@@ -14,6 +14,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
@@ -55,11 +57,13 @@ public class Ec3kSensorHandler extends JeeLinkSensorHandler<Ec3kReading> {
                             getThing().getUID().getId(), currentWatt, reading.getCurrentWatt(), maxWatt,
                             reading.getConsumptionTotal(), reading.getApplianceTime(), reading.getSensorTime());
 
-                    updateState(CURRENT_WATT_CHANNEL, new DecimalType(currentWatt));
-                    updateState(MAX_WATT_CHANNEL, new DecimalType(maxWatt));
-                    updateState(CONSUMPTION_CHANNEL, new DecimalType(reading.getConsumptionTotal()));
-                    updateState(APPLIANCE_TIME_CHANNEL, new DecimalType(reading.getApplianceTime()));
-                    updateState(SENSOR_TIME_CHANNEL, new DecimalType(reading.getSensorTime()));
+                    updateState(CURRENT_POWER_CHANNEL, new QuantityType<>(currentWatt, SmartHomeUnits.WATT));
+                    updateState(MAX_POWER_CHANNEL, new QuantityType<>(maxWatt, SmartHomeUnits.WATT));
+                    updateState(CONSUMPTION_CHANNEL,
+                            new QuantityType<>(reading.getConsumptionTotal(), SmartHomeUnits.WATT_HOUR));
+                    updateState(APPLIANCE_TIME_CHANNEL,
+                            new QuantityType<>(reading.getApplianceTime(), SmartHomeUnits.HOUR));
+                    updateState(SENSOR_TIME_CHANNEL, new QuantityType<>(reading.getSensorTime(), SmartHomeUnits.HOUR));
                     updateState(RESETS_CHANNEL, new DecimalType(reading.getResets()));
                 }
             }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.jeelink.internal.lacrosse;
 
+import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.openhab.binding.jeelink.JeeLinkBindingConstants.*;
 
 import java.math.BigDecimal;
@@ -20,6 +21,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -123,7 +125,7 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                                 "updating states for thing {} ({}): temp={} ({}), humidity={}, batteryNew={}, batteryLow={}",
                                 getThing().getLabel(), getThing().getUID().getId(), temp, reading.getTemperature(),
                                 reading.getHumidity(), reading.isBatteryNew(), reading.isBatteryLow());
-                        updateState(TEMPERATURE_CHANNEL, new DecimalType(temp));
+                        updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, CELSIUS));
                         updateState(HUMIDITY_CHANNEL, new DecimalType(reading.getHumidity()));
                         updateState(BATTERY_NEW_CHANNEL, reading.isBatteryNew() ? OnOffType.ON : OnOffType.OFF);
                         updateState(BATTERY_LOW_CHANNEL, reading.isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
@@ -131,7 +133,7 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                         logger.debug("updating states for channel {} of thing {} ({}): temp={} ({}), humidity={}",
                                 reading.getChannel(), getThing().getLabel(), getThing().getUID().getId(), temp,
                                 reading.getTemperature(), reading.getHumidity());
-                        updateState(TEMPERATURE_CHANNEL + reading.getChannel(), new DecimalType(temp));
+                        updateState(TEMPERATURE_CHANNEL + reading.getChannel(), new QuantityType<>(temp, CELSIUS));
                         updateState(HUMIDITY_CHANNEL + reading.getChannel(), new DecimalType(reading.getHumidity()));
                     }
                 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -18,10 +18,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -126,7 +126,8 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                                 getThing().getLabel(), getThing().getUID().getId(), temp, reading.getTemperature(),
                                 reading.getHumidity(), reading.isBatteryNew(), reading.isBatteryLow());
                         updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, SIUnits.CELSIUS));
-                        updateState(HUMIDITY_CHANNEL, new DecimalType(reading.getHumidity()));
+                        updateState(HUMIDITY_CHANNEL,
+                                new QuantityType<>(reading.getHumidity(), SmartHomeUnits.PERCENT));
                         updateState(BATTERY_NEW_CHANNEL, reading.isBatteryNew() ? OnOffType.ON : OnOffType.OFF);
                         updateState(BATTERY_LOW_CHANNEL, reading.isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
                     } else {
@@ -135,7 +136,8 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                                 reading.getTemperature(), reading.getHumidity());
                         updateState(TEMPERATURE_CHANNEL + reading.getChannel(),
                                 new QuantityType<>(temp, SIUnits.CELSIUS));
-                        updateState(HUMIDITY_CHANNEL + reading.getChannel(), new DecimalType(reading.getHumidity()));
+                        updateState(HUMIDITY_CHANNEL + reading.getChannel(),
+                                new QuantityType<>(reading.getHumidity(), SmartHomeUnits.PERCENT));
                     }
                 }
             }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.binding.jeelink.internal.lacrosse;
 
-import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
 import static org.openhab.binding.jeelink.JeeLinkBindingConstants.*;
 
 import java.math.BigDecimal;
@@ -22,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -125,7 +125,7 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                                 "updating states for thing {} ({}): temp={} ({}), humidity={}, batteryNew={}, batteryLow={}",
                                 getThing().getLabel(), getThing().getUID().getId(), temp, reading.getTemperature(),
                                 reading.getHumidity(), reading.isBatteryNew(), reading.isBatteryLow());
-                        updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, CELSIUS));
+                        updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, SIUnits.CELSIUS));
                         updateState(HUMIDITY_CHANNEL, new DecimalType(reading.getHumidity()));
                         updateState(BATTERY_NEW_CHANNEL, reading.isBatteryNew() ? OnOffType.ON : OnOffType.OFF);
                         updateState(BATTERY_LOW_CHANNEL, reading.isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
@@ -133,7 +133,8 @@ public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCro
                         logger.debug("updating states for channel {} of thing {} ({}): temp={} ({}), humidity={}",
                                 reading.getChannel(), getThing().getLabel(), getThing().getUID().getId(), temp,
                                 reading.getTemperature(), reading.getHumidity());
-                        updateState(TEMPERATURE_CHANNEL + reading.getChannel(), new QuantityType<>(temp, CELSIUS));
+                        updateState(TEMPERATURE_CHANNEL + reading.getChannel(),
+                                new QuantityType<>(temp, SIUnits.CELSIUS));
                         updateState(HUMIDITY_CHANNEL + reading.getChannel(), new DecimalType(reading.getHumidity()));
                     }
                 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
@@ -16,8 +16,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
@@ -99,8 +100,8 @@ public class Pca301SensorHandler extends JeeLinkSensorHandler<Pca301Reading> {
                     BigDecimal current = new BigDecimal(reading.getCurrent()).setScale(1, RoundingMode.HALF_UP);
                     state = reading.isOn() ? OnOffType.ON : OnOffType.OFF;
 
-                    updateState(CURRENT_WATT_CHANNEL, new DecimalType(current));
-                    updateState(CONSUMPTION_CHANNEL, new DecimalType(reading.getTotal()));
+                    updateState(CURRENT_POWER_CHANNEL, new QuantityType<>(current, SmartHomeUnits.WATT));
+                    updateState(CONSUMPTION_CHANNEL, new QuantityType<>(reading.getTotal(), SmartHomeUnits.WATT_HOUR));
                     updateState(SWITCHING_STATE_CHANNEL, state);
 
                     logger.debug("updated states for thing {} ({}): state={}, current={}, total={}",

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
@@ -149,9 +149,13 @@ public class Pca301SensorHandler extends JeeLinkSensorHandler<Pca301Reading> {
 
                     sendCommand(command);
                     remainingRetries--;
-                } else if (state != command) {
-                    logger.debug("giving up command for thing {} ({}): {}", getThing().getLabel(),
-                            getThing().getUID().getId(), command);
+                } else {
+                    // we get here when the state is as expected or when the state is still not as expected after
+                    // the configured number of retries. we should cancel the retry for both cases
+                    if (state != command) {
+                        logger.debug("giving up command for thing {} ({}): {}", getThing().getLabel(),
+                                getThing().getUID().getId(), command);
+                    }
 
                     cancelRetry();
                 }


### PR DESCRIPTION
This adds unit of measurement to the LaCrosse Sensor temperature channel.

AFAICS on https://www.openhab.org/docs/concepts/units-of-measurement.html#quantitytype, this is the only channel for which I could add unit support, or have I missed something?

Signed-off-by: Volker Bier <volker.bier@web.de>
