### PR TITLE
[MiHome] fix #4136

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/ChannelMapper.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/ChannelMapper.java
@@ -24,8 +24,11 @@ public class ChannelMapper {
     static {
         // Alphabetical order
         SYSTEM_BUTTON_MAP.put("CLICK", CommonTriggerEvents.SHORT_PRESSED);
+        SYSTEM_BUTTON_MAP.put("BOTH_CLICK", CommonTriggerEvents.SHORT_PRESSED);
         SYSTEM_BUTTON_MAP.put("DOUBLE_CLICK", CommonTriggerEvents.DOUBLE_PRESSED);
         SYSTEM_BUTTON_MAP.put("LONG_CLICK_PRESS", CommonTriggerEvents.LONG_PRESSED);
+        SYSTEM_BUTTON_MAP.put("LONG_CLICK", CommonTriggerEvents.LONG_PRESSED);
+        SYSTEM_BUTTON_MAP.put("LONG_BOTH_CLICK", CommonTriggerEvents.LONG_PRESSED);
         SYSTEM_BUTTON_MAP.put("LONG_CLICK_RELEASE", "LONG_RELEASED");
     }
 

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiAqaraSensorSwitch2Handler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiAqaraSensorSwitch2Handler.java
@@ -10,7 +10,6 @@ package org.openhab.binding.mihome.internal.handler;
 
 import static org.openhab.binding.mihome.internal.XiaomiGatewayBindingConstants.*;
 
-import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.mihome.internal.ChannelMapper;
 
@@ -42,7 +41,8 @@ public class XiaomiAqaraSensorSwitch2Handler extends XiaomiSensorBaseHandler {
                     ChannelMapper.getChannelEvent(data.get(CHANNEL_1).getAsString().toUpperCase()));
         }
         if (data.has(DUAL_CHANNEL)) {
-            triggerChannel(CHANNEL_SWITCH_DUAL_CH, CommonTriggerEvents.SHORT_PRESSED);
+            triggerChannel(CHANNEL_SWITCH_DUAL_CH,
+                    ChannelMapper.getChannelEvent(data.get(DUAL_CHANNEL).getAsString().toUpperCase()));
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue described in #4136 

### Problem 1:
___Single press reports an extra event as "UNKNOWN_EVENT" after "SHORT_PRESSED"___
#### Solution:
The log shows, that the button is sending __click__ and shortly afterwards __long_click__.
The proposed solution is to trigger on both messages and distinguish one event as SHORT_PRESSED, the other as LONG_PRESSED. 
The issue states, that maybe the button is not even able to only send one __click__ event and always sends both. I am against suppressing the second one. There is no downside in having two event triggers - on the other hand there may be devices (or new firmware versions in the future) sending __click__ and __long_click__ seperately.

### Problem 2:
___Double press reports "SHORT_PRESSED" twice in a row.___
#### Solution:
The log shows a unrecognized message __long_both_click__. It is now being mapped to the generic system button event LONG_PRESSED.
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
