### PR TITLE
[Lutron] Add support for shades

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
@@ -54,7 +54,6 @@
 		</config-description>
 	</thing-type>
 
-
 	<thing-type id="shade">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>
@@ -74,7 +73,6 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-
 
 	<thing-type id="switch">
 		<supported-bridge-type-refs>
@@ -242,7 +240,6 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-
 
 	<thing-type id="ttkeypad">
 		<supported-bridge-type-refs>

--- a/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
@@ -54,6 +54,28 @@
 		</config-description>
 	</thing-type>
 
+
+	<thing-type id="shade">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Sivoia QS Shade</label>
+		<description>Controls roller shades</description>
+
+		<channels>
+			<channel id="shadelevel" typeId="shadeControl"/>
+		</channels>
+
+		<config-description>
+			<parameter name="integrationId" type="integer" required="true">
+				<label>Integration ID</label>
+				<description>Address of shade in the Lutron system</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+
 	<thing-type id="switch">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>
@@ -663,6 +685,14 @@
 		<label>Light Level</label>
 		<description>Increase/decrease the light level</description>
 		<category>DimmableLight</category>
+		<state min="0" max="100" pattern="%d %%"/>
+	</channel-type>
+
+	<channel-type id="shadeControl">
+		<item-type>Rollershutter</item-type>
+		<label>Shade Level</label>
+		<description>Raise/lower the shade level</description>
+		<category>Rollershutter</category>
 		<state min="0" max="100" pattern="%d %%"/>
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.lutron/README.md
+++ b/addons/binding/org.openhab.binding.lutron/README.md
@@ -246,16 +246,16 @@ The behavior of this binding is the same as the other keypad bindings, with the 
 
 The following channels are supported:
 
-| Thing Type          | Channel ID        | Item Type    | Description                                  |
-|---------------------|-------------------|--------------|--------------------------------------------- |
-| dimmer              | lightlevel        | Dimmer       | Increase/decrease the light level            |
-| switch              | switchstatus      | Switch       | On/off status of the switch                  |
-| occupancysensor     | occupancystatus   | Switch       | Occupancy status                             |
-| cco                 | switchstatus      | Switch       | On/off status of the CCO                     |
-| keypads (all)       | button*           | Switch       | Keypad button                                |
-| keypads(except pico)| led*              | Switch       | LED indicator for the associated button      |
-| vcrx                | cci*              | Contact      | Contact closure input on/off status          |
-| shade           | shadelevel        | Rollershutter | Accepts Up, Down, Stop, & Percent   |
+| Thing Type          | Channel ID        | Item Type     | Description                                  |
+|---------------------|-------------------|---------------|--------------------------------------------- |
+| dimmer              | lightlevel        | Dimmer        | Increase/decrease the light level            |
+| switch              | switchstatus      | Switch        | On/off status of the switch                  |
+| occupancysensor     | occupancystatus   | Switch        | Occupancy status                             |
+| cco                 | switchstatus      | Switch        | On/off status of the CCO                     |
+| keypads (all)       | button*           | Switch        | Keypad button                                |
+| keypads(except pico)| led*              | Switch        | LED indicator for the associated button      |
+| vcrx                | cci*              | Contact       | Contact closure input on/off status          |
+| shade               | shadelevel        | Rollershutter | Accepts Up, Down, Stop, & Percent commands   |
 
 The channels available on each keypad device (i.e. keypad, ttkeypad, pico, vcrx, and virtualkeypad) will vary with keypad type and model.
 Appropriate channels will created automatically by the keypad, ttkeypad, and pico handlers based on the setting of the "model" parameter for those thing types.

--- a/addons/binding/org.openhab.binding.lutron/README.md
+++ b/addons/binding/org.openhab.binding.lutron/README.md
@@ -25,7 +25,7 @@ This binding currently supports the following thing types:
 * pico - Pico Keypad
 * vcrx - Visor control receiver
 * virtualkeypad - Repeater virtual keypad
-* shade
+* shade - Lutron shade or motorized drape
 
 ## Discovery
 
@@ -62,9 +62,10 @@ In the thing file, this looks e.g. like:
 ```
 Thing lutron:dimmer:livingroom (lutron:ipbridge:radiora2) [ integrationId=8, fadeInTime=0.5, fadeOutTime=5 ]
 ```
+
 ### Shades
 
-Each Lutron Sivoia QS shade is controlled by a “shade” thing.
+Each Lutron shade or motorized drape is controlled by a “shade” thing.
 The only configuration parameter it accepts is integrationId. 
 
 A single channel shadelevel with item type Rollershutter and category Rollershutter will be created for each shade thing.
@@ -72,6 +73,7 @@ It accepts Percent, Up, Down, Stop and Refresh commands.
 Sending a Percent command will cause the shade to immediately move so as to be open the specified percentage.
 You can also read the current shade level from the channel.
 It is specified as a percentage, where 0% = closed and 100% = fully open. Movement delays are not currently supported.
+The shade handler should be compatible with all Lutron devices which appear to the system as shades, including roller shades, honeycomb shades, pleated shades, roman shades, tension roller shades, drapes, and Kirbe vertical drapes.
 
 **Note:** While a shade is moving, the Lutron system will report the target level for the shade rather than the actual current level.
 

--- a/addons/binding/org.openhab.binding.lutron/README.md
+++ b/addons/binding/org.openhab.binding.lutron/README.md
@@ -25,6 +25,7 @@ This binding currently supports the following thing types:
 * pico - Pico Keypad
 * vcrx - Visor control receiver
 * virtualkeypad - Repeater virtual keypad
+* shade
 
 ## Discovery
 
@@ -60,6 +61,24 @@ In the thing file, this looks e.g. like:
 
 ```
 Thing lutron:dimmer:livingroom (lutron:ipbridge:radiora2) [ integrationId=8, fadeInTime=0.5, fadeOutTime=5 ]
+```
+### Shades
+
+Each Lutron Sivoia QS shade is controlled by a “shade” thing.
+The only configuration parameter it accepts is integrationId. 
+
+A single channel shadelevel with item type Rollershutter and category Rollershutter will be created for each shade thing.
+It accepts Percent, Up, Down, Stop and Refresh commands.
+Sending a Percent command will cause the shade to immediately move so as to be open the specified percentage.
+You can also read the current shade level from the channel.
+It is specified as a percentage, where 0% = closed and 100% = fully open. Movement delays are not currently supported.
+
+**Note:** While a shade is moving, the Lutron system will report the target level for the shade rather than the actual current level.
+
+Example:
+
+```
+Thing lutron:shade:libraryshade (lutron:ipbridge:radiora2) [ integrationId=33]
 ```
 
 ### Switches
@@ -234,6 +253,7 @@ The following channels are supported:
 | keypads (all)       | button*           | Switch       | Keypad button                                |
 | keypads(except pico)| led*              | Switch       | LED indicator for the associated button      |
 | vcrx                | cci*              | Contact      | Contact closure input on/off status          |
+| shade           | shadelevel        | Rollershutter | Accepts Up, Down, Stop, & Percent   |
 
 The channels available on each keypad device (i.e. keypad, ttkeypad, pico, vcrx, and virtualkeypad) will vary with keypad type and model.
 Appropriate channels will created automatically by the keypad, ttkeypad, and pico handlers based on the setting of the "model" parameter for those thing types.

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
@@ -27,6 +27,7 @@ public class LutronBindingConstants {
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "dimmer");
+    public static final ThingTypeUID THING_TYPE_SHADE = new ThingTypeUID(BINDING_ID, "shade");
     public static final ThingTypeUID THING_TYPE_SWITCH = new ThingTypeUID(BINDING_ID, "switch");
     public static final ThingTypeUID THING_TYPE_OCCUPANCYSENSOR = new ThingTypeUID(BINDING_ID, "occupancysensor");
     public static final ThingTypeUID THING_TYPE_KEYPAD = new ThingTypeUID(BINDING_ID, "keypad");
@@ -40,6 +41,7 @@ public class LutronBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_LIGHTLEVEL = "lightlevel";
+    public static final String CHANNEL_SHADELEVEL = "shadelevel";
     public static final String CHANNEL_SWITCH = "switchstatus";
     public static final String CHANNEL_OCCUPANCYSTATUS = "occupancystatus";
     public static final String CHANNEL_BUTTON1 = "button1";

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/LutronBindingConstants.java
@@ -44,24 +44,6 @@ public class LutronBindingConstants {
     public static final String CHANNEL_SHADELEVEL = "shadelevel";
     public static final String CHANNEL_SWITCH = "switchstatus";
     public static final String CHANNEL_OCCUPANCYSTATUS = "occupancystatus";
-    public static final String CHANNEL_BUTTON1 = "button1";
-    public static final String CHANNEL_BUTTON2 = "button2";
-    public static final String CHANNEL_BUTTON3 = "button3";
-    public static final String CHANNEL_BUTTON4 = "button4";
-    public static final String CHANNEL_BUTTON5 = "button5";
-    public static final String CHANNEL_BUTTON6 = "button6";
-    public static final String CHANNEL_BUTTON7 = "button7";
-    public static final String CHANNEL_BUTTONTOPRAISE = "buttontopraise";
-    public static final String CHANNEL_BUTTONTOPLOWER = "buttontoplower";
-    public static final String CHANNEL_BUTTONBOTTOMRAISE = "buttonbottomraise";
-    public static final String CHANNEL_BUTTONBOTTOMLOWER = "buttonbottomlower";
-    public static final String CHANNEL_LED1 = "led1";
-    public static final String CHANNEL_LED2 = "led2";
-    public static final String CHANNEL_LED3 = "led3";
-    public static final String CHANNEL_LED4 = "led4";
-    public static final String CHANNEL_LED5 = "led5";
-    public static final String CHANNEL_LED6 = "led6";
-    public static final String CHANNEL_LED7 = "led7";
 
     // Bridge config properties
     public static final String HOST = "ipAddress";

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
@@ -57,6 +57,11 @@ public class IPBridgeHandler extends BaseBridgeHandler {
 
     private static final int MAX_LOGIN_ATTEMPTS = 2;
 
+    private static final String PROMPT_GNET = "GNET>";
+    private static final String PROMPT_QNET = "QNET>";
+    private static final String PROMPT_SAFE = "SAFE>";
+    private static final String LOGIN_MATCH_REGEX = "(login:|[GQ]NET>|SAFE>)";
+
     private static final String DEFAULT_USER = "lutron";
     private static final String DEFAULT_PASSWORD = "integration";
 
@@ -269,11 +274,11 @@ public class IPBridgeHandler extends BaseBridgeHandler {
             this.session.waitFor("password:");
             this.session.writeLine(config.getPassword() != null ? config.getPassword() : DEFAULT_PASSWORD);
 
-            MatchResult matchResult = this.session.waitFor("(login:|[GQ]NET>|SAFE>)");
+            MatchResult matchResult = this.session.waitFor(LOGIN_MATCH_REGEX);
 
-            if ("GNET>".equals(matchResult.group()) || "QNET>".equals(matchResult.group())) {
+            if (PROMPT_GNET.equals(matchResult.group()) || PROMPT_QNET.equals(matchResult.group())) {
                 return true;
-            } else if ("SAFE>".equals(matchResult.group())) {
+            } else if (PROMPT_SAFE.equals(matchResult.group())) {
                 logger.warn("Lutron repeater is in safe mode. Unable to connect.");
                 throw new LutronSafemodeException("Lutron repeater in safe mode");
             }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/IPBridgeHandler.java
@@ -74,8 +74,12 @@ public class IPBridgeHandler extends BaseBridgeHandler {
     private Date lastDbUpdateDate;
     private ServiceRegistration<DiscoveryService> discoveryServiceRegistration;
 
-    private class LutronSafemodeException extends Exception {
+    public class LutronSafemodeException extends Exception {
         private static final long serialVersionUID = 1L;
+
+        public LutronSafemodeException(String message) {
+            super(message);
+        }
     }
 
     public IPBridgeHandler(Bridge bridge) {
@@ -271,7 +275,7 @@ public class IPBridgeHandler extends BaseBridgeHandler {
                 return true;
             } else if ("SAFE>".equals(matchResult.group())) {
                 logger.warn("Lutron repeater is in safe mode. Unable to connect.");
-                throw new LutronSafemodeException();
+                throw new LutronSafemodeException("Lutron repeater in safe mode");
             }
 
             else {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/ShadeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/ShadeHandler.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.lutron.handler;
+
+import static org.openhab.binding.lutron.LutronBindingConstants.CHANNEL_SHADELEVEL;
+
+import java.math.BigDecimal;
+
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.lutron.internal.protocol.LutronCommandType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler responsible for communicating with a Lutron Sivoia QS shade
+ *
+ * @author Bob Adair - Initial contribution
+ *         Based on Alan Tong's DimmerHandler
+ */
+public class ShadeHandler extends LutronHandler {
+    private static final Integer ACTION_ZONELEVEL = 1;
+    private static final Integer ACTION_STARTRAISING = 2;
+    private static final Integer ACTION_STARTLOWERING = 3;
+    private static final Integer ACTION_STOP = 4;
+
+    private final Logger logger = LoggerFactory.getLogger(ShadeHandler.class);
+
+    protected int integrationId;
+
+    public ShadeHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public int getIntegrationId() {
+        return integrationId;
+    }
+
+    @Override
+    public void initialize() {
+        Number id = (Number) getThing().getConfiguration().get("integrationId");
+        if (id == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId");
+            return;
+        }
+        integrationId = id.intValue();
+
+        logger.debug("Initializing Shade handler for integration ID {}", id);
+
+        if (getThing().getBridgeUID() == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");
+            return;
+        }
+        updateStatus(ThingStatus.ONLINE);
+        queryOutput(ACTION_ZONELEVEL);
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        // Refresh state when new item is linked.
+        if (channelUID.getId().equals(CHANNEL_SHADELEVEL)) {
+            queryOutput(ACTION_ZONELEVEL);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_SHADELEVEL)) {
+            if (command instanceof PercentType) {
+                int level = ((PercentType) command).intValue();
+                output(ACTION_ZONELEVEL, level, 0);
+            } else if (command.equals(UpDownType.UP)) {
+                output(ACTION_STARTRAISING);
+            } else if (command.equals(UpDownType.DOWN)) {
+                output(ACTION_STARTLOWERING);
+            } else if (command.equals(StopMoveType.STOP)) {
+                output(ACTION_STOP);
+            } else if (command instanceof RefreshType) {
+                queryOutput(ACTION_ZONELEVEL);
+            }
+        }
+    }
+
+    @Override
+    public void handleUpdate(LutronCommandType type, String... parameters) {
+        if (type == LutronCommandType.OUTPUT && parameters.length > 1
+                && ACTION_ZONELEVEL.toString().equals(parameters[0])) {
+            BigDecimal level = new BigDecimal(parameters[1]);
+            updateState(CHANNEL_SHADELEVEL, new PercentType(level));
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/ShadeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/handler/ShadeHandler.java
@@ -28,8 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Handler responsible for communicating with a Lutron Sivoia QS shade
  *
- * @author Bob Adair - Initial contribution
- *         Based on Alan Tong's DimmerHandler
+ * @author Bob Adair - Initial contribution based on Alan Tong's DimmerHandler
  */
 public class ShadeHandler extends LutronHandler {
     private static final Integer ACTION_ZONELEVEL = 1;
@@ -97,7 +96,7 @@ public class ShadeHandler extends LutronHandler {
 
     @Override
     public void handleUpdate(LutronCommandType type, String... parameters) {
-        if (type == LutronCommandType.OUTPUT && parameters.length > 1
+        if (type == LutronCommandType.OUTPUT && parameters.length >= 2
                 && ACTION_ZONELEVEL.toString().equals(parameters[0])) {
             BigDecimal level = new BigDecimal(parameters[1]);
             updateState(CHANNEL_SHADELEVEL, new PercentType(level));

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -25,6 +25,7 @@ import org.openhab.binding.lutron.handler.MaintainedCcoHandler;
 import org.openhab.binding.lutron.handler.OccupancySensorHandler;
 import org.openhab.binding.lutron.handler.PicoKeypadHandler;
 import org.openhab.binding.lutron.handler.PulsedCcoHandler;
+import org.openhab.binding.lutron.handler.ShadeHandler;
 import org.openhab.binding.lutron.handler.SwitchHandler;
 import org.openhab.binding.lutron.handler.TabletopKeypadHandler;
 import org.openhab.binding.lutron.handler.VcrxHandler;
@@ -49,7 +50,8 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
     // Used by LutronDeviceDiscoveryService to discover these types
     public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMER,
             THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR, THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_PICO,
-            THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED);
+            THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED,
+            THING_TYPE_SHADE);
 
     // Other types that can be initiated but not discovered
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_IPBRIDGE,
@@ -71,6 +73,8 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
             return new IPBridgeHandler((Bridge) thing);
         } else if (thingTypeUID.equals(THING_TYPE_DIMMER)) {
             return new DimmerHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_SHADE)) {
+            return new ShadeHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_SWITCH)) {
             return new SwitchHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_CCO)) {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -194,6 +194,7 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                     break;
 
                 case SYSTEM_SHADE:
+                    notifyDiscovery(THING_TYPE_SHADE, output.getIntegrationId(), label);
                     break;
             }
         } else {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
@@ -22,5 +22,5 @@ public enum OutputType {
     NON_DIM,
     NON_DIM_ELV,
     NON_DIM_INC,
-    SYSTEM_SHADE
+    SYSTEM_SHADE,
 }


### PR DESCRIPTION
Hi. This PR contains an improvement to the Lutron binding that adds support for Lutron Sivoia QS wireless shades on Radio RA2 systems.  It should also support other Lutron shades on other Lutron system which support Lutron Integration Protocol.

From the updated docs:

Each Lutron Sivoia QS shade is controlled by a “shade” thing. The only configuration parameter it accepts is integrationId.

A single channel shadelevel with item type Rollershutter and category Rollershutter will be created for each shade thing. It accepts Percent, Up, Down, Stop and Refresh commands. Sending a Percent command will cause the shade to immediately move so as to be open the specified percentage. You can also read the current shade level from the channel. It is specified as a percentage, where 0% = closed and 100% = fully open. Movement delays are not currently supported.

Note: While a shade is moving, the Lutron system will report the target level for the shade rather than the actual current level.

Technically, the changes amount to the following:

- Adds a new handler for shade things (ShadeHandler)
- Adds RA2 auto-discovery support for shades
- Update to docs in README.md
- Includes a minor change to IPBridgeHandler to fix login for HWQS systems (as previously discussed in the forums) and recognize when the repeater is in "safe" mode.

  Regards,
       Bob Adair

Closes #3845 
Closes #1119
