### PR TITLE
Removed forbidden import 'com.google.common.base' in MANIFEST files where not needed

### DIFF
--- a/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Bundle-SymbolicName: org.openhab.binding.freebox;singleton:=true
 Bundle-Vendor: openHAB
 Bundle-Version: 2.4.0.qualifier
 Import-Package: 
- com.google.common.base,
  com.google.common.collect,
  javax.jmdns,
  javax.net,

--- a/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Bundle-SymbolicName: org.openhab.binding.harmonyhub;singleton:=true
 Bundle-Vendor: openHAB
 Bundle-Version: 2.4.0.qualifier
 Import-Package: 
- com.google.common.base,
  com.google.common.collect,
  com.google.common.io,
  com.google.inject,


### PR DESCRIPTION
- Removed forbidden import 'com.google.common.base' in MANIFEST files where not needed

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>