### PR TITLE
[dsmr] Changed when meter is set offline on no cosem values available.

### DIFF
--- a/addons/binding/org.openhab.binding.dsmr.test/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.dsmr.test/META-INF/MANIFEST.MF
@@ -33,6 +33,6 @@ Import-Package:
  org.osgi.service.component,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.eclipse.smarthome.core,
+Require-Bundle: 
  org.hamcrest,
  org.junit

--- a/addons/binding/org.openhab.binding.dsmr.test/src/test/java/org/openhab/binding/dsmr/internal/TelegramReaderUtil.java
+++ b/addons/binding/org.openhab.binding.dsmr.test/src/test/java/org/openhab/binding/dsmr/internal/TelegramReaderUtil.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.dsmr.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,20 +38,17 @@ public final class TelegramReaderUtil {
      * @return The raw bytes of a telegram
      */
     public static byte[] readRawTelegram(String telegramName) {
-        byte[] telegram = null;
-
         try (InputStream is = TelegramReaderUtil.class.getResourceAsStream(telegramName + TELEGRAM_EXT)) {
-            telegram = IOUtils.toByteArray(is);
+            return IOUtils.toByteArray(is);
         } catch (IOException e) {
-            fail("IOException reading telegram data:" + e);
+            throw new AssertionError("IOException reading telegram data: ", e);
         }
-        return telegram;
     }
 
     /**
      * Reads a telegram given the file relative to this package and returns the objects.
      *
-     * @param telegramName          name of the telegram file to read
+     * @param telegramName name of the telegram file to read
      * @param expectedTelegramState expected state of the telegram read
      * @return a P1Telegram object
      */


### PR DESCRIPTION
Instead of setting meter offline when updateState is called it's now set offline when no cosem values in received telegram. If no values are available there will simply by no update done. When no messages were received at all the meter will still go offline because this is monitored by the bridge. This was how it already worked, and what should trigger the offline status. This fixes the problem that the meter will go offline if the refresh rate is set to a value lower than the actual speed with which the messages are send by the meter. Closes #3920

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>