### PR TITLE
[Lutron] Add support for Radio RA2 Timeclock and Green Mode control

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
@@ -385,13 +385,13 @@
 				<description>Today's sunset time</description>
 			</channel>
 			<channel id="execevent" typeId="eventindex">
-			<label>Execute Event</label>
+				<label>Execute Event</label>
 			</channel>
 			<channel id="enableevent" typeId="eventindex">
-			<label>Enable Event</label>
+				<label>Enable Event</label>
 			</channel>
 			<channel id="disableevent" typeId="eventindex">
-			<label>Disable Event</label>
+				<label>Disable Event</label>
 			</channel>
 		</channels>
 

--- a/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
@@ -366,6 +366,69 @@
 		</config-description>
 	</thing-type>
 
+	<thing-type id="timeclock">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Timeclock</label>
+		<description>RA2/HWQS timeclock and scheduler module</description>
+
+		<channels>
+			<channel id="clockmode" typeId="clockmode"/>
+			<channel id="sunrise" typeId="timeROAdvanced">
+				<label>Sunrise</label>
+				<description>Today's sunrise time</description>
+			</channel>
+			<channel id="sunset" typeId="timeROAdvanced">
+				<label>Sunset</label>
+				<description>Today's sunset time</description>
+			</channel>
+			<channel id="execevent" typeId="eventindex">
+			<label>Execute Event</label>
+			</channel>
+			<channel id="enableevent" typeId="eventindex">
+			<label>Enable Event</label>
+			</channel>
+			<channel id="disableevent" typeId="eventindex">
+			<label>Disable Event</label>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="integrationId" type="integer" required="true">
+				<label>Integration ID</label>
+				<description>Address of timeclock in the Lutron control system</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<thing-type id="greenmode">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Green Mode</label>
+		<description>Green mode step control</description>
+
+		<channels>
+			<channel id="step" typeId="greenstep"/>
+		</channels>
+
+		<config-description>
+			<parameter name="integrationId" type="integer" required="true">
+				<label>Integration ID</label>
+				<description>Address of green mode controller in the Lutron control system</description>
+			</parameter>
+			<parameter name="pollInterval" type="integer" min="0" max="240" unit="min">
+				<label>Poll Interval</label>
+				<description>Poll interval in minutes (0 = polling disabled)</description>
+				<unitLabel>minutes</unitLabel>
+				<default>15</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<bridge-type id="prgbridge">
 		<label>Lutron GRX-PRG or GRX-CI-PRG Bridge</label>
 		<description>Ethernet access point to Lutron Grafik Eye 3x/4x Systems</description>
@@ -861,10 +924,42 @@
 
 	<channel-type id="sunrisesunset">
 		<item-type>DateTime</item-type>
-		<label>Sunrise</label>
-		<description>Today's sunrise</description>
+		<label>Sunrise/Sunset</label>
+		<description>Today's sunrise/sunset time</description>
 		<category>Schedule</category>
 		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="timeROAdvanced" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>DateTime</label>
+		<description>Advanced read-only DateTime</description>
+		<category>Schedule</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="clockmode">
+		<item-type>Number</item-type>
+		<label>Timeclock Mode</label>
+		<description>Mode number for timeclock</description>
+		<category>Number</category>
+		<state min="0"/>
+	</channel-type>
+
+	<channel-type id="eventindex" advanced="true">
+		<item-type>Number</item-type>
+		<label>Timeclock Event Index</label>
+		<description>Timeclock event index number</description>
+		<category>Number</category>
+		<state min="1"/>
+	</channel-type>
+
+	<channel-type id="greenstep">
+		<item-type>Number</item-type>
+		<label>Step</label>
+		<description>Green mode step number</description>
+		<category>Number</category>
+		<state min="1"/>
 	</channel-type>
 
 	<channel-type id="superschedulebutton">

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -38,12 +38,21 @@ public class LutronBindingConstants {
     public static final ThingTypeUID THING_TYPE_CCO = new ThingTypeUID(BINDING_ID, "cco");
     public static final ThingTypeUID THING_TYPE_CCO_PULSED = new ThingTypeUID(BINDING_ID, "ccopulsed");
     public static final ThingTypeUID THING_TYPE_CCO_MAINTAINED = new ThingTypeUID(BINDING_ID, "ccomaintained");
+    public static final ThingTypeUID THING_TYPE_TIMECLOCK = new ThingTypeUID(BINDING_ID, "timeclock");
+    public static final ThingTypeUID THING_TYPE_GREENMODE = new ThingTypeUID(BINDING_ID, "greenmode");
 
     // List of all Channel ids
     public static final String CHANNEL_LIGHTLEVEL = "lightlevel";
     public static final String CHANNEL_SHADELEVEL = "shadelevel";
     public static final String CHANNEL_SWITCH = "switchstatus";
     public static final String CHANNEL_OCCUPANCYSTATUS = "occupancystatus";
+    public static final String CHANNEL_CLOCKMODE = "clockmode";
+    public static final String CHANNEL_SUNRISE = "sunrise";
+    public static final String CHANNEL_SUNSET = "sunset";
+    public static final String CHANNEL_EXECEVENT = "execevent";
+    public static final String CHANNEL_ENABLEEVENT = "enableevent";
+    public static final String CHANNEL_DISABLEEVENT = "disableevent";
+    public static final String CHANNEL_STEP = "step";
 
     // Bridge config properties (used by discovery service)
     public static final String HOST = "ipAddress";
@@ -59,4 +68,7 @@ public class LutronBindingConstants {
     public static final String OUTPUT_TYPE_PULSED = "Pulsed";
     public static final String OUTPUT_TYPE_MAINTAINED = "Maintained";
     public static final String DEFAULT_PULSE = "pulseLength";
+
+    // GreenMode config properties
+    public static final String POLL_INTERVAL = "pollInterval";
 }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -22,6 +22,7 @@ import org.openhab.binding.lutron.internal.grxprg.PrgBridgeHandler;
 import org.openhab.binding.lutron.internal.grxprg.PrgConstants;
 import org.openhab.binding.lutron.internal.handler.CcoHandler;
 import org.openhab.binding.lutron.internal.handler.DimmerHandler;
+import org.openhab.binding.lutron.internal.handler.GreenModeHandler;
 import org.openhab.binding.lutron.internal.handler.IPBridgeHandler;
 import org.openhab.binding.lutron.internal.handler.KeypadHandler;
 import org.openhab.binding.lutron.internal.handler.MaintainedCcoHandler;
@@ -31,6 +32,7 @@ import org.openhab.binding.lutron.internal.handler.PulsedCcoHandler;
 import org.openhab.binding.lutron.internal.handler.ShadeHandler;
 import org.openhab.binding.lutron.internal.handler.SwitchHandler;
 import org.openhab.binding.lutron.internal.handler.TabletopKeypadHandler;
+import org.openhab.binding.lutron.internal.handler.TimeclockHandler;
 import org.openhab.binding.lutron.internal.handler.VcrxHandler;
 import org.openhab.binding.lutron.internal.handler.VirtualKeypadHandler;
 import org.openhab.binding.lutron.internal.hw.HwConstants;
@@ -54,7 +56,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
     public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMER,
             THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR, THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_PICO,
             THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED,
-            THING_TYPE_SHADE);
+            THING_TYPE_SHADE, THING_TYPE_TIMECLOCK, THING_TYPE_GREENMODE);
 
     // Used by the HwDiscoveryService
     public static final Set<ThingTypeUID> HW_DISCOVERABLE_DEVICE_TYPES_UIDS = ImmutableSet
@@ -103,6 +105,10 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
             return new VirtualKeypadHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_VCRX)) {
             return new VcrxHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_TIMECLOCK)) {
+            return new TimeclockHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_GREENMODE)) {
+            return new GreenModeHandler(thing);
         } else if (thingTypeUID.equals(PrgConstants.THING_TYPE_PRGBRIDGE)) {
             return new PrgBridgeHandler((Bridge) thing);
         } else if (thingTypeUID.equals(PrgConstants.THING_TYPE_GRAFIKEYE)) {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -29,9 +29,11 @@ import org.openhab.binding.lutron.internal.discovery.project.Device;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceGroup;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceNode;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceType;
+import org.openhab.binding.lutron.internal.discovery.project.GreenMode;
 import org.openhab.binding.lutron.internal.discovery.project.Output;
 import org.openhab.binding.lutron.internal.discovery.project.OutputType;
 import org.openhab.binding.lutron.internal.discovery.project.Project;
+import org.openhab.binding.lutron.internal.discovery.project.Timeclock;
 import org.openhab.binding.lutron.internal.handler.IPBridgeHandler;
 import org.openhab.binding.lutron.internal.xml.DbXmlInfoReader;
 import org.slf4j.Logger;
@@ -42,7 +44,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Allan Tong - Initial contribution
  * @author Bob Adair - Added support for phase-selectable dimmers, Pico, tabletop keypads, switch modules, VCRX,
- *         and repeater virtual buttons
+ *         repeater virtual buttons, Timeclock, and Green Mode
  */
 public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
@@ -90,6 +92,12 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
             for (Area area : project.getAreas()) {
                 processArea(area, locationContext);
+            }
+            for (Timeclock timeclock : project.getTimeclocks()) {
+                processTimeclocks(timeclock, locationContext);
+            }
+            for (GreenMode greenMode : project.getGreenModes()) {
+                processGreenModes(greenMode, locationContext);
             }
         } else {
             logger.info("Could not read project file at {}", address);
@@ -199,6 +207,16 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
         } else {
             logger.warn("Unrecognized output type {}", output.getType());
         }
+    }
+
+    private void processTimeclocks(Timeclock timeclock, Stack<String> context) {
+        String label = generateLabel(context, timeclock.getName());
+        notifyDiscovery(THING_TYPE_TIMECLOCK, timeclock.getIntegrationId(), label);
+    }
+
+    private void processGreenModes(GreenMode greenmode, Stack<String> context) {
+        String label = generateLabel(context, greenmode.getName());
+        notifyDiscovery(THING_TYPE_GREENMODE, greenmode.getIntegrationId(), label);
     }
 
     private void notifyDiscovery(ThingTypeUID thingTypeUID, Integer integrationId, String label) {

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/GreenMode.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/GreenMode.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.lutron.internal.discovery.project;
+
+/**
+ * A Green Mode subsystem in a Lutron RadioRA2 controller
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class GreenMode {
+
+    private String name;
+    private Integer integrationId;
+
+    public String getName() {
+        // There may be no name in the XML document
+        return name != null ? name : "Green Mode Subsystem";
+    }
+
+    public Integer getIntegrationId() {
+        return integrationId;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/Project.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/Project.java
@@ -16,11 +16,14 @@ import java.util.List;
  * that system.
  *
  * @author Allan Tong - Initial contribution
+ * @author Bob Adair - Added Timeclock and Green Mode support
  */
 public class Project {
     private String appVersion;
     private String xmlVersion;
     private List<Area> areas;
+    private List<Timeclock> timeclocks;
+    private List<GreenMode> greenmodes;
 
     public String getAppVersion() {
         return appVersion;
@@ -33,4 +36,13 @@ public class Project {
     public List<Area> getAreas() {
         return areas != null ? areas : Collections.<Area> emptyList();
     }
+
+    public List<Timeclock> getTimeclocks() {
+        return timeclocks != null ? timeclocks : Collections.<Timeclock> emptyList();
+    }
+
+    public List<GreenMode> getGreenModes() {
+        return greenmodes != null ? greenmodes : Collections.<GreenMode> emptyList();
+    }
+
 }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/Timeclock.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/Timeclock.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.lutron.internal.discovery.project;
+
+/**
+ * A Timeclock subsystem in a Lutron RadioRA2 or HWQS controller
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class Timeclock {
+
+    private String name;
+    private Integer integrationId;
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getIntegrationId() {
+        return integrationId;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GreenModeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GreenModeHandler.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.lutron.internal.handler;
+
+import static org.openhab.binding.lutron.internal.LutronBindingConstants.*;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.lutron.internal.protocol.LutronCommandType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler responsible for communicating with RadioRA 2 Green Mode subsystem
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class GreenModeHandler extends LutronHandler {
+    private static final Integer ACTION_STEP = 1;
+    public static final int GREENSTEP_MIN = 1;
+
+    // poll interval parameters are in minutes
+    private static final int POLL_INTERVAL_DEFAULT = 15;
+    private static final int POLL_INTERVAL_MAX = 240;
+    private static final int POLL_INTERVAL_MIN = 0;
+
+    private final Logger logger = LoggerFactory.getLogger(GreenModeHandler.class);
+
+    private int integrationId;
+    private int pollInterval;
+    private ScheduledFuture<?> pollJob;
+
+    public GreenModeHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public int getIntegrationId() {
+        return integrationId;
+    }
+
+    @Override
+    public void initialize() {
+        Number id = (Number) getThing().getConfiguration().get(INTEGRATION_ID);
+        if (id == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId");
+            return;
+        }
+        integrationId = id.intValue();
+
+        Number pollInterval = (Number) getThing().getConfiguration().get(POLL_INTERVAL);
+        if (pollInterval == null) {
+            this.pollInterval = POLL_INTERVAL_DEFAULT;
+        } else {
+            this.pollInterval = pollInterval.intValue();
+            this.pollInterval = Math.min(this.pollInterval, POLL_INTERVAL_MAX);
+            this.pollInterval = Math.max(this.pollInterval, POLL_INTERVAL_MIN);
+        }
+        logger.debug("Initializing Green Mode handler for integration ID {} with poll interval {}", integrationId,
+                this.pollInterval);
+
+        initDeviceState();
+    }
+
+    @Override
+    protected void initDeviceState() {
+        logger.debug("Initializing device state for Green Mode subsystem {}", getIntegrationId());
+        stopPolling();
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");
+        } else if (bridge.getStatus() == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Awaiting initial response");
+            queryGreenMode(ACTION_STEP); // handleUpdate() will set thing status to online when response arrives
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    @Override
+    protected void thingOfflineNotify() {
+        stopPolling();
+    }
+
+    private void startPolling() {
+        if (pollInterval > 0 && pollJob == null) {
+            logger.debug("Scheduling green mode polling job for integration ID {}", integrationId);
+            pollJob = scheduler.scheduleWithFixedDelay(this::pollState, pollInterval, pollInterval, TimeUnit.MINUTES);
+        }
+    }
+
+    private void stopPolling() {
+        if (pollJob != null) {
+            logger.debug("Canceling green mode polling job for integration ID {}", integrationId);
+            pollJob.cancel(true);
+            pollJob = null;
+        }
+    }
+
+    private synchronized void pollState() {
+        logger.trace("Executing green mode polling job for integration ID {}", integrationId);
+        queryGreenMode(ACTION_STEP);
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        if (channelUID.getId().equals(CHANNEL_STEP)) {
+            queryGreenMode(ACTION_STEP);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_STEP)) {
+            if (command.equals(OnOffType.ON)) {
+                greenMode(ACTION_STEP, 2);
+            } else if (command.equals(OnOffType.OFF)) {
+                greenMode(ACTION_STEP, 1);
+            } else if (command instanceof Number) {
+                Integer step = new Integer(((Number) command).intValue());
+                if (step.intValue() >= GREENSTEP_MIN) {
+                    greenMode(ACTION_STEP, step);
+                }
+            } else if (command instanceof RefreshType) {
+                queryGreenMode(ACTION_STEP);
+            } else {
+                logger.debug("Ignoring invalid command {} for id {}", command.toString(), integrationId);
+            }
+        } else {
+            logger.debug("Ignoring command to invalid channel {} for id {}", channelUID.getId(), integrationId);
+        }
+    }
+
+    @Override
+    public void handleUpdate(LutronCommandType type, String... parameters) {
+        try {
+            if (type == LutronCommandType.MODE && parameters.length > 1
+                    && ACTION_STEP.toString().equals(parameters[0])) {
+                Long step = new Long(parameters[1]);
+                if (getThing().getStatus() == ThingStatus.UNKNOWN) {
+                    updateStatus(ThingStatus.ONLINE);
+                    startPolling();
+                }
+                updateState(CHANNEL_STEP, new DecimalType(step.longValue()));
+            } else {
+                logger.debug("Ignoring unexpected update for id {}", integrationId);
+            }
+        } catch (NumberFormatException e) {
+            logger.debug("Encountered number format exception while handling update for greenmode {}", integrationId);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        stopPolling();
+    }
+}

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GreenModeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GreenModeHandler.java
@@ -128,9 +128,9 @@ public class GreenModeHandler extends LutronHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (channelUID.getId().equals(CHANNEL_STEP)) {
-            if (command.equals(OnOffType.ON)) {
+            if (command == OnOffType.ON) {
                 greenMode(ACTION_STEP, 2);
-            } else if (command.equals(OnOffType.OFF)) {
+            } else if (command == OnOffType.OFF) {
                 greenMode(ACTION_STEP, 1);
             } else if (command instanceof Number) {
                 Integer step = new Integer(((Number) command).intValue());
@@ -140,7 +140,7 @@ public class GreenModeHandler extends LutronHandler {
             } else if (command instanceof RefreshType) {
                 queryGreenMode(ACTION_STEP);
             } else {
-                logger.debug("Ignoring invalid command {} for id {}", command.toString(), integrationId);
+                logger.debug("Ignoring invalid command {} for id {}", command, integrationId);
             }
         } else {
             logger.debug("Ignoring command to invalid channel {} for id {}", channelUID.getId(), integrationId);

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Adair - Added reconnect and heartbeat config parameters
  */
 public class IPBridgeHandler extends BaseBridgeHandler {
-    private static final Pattern STATUS_REGEX = Pattern.compile("~(OUTPUT|DEVICE|SYSTEM),([^,]+),(.*)");
+    private static final Pattern STATUS_REGEX = Pattern.compile("~(OUTPUT|DEVICE|SYSTEM|TIMECLOCK|MODE),([^,]+),(.*)");
 
     private static final String DB_UPDATE_DATE_FORMAT = "MM/dd/yyyy HH:mm:ss";
 
@@ -315,7 +315,7 @@ public class IPBridgeHandler extends BaseBridgeHandler {
             if (thing.getHandler() instanceof LutronHandler) {
                 LutronHandler handler = (LutronHandler) thing.getHandler();
 
-                if (handler.getIntegrationId() == integrationId) {
+                if (handler != null && handler.getIntegrationId() == integrationId) {
                     return handler;
                 }
             }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/LutronHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/LutronHandler.java
@@ -44,6 +44,12 @@ public abstract class LutronHandler extends BaseThingHandler {
      */
     protected abstract void initDeviceState();
 
+    /**
+     * Called when changing thing status to offline. Subclasses may override to take any needed actions.
+     */
+    protected void thingOfflineNotify() {
+    }
+
     protected IPBridgeHandler getBridgeHandler() {
         Bridge bridge = getBridge();
 
@@ -61,6 +67,7 @@ public abstract class LutronHandler extends BaseThingHandler {
 
         } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            thingOfflineNotify();
         }
     }
 
@@ -69,6 +76,7 @@ public abstract class LutronHandler extends BaseThingHandler {
 
         if (bridgeHandler == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_MISSING_ERROR, "No bridge associated");
+            thingOfflineNotify();
         } else {
             bridgeHandler.sendCommand(command);
         }
@@ -84,6 +92,15 @@ public abstract class LutronHandler extends BaseThingHandler {
                 new LutronCommand(LutronOperation.EXECUTE, LutronCommandType.DEVICE, getIntegrationId(), parameters));
     }
 
+    protected void timeclock(Object... parameters) {
+        sendCommand(new LutronCommand(LutronOperation.EXECUTE, LutronCommandType.TIMECLOCK, getIntegrationId(),
+                parameters));
+    }
+
+    protected void greenMode(Object... parameters) {
+        sendCommand(new LutronCommand(LutronOperation.EXECUTE, LutronCommandType.MODE, getIntegrationId(), parameters));
+    }
+
     protected void queryOutput(Object... parameters) {
         sendCommand(new LutronCommand(LutronOperation.QUERY, LutronCommandType.OUTPUT, getIntegrationId(), parameters));
     }
@@ -91,4 +108,14 @@ public abstract class LutronHandler extends BaseThingHandler {
     protected void queryDevice(Object... parameters) {
         sendCommand(new LutronCommand(LutronOperation.QUERY, LutronCommandType.DEVICE, getIntegrationId(), parameters));
     }
+
+    protected void queryTimeclock(Object... parameters) {
+        sendCommand(
+                new LutronCommand(LutronOperation.QUERY, LutronCommandType.TIMECLOCK, getIntegrationId(), parameters));
+    }
+
+    protected void queryGreenMode(Object... parameters) {
+        sendCommand(new LutronCommand(LutronOperation.QUERY, LutronCommandType.MODE, getIntegrationId(), parameters));
+    }
+
 }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TabletopKeypadHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TabletopKeypadHandler.java
@@ -65,7 +65,10 @@ public class TabletopKeypadHandler extends BaseKeypadHandler {
         LED12(92, "led12", "LED 12"),
         LED13(93, "led13", "LED 13"),
         LED14(94, "led14", "LED 14"),
-        LED15(95, "led15", "LED 15");
+        LED15(95, "led15", "LED 15"),
+
+        LED16(96, "led16", "LED 16"),
+        LED17(97, "led17", "LED 17");
 
         private final int id;
         private final String channel;
@@ -113,6 +116,8 @@ public class TabletopKeypadHandler extends BaseKeypadHandler {
     private static final List<Component> ledGroup3 = Arrays.asList(Component.LED11, Component.LED12, Component.LED13,
             Component.LED14, Component.LED15);
 
+    private static final List<Component> LedsBottomRL = Arrays.asList(Component.LED16, Component.LED17);
+
     private final Logger logger = LoggerFactory.getLogger(TabletopKeypadHandler.class);
 
     @Override
@@ -152,6 +157,7 @@ public class TabletopKeypadHandler extends BaseKeypadHandler {
                 buttonList.addAll(buttonGroup1);
                 buttonList.addAll(buttonsBottomRL);
                 ledList.addAll(ledGroup1);
+                ledList.addAll(LedsBottomRL);
                 break;
 
             case "T15CRL":

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TimeclockHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TimeclockHandler.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.lutron.internal.handler;
+
+import static org.openhab.binding.lutron.internal.LutronBindingConstants.*;
+
+import java.util.Calendar;
+
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.lutron.internal.protocol.LutronCommandType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler responsible for communicating with the RA2 time clock.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class TimeclockHandler extends LutronHandler {
+    private static final Integer ACTION_CLOCKMODE = 1;
+    private static final Integer ACTION_SUNRISE = 2;
+    private static final Integer ACTION_SUNSET = 3;
+    private static final Integer ACTION_EXECEVENT = 5;
+    private static final Integer ACTION_SETEVENT = 6;
+    private static final Integer EVENT_ENABLE = 1;
+    private static final Integer EVENT_DISABLE = 2;
+
+    private final Logger logger = LoggerFactory.getLogger(TimeclockHandler.class);
+
+    private int integrationId;
+
+    public TimeclockHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public int getIntegrationId() {
+        return integrationId;
+    }
+
+    @Override
+    public void initialize() {
+        Number id = (Number) getThing().getConfiguration().get("integrationId");
+        logger.debug("Initializing timeclock handler");
+        if (id == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId");
+            return;
+        }
+        integrationId = id.intValue();
+        initDeviceState();
+    }
+
+    @Override
+    protected void initDeviceState() {
+        logger.debug("Initializing device state for Timeclock {}", getIntegrationId());
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");
+        } else if (bridge.getStatus() == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Awaiting initial response");
+            queryTimeclock(ACTION_CLOCKMODE); // handleUpdate() will set thing status to online when response arrives
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        logger.debug("Handling channel link request for timeclock {}", integrationId);
+        if (channelUID.getId().equals(CHANNEL_CLOCKMODE)) {
+            queryTimeclock(ACTION_CLOCKMODE);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        String channelID = channelUID.getId();
+        logger.debug("Handling timeclock command {} on channel {}", command, channelID);
+
+        if (channelUID.getId().equals(CHANNEL_CLOCKMODE)) {
+            if (command instanceof DecimalType) {
+                Integer mode = new Integer(((DecimalType) command).intValue());
+                timeclock(ACTION_CLOCKMODE, mode);
+            } else if (command instanceof RefreshType) {
+                queryTimeclock(ACTION_CLOCKMODE);
+            } else {
+                logger.debug("Invalid command type for clockmode channnel");
+            }
+        } else if (channelUID.getId().equals(CHANNEL_EXECEVENT)) {
+            if (command instanceof DecimalType) {
+                Integer index = new Integer(((DecimalType) command).intValue());
+                timeclock(ACTION_EXECEVENT, index);
+            } else {
+                logger.debug("Invalid command type for execevent channnel");
+            }
+        } else if (channelUID.getId().equals(CHANNEL_SUNRISE)) {
+            if (command instanceof RefreshType) {
+                queryTimeclock(ACTION_SUNRISE);
+            } else {
+                logger.debug("Invalid command type for sunrise channnel");
+            }
+        } else if (channelUID.getId().equals(CHANNEL_SUNSET)) {
+            if (command instanceof RefreshType) {
+                queryTimeclock(ACTION_SUNSET);
+            } else {
+                logger.debug("Invalid command type for sunset channnel");
+            }
+        } else if (channelUID.getId().equals(CHANNEL_ENABLEEVENT)) {
+            if (command instanceof DecimalType) {
+                Integer index = new Integer(((DecimalType) command).intValue());
+                timeclock(ACTION_SETEVENT, index, EVENT_ENABLE);
+            } else {
+                logger.debug("Invalid command type for enableevent channnel");
+            }
+        } else if (channelUID.getId().equals(CHANNEL_DISABLEEVENT)) {
+            if (command instanceof DecimalType) {
+                Integer index = new Integer(((DecimalType) command).intValue());
+                timeclock(ACTION_SETEVENT, index, EVENT_DISABLE);
+            } else {
+                logger.debug("Invalid command type for disableevent channnel");
+            }
+        } else {
+            logger.debug("Command received on invalid channel");
+        }
+    }
+
+    private Calendar parseLutronTime(final String timeString) {
+        Integer hour, minute;
+        Calendar calendar = Calendar.getInstance();
+        try {
+            String hh = timeString.split(":", 2)[0];
+            String mm = timeString.split(":", 2)[1];
+            hour = Integer.parseInt(hh);
+            minute = Integer.parseInt(mm);
+        } catch (NumberFormatException | IndexOutOfBoundsException exception) {
+            logger.warn("Invaid time format received from timeclock {}", integrationId);
+            return null;
+        }
+        calendar.set(Calendar.HOUR_OF_DAY, hour);
+        calendar.set(Calendar.MINUTE, minute);
+        return calendar;
+    }
+
+    @Override
+    public void handleUpdate(LutronCommandType type, String... parameters) {
+        if (type != LutronCommandType.TIMECLOCK) {
+            return;
+        }
+        logger.debug("Handling update received from timeclock {}", integrationId);
+
+        try {
+            if (parameters.length >= 2 && ACTION_CLOCKMODE.toString().equals(parameters[0])) {
+                Integer mode = new Integer(parameters[1]);
+                if (getThing().getStatus() == ThingStatus.UNKNOWN) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+                updateState(CHANNEL_CLOCKMODE, new DecimalType(mode));
+
+            } else if (parameters.length >= 2 && ACTION_SUNRISE.toString().equals(parameters[0])) {
+                Calendar calendar = parseLutronTime(parameters[1]);
+                if (calendar != null) {
+                    updateState(CHANNEL_SUNRISE, new DateTimeType(calendar));
+                }
+
+            } else if (parameters.length >= 2 && ACTION_SUNSET.toString().equals(parameters[0])) {
+                Calendar calendar = parseLutronTime(parameters[1]);
+                if (calendar != null) {
+                    updateState(CHANNEL_SUNSET, new DateTimeType(calendar));
+                }
+
+            } else if (parameters.length >= 2 && ACTION_EXECEVENT.toString().equals(parameters[0])) {
+                Integer index = new Integer(parameters[1]);
+                updateState(CHANNEL_EXECEVENT, new DecimalType(index));
+
+            } else if (parameters.length >= 3 && ACTION_SETEVENT.toString().equals(parameters[0])) {
+                Integer index = new Integer(parameters[1]);
+                Integer state = new Integer(parameters[2]);
+                if (state.equals(EVENT_ENABLE)) {
+                    updateState(CHANNEL_ENABLEEVENT, new DecimalType(index));
+                } else if (state.equals(EVENT_DISABLE)) {
+                    updateState(CHANNEL_DISABLEEVENT, new DecimalType(index));
+                }
+            }
+        } catch (NumberFormatException e) {
+            logger.debug("Encountered number format exception while handling update for timeclock {}", integrationId);
+            return;
+        }
+    }
+
+}

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronCommandType.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronCommandType.java
@@ -22,5 +22,5 @@ public enum LutronCommandType {
     MONITORING,
     OUTPUT,
     SYSTEM,
-    TIMECLOCK
+    TIMECLOCK,
 }

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
@@ -13,8 +13,10 @@ import org.openhab.binding.lutron.internal.discovery.project.Area;
 import org.openhab.binding.lutron.internal.discovery.project.Component;
 import org.openhab.binding.lutron.internal.discovery.project.Device;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceGroup;
+import org.openhab.binding.lutron.internal.discovery.project.GreenMode;
 import org.openhab.binding.lutron.internal.discovery.project.Output;
 import org.openhab.binding.lutron.internal.discovery.project.Project;
+import org.openhab.binding.lutron.internal.discovery.project.Timeclock;
 
 import com.thoughtworks.xstream.XStream;
 
@@ -40,6 +42,8 @@ public class DbXmlInfoReader extends XmlDocumentReader<Project> {
         xstream.aliasField("AppVer", Project.class, "appVersion");
         xstream.aliasField("XMLVer", Project.class, "xmlVersion");
         xstream.aliasField("Areas", Project.class, "areas");
+        xstream.aliasField("Timeclocks", Project.class, "timeclocks");
+        xstream.aliasField("GreenModes", Project.class, "greenmodes");
 
         xstream.alias("Area", Area.class);
         xstream.aliasField("Name", Area.class, "name");
@@ -75,6 +79,18 @@ public class DbXmlInfoReader extends XmlDocumentReader<Project> {
         xstream.useAttributeFor(Output.class, "integrationId");
         xstream.aliasField("OutputType", Output.class, "type");
         xstream.useAttributeFor(Output.class, "type");
+
+        xstream.alias("Timeclock", Timeclock.class);
+        xstream.aliasField("Name", Timeclock.class, "name");
+        xstream.useAttributeFor(Timeclock.class, "name");
+        xstream.aliasField("IntegrationID", Timeclock.class, "integrationId");
+        xstream.useAttributeFor(Timeclock.class, "integrationId");
+
+        xstream.alias("GreenMode", GreenMode.class);
+        xstream.aliasField("Name", GreenMode.class, "name");
+        xstream.useAttributeFor(GreenMode.class, "name");
+        xstream.aliasField("IntegrationID", GreenMode.class, "integrationId");
+        xstream.useAttributeFor(GreenMode.class, "integrationId");
 
         // This reader is only interested in device thing information and does not read
         // everything contained in DbXmlInfo. Ignoring unknown elements also makes the


### PR DESCRIPTION
[Lutron] Add support for Radio RA2 Timeclock and Green Mode control

This PR adds support for controlling Lutron Radio RA2 Timeclock and Green Mode subsystems, as described in Issue #4122.

It consists of the following:
* Addition of new GreenModeHandler and TimeclockHandler classes.
* Changes to the discovery service and xml parser to support timeclock and green mode discovery.
* Changes to IPBridgeHandler and LutronHandler to add support for TIMECLOCK and MODE commands sets.
* Doc updates
* Includes a minor fix to the indicator LED configuration for some keypad models supported by TabletopKeypadHandler.

Closes: #4122

