### PR TITLE
[meteostick] Add example of working with UoM in example rule

### DIFF
--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -126,9 +126,9 @@ import java.util.Date
 import java.util.Map
 import java.util.TimeZone
 
-/* Uploads weather station data using this format:
+/* Uploads weather station data using the format documented here:
 
-   http://wiki.wunderground.com/index.php/PWS_-_Upload_Protocol
+   https://feedback.weather.com/customer/en/portal/articles/2924682-pws-upload-protocol?b_id=17298
  */
 
 rule PWS

--- a/addons/binding/org.openhab.binding.meteostick/README.md
+++ b/addons/binding/org.openhab.binding.meteostick/README.md
@@ -139,6 +139,10 @@ then
 	val pw = 'your_password'
 	val sdf = new SimpleDateFormat('yyyy-MM-dd HH:mm:ss')
 	sdf.setTimeZone(TimeZone.getTimeZone('UTC'))
+	val double rh = DavisVantageVueHumidity.getStateAs(DecimalType).doubleValue
+	val double tempc = DavisVantageVueOutdoorTemperature.getStateAs(QuantityType).toUnit('°C').doubleValue
+	val double dewptc = 243.04 * (Math.log(rh/100) + ((17.625 * tempc) / (243.04 + tempc))) / (17.625 - Math.log(rh/100) - ((17.625 * tempc) / (243.04 + tempc)))
+	val double dewptf = new QuantityType(dewptc, CELSIUS).toUnit('°F').doubleValue
 	val Map<String, Object> params = newLinkedHashMap(
 		'action' ->           'updateraw',
 		'ID' ->               id,
@@ -151,10 +155,11 @@ then
 		'windspdmph_avg2m' -> DavisVantageVueWindSpeedAverage.getStateAs(QuantityType).toUnit('mph').doubleValue,
 		'winddir_avg2m' ->    DavisVantageVueWindDirectionAverage.getStateAs(QuantityType).toUnit('°').intValue,
 		'humidity' ->         DavisVantageVueHumidity.state,
+		'dewptf' ->           dewptf,
 		'tempf' ->            DavisVantageVueOutdoorTemperature.getStateAs(QuantityType).toUnit('°F').doubleValue,
 		'rainin' ->           DavisVantageVueRainCurrentHour.getStateAs(QuantityType).toUnit('in').doubleValue,
 		'baromin' ->          MeteoStickPressure.getStateAs(QuantityType).toUnit('inHg').doubleValue,
-		'softwaretype' ->     'openHAB 2.3')
+		'softwaretype' ->     'openHAB 2.4')
 
 	var url = 'https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php?'
 	var first = true


### PR DESCRIPTION
Added dewpoint temperature to the report to Weather Underground in the rule example in the doc, derived from relative humidity and temperature as computed with the "reverse" Magnus formula.  This example wasn't possible in the openHAB 2.3 release but is possible in 2.4 with improvements to the UoM support from rules.

Signed-off-by: John Cocula <john@cocula.com>
