### PR TITLE
[LG webOS] Fixed NullPointerException Closes #3903

### DIFF
--- a/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lgwebos/ESH-INF/thing/thing-types.xml
@@ -34,11 +34,13 @@
 		<item-type>Switch</item-type>
 		<label>Mute</label>
 		<description>Current Mute Setting</description>
+		<category>SoundVolume</category>
 	</channel-type>
 	<channel-type id="volumeType">
 		<item-type>Dimmer</item-type>
 		<label>Volume</label>
 		<description>Current Volume Setting</description>
+		<category>SoundVolume</category>
 		<state min="0" max="100" step="1"></state>
 	</channel-type>
 	<channel-type id="channelType">
@@ -62,6 +64,7 @@
 		<item-type>Player</item-type>
 		<label>Media Control</label>
 		<description>Control media (e.g. audio or video) playback</description>
+		<category>MediaControl</category>
 	</channel-type>
 	<channel-type id="mediaStopType">
 		<item-type>Switch</item-type>

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/LGWebOSBindingConstants.java
@@ -28,6 +28,8 @@ public class LGWebOSBindingConstants {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WEBOSTV);
 
+    public static final String BINDING_CONFIGURATION_LOCALIP = "localIP";
+
     public static final String PROPERTY_DEVICE_ID = "deviceId";
 
     // List of all Channel ids. Values have to match ids in thing-types.xml
@@ -35,12 +37,9 @@ public class LGWebOSBindingConstants {
     public static final String CHANNEL_POWER = "power";
     public static final String CHANNEL_MUTE = "mute";
     public static final String CHANNEL_CHANNEL = "channel";
-    public static final String CHANNEL_TOAST = "toast";
-    public static final String CHANNEL_CHANNEL_UP = "channelUp";
-    public static final String CHANNEL_CHANNEL_DOWN = "channelDown";
     public static final String CHANNEL_CHANNEL_NAME = "channelName";
-    public static final String CHANNEL_PROGRAM = "program";
+    public static final String CHANNEL_TOAST = "toast";
+    public static final String CHANNEL_MEDIA_PLAYER = "mediaPlayer";
     public static final String CHANNEL_MEDIA_STOP = "mediaStop";
     public static final String CHANNEL_APP_LAUNCHER = "appLauncher";
-    public static final String CHANNEL_MEDIA_PLAYER = "mediaPlayer";
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/BaseChannelHandler.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/BaseChannelHandler.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,17 +28,28 @@ import com.connectsdk.service.command.ServiceSubscription;
  *
  * @author Sebastian Prehn - initial contribution
  */
-abstract class BaseChannelHandler<T> implements ChannelHandler {
+@NonNullByDefault
+abstract class BaseChannelHandler<T, R> implements ChannelHandler {
     private final Logger logger = LoggerFactory.getLogger(BaseChannelHandler.class);
 
+    private final ResponseListener<R> defaultResponseListener = new ResponseListener<R>() {
+
+        @Override
+        public void onError(@Nullable ServiceCommandError error) {
+            logger.warn("{}: received error response: ", getClass().getName(), error);
+        }
+
+        @Override
+        public void onSuccess(R object) {
+            logger.debug("{}: {}.", getClass().getName(), object);
+        }
+    };
+
     // IP to Subscriptions map
-    private Map<String, ServiceSubscription<T>> subscriptions;
+    private Map<String, ServiceSubscription<T>> subscriptions = new ConcurrentHashMap<>();
 
     // lazy init
     private synchronized Map<String, ServiceSubscription<T>> getSubscriptions() {
-        if (subscriptions == null) {
-            subscriptions = new ConcurrentHashMap<>();
-        }
         return subscriptions;
     }
 
@@ -56,6 +69,7 @@ abstract class BaseChannelHandler<T> implements ChannelHandler {
         removeAnySubscription(device);
         if (handler.isChannelInUse(channelId)) { // only listen if least one item is configured for this channel
             Optional<ServiceSubscription<T>> listener = getSubscription(device, channelId, handler);
+
             if (listener.isPresent()) {
                 logger.debug("Subscribed {} on IP: {}", this.getClass().getName(), device.getIpAddress());
                 getSubscriptions().put(device.getIpAddress(), listener.get());
@@ -79,28 +93,15 @@ abstract class BaseChannelHandler<T> implements ChannelHandler {
 
     @Override
     public final synchronized void removeAnySubscription(ConnectableDevice device) {
-        if (subscriptions != null) { // only if subscriptions was initialized (lazy loading)
-            ServiceSubscription<T> l = subscriptions.remove(device.getIpAddress());
-            if (l != null) {
-                l.unsubscribe();
-                logger.debug("Unsubscribed {} on IP: {}", this.getClass().getName(), device.getIpAddress());
-            }
+        ServiceSubscription<T> l = subscriptions.remove(device.getIpAddress());
+
+        if (l != null) {
+            l.unsubscribe();
+            logger.debug("Unsubscribed {} on IP: {}", this.getClass().getName(), device.getIpAddress());
         }
     }
 
-    protected <O> ResponseListener<O> createDefaultResponseListener() {
-        return new ResponseListener<O>() {
-
-            @Override
-            public void onError(ServiceCommandError error) {
-                logger.warn("{}: received error response: ", BaseChannelHandler.this.getClass().getName(), error);
-            }
-
-            @Override
-            public void onSuccess(O object) {
-                logger.debug("{}: {}.", BaseChannelHandler.this.getClass().getName(), object);
-            }
-        };
+    protected ResponseListener<R> getDefaultResponseListener() {
+        return defaultResponseListener;
     }
-
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/ChannelHandler.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/ChannelHandler.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.lgwebos.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
 
@@ -18,6 +20,7 @@ import com.connectsdk.device.ConnectableDevice;
  *
  * @author Sebastian Prehn - initial contribution
  */
+@NonNullByDefault
 public interface ChannelHandler {
 
     /**
@@ -29,7 +32,8 @@ public interface ChannelHandler {
      * @param handler must not be <code>null</code>
      * @param command must not be <code>null</code>
      */
-    void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command);
+    void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command);
 
     /**
      * Handle underlying subscription status if device changes online state, capabilities or channel gets linked or

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/MediaControlPlayer.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/MediaControlPlayer.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.lgwebos.internal;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.NextPreviousType;
 import org.eclipse.smarthome.core.library.types.PlayPauseType;
 import org.eclipse.smarthome.core.library.types.RewindFastforwardType;
@@ -27,7 +28,7 @@ import com.connectsdk.service.capability.PlaylistControl;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class MediaControlPlayer extends BaseChannelHandler<PlayStateListener> {
+public class MediaControlPlayer extends BaseChannelHandler<PlayStateListener, Object> {
     private final Logger logger = LoggerFactory.getLogger(MediaControlPlayer.class);
 
     private MediaControl getMediaControl(ConnectableDevice device) {
@@ -39,33 +40,34 @@ public class MediaControlPlayer extends BaseChannelHandler<PlayStateListener> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             return;
         }
         if (NextPreviousType.NEXT == command) {
             if (device.hasCapabilities(PlaylistControl.Next)) {
-                getPlayListControl(device).next(createDefaultResponseListener());
+                getPlayListControl(device).next(getDefaultResponseListener());
             }
         } else if (NextPreviousType.PREVIOUS == command) {
             if (device.hasCapabilities(PlaylistControl.Previous)) {
-                getPlayListControl(device).previous(createDefaultResponseListener());
+                getPlayListControl(device).previous(getDefaultResponseListener());
             }
         } else if (PlayPauseType.PLAY == command) {
             if (device.hasCapabilities(MediaControl.Play)) {
-                getMediaControl(device).play(createDefaultResponseListener());
+                getMediaControl(device).play(getDefaultResponseListener());
             }
         } else if (PlayPauseType.PAUSE == command) {
             if (device.hasCapabilities(MediaControl.Pause)) {
-                getMediaControl(device).pause(createDefaultResponseListener());
+                getMediaControl(device).pause(getDefaultResponseListener());
             }
         } else if (RewindFastforwardType.FASTFORWARD == command) {
             if (device.hasCapabilities(MediaControl.FastForward)) {
-                getMediaControl(device).fastForward(createDefaultResponseListener());
+                getMediaControl(device).fastForward(getDefaultResponseListener());
             }
         } else if (RewindFastforwardType.REWIND == command) {
             if (device.hasCapabilities(MediaControl.Rewind)) {
-                getMediaControl(device).rewind(createDefaultResponseListener());
+                getMediaControl(device).rewind(getDefaultResponseListener());
             }
         } else {
             logger.warn("Only accept NextPreviousType, PlayPauseType, RewindFastforwardType. Type was {}.",

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/MediaControlStop.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/MediaControlStop.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.lgwebos.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
 
@@ -19,19 +21,21 @@ import com.connectsdk.service.capability.MediaControl;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class MediaControlStop extends BaseChannelHandler<Void> {
+@NonNullByDefault
+public class MediaControlStop extends BaseChannelHandler<Void, Object> {
 
     private MediaControl getControl(ConnectableDevice device) {
         return device.getCapability(MediaControl.class);
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             return;
         }
         if (device.hasCapabilities(MediaControl.Stop)) {
-            getControl(device).stop(createDefaultResponseListener());
+            getControl(device).stop(getDefaultResponseListener());
         }
     }
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/PowerControlPower.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/PowerControlPower.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.lgwebos.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
@@ -23,7 +25,8 @@ import com.connectsdk.service.capability.PowerControl;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class PowerControlPower extends BaseChannelHandler<Void> {
+@NonNullByDefault
+public class PowerControlPower extends BaseChannelHandler<Void, Object> {
     private final Logger logger = LoggerFactory.getLogger(PowerControlPower.class);
 
     private PowerControl getControl(ConnectableDevice device) {
@@ -31,7 +34,8 @@ public class PowerControlPower extends BaseChannelHandler<Void> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             /*
              * Unable to send anything to a null device. Unless the user configured autoupdate="false" neither
@@ -44,25 +48,22 @@ public class PowerControlPower extends BaseChannelHandler<Void> {
 
         if (OnOffType.ON == command || OnOffType.OFF == command) {
             if (OnOffType.ON == command && device.hasCapabilities(PowerControl.On)) {
-                getControl(device).powerOn(createDefaultResponseListener());
+                getControl(device).powerOn(getDefaultResponseListener());
             } else if (OnOffType.OFF == command && device.hasCapabilities(PowerControl.Off)) {
-                getControl(device).powerOff(createDefaultResponseListener());
+                getControl(device).powerOff(getDefaultResponseListener());
             }
         } else {
-            logger.warn("only accept OnOffType");
-            return;
+            logger.warn("Only accept OnOffType");
         }
     }
 
     @Override
     public void onDeviceReady(ConnectableDevice device, String channelId, LGWebOSHandler handler) {
-        super.onDeviceReady(device, channelId, handler);
         handler.postUpdate(channelId, OnOffType.ON);
     }
 
     @Override
     public void onDeviceRemoved(ConnectableDevice device, String channelId, LGWebOSHandler handler) {
-        super.onDeviceRemoved(device, channelId, handler);
         handler.postUpdate(channelId, OnOffType.OFF);
     }
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/TVControlChannelName.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/TVControlChannelName.java
@@ -10,8 +10,11 @@ package org.openhab.binding.lgwebos.internal;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +32,8 @@ import com.connectsdk.service.command.ServiceSubscription;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class TVControlChannelName extends BaseChannelHandler<ChannelListener> {
+@NonNullByDefault
+public class TVControlChannelName extends BaseChannelHandler<ChannelListener, Object> {
     private final Logger logger = LoggerFactory.getLogger(TVControlChannelName.class);
 
     private TVControl getControl(ConnectableDevice device) {
@@ -37,7 +41,8 @@ public class TVControlChannelName extends BaseChannelHandler<ChannelListener> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         // nothing to do, this is read only.
     }
 
@@ -48,17 +53,18 @@ public class TVControlChannelName extends BaseChannelHandler<ChannelListener> {
             return Optional.of(getControl(device).subscribeCurrentChannel(new ChannelListener() {
 
                 @Override
-                public void onError(ServiceCommandError error) {
+                public void onError(@Nullable ServiceCommandError error) {
                     logger.debug("{} {} {}", error.getCode(), error.getPayload(), error.getMessage());
+                    handler.postUpdate(channelId, UnDefType.UNDEF);
                 }
 
                 @Override
-                public void onSuccess(ChannelInfo channelInfo) {
+                public void onSuccess(@Nullable ChannelInfo channelInfo) {
                     handler.postUpdate(channelId, new StringType(channelInfo.getName()));
                 }
             }));
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/ToastControlToast.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/ToastControlToast.java
@@ -17,6 +17,8 @@ import java.util.Base64;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
 import org.slf4j.Logger;
@@ -30,7 +32,8 @@ import com.connectsdk.service.capability.ToastControl;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class ToastControlToast extends BaseChannelHandler<Void> {
+@NonNullByDefault
+public class ToastControlToast extends BaseChannelHandler<Void, Object> {
     private final Logger logger = LoggerFactory.getLogger(ToastControlToast.class);
 
     private ToastControl getControl(ConnectableDevice device) {
@@ -38,7 +41,8 @@ public class ToastControlToast extends BaseChannelHandler<Void> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             return;
         }
@@ -51,7 +55,7 @@ public class ToastControlToast extends BaseChannelHandler<Void> {
                         OutputStream b64 = Base64.getEncoder().wrap(os);) {
                     ImageIO.write(bi, "png", b64);
                     control.showToast(value, os.toString(StandardCharsets.UTF_8.name()), "png",
-                            createDefaultResponseListener());
+                            getDefaultResponseListener());
                 }
             } catch (IOException ex) {
                 logger.warn("Failed to load toast icon: {}", ex.getMessage());

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlMute.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlMute.java
@@ -10,6 +10,8 @@ package org.openhab.binding.lgwebos.internal;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.lgwebos.handler.LGWebOSHandler;
@@ -27,7 +29,8 @@ import com.connectsdk.service.command.ServiceSubscription;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class VolumeControlMute extends BaseChannelHandler<MuteListener> {
+@NonNullByDefault
+public class VolumeControlMute extends BaseChannelHandler<MuteListener, Object> {
     private final Logger logger = LoggerFactory.getLogger(VolumeControlMute.class);
 
     private VolumeControl getControl(ConnectableDevice device) {
@@ -35,16 +38,17 @@ public class VolumeControlMute extends BaseChannelHandler<MuteListener> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             return;
         }
         if (OnOffType.ON == command || OnOffType.OFF == command) {
             if (device.hasCapabilities(VolumeControl.Mute_Set)) {
-                getControl(device).setMute(OnOffType.ON == command, createDefaultResponseListener());
+                getControl(device).setMute(OnOffType.ON == command, getDefaultResponseListener());
             }
         } else {
-            logger.warn("only accept OnOffType");
+            logger.warn("Only accept OnOffType");
         }
     }
 
@@ -55,17 +59,17 @@ public class VolumeControlMute extends BaseChannelHandler<MuteListener> {
             return Optional.of(getControl(device).subscribeMute(new MuteListener() {
 
                 @Override
-                public void onError(ServiceCommandError error) {
+                public void onError(@Nullable ServiceCommandError error) {
                     logger.debug("{} {} {}", error.getCode(), error.getPayload(), error.getMessage());
                 }
 
                 @Override
-                public void onSuccess(Boolean value) {
-                    handler.postUpdate(channelId, value ? OnOffType.ON : OnOffType.OFF);
+                public void onSuccess(@Nullable Boolean value) {
+                    handler.postUpdate(channelId, OnOffType.from(value));
                 }
             }));
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
@@ -10,6 +10,7 @@ package org.openhab.binding.lgwebos.internal;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -32,7 +33,7 @@ import com.connectsdk.service.command.ServiceSubscription;
  *
  * @author Sebastian Prehn - initial contribution
  */
-public class VolumeControlVolume extends BaseChannelHandler<VolumeListener> {
+public class VolumeControlVolume extends BaseChannelHandler<VolumeListener, Object> {
     private final Logger logger = LoggerFactory.getLogger(VolumeControlVolume.class);
 
     private VolumeControl getControl(ConnectableDevice device) {
@@ -40,7 +41,8 @@ public class VolumeControlVolume extends BaseChannelHandler<VolumeListener> {
     }
 
     @Override
-    public void onReceiveCommand(ConnectableDevice device, String channelId, LGWebOSHandler handler, Command command) {
+    public void onReceiveCommand(@Nullable ConnectableDevice device, String channelId, LGWebOSHandler handler,
+            Command command) {
         if (device == null) {
             return;
         }
@@ -54,23 +56,22 @@ public class VolumeControlVolume extends BaseChannelHandler<VolumeListener> {
         }
         if (percent != null) {
             if (device.hasCapabilities(VolumeControl.Volume_Set)) {
-                getControl(device).setVolume(percent.floatValue() / 100.0f, createDefaultResponseListener());
+                getControl(device).setVolume(percent.floatValue() / 100.0f, getDefaultResponseListener());
             }
         } else if (IncreaseDecreaseType.INCREASE == command) {
             if (device.hasCapabilities(VolumeControl.Volume_Up_Down)) {
-                getControl(device).volumeUp(createDefaultResponseListener());
+                getControl(device).volumeUp(getDefaultResponseListener());
             }
         } else if (IncreaseDecreaseType.DECREASE == command) {
             if (device.hasCapabilities(VolumeControl.Volume_Up_Down)) {
-                getControl(device).volumeDown(createDefaultResponseListener());
+                getControl(device).volumeDown(getDefaultResponseListener());
             }
         } else if (OnOffType.OFF == command || OnOffType.ON == command) {
             if (device.hasCapabilities(VolumeControl.Mute_Set)) {
-                getControl(device).setMute(OnOffType.OFF == command, createDefaultResponseListener());
+                getControl(device).setMute(OnOffType.OFF == command, getDefaultResponseListener());
             }
         } else {
-            logger.warn(
-                    "Only accept PercentType, DecimalType, StringType, OnOffType, IncreaseDecreaseType. Type was {}.",
+            logger.warn("Only accept PercentType, DecimalType, StringType command. Command was {}({}).", command,
                     command.getClass());
         }
     }
@@ -92,7 +93,7 @@ public class VolumeControlVolume extends BaseChannelHandler<VolumeListener> {
                 }
             }));
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
+++ b/addons/binding/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/discovery/LGWebOSDiscovery.java
@@ -40,7 +40,7 @@ import com.connectsdk.service.command.ServiceCommandError;
 /**
  * This class provides the bridges between openhab thing discovery and connect sdk device discovery.
  *
- * @author Sebastian Prehn
+ * @author Sebastian Prehn - initial contribution
  */
 @Component(service = { DiscoveryService.class,
         LGWebOSDiscovery.class }, immediate = true, configurationPid = "binding.lgwebos")
@@ -71,7 +71,8 @@ public class LGWebOSDiscovery extends AbstractDiscoveryService implements Discov
     @Override
     protected void activate(Map<String, Object> configProperties) {
         logger.debug("Config Parameters: {}", configProperties);
-        localInetAddressesOverride = evaluateConfigPropertyLocalIP((String) configProperties.get("localIP"));
+        localInetAddressesOverride = evaluateConfigPropertyLocalIP(
+                (String) configProperties.get(BINDING_CONFIGURATION_LOCALIP));
         Util.init(scheduler);
         discoveryManager = DiscoveryManager.getInstance();
         discoveryManager.setPairingLevel(DiscoveryManager.PairingLevel.ON);


### PR DESCRIPTION
Closes #3903

Method getSubscription expects an optional, but most implementing classes returned a null if the capability was not supported.
Also:
- Cleanup of constants
- Added @NonNullByDefault
- Made the default response listener a final field method instead of creating one on each and every handle command call.