### PR TITLE
[nikohomecontrol] Fix thermostat parameter.

### DIFF
--- a/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.nikohomecontrol/ESH-INF/thing/thing-types.xml
@@ -88,12 +88,6 @@
 				<description>Niko Home Control IP Interface Action Object ID</description>
 				<advanced>false</advanced>
 			</parameter>
-			<parameter name="overruleTime" type="integer" required="false">
-				<label>Overrule time</label>
-				<description>Default overrule duration in minutes when an overrule temperature is set without providing overrule time, 60 minutes by default</description>
-				<default>60</default>
-				<advanced>true</advanced>
-			</parameter>
 		</config-description>
 	</thing-type>
 	<thing-type id="thermostat">
@@ -113,6 +107,12 @@
 				<label>Thermostat ID</label>
 				<description>Niko Home Control IP Interface Thermostat Object ID</description>
 				<advanced>false</advanced>
+			</parameter>
+			<parameter name="overruleTime" type="integer" required="false">
+				<label>Overrule time</label>
+				<description>Default overrule duration in minutes when an overrule temperature is set without providing overrule time, 60 minutes by default</description>
+				<default>60</default>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

Fix for thermostat parameter being attached to the wrong thing.