### PR TITLE
[samsungtv] Add LE40D579 to the tested TV models

### DIFF
--- a/addons/binding/org.openhab.binding.samsungtv/README.md
+++ b/addons/binding/org.openhab.binding.samsungtv/README.md
@@ -9,11 +9,12 @@ Because Samsung does not publish any documentation about the TV's UPnP interface
 
 Tested TV models:
 
-| Model     | State   | Notes                                                                                |
-|-----------|---------|--------------------------------------------------------------------------------------|
-| UE46E5505 | OK      | Initial contribution is done by this model                                           |
-| UE46D5700 | PARTIAL | Supports at my home only commands via the fake remote, no discovery                  |
-| UE40F6500 | OK      | All channels except `colorTemperature`, `programTitle` and `channelName` are working |
+| Model     | State   | Notes                                                                                                            |
+|-----------|---------|------------------------------------------------------------------------------------------------------------------|
+| UE46E5505 | OK      | Initial contribution is done by this model                                                                       |
+| UE46D5700 | PARTIAL | Supports at my home only commands via the fake remote, no discovery                                              |
+| UE40F6500 | OK      | All channels except `colorTemperature`, `programTitle` and `channelName` are working                             |
+| LE40D579  | PARTIAL | Supported channels: `volume`, `mute`, `sourceName`, `channel`, `programTitle`, `channelName`, `keyCode`, `power` |
 
 
 ## Discovery


### PR DESCRIPTION
I have tested the LE40D579 with the Samsung TV Binding...

Signed-off-by: Jan Haffner <info@jan-haffner.de>