### PR TITLE
[modbus] Expose modbus exceptions

### DIFF
--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
@@ -93,9 +93,6 @@ abstract public class ModbusSlaveErrorResponseException extends ModbusTransportE
      */
     public static final int GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND = 11;
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -1435199498550990487L;
 
     /**

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
@@ -14,14 +14,93 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * Exception for explicit exception responses from Modbus slave
  *
  * @author Sami Salonen - Initial contribution
+ * @author Nagy Attila Gabor - added getter for error type
  *
  */
 @NonNullByDefault
-public class ModbusSlaveErrorResponseException extends ModbusTransportException {
+abstract public class ModbusSlaveErrorResponseException extends ModbusTransportException {
+
+    /**
+     * The function code received in the query is not an allowable action for the slave. This may be because the
+     * function code is only applicable to newer devices, and was not implemented in the unit selected. It could also
+     * indicate that the slave is in the wrong state to process a request of this type, for example because it is
+     * unconfigured and is being asked to return register values. If a Poll Program Complete command was issued, this
+     * code indicates that no program function preceded it.
+     */
+    public static final int ILLEGAL_FUNCTION = 1;
+
+    /**
+     * The data address received in the query is not an allowable address for the slave. More specifically, the
+     * combination of reference number and transfer length is invalid. For a controller with 100 registers, a request
+     * with offset 96 and length 4 would succeed, a request with offset 96 and length 5 will generate exception 02.
+     */
+    public static final int ILLEGAL_DATA_ACCESS = 2;
+
+    /**
+     * A value contained in the query data field is not an allowable value for the slave. This indicates a fault in the
+     * structure of remainder of a complex request, such as that the implied length is incorrect. It specifically does
+     * NOT mean that a data item submitted for storage in a register has a value outside the expectation of the
+     * application program, since the MODBUS protocol is unaware of the significance of any particular value of any
+     * particular register.
+     */
+    public static final int ILLEGAL_DATA_VALUE = 3;
+
+    /**
+     * An unrecoverable error occurred while the slave was attempting to perform the requested action.
+     */
+    public static final int SLAVE_DEVICE_FAILURE = 4;
+
+    /**
+     * Specialized use in conjunction with programming commands.
+     * The slave has accepted the request and is processing it, but a long duration of time will be required to do so.
+     * This response is returned to prevent a timeout error from occurring in the master. The master can next issue a
+     * Poll Program Complete message to determine if processing is completed.
+     */
+    public static final int ACKNOWLEDGE = 5;
+
+    /**
+     * Specialized use in conjunction with programming commands.
+     * The slave is engaged in processing a long-duration program command. The master should retransmit the message
+     * later when the slave is free..
+     */
+    public static final int SLAVE_DEVICE_BUSY = 6;
+
+    /**
+     * The slave cannot perform the program function received in the query. This code is returned for an unsuccessful
+     * programming request using function code 13 or 14 decimal. The master should request diagnostic or error
+     * information from the slave.
+     */
+    public static final int NEGATIVE_ACKNOWLEDGE = 7;
+
+    /**
+     * Specialized use in conjunction with function codes 20 and 21 and reference type 6, to indicate that the extended
+     * file area failed to pass a consistency check.
+     * The slave attempted to read extended memory or record file, but detected a parity error in memory. The master can
+     * retry the request, but service may be required on the slave device.
+     */
+    public static final int MEMORY_PARITY_ERROR = 8;
+
+    /**
+     * Specialized use in conjunction with gateways, indicates that the gateway was unable to allocate an internal
+     * communication path from the input port to the output port for processing the request. Usually means the gateway
+     * is misconfigured or overloaded.
+     */
+    public static final int GATEWAY_PATH_UNVAVAILABLE = 10;
+
+    /**
+     * Specialized use in conjunction with gateways, indicates that no response was obtained from the target device.
+     * Usually means that the device is not present on the network.
+     */
+    public static final int GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND = 11;
 
     /**
      *
      */
     private static final long serialVersionUID = -1435199498550990487L;
+
+    /**
+     * @return the modbus exception code that happened
+     */
+    abstract public int getExceptionCode();
 
 }

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusSlaveErrorResponseException.java
@@ -40,7 +40,7 @@ abstract public class ModbusSlaveErrorResponseException extends ModbusTransportE
      * A value contained in the query data field is not an allowable value for the slave. This indicates a fault in the
      * structure of remainder of a complex request, such as that the implied length is incorrect. It specifically does
      * NOT mean that a data item submitted for storage in a register has a value outside the expectation of the
-     * application program, since the MODBUS protocol is unaware of the significance of any particular value of any
+     * application program, since the Modbus protocol is unaware of the significance of any particular value of any
      * particular register.
      */
     public static final int ILLEGAL_DATA_VALUE = 3;
@@ -61,7 +61,7 @@ abstract public class ModbusSlaveErrorResponseException extends ModbusTransportE
     /**
      * Specialized use in conjunction with programming commands.
      * The slave is engaged in processing a long-duration program command. The master should retransmit the message
-     * later when the slave is free..
+     * later when the slave is free.
      */
     public static final int SLAVE_DEVICE_BUSY = 6;
 
@@ -99,7 +99,7 @@ abstract public class ModbusSlaveErrorResponseException extends ModbusTransportE
     private static final long serialVersionUID = -1435199498550990487L;
 
     /**
-     * @return the modbus exception code that happened
+     * @return the Modbus exception code that happened
      */
     abstract public int getExceptionCode();
 

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
@@ -31,7 +31,7 @@ public class ModbusSlaveErrorResponseExceptionImpl extends ModbusSlaveErrorRespo
     }
 
     /**
-     * @return the modbus exception code that happened
+     * @return the Modbus exception code that happened
      */
     @Override
     public int getExceptionCode() {

--- a/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
+++ b/addons/io/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
@@ -17,6 +17,7 @@ import net.wimpi.modbus.ModbusSlaveException;
  * Exception for explicit exception responses from Modbus slave
  *
  * @author Sami Salonen - Initial contribution
+ * @author Nagy Attila Gabor - added getter for error type
  *
  */
 @NonNullByDefault
@@ -27,6 +28,14 @@ public class ModbusSlaveErrorResponseExceptionImpl extends ModbusSlaveErrorRespo
 
     public ModbusSlaveErrorResponseExceptionImpl(ModbusSlaveException e) {
         type = e.getType();
+    }
+
+    /**
+     * @return the modbus exception code that happened
+     */
+    @Override
+    public int getExceptionCode() {
+        return type;
     }
 
     @Override


### PR DESCRIPTION
This is a minor addition to the modbus transport.

The modbus protocol uses a custom error handling method, where a few predefined exceptions can be sent to the master by the salve when it can not fulfill the request. These exception codes will tell the master what is the exact cause of the failure.

The modbus implementation in the master branch failed to expose this value, and that made writing sophisticated error handling impossible.

This change is related to an upcoming extension of the modbus addon, see #3216 