### PR TITLE
[homekit] Fix: Rounding of Setpoint Temperatures to 2 decimals

### DIFF
--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -9,6 +9,7 @@
 package org.openhab.io.homekit.internal.accessories;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.smarthome.core.items.GenericItem;
@@ -181,7 +182,8 @@ class HomekitThermostatImpl extends AbstractTemperatureHomekitAccessoryImpl<Grou
     @Override
     public void setTargetTemperature(Double value) throws Exception {
         NumberItem item = getGenericItem(targetTemperatureItemName);
-        item.send(new DecimalType(BigDecimal.valueOf(convertFromCelsius(value))));
+        BigDecimal ret = BigDecimal.valueOf(convertFromCelsius(value));
+        item.send(new DecimalType(ret.setScale(2, RoundingMode.CEILING)));
     }
 
     @Override


### PR DESCRIPTION


[homekit] Rounding of setpoint temperatures for homekit thermostats

This bugfix adresses the problem that setpoint temperatures when set via homekit devices may end up like this: 21.60000000000001. Probably due to rounding issues. If e.g. pushed out via z-wave that can lead to following errors, as happened in my installation:
`2018-10-06 16:47:07.603 [ERROR] [.ZWaveThermostatSetpointCommandClass] - NODE 19: Got an arithmetic exception converting value 21.60000000000001 to a valid Z-Wave value. Ignoring THERMOSTAT_SETPOINT_SET message.
2018-10-06 16:47:07.605 [WARN ] [ter.ZWaveThermostatSetpointConverter] - NODE 19: Generating message failed for command class = THERMOSTAT_SETPOINT, endpoint = 0`

As more precise temperatures than 2 decimals make not much sense from a measurement precision perspective, the PR suggests to round to 2 decimals when setting temperatures from homekit to openhab.