### PR TITLE
[jeelink] add support for TX22 sensors and connected TX23 & TX26 sensors.

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
@@ -84,3 +84,5 @@ channel-type.rain.label = Rain
 channel-type.rain.description = Quantity of water
 channel-type.pressure.label = Pressure
 channel-type.pressure.description = Current pressure
+gust-strength.label = Gust Strength
+gust-strength.description = Current gust speed

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink.properties
@@ -19,6 +19,8 @@ thing-type.ec3k.label = ec3k
 thing-type.ec3k.description = Thing for a EnergyCount 3000 Power Monitor connected to a JeeLink USB Receiver.
 thing-type.pca301.label = PCA301
 thing-type.pca301.description = Thing for a PCA301 power monitoring wireless socket connected to a JeeLink USB Receiver.
+thing-type.tx22.label = TX22 Sensor
+thing-type.tx22.description = Thing for a TX22 Sensor connected to a JeeLink USB Receiver.
 
 # parameters
 parameter.serialport.label = Serial Port
@@ -74,3 +76,11 @@ channel-type.battery-new.label = Battery New
 channel-type.battery-new.description = Indicator for new battery.
 channel-type.switching-state.label = Switching State
 channel-type.switching-state.description = Whether the socket is currently switched on or not.
+channel-type.wind-angle.label = Wind Angle
+channel-type.wind-angle.description = Current wind direction
+channel-type.wind-strength.label = Wind Strength
+channel-type.wind-strength.description = Current wind speed
+channel-type.rain.label = Rain
+channel-type.rain.description = Quantity of water
+channel-type.pressure.label = Pressure
+channel-type.pressure.description = Current pressure

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
@@ -19,6 +19,8 @@ thing-type.ec3k.label = ec3k
 thing-type.ec3k.description = Ein mit dem JeeLink USB Empfänger verbundenes EC3000 Energiekosten-Messgerät.
 thing-type.pca301.label = PCA301
 thing-type.pca301.description = Eine mit dem JeeLink USB Empfänger verbundene PCA301 Steckdose.
+thing-type.tx22.label = TX22 Sensor
+thing-type.tx22.description = Eine mit dem JeeLink USB Empfänger verbundener TX22 Sensor.
 
 # parameters
 parameter.serialport.label = Serielle Schnittstelle
@@ -74,3 +76,11 @@ channel-type.battery-new.label = Battery neu
 channel-type.battery-new.description = Indikator für eine neu eingesetzte Batterie.
 channel-type.switching-state.label = Steckdose Ein
 channel-type.switching-state.description = Schaltzustand der Steckdose.
+channel-type.wind-angle.label = Wind Richtung
+channel-type.wind-angle.description = Momentane Wind Richtung
+channel-type.wind-strength.label = Windstärke
+channel-type.wind-strength.description = Momentane Windstärke
+channel-type.rain.label = Regen
+channel-type.rain.description = Regenmenge
+channel-type.pressure.label = Luftdruck
+channel-type.pressure.description = Momentaner Luftdruck

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/i18n/jeelink_de.properties
@@ -84,3 +84,5 @@ channel-type.rain.label = Regen
 channel-type.rain.description = Regenmenge
 channel-type.pressure.label = Luftdruck
 channel-type.pressure.description = Momentaner Luftdruck
+gust-strength.label = Böenstärke
+gust-strength.description = Momentane Böenstärke

--- a/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.jeelink/ESH-INF/thing/thing-types.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="jeelink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="jeelink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -263,6 +264,78 @@
 			</parameter>
 		</config-description>
 	</thing-type>
+
+	<!-- TX22 Temperature/Humidity SensorThing Type -->
+	<thing-type id="tx22">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="jeelinkTcp" />
+			<bridge-type-ref id="jeelinkUsb" />
+			<bridge-type-ref id="lgwTcp" />
+			<bridge-type-ref id="lgwUsb" />
+		</supported-bridge-type-refs>
+
+		<label>@text/thing-type.tx22.label</label>
+		<description>@text/thing-type.tx22.description</description>
+
+		<channels>
+			<channel id="temperature" typeId="temperature" />
+			<channel id="humidity" typeId="humidity" />
+			<channel id="batteryNew" typeId="battery-new" />
+			<channel id="batteryLow" typeId="system.low-battery" />
+			<channel id="pressure" typeId="pressure" />
+			<channel id="rain" typeId="rain" />
+			<channel id="windStrength" typeId="wind-strength" />
+			<channel id="windAngle" typeId="wind-angle" />
+			<channel id="gustStrength" typeId="wind-strength">
+				<label>@text/gust-strength.label</label>
+				<description>@text/gust-strength.description</description>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="sensorId" type="text" required="true">
+				<label>@text/parameter.sensorid.label</label>
+				<description>@text/parameter.sensorid.description</description>
+			</parameter>
+			<parameter name="sensorTimeout" type="integer" required="false" min="5" max="3600" unit="s" step="5">
+				<label>@text/parameter.sensortimeout.label</label>
+				<description>@text/parameter.sensortimeout.description</description>
+				<default>600</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="wind-angle">
+		<item-type>Number:Angle</item-type>
+		<label>@text/channel-type.wind-angle.label</label>
+		<description>@text/channel-type.wind-angle.description</description>
+		<category>Wind</category>
+		<state min="0" max="360" step="1" readOnly="true" pattern="%d %unit%" />
+	</channel-type>
+
+	<channel-type id="wind-strength">
+		<item-type>Number:Speed</item-type>
+		<label>@text/channel-type.wind-strength.label</label>
+		<description>@text/channel-type.wind-strength.description</description>
+		<category>Wind</category>
+		<state readOnly="true" pattern="%.1f %unit%" />
+	</channel-type>
+
+	<channel-type id="rain">
+		<item-type>Number:Length</item-type>
+		<label>@text/channel-type.rain.label</label>
+		<description>@text/channel-type.rain.description</description>
+		<category>Rain</category>
+		<state readOnly="true" pattern="%.2f %unit%" />
+	</channel-type>
+
+	<channel-type id="pressure">
+		<item-type>Number:Pressure</item-type>
+		<label>@text/channel-type.pressure.label</label>
+		<description>@text/channel-type.pressure.description</description>
+		<category>Pressure</category>
+		<state readOnly="true" pattern="%.3f %unit%" />
+	</channel-type>
 
 	<!-- Current Power Channel Type -->
 	<channel-type id="current-power">

--- a/addons/binding/org.openhab.binding.jeelink/README.md
+++ b/addons/binding/org.openhab.binding.jeelink/README.md
@@ -4,7 +4,7 @@ This binding integrates JeeLink USB RF receivers and LaCrosseGateways.
 
 ## Introduction
 
-Binding should be compatible with JeeLink USB receivers and LaCrosseGateways. It supports connected LaCrosse temperature sensors as well as EC3000 sensors and PCA301 power monitoring wireless sockets.
+Binding should be compatible with JeeLink USB receivers and LaCrosseGateways. It supports connected LaCrosse temperature sensors, EC3000 sensors, PCA301 power monitoring wireless sockets and TX22 temperature and humidity sensors (including connected TX23 wind and TX26 rain sensors).
 
 ## Supported Things
 
@@ -14,9 +14,10 @@ This binding supports:
 *   JeeLink (connected over TCP)
 *   LaCrosseGateway (connected to USB)
 *   LaCrosseGateway (connected over TCP)
-*   LaCrosse Temperature Sensors
-*   EC3000 Power Monitors
+*   LaCrosse temperature sensors
+*   EC3000 power monitors
 *   PCA301 power monitoring wireless sockets
+*   TX22 temperature & humidity Sensors (including connected TX23 wind and TX26 rain sensors)
 
 ## Binding configuration
 
@@ -67,7 +68,6 @@ The available init commands depend on the sketch that is running on the USB stic
 | Upper Temperature Limit    | Decimal   | The highest allowed valid temperature. Higher temperature readings will be ignored                                                                   |
 | Maximum allowed difference | Decimal   | The maximum allowed difference from a value to the previous value (0 disables this check). If the difference is higher, the reading will be ignored. |
 
-
 #### EC3000 power monitors
 
 | Parameter       | Item Type | Description                                                                                                             |
@@ -95,6 +95,18 @@ The available init commands depend on the sketch that is running on the USB stic
 | humidity        | Number:Dimensionless  | Humidity reading                                  |
 | batteryNew      | Contact               | Whether the battery is new (CLOSED) or not (OPEN) |
 | batteryLow      | Contact               | Whether the battery is low (CLOSED) or not (OPEN) |
+
+#### TX22 temperature and humidity sensors
+
+| Channel Type ID | Item Type             | Description                |
+|-----------------|-----------------------|----------------------------|
+| temperature     | Number:Temperature    | Temperature reading        |
+| humidity        | Number:Dimensionless  | Humidity reading           |
+| pressure        | Number:Pressure       | Current pressure reading   |
+| rain            | Number:Length         | Rainfall today             |
+| windStrength    | Number:Speed          | Current wind speed         |
+| windAngle       | Number:Angle          | Current wind direction     |
+| gustStrength    | Number:Speed          | Gust speed                 |
 
 #### EC3000 power monitors
 
@@ -163,4 +175,17 @@ A typical item configuration for a PCA301 power monitoring wireless sockets look
 Switch SocketSwitch {channel="jeelink:pca301:1-160-236:switchingState"}
 Number:Power SocketWattage {channel="jeelink:pca301:1-160-236:currentPower"}
 Number:Energy SocketConsumption {channel="jeelink:pca301:1-160-236:consumptionTotal"}
+```
+
+A typical item configuration for a TX22 temperature and humidity sensor looks like this:
+
+```
+Number:Dimensionless Humidity "Outside [%.1f %unit%]" <humidity> {channel="jeelink:tx22:42:humidity"}
+Number:Temperature Temperature "Outside [%.1f %unit%]" <temperature> {channel="jeelink:tx22:42:temperature"}
+Contact Battery_Low_LR "Battery Low Outside" {channel="jeelink:tx22:42:batteryLow"}
+Contact Battery_New_LR "Battery New Outside" {channel="jeelink:tx22:42:batteryLow"}
+Number:Length Rain "Outside [%.1f %unit%]" {channel="jeelink:tx22:42:rain"}
+Number:Speed WindStrength "Wind [%.1f %unit%]" {channel="jeelink:tx22:42:windStrength"}
+Number:Angle WindDir "Wind dir [%.1f %unit%]" {channel="jeelink:tx22:42:windAngle"}
+Number:Speed GustStrength "Gust [%.1f %unit%]" {channel="jeelink:tx22:42:gustStrength"}
 ```

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/JeeLinkBindingConstants.java
@@ -39,6 +39,7 @@ public class JeeLinkBindingConstants {
     public static final ThingTypeUID LACROSSE_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "lacrosse");
     public static final ThingTypeUID EC3000_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "ec3k");
     public static final ThingTypeUID PCA301_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "pca301");
+    public static final ThingTypeUID TX22_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "tx22");
 
     // List of all channel ids for lacrosse sensor things
     public static final String TEMPERATURE_CHANNEL = "temperature";
@@ -58,6 +59,13 @@ public class JeeLinkBindingConstants {
 
     // List of all additional channel ids for pca301 sensor things
     public static final String SWITCHING_STATE_CHANNEL = "switchingState";
+
+    // List of all additional channel ids for tx22 sensor things
+    public static final String PRESSURE_CHANNEL = "pressure";
+    public static final String RAIN_CHANNEL = "rain";
+    public static final String WIND_STENGTH_CHANNEL = "windStrength";
+    public static final String WIND_ANGLE_CHANNEL = "windAngle";
+    public static final String GUST_STRENGTH_CHANNEL = "gustStrength";
 
     static {
         for (SensorDefinition<?> def : SensorDefinition.getDefinitions()) {

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Volker Bier - Initial contribution
  */
 public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, ConnectionListener {
-    private static final Pattern READING_P = Pattern.compile("^OK\\s+([0-9]+)(?:\\s+([0-9]+))+$");
+    private static final Pattern READING_P = Pattern.compile("^OK\\s+(WS|[0-9]+)(?:\\s+([0-9]+))+$");
 
     private final Logger logger = LoggerFactory.getLogger(JeeLinkHandler.class);
 

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -15,6 +15,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.openhab.binding.jeelink.internal.ec3k.Ec3kSensorDefinition;
 import org.openhab.binding.jeelink.internal.lacrosse.LaCrosseSensorDefinition;
+import org.openhab.binding.jeelink.internal.lacrosse.Tx22SensorDefinition;
 import org.openhab.binding.jeelink.internal.pca301.Pca301SensorDefinition;
 
 /**
@@ -35,6 +36,7 @@ public abstract class SensorDefinition<R extends Reading> {
         SENSOR_DEFS.add(new LaCrosseSensorDefinition());
         SENSOR_DEFS.add(new Ec3kSensorDefinition());
         SENSOR_DEFS.add(new Pca301SensorDefinition());
+        SENSOR_DEFS.add(new Tx22SensorDefinition());
     }
 
     public SensorDefinition(ThingTypeUID thingTypeUid, String name, String type) {
@@ -53,7 +55,7 @@ public abstract class SensorDefinition<R extends Reading> {
 
     public abstract Class<R> getReadingClass();
 
-    public abstract JeeLinkSensorHandler createHandler(Thing thing);
+    public abstract JeeLinkSensorHandler<R> createHandler(Thing thing);
 
     public abstract JeeLinkReadingConverter<R> createConverter();
 

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureReading.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureReading.java
@@ -24,12 +24,12 @@ public class LaCrosseTemperatureReading implements Reading {
     private boolean batteryNew;
     private boolean batteryLow;
 
-    public LaCrosseTemperatureReading(int sensorId, int sensorType, int channel, float temp, int humidity,
+    public LaCrosseTemperatureReading(int sensorId, int sensorType, int channel, Float temp, Integer humidity,
             boolean batteryNew, boolean batteryLow) {
         this(String.valueOf(sensorId), sensorType, channel, temp, humidity, batteryNew, batteryLow);
     }
 
-    public LaCrosseTemperatureReading(String sensorId, int sensorType, int channel, float temp, int humidity,
+    public LaCrosseTemperatureReading(String sensorId, int sensorType, int channel, Float temp, Integer humidity,
             boolean batteryNew, boolean batteryLow) {
         this.sensorId = sensorId;
         this.sensorType = sensorType;

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureReading.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureReading.java
@@ -19,8 +19,8 @@ public class LaCrosseTemperatureReading implements Reading {
     private String sensorId;
     private int sensorType;
     private int channel;
-    private float temp;
-    private int humidity;
+    private Float temp;
+    private Integer humidity;
     private boolean batteryNew;
     private boolean batteryLow;
 
@@ -49,11 +49,11 @@ public class LaCrosseTemperatureReading implements Reading {
         return sensorType;
     }
 
-    public float getTemperature() {
+    public Float getTemperature() {
         return temp;
     }
 
-    public int getHumidity() {
+    public Integer getHumidity() {
         return humidity;
     }
 

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
@@ -78,4 +78,10 @@ public class Tx22Reading extends LaCrosseTemperatureReading {
     public boolean hasTemperature() {
         return getTemperature() != null;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + " rain=" + rain + " windDirection=" + windDirection + " windSpeed=" + windSpeed
+                + " windGust=" + windGust + " pressure=" + pressure;
+    }
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+/**
+ * Reading of a TX22 Temperature/Humidity Sensor.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class Tx22Reading extends LaCrosseTemperatureReading {
+    private int rain;
+    private float windDirection;
+    private float windSpeed;
+    private float windGust;
+    private float pressure;
+
+    public Tx22Reading(int sensorId, int sensorType, int channel, float temp, int humidity, boolean batteryNew,
+            boolean batteryLow, int rain, float windDirection, float windSpeed, float windGust, float pressure) {
+        this(String.valueOf(sensorId), sensorType, channel, temp, humidity, batteryNew, batteryLow, rain, windDirection,
+                windSpeed, windGust, pressure);
+    }
+
+    public Tx22Reading(String sensorId, int sensorType, int channel, float temp, int humidity, boolean batteryNew,
+            boolean batteryLow, int rain, float windDirection, float windSpeed, float windGust, float pressure) {
+        super(sensorId, sensorType, channel, temp, humidity, batteryNew, batteryLow);
+
+        this.rain = rain;
+        this.windDirection = windDirection;
+        this.windSpeed = windSpeed;
+        this.windGust = windGust;
+        this.pressure = pressure;
+    }
+
+    public int getRain() {
+        return rain;
+    }
+
+    public float getWindDirection() {
+        return windDirection;
+    }
+
+    public float getWindSpeed() {
+        return windSpeed;
+    }
+
+    public float getWindGust() {
+        return windGust;
+    }
+
+    public float getPressure() {
+        return pressure;
+    }
+
+    public boolean hasWindGust() {
+        return windGust != Float.MAX_VALUE;
+    }
+
+    public boolean hasWindSpeed() {
+        return windSpeed != Float.MAX_VALUE;
+    }
+
+    public boolean hasWindDirection() {
+        return windDirection != Float.MAX_VALUE;
+    }
+
+    public boolean hasPressure() {
+        return pressure != Float.MAX_VALUE;
+    }
+
+    public boolean hasRain() {
+        return rain != Integer.MAX_VALUE;
+    }
+
+    public boolean hasHumidity() {
+        return getHumidity() != Integer.MAX_VALUE;
+    }
+
+    public boolean hasTemperature() {
+        return getTemperature() != Float.MAX_VALUE;
+    }
+}

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22Reading.java
@@ -14,21 +14,15 @@ package org.openhab.binding.jeelink.internal.lacrosse;
  * @author Volker Bier - Initial contribution
  */
 public class Tx22Reading extends LaCrosseTemperatureReading {
-    private int rain;
-    private float windDirection;
-    private float windSpeed;
-    private float windGust;
-    private float pressure;
+    private Integer rain;
+    private Float windDirection;
+    private Float windSpeed;
+    private Float windGust;
+    private Integer pressure;
 
-    public Tx22Reading(int sensorId, int sensorType, int channel, float temp, int humidity, boolean batteryNew,
-            boolean batteryLow, int rain, float windDirection, float windSpeed, float windGust, float pressure) {
-        this(String.valueOf(sensorId), sensorType, channel, temp, humidity, batteryNew, batteryLow, rain, windDirection,
-                windSpeed, windGust, pressure);
-    }
-
-    public Tx22Reading(String sensorId, int sensorType, int channel, float temp, int humidity, boolean batteryNew,
-            boolean batteryLow, int rain, float windDirection, float windSpeed, float windGust, float pressure) {
-        super(sensorId, sensorType, channel, temp, humidity, batteryNew, batteryLow);
+    public Tx22Reading(int sensorId, int sensorType, int channel, Float temp, Integer humidity, boolean batteryNew,
+            boolean batteryLow, Integer rain, Float windDirection, Float windSpeed, Float windGust, Integer pressure) {
+        super(String.valueOf(sensorId), sensorType, channel, temp, humidity, batteryNew, batteryLow);
 
         this.rain = rain;
         this.windDirection = windDirection;
@@ -37,51 +31,51 @@ public class Tx22Reading extends LaCrosseTemperatureReading {
         this.pressure = pressure;
     }
 
-    public int getRain() {
+    public Integer getRain() {
         return rain;
     }
 
-    public float getWindDirection() {
+    public Float getWindDirection() {
         return windDirection;
     }
 
-    public float getWindSpeed() {
+    public Float getWindSpeed() {
         return windSpeed;
     }
 
-    public float getWindGust() {
+    public Float getWindGust() {
         return windGust;
     }
 
-    public float getPressure() {
+    public Integer getPressure() {
         return pressure;
     }
 
     public boolean hasWindGust() {
-        return windGust != Float.MAX_VALUE;
+        return windGust != null;
     }
 
     public boolean hasWindSpeed() {
-        return windSpeed != Float.MAX_VALUE;
+        return windSpeed != null;
     }
 
     public boolean hasWindDirection() {
-        return windDirection != Float.MAX_VALUE;
+        return windDirection != null;
     }
 
     public boolean hasPressure() {
-        return pressure != Float.MAX_VALUE;
+        return pressure != null;
     }
 
     public boolean hasRain() {
-        return rain != Integer.MAX_VALUE;
+        return rain != null;
     }
 
     public boolean hasHumidity() {
-        return getHumidity() != Integer.MAX_VALUE;
+        return getHumidity() != null;
     }
 
     public boolean hasTemperature() {
-        return getTemperature() != Float.MAX_VALUE;
+        return getTemperature() != null;
     }
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading> {
     private static final Pattern LINE_P = Pattern.compile(
-            "OK\\s+WS\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)");
+            "OK\\s+WS\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)(?:\\s+([0-9]+)\\s+([0-9]+))?");
 
     private final Logger logger = LoggerFactory.getLogger(Tx22ReadingConverter.class);
 
@@ -39,8 +39,8 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
                  * OK WS 14 1 4 208 53 0 0 7 8 0 29 0 31 1 4 1 I D=0E 23.2°C 52%rH 0mm Dir.: 180.0° Wind:2.9m/s
                  * Gust:3.1m/s new Batt. 1025 hPa
                  * OK WS ID XXX TTT TTT HHH RRR RRR DDD DDD SSS SSS GGG GGG FFF PPP PPP
-                 * | | | | | | | | | | | | | | | | | |-- Pressure LSB
-                 * | | | | | | | | | | | | | | | | |------ Pressure MSB
+                 * | | | | | | | | | | | | | | | | | |-- Pressure LSB (optional, FF/FF = none)
+                 * | | | | | | | | | | | | | | | | |------ Pressure MSB (optional)
                  * | | | | | | | | | | | | | | | |---------- Flags *
                  * | | | | | | | | | | | | | | |-------------- WindGust * 10 LSB (0.0 ... 50.0 m/s) FF/FF = none
                  * | | | | | | | | | | | | | |------------------ WindGust * 10 MSB
@@ -72,30 +72,30 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
                 int sensorId = Integer.parseInt(matcher.group(1));
                 int type = Integer.parseInt(matcher.group(2));
 
-                float temperature = "255".equals(matcher.group(3)) ? Float.MAX_VALUE
+                Float temperature = "255".equals(matcher.group(3)) ? null
                         : (float) (Integer.parseInt(matcher.group(3)) * 256 + Integer.parseInt(matcher.group(4)) - 1000)
                                 / 10;
 
-                int humidity = "255".equals(matcher.group(5)) ? Integer.MAX_VALUE : Integer.parseInt(matcher.group(5));
+                Integer humidity = "255".equals(matcher.group(5)) ? null : Integer.parseInt(matcher.group(5));
 
-                int rain = "255".equals(matcher.group(6)) ? Integer.MAX_VALUE
+                Integer rain = "255".equals(matcher.group(6)) ? null
                         : (Integer.parseInt(matcher.group(6)) * 256 + Integer.parseInt(matcher.group(7))) * 2;
 
-                float windDirection = "255".equals(matcher.group(8)) ? Float.MAX_VALUE
-                        : (float) (Integer.parseInt(matcher.group(8)) * 256 + Integer.parseInt(matcher.group(9))) / 10;
-                float windSpeed = "255".equals(matcher.group(10)) ? Float.MAX_VALUE
-                        : (float) (Integer.parseInt(matcher.group(10)) * 256 + Integer.parseInt(matcher.group(11)))
-                                / 10;
-                float windGust = "255".equals(matcher.group(12)) ? Float.MAX_VALUE
-                        : (float) (Integer.parseInt(matcher.group(12)) * 256 + Integer.parseInt(matcher.group(13)))
-                                / 10;
+                Float windDirection = "255".equals(matcher.group(8)) ? null
+                        : (Integer.parseInt(matcher.group(8)) * 256 + Integer.parseInt(matcher.group(9))) / 10f;
+                Float windSpeed = "255".equals(matcher.group(10)) ? null
+                        : (Integer.parseInt(matcher.group(10)) * 256 + Integer.parseInt(matcher.group(11))) / 10f;
+                Float windGust = "255".equals(matcher.group(12)) ? null
+                        : (Integer.parseInt(matcher.group(12)) * 256 + Integer.parseInt(matcher.group(13))) / 10f;
 
                 byte flags = Byte.parseByte(matcher.group(14));
-                float pressure = "255".equals(matcher.group(15)) ? Float.MAX_VALUE
-                        : Integer.parseInt(matcher.group(15)) * 256 + Integer.parseInt(matcher.group(16));
-
                 boolean batteryNew = (flags & (byte) 1) > 0;
                 boolean batteryLow = (flags & (byte) 4) > 0;
+
+                Integer pressure = null;
+                if (matcher.groupCount() > 14 && matcher.group(15) != null && !"255".equals(matcher.group(15))) {
+                    pressure = Integer.parseInt(matcher.group(15)) * 256 + Integer.parseInt(matcher.group(16));
+                }
 
                 return new Tx22Reading(sensorId, type, 0, temperature, humidity, batteryNew, batteryLow, rain,
                         windDirection, windSpeed, windGust, pressure);

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+import org.openhab.binding.jeelink.internal.Reading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,7 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
                 Float windGust = "255".equals(matcher.group(12)) ? null
                         : (Integer.parseInt(matcher.group(12)) * 256 + Integer.parseInt(matcher.group(13))) / 10f;
 
-                byte flags = Byte.parseByte(matcher.group(14));
+                int flags = Integer.parseInt(matcher.group(14));
                 boolean batteryNew = (flags & (byte) 1) > 0;
                 boolean batteryLow = (flags & (byte) 4) > 0;
 
@@ -103,5 +104,11 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
         }
 
         return null;
+    }
+
+    public static void main(String[] args) {
+        Tx22ReadingConverter c = new Tx22ReadingConverter();
+        Reading r = c.createReading("OK WS 24 1 255 255 255 255 255 255 255 255 255 255 255 255");
+        System.out.println(r);
     }
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converter for converting a line read from a LaCrosseITPlusReader sketch to a LaCrosseTemperatureReading.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading> {
+    private static final Pattern LINE_P = Pattern.compile(
+            "OK\\s+WS\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)");
+
+    private final Logger logger = LoggerFactory.getLogger(Tx22ReadingConverter.class);
+
+    @Override
+    public Tx22Reading createReading(String inputLine) {
+        // parse lines only if we have registered listeners
+        if (inputLine != null) {
+            Matcher matcher = LINE_P.matcher(inputLine);
+            if (matcher.matches()) {
+                /**
+                 * Format
+                 * 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+                 * -------------------------------------------------------------------
+                 * OK WS 14 1 4 208 53 0 0 7 8 0 29 0 31 1 4 1 I D=0E 23.2°C 52%rH 0mm Dir.: 180.0° Wind:2.9m/s
+                 * Gust:3.1m/s new Batt. 1025 hPa
+                 * OK WS ID XXX TTT TTT HHH RRR RRR DDD DDD SSS SSS GGG GGG FFF PPP PPP
+                 * | | | | | | | | | | | | | | | | | |-- Pressure LSB
+                 * | | | | | | | | | | | | | | | | |------ Pressure MSB
+                 * | | | | | | | | | | | | | | | |---------- Flags *
+                 * | | | | | | | | | | | | | | |-------------- WindGust * 10 LSB (0.0 ... 50.0 m/s) FF/FF = none
+                 * | | | | | | | | | | | | | |------------------ WindGust * 10 MSB
+                 * | | | | | | | | | | | | |---------------------- WindSpeed * 10 LSB(0.0 ... 50.0 m/s) FF/FF = none
+                 * | | | | | | | | | | | |-------------------------- WindSpeed * 10 MSB
+                 * | | | | | | | | | | |------------------------------ WindDirection * 10 LSB (0.0 ... 365.0 Degrees)
+                 * FF/FF = none
+                 * | | | | | | | | | |---------------------------------- WindDirection * 10 MSB
+                 * | | | | | | | | |-------------------------------------- Rain * 0.5mm LSB (0 ... 9999 mm) FF/FF = none
+                 * | | | | | | | |------------------------------------------ Rain * 0.5mm MSB
+                 * | | | | | | |---------------------------------------------- Humidity (1 ... 99 %rH) FF = none
+                 * | | | | | |-------------------------------------------------- Temp * 10 + 1000 LSB (-40 ... +60 °C)
+                 * FF/FF = none
+                 * | | | | |------------------------------------------------------ Temp * 10 + 1000 MSB
+                 * | | | |---------------------------------------------------------- Sensor type (1=TX22, 2=NodeSensor)
+                 * | | |------------------------------------------------------------- Sensor ID (0 ... 63)
+                 * | |---------------------------------------------------------------- fix "WS"
+                 * |------------------------------------------------------------------- fix "OK"
+                 *
+                 * Flags: 128 64 32 16 8 4 2 1
+                 * | | |
+                 * | | |-- New battery
+                 * | |------ ERROR
+                 * |---------- Low battery
+                 */
+
+                logger.trace("Creating reading from: {}", inputLine);
+
+                int sensorId = Integer.parseInt(matcher.group(1));
+                int type = Integer.parseInt(matcher.group(2));
+
+                float temperature = "255".equals(matcher.group(3)) ? Float.MAX_VALUE
+                        : (float) (Integer.parseInt(matcher.group(3)) * 256 + Integer.parseInt(matcher.group(4)) - 1000)
+                                / 10;
+
+                int humidity = "255".equals(matcher.group(5)) ? Integer.MAX_VALUE : Integer.parseInt(matcher.group(5));
+
+                int rain = "255".equals(matcher.group(6)) ? Integer.MAX_VALUE
+                        : (Integer.parseInt(matcher.group(6)) * 256 + Integer.parseInt(matcher.group(7))) * 2;
+
+                float windDirection = "255".equals(matcher.group(8)) ? Float.MAX_VALUE
+                        : (float) (Integer.parseInt(matcher.group(8)) * 256 + Integer.parseInt(matcher.group(9))) / 10;
+                float windSpeed = "255".equals(matcher.group(10)) ? Float.MAX_VALUE
+                        : (float) (Integer.parseInt(matcher.group(10)) * 256 + Integer.parseInt(matcher.group(11)))
+                                / 10;
+                float windGust = "255".equals(matcher.group(12)) ? Float.MAX_VALUE
+                        : (float) (Integer.parseInt(matcher.group(12)) * 256 + Integer.parseInt(matcher.group(13)))
+                                / 10;
+
+                byte flags = Byte.parseByte(matcher.group(14));
+                float pressure = "255".equals(matcher.group(15)) ? Float.MAX_VALUE
+                        : Integer.parseInt(matcher.group(15)) * 256 + Integer.parseInt(matcher.group(16));
+
+                boolean batteryNew = (flags & (byte) 1) > 0;
+                boolean batteryLow = (flags & (byte) 4) > 0;
+
+                return new Tx22Reading(sensorId, type, 0, temperature, humidity, batteryNew, batteryLow, rain,
+                        windDirection, windSpeed, windGust, pressure);
+            }
+        }
+
+        return null;
+    }
+}

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -12,7 +12,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
-import org.openhab.binding.jeelink.internal.Reading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,11 +103,5 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
         }
 
         return null;
-    }
-
-    public static void main(String[] args) {
-        Tx22ReadingConverter c = new Tx22ReadingConverter();
-        Reading r = c.createReading("OK WS 24 1 255 255 255 255 255 255 255 255 255 255 255 255");
-        System.out.println(r);
     }
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Converter for converting a line read from a LaCrosseITPlusReader sketch to a LaCrosseTemperatureReading.
+ * Converter for converting a line read from a LaCrosseITPlusReader sketch to a Tx22Reading.
  *
  * @author Volker Bier - Initial contribution
  */

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
@@ -15,7 +15,7 @@ import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.SensorDefinition;
 
 /**
- * Sensor Defintion of a LaCrosse Temperature Sensor
+ * Sensor Defintion of a TX22 Temperature/Humidity Sensor.
  *
  * @author Volker Bier - Initial contribution
  */

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.jeelink.JeeLinkBindingConstants;
+import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
+import org.openhab.binding.jeelink.internal.SensorDefinition;
+
+/**
+ * Sensor Defintion of a LaCrosse Temperature Sensor
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class Tx22SensorDefinition extends SensorDefinition<Tx22Reading> {
+
+    public Tx22SensorDefinition() {
+        super(JeeLinkBindingConstants.TX22_SENSOR_THING_TYPE, "TX22 Temperature/Humidity Sensor", "WS");
+    }
+
+    @Override
+    public JeeLinkReadingConverter<Tx22Reading> createConverter() {
+        return new Tx22ReadingConverter();
+    }
+
+    @Override
+    public Class<Tx22Reading> getReadingClass() {
+        return Tx22Reading.class;
+    }
+
+    @Override
+    public JeeLinkSensorHandler<Tx22Reading> createHandler(Thing thing) {
+        return new Tx22SensorHandler(thing);
+    }
+}

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handler for a LaCrosse Temperature Sensor thing.
+ * Handler for a TX22 Temperature/Humidity Sensor thing.
  *
  * @author Volker Bier - Initial contribution
  */

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
@@ -48,23 +48,14 @@ public class Tx22SensorHandler extends JeeLinkSensorHandler<Tx22Reading> {
             @Override
             public void publish(Tx22Reading reading) {
                 if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
-                    BigDecimal temp = new BigDecimal(reading.getTemperature()).setScale(1, RoundingMode.HALF_UP);
-
-                    logger.debug(
-                            "updating states for thing {} ({}): temp={} ({}), hum={}, batNew={}, batLow={}, rain={}, pressure={}, wDir={}, wSpeed={}, gSpeed={}",
-                            getThing().getLabel(), getThing().getUID().getId(), reading.hasTemperature() ? temp : "-",
-                            reading.hasTemperature() ? reading.getTemperature() : "-",
-                            reading.hasHumidity() ? reading.getHumidity() : "-", reading.isBatteryNew(),
-                            reading.isBatteryLow(), reading.hasRain() ? reading.getRain() : "-",
-                            reading.hasPressure() ? reading.getPressure() : "-",
-                            reading.hasWindDirection() ? reading.getWindDirection() : "-",
-                            reading.hasWindSpeed() ? reading.getWindSpeed() : "-",
-                            reading.hasWindGust() ? reading.getWindGust() : "-");
+                    logger.debug("updating states for thing {} ({}): {}", getThing().getLabel(),
+                            getThing().getUID().getId(), reading);
 
                     updateState(BATTERY_NEW_CHANNEL, reading.isBatteryNew() ? OnOffType.ON : OnOffType.OFF);
                     updateState(BATTERY_LOW_CHANNEL, reading.isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
 
                     if (reading.hasTemperature()) {
+                        BigDecimal temp = new BigDecimal(reading.getTemperature()).setScale(1, RoundingMode.HALF_UP);
                         updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, SIUnits.CELSIUS));
                     }
                     if (reading.hasHumidity()) {

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
@@ -88,8 +88,6 @@ public class Tx22SensorHandler extends JeeLinkSensorHandler<Tx22Reading> {
             }
         };
 
-        // TODO.vb. chain publishers
-
         return publisher;
     }
 }

--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.*;
+import static org.openhab.binding.jeelink.JeeLinkBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
+import org.openhab.binding.jeelink.internal.ReadingPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for a LaCrosse Temperature Sensor thing.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class Tx22SensorHandler extends JeeLinkSensorHandler<Tx22Reading> {
+    private final Logger logger = LoggerFactory.getLogger(Tx22SensorHandler.class);
+
+    public Tx22SensorHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public Class<Tx22Reading> getReadingClass() {
+        return Tx22Reading.class;
+    }
+
+    @Override
+    public ReadingPublisher<Tx22Reading> createPublisher() {
+        ReadingPublisher<Tx22Reading> publisher = new ReadingPublisher<Tx22Reading>() {
+            @Override
+            public void publish(Tx22Reading reading) {
+                if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
+                    BigDecimal temp = new BigDecimal(reading.getTemperature()).setScale(1, RoundingMode.HALF_UP);
+
+                    logger.debug(
+                            "updating states for thing {} ({}): temp={} ({}), hum={}, batNew={}, batLow={}, rain={}, pressure={}, wDir={}, wSpeed={}, gSpeed={}",
+                            getThing().getLabel(), getThing().getUID().getId(), reading.hasTemperature() ? temp : "-",
+                            reading.hasTemperature() ? reading.getTemperature() : "-",
+                            reading.hasHumidity() ? reading.getHumidity() : "-", reading.isBatteryNew(),
+                            reading.isBatteryLow(), reading.hasRain() ? reading.getRain() : "-",
+                            reading.hasPressure() ? reading.getPressure() : "-",
+                            reading.hasWindDirection() ? reading.getWindDirection() : "-",
+                            reading.hasWindSpeed() ? reading.getWindSpeed() : "-",
+                            reading.hasWindGust() ? reading.getWindGust() : "-");
+
+                    updateState(BATTERY_NEW_CHANNEL, reading.isBatteryNew() ? OnOffType.ON : OnOffType.OFF);
+                    updateState(BATTERY_LOW_CHANNEL, reading.isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
+
+                    if (reading.hasTemperature()) {
+                        updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, SIUnits.CELSIUS));
+                    }
+                    if (reading.hasHumidity()) {
+                        updateState(HUMIDITY_CHANNEL,
+                                new QuantityType<>(reading.getHumidity(), SmartHomeUnits.PERCENT));
+                    }
+                    if (reading.hasRain()) {
+                        updateState(RAIN_CHANNEL, new QuantityType<>(reading.getRain(), MILLI(SIUnits.METRE)));
+                    }
+                    if (reading.hasPressure()) {
+                        updateState(PRESSURE_CHANNEL, new QuantityType<>(reading.getPressure(), HECTO(SIUnits.PASCAL)));
+                    }
+                    if (reading.hasWindDirection()) {
+                        updateState(WIND_ANGLE_CHANNEL,
+                                new QuantityType<>(reading.getWindDirection(), SmartHomeUnits.DEGREE_ANGLE));
+                    }
+                    if (reading.hasWindSpeed()) {
+                        updateState(WIND_STENGTH_CHANNEL,
+                                new QuantityType<>(reading.getWindSpeed(), SmartHomeUnits.METRE_PER_SECOND));
+                    }
+                    if (reading.hasWindGust()) {
+                        updateState(GUST_STRENGTH_CHANNEL,
+                                new QuantityType<>(reading.getWindGust(), SmartHomeUnits.METRE_PER_SECOND));
+                    }
+                }
+            }
+
+            @Override
+            public void dispose() {
+            }
+        };
+
+        // TODO.vb. chain publishers
+
+        return publisher;
+    }
+}


### PR DESCRIPTION
This adds support for reading TX22 temperature and humidity sensors (as well as TX23 wind sensors and TX26 rain sensors wired to the TX22).

Signed-off-by: Volker Bier <volker.bier@web.de>
