### PR TITLE
[modbus] Export thing handler interface for upcoming bundles

### DIFF
--- a/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
+++ b/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
@@ -83,11 +83,13 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.internal.ModbusBindingConstants;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
 import org.openhab.binding.modbus.internal.handler.ModbusPollerThingHandler;
 import org.openhab.binding.modbus.internal.handler.ModbusPollerThingHandlerImpl;
 import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
+import org.openhab.io.transport.modbus.BasicModbusRegister;
+import org.openhab.io.transport.modbus.BasicModbusRegisterArray;
 import org.openhab.io.transport.modbus.BitArray;
 import org.openhab.io.transport.modbus.ModbusConstants;
 import org.openhab.io.transport.modbus.ModbusConstants.ValueType;
@@ -96,8 +98,6 @@ import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
 import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
 import org.openhab.io.transport.modbus.ModbusRegister;
 import org.openhab.io.transport.modbus.ModbusRegisterArray;
-import org.openhab.io.transport.modbus.BasicModbusRegisterArray;
-import org.openhab.io.transport.modbus.BasicModbusRegister;
 import org.openhab.io.transport.modbus.ModbusResponse;
 import org.openhab.io.transport.modbus.ModbusWriteCoilRequestBlueprint;
 import org.openhab.io.transport.modbus.ModbusWriteFunctionCode;
@@ -225,13 +225,13 @@ public class ModbusDataHandlerTest extends JavaTest {
 
     private static final Map<String, Class<? extends Item>> channelToItemClass = new HashMap<>();
     static {
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_SWITCH, SwitchItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_CONTACT, ContactItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_DATETIME, DateTimeItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_DIMMER, DimmerItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_NUMBER, NumberItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_STRING, StringItem.class);
-        channelToItemClass.put(ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, RollershutterItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_SWITCH, SwitchItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_CONTACT, ContactItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_DATETIME, DateTimeItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_DIMMER, DimmerItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_NUMBER, NumberItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_STRING, StringItem.class);
+        channelToItemClass.put(ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER, RollershutterItem.class);
     }
 
     private List<Thing> things = new ArrayList<>();
@@ -256,15 +256,17 @@ public class ModbusDataHandlerTest extends JavaTest {
     Map<ChannelUID, List<State>> stateUpdates = new HashMap<>();
 
     private Map<String, String> channelToAcceptedType = ImmutableMap.<String, String> builder()
-            .put(ModbusBindingConstants.CHANNEL_SWITCH, "Switch").put(ModbusBindingConstants.CHANNEL_CONTACT, "Contact")
-            .put(ModbusBindingConstants.CHANNEL_DATETIME, "DateTime")
-            .put(ModbusBindingConstants.CHANNEL_DIMMER, "Dimmer").put(ModbusBindingConstants.CHANNEL_NUMBER, "Number")
-            .put(ModbusBindingConstants.CHANNEL_STRING, "String")
-            .put(ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, "Rollershutter")
-            .put(ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS, "DateTime")
-            .put(ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS, "DateTime")
-            .put(ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR, "DateTime")
-            .put(ModbusBindingConstants.CHANNEL_LAST_READ_ERROR, "DateTime").build();
+            .put(ModbusBindingConstantsInternal.CHANNEL_SWITCH, "Switch")
+            .put(ModbusBindingConstantsInternal.CHANNEL_CONTACT, "Contact")
+            .put(ModbusBindingConstantsInternal.CHANNEL_DATETIME, "DateTime")
+            .put(ModbusBindingConstantsInternal.CHANNEL_DIMMER, "Dimmer")
+            .put(ModbusBindingConstantsInternal.CHANNEL_NUMBER, "Number")
+            .put(ModbusBindingConstantsInternal.CHANNEL_STRING, "String")
+            .put(ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER, "Rollershutter")
+            .put(ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS, "DateTime")
+            .put(ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS, "DateTime")
+            .put(ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR, "DateTime")
+            .put(ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR, "DateTime").build();
 
     private void registerThingToMockRegistry(Thing thing) {
         things.add(thing);
@@ -330,8 +332,8 @@ public class ModbusDataHandlerTest extends JavaTest {
     private Bridge createPollerMock(String pollerId, PollTask task) {
 
         final Bridge poller;
-        ThingUID thingUID = new ThingUID(ModbusBindingConstants.THING_TYPE_MODBUS_POLLER, pollerId);
-        BridgeBuilder builder = BridgeBuilder.create(ModbusBindingConstants.THING_TYPE_MODBUS_POLLER, thingUID)
+        ThingUID thingUID = new ThingUID(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_POLLER, pollerId);
+        BridgeBuilder builder = BridgeBuilder.create(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_POLLER, thingUID)
                 .withLabel("label for " + pollerId);
         for (Entry<String, String> entry : channelToAcceptedType.entrySet()) {
             String channelId = entry.getKey();
@@ -379,8 +381,8 @@ public class ModbusDataHandlerTest extends JavaTest {
     private ModbusDataThingHandler createDataHandler(String id, Bridge bridge,
             Function<ThingBuilder, ThingBuilder> builderConfigurator, BundleContext context,
             boolean autoCreateItemsAndLinkToChannels) {
-        ThingUID thingUID = new ThingUID(ModbusBindingConstants.THING_TYPE_MODBUS_DATA, id);
-        ThingBuilder builder = ThingBuilder.create(ModbusBindingConstants.THING_TYPE_MODBUS_DATA, thingUID)
+        ThingUID thingUID = new ThingUID(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_DATA, id);
+        ThingBuilder builder = ThingBuilder.create(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_DATA, thingUID)
                 .withLabel("label for " + id);
         for (Entry<String, String> entry : channelToAcceptedType.entrySet()) {
             String channelId = entry.getKey();
@@ -701,31 +703,32 @@ public class ModbusDataHandlerTest extends JavaTest {
 
         assertThat(stateUpdates.size(), is(equalTo(1)));
         assertThat(
-                stateUpdates.get(
-                        dataHandler.getThing().getChannel(ModbusBindingConstants.CHANNEL_LAST_READ_ERROR).getUID()),
+                stateUpdates.get(dataHandler.getThing()
+                        .getChannel(ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR).getUID()),
                 is(notNullValue()));
     }
 
     @Test
     public void testOnRegistersInt16StaticTransformation() {
         ModbusDataThingHandler dataHandler = testReadHandlingGeneric(ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS,
-                "0", "-3", ModbusConstants.ValueType.INT16, null,
-                new BasicModbusRegisterArray(new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
+                "0", "-3", ModbusConstants.ValueType.INT16, null, new BasicModbusRegisterArray(
+                        new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
                 null);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR,
                 is(nullValue(State.class)));
 
         // -3 converts to "true"
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_CONTACT, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_SWITCH, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_DIMMER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_NUMBER, new DecimalType(-3));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_CONTACT,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_SWITCH, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_DIMMER, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_NUMBER, new DecimalType(-3));
         // roller shutter fails since -3 is invalid value (not between 0...100)
-        // assertThatStateContains(state, ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, new PercentType(1));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_STRING, new StringType("-3"));
+        // assertThatStateContains(state, ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER, new PercentType(1));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_STRING, new StringType("-3"));
         // no datetime, conversion not possible without transformation
     }
 
@@ -746,22 +749,25 @@ public class ModbusDataHandlerTest extends JavaTest {
         });
         ModbusDataThingHandler dataHandler = testReadHandlingGeneric(ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS,
                 "0", "MULTIPLY(10)", ModbusConstants.ValueType.INT16, null,
-                new BasicModbusRegisterArray(new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
+                new BasicModbusRegisterArray(
+                        new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
                 null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR,
                 is(nullValue(State.class)));
 
         // -3 converts to "true"
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_CONTACT, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_SWITCH, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_DIMMER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_NUMBER, new DecimalType(-30));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_CONTACT,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_SWITCH, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_DIMMER, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_NUMBER, new DecimalType(-30));
         // roller shutter fails since -3 is invalid value (not between 0...100)
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_STRING, new StringType("-30"));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_STRING, new StringType("-30"));
         // no datetime, conversion not possible without transformation
     }
 
@@ -776,23 +782,26 @@ public class ModbusDataHandlerTest extends JavaTest {
         });
         ModbusDataThingHandler dataHandler = testReadHandlingGeneric(ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS,
                 "0", "MULTIPLY(10)", ModbusConstants.ValueType.INT16, null,
-                new BasicModbusRegisterArray(new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
+                new BasicModbusRegisterArray(
+                        new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
                 null, bundleContext,
                 // Not linking items and channels
                 false);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR,
                 is(nullValue(State.class)));
 
         // Since channles are not linked, they are not updated (are null)
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_CONTACT, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_SWITCH, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_DIMMER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_NUMBER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_STRING, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_CONTACT,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_SWITCH, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_DIMMER, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_NUMBER, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_STRING, is(nullValue(State.class)));
     }
 
     @Test
@@ -806,20 +815,24 @@ public class ModbusDataHandlerTest extends JavaTest {
         });
         ModbusDataThingHandler dataHandler = testReadHandlingGeneric(ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS,
                 "0", "ONOFF(10)", ModbusConstants.ValueType.INT16, null,
-                new BasicModbusRegisterArray(new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
+                new BasicModbusRegisterArray(
+                        new ModbusRegister[] { new BasicModbusRegister((byte) 0xff, (byte) 0xfd) }),
                 null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_READ_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR,
                 is(nullValue(State.class)));
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_CONTACT, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_SWITCH, is(equalTo(OnOffType.ON)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_DIMMER, is(equalTo(OnOffType.ON)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_NUMBER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_ROLLERSHUTTER, is(nullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_STRING, is(equalTo(new StringType("ON"))));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_CONTACT,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_SWITCH, is(equalTo(OnOffType.ON)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_DIMMER, is(equalTo(OnOffType.ON)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_NUMBER, is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER,
+                is(nullValue(State.class)));
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_STRING,
+                is(equalTo(new StringType("ON"))));
     }
 
     @Test
@@ -835,9 +848,9 @@ public class ModbusDataHandlerTest extends JavaTest {
                 ModbusConstants.ValueType.BIT, "coil", ModbusWriteFunctionCode.WRITE_COIL, "number",
                 new DecimalType("2"), null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR,
                 is(nullValue(State.class)));
         assertThat(writeTasks.size(), is(equalTo(1)));
         WriteTask writeTask = writeTasks.get(0);
@@ -861,9 +874,9 @@ public class ModbusDataHandlerTest extends JavaTest {
                 ModbusConstants.ValueType.BIT, "coil", ModbusWriteFunctionCode.WRITE_COIL, "number",
                 new DecimalType("2"), null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR,
                 is(nullValue(State.class)));
         assertThat(writeTasks.size(), is(equalTo(1)));
         WriteTask writeTask = writeTasks.get(0);
@@ -887,9 +900,9 @@ public class ModbusDataHandlerTest extends JavaTest {
                 ModbusConstants.ValueType.INT16, "holding", ModbusWriteFunctionCode.WRITE_SINGLE_REGISTER, "number",
                 new DecimalType("2"), null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR,
                 is(nullValue(State.class)));
         assertThat(writeTasks.size(), is(equalTo(1)));
         WriteTask writeTask = writeTasks.get(0);
@@ -932,9 +945,9 @@ public class ModbusDataHandlerTest extends JavaTest {
                 ModbusConstants.ValueType.INT16, "holding", ModbusWriteFunctionCode.WRITE_MULTIPLE_REGISTERS, "number",
                 new DecimalType("2"), null, bundleContext);
 
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS,
                 is(notNullValue(State.class)));
-        assertSingleStateUpdate(dataHandler, ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR,
+        assertSingleStateUpdate(dataHandler, ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR,
                 is(nullValue(State.class)));
         assertThat(writeTasks.size(), is(equalTo(2)));
         {

--- a/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
+++ b/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
@@ -45,7 +45,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.internal.ModbusBindingConstants;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
 import org.openhab.binding.modbus.internal.handler.ModbusPollerThingHandler;
 import org.openhab.binding.modbus.internal.handler.ModbusPollerThingHandlerImpl;
@@ -77,13 +77,13 @@ public class ModbusPollerThingHandlerTest {
     private ThingHandlerCallback thingCallback;
 
     public static BridgeBuilder createTcpThingBuilder(String id) {
-        return BridgeBuilder.create(ModbusBindingConstants.THING_TYPE_MODBUS_TCP,
-                new ThingUID(ModbusBindingConstants.THING_TYPE_MODBUS_TCP, id)).withLabel("label for " + id);
+        return BridgeBuilder.create(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_TCP,
+                new ThingUID(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_TCP, id)).withLabel("label for " + id);
     }
 
     public static BridgeBuilder createPollerThingBuilder(String id) {
-        return BridgeBuilder.create(ModbusBindingConstants.THING_TYPE_MODBUS_POLLER,
-                new ThingUID(ModbusBindingConstants.THING_TYPE_MODBUS_POLLER, id)).withLabel("label for " + id);
+        return BridgeBuilder.create(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_POLLER,
+                new ThingUID(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_POLLER, id)).withLabel("label for " + id);
     }
 
     private void registerThingToMockRegistry(Thing thing) {
@@ -168,7 +168,7 @@ public class ModbusPollerThingHandlerTest {
         pollerConfig.put("refresh", 0L); // 0 -> non polling
         pollerConfig.put("start", 5);
         pollerConfig.put("length", 9);
-        pollerConfig.put("type", ModbusBindingConstants.READ_TYPE_HOLDING_REGISTER);
+        pollerConfig.put("type", ModbusBindingConstantsInternal.READ_TYPE_HOLDING_REGISTER);
         poller = createPollerThingBuilder("poller").withConfiguration(pollerConfig).withBridge(endpoint.getUID())
                 .build();
         registerThingToMockRegistry(poller);

--- a/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusTcpThingHandlerTest.java
+++ b/addons/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ModbusTcpThingHandlerTest.java
@@ -28,7 +28,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.internal.ModbusBindingConstants;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
 import org.openhab.io.transport.modbus.ModbusManager;
 import org.openhab.io.transport.modbus.endpoint.EndpointPoolConfiguration;
@@ -42,8 +42,8 @@ public class ModbusTcpThingHandlerTest {
     private ModbusManager modbusManager;
 
     private static BridgeBuilder createTcpThingBuilder(String id) {
-        return BridgeBuilder.create(ModbusBindingConstants.THING_TYPE_MODBUS_TCP,
-                new ThingUID(ModbusBindingConstants.THING_TYPE_MODBUS_TCP, id));
+        return BridgeBuilder.create(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_TCP,
+                new ThingUID(ModbusBindingConstantsInternal.THING_TYPE_MODBUS_TCP, id));
     }
 
     @SuppressWarnings("null")

--- a/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
@@ -23,4 +23,6 @@ Import-Package: org.apache.commons.lang,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.modbus,
+ org.openhab.binding.modbus.handler
 Bundle-ActivationPolicy: lazy

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingConstants.java
@@ -6,19 +6,20 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.modbus.internal.handler;
+package org.openhab.binding.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Signals that {@link ModbusEndpointThingHandler} is not properly initialized yet, and the requested operation cannot
- * be completed.
+ * The {@link ModbusBinding} class defines some constants
+ * public that might be used from other bundles as well.
  *
  * @author Sami Salonen - Initial contribution
+ * @author Nagy Attila Gabor - Split the original ModbusBindingConstants in two
  */
 @NonNullByDefault
-public class EndpointNotInitializedException extends Exception {
+public class ModbusBindingConstants {
 
-    private static final long serialVersionUID = -6721646244844348903L;
+    public static final String BINDING_ID = "modbus";
 
 }

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/EndpointNotInitializedException.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/EndpointNotInitializedException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.modbus.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Signals that {@link ModbusEndpointThingHandler} is not properly initialized yet, and the requested operation cannot
+ * be completed.
+ *
+ * @author Sami Salonen - Initial contribution
+ */
+@NonNullByDefault
+public class EndpointNotInitializedException extends Exception {
+
+    private static final long serialVersionUID = -6721646244844348903L;
+
+}

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusEndpointThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusEndpointThingHandler.java
@@ -6,7 +6,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.modbus.internal.handler;
+package org.openhab.binding.modbus.handler;
 
 import java.util.function.Supplier;
 

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstants.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.modbus.internal;
 
+import static org.openhab.binding.modbus.ModbusBindingConstants.BINDING_ID;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,8 +25,6 @@ import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
  */
 @NonNullByDefault
 public class ModbusBindingConstants {
-
-    public static final String BINDING_ID = "modbus";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_MODBUS_TCP = new ThingTypeUID(BINDING_ID, "tcp");

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstantsInternal.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstantsInternal.java
@@ -24,7 +24,7 @@ import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
  * @author Sami Salonen - Initial contribution
  */
 @NonNullByDefault
-public class ModbusBindingConstants {
+public class ModbusBindingConstantsInternal {
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_MODBUS_TCP = new ThingTypeUID(BINDING_ID, "tcp");

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusHandlerFactory.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.modbus.internal;
 
-import static org.openhab.binding.modbus.internal.ModbusBindingConstants.*;
+import static org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal.*;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.ModbusConfigurationException;
 import org.openhab.io.transport.modbus.ModbusManager;
 import org.openhab.io.transport.modbus.ModbusManagerListener;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.modbus.internal.handler;
 
-import static org.openhab.binding.modbus.internal.ModbusBindingConstants.*;
+import static org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal.*;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -48,7 +48,7 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
 import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
-import org.openhab.binding.modbus.internal.ModbusBindingConstants;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.ModbusConfigurationException;
 import org.openhab.binding.modbus.internal.Transformation;
 import org.openhab.binding.modbus.internal.config.ModbusDataConfiguration;
@@ -94,19 +94,19 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
     private static final Map<String, List<Class<? extends State>>> CHANNEL_ID_TO_ACCEPTED_TYPES = new HashMap<>();
 
     static {
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_SWITCH,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_SWITCH,
                 new SwitchItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_CONTACT,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_CONTACT,
                 new ContactItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_DATETIME,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_DATETIME,
                 new DateTimeItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_DIMMER,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_DIMMER,
                 new DimmerItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_NUMBER,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_NUMBER,
                 new NumberItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_STRING,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_STRING,
                 new StringItem("").getAcceptedDataTypes());
-        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstants.CHANNEL_ROLLERSHUTTER,
+        CHANNEL_ID_TO_ACCEPTED_TYPES.put(ModbusBindingConstantsInternal.CHANNEL_ROLLERSHUTTER,
                 new RollershutterItem("").getAcceptedDataTypes());
     }
 
@@ -694,7 +694,7 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
                     error.getMessage(), error);
         }
         Map<@NonNull ChannelUID, @NonNull State> states = new HashMap<>();
-        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstants.CHANNEL_LAST_READ_ERROR),
+        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR),
                 new DateTimeType());
 
         synchronized (this) {
@@ -729,7 +729,7 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
                     error.getMessage(), error);
         }
         Map<@NonNull ChannelUID, @NonNull State> states = new HashMap<>();
-        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstants.CHANNEL_LAST_WRITE_ERROR),
+        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR),
                 new DateTimeType());
 
         synchronized (this) {
@@ -754,7 +754,7 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
         logger.debug("Successful write, matching request {}", request);
         DateTimeType now = new DateTimeType();
         updateStatus(ThingStatus.ONLINE);
-        updateState(ModbusBindingConstants.CHANNEL_LAST_WRITE_SUCCESS, now);
+        updateState(ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_SUCCESS, now);
     }
 
     /**
@@ -815,7 +815,7 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
             }
         });
 
-        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstants.CHANNEL_LAST_READ_SUCCESS),
+        states.put(new ChannelUID(getThing().getUID(), ModbusBindingConstantsInternal.CHANNEL_LAST_READ_SUCCESS),
                 new DateTimeType());
 
         synchronized (this) {

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -46,6 +46,8 @@ import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.ModbusBindingConstants;
 import org.openhab.binding.modbus.internal.ModbusConfigurationException;
 import org.openhab.binding.modbus.internal.Transformation;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
@@ -32,7 +32,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
 import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.AtomicStampedKeyValue;
-import org.openhab.binding.modbus.internal.ModbusBindingConstants;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.config.ModbusPollerConfiguration;
 import org.openhab.io.transport.modbus.BitArray;
 import org.openhab.io.transport.modbus.ModbusManager;
@@ -224,14 +224,14 @@ public class ModbusPollerThingHandlerImpl extends BaseBridgeHandler implements M
     private static class ModbusPollerReadRequest extends BasicModbusReadRequestBlueprint {
 
         private static ModbusReadFunctionCode getFunctionCode(@Nullable String type) {
-            if (!ModbusBindingConstants.READ_FUNCTION_CODES.containsKey(type)) {
-                Object[] acceptedTypes = ModbusBindingConstants.READ_FUNCTION_CODES.keySet().toArray();
+            if (!ModbusBindingConstantsInternal.READ_FUNCTION_CODES.containsKey(type)) {
+                Object[] acceptedTypes = ModbusBindingConstantsInternal.READ_FUNCTION_CODES.keySet().toArray();
                 Arrays.sort(acceptedTypes);
                 throw new IllegalArgumentException(
                         String.format("No function code found for type='%s'. Was expecting one of: %s", type,
                                 StringUtils.join(acceptedTypes, ", ")));
             }
-            ModbusReadFunctionCode functionCode = ModbusBindingConstants.READ_FUNCTION_CODES.get(type);
+            ModbusReadFunctionCode functionCode = ModbusBindingConstantsInternal.READ_FUNCTION_CODES.get(type);
             return functionCode;
         }
 

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
@@ -29,6 +29,8 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.AtomicStampedKeyValue;
 import org.openhab.binding.modbus.internal.ModbusBindingConstants;
 import org.openhab.binding.modbus.internal.config.ModbusPollerConfiguration;


### PR DESCRIPTION
This is a follow up to PR #4053 

The modbus binding could easily be extended by other bundles to add device specific things and their handlers. There is already such a work in progress, see issue #3216 

Fortunately @ssalonen  did a nice work separating interfaces from actual implementations so exporting the base handler interfaces is quite straightforward.

This work is based on the zigbee and bluetooth package practices and work by @triller-telekom 

I've split the ModbusBindingConstants class also in two: one that is public and could be used by other bundles and one that remains internal.

