### PR TITLE
[onewiregpio] Temperature localization: declare sysfs reading as Celsius

### DIFF
--- a/addons/binding/org.openhab.binding.onewiregpio/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.onewiregpio/ESH-INF/thing/thing-types.xml
@@ -26,10 +26,10 @@
 	</thing-type>
 
 	<channel-type id="temperature">
-		<item-type>Number</item-type>
+		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
-		<description>Indicates the temperature read from one wire gpio sensor in Celsius</description>
-		<state readOnly="true" pattern="%.3f °C" />
+		<description>Indicates the temperature read from one wire gpio sensor</description>
+		<state readOnly="true" pattern="%.3f %unit%" />
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.onewiregpio/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.onewiregpio/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Version: 2.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: 
+ javax.measure.quantity,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
@@ -17,6 +18,7 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.core.library.unit,
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.onewiregpio/README.md
+++ b/addons/binding/org.openhab.binding.onewiregpio/README.md
@@ -20,6 +20,7 @@ Configuration is proper when /sys/bus/w1/devices folder is present, and contains
 The sensors are visible in the system as folders containing files with sensor data.
 By default all OneWire GPIO devices are stored in /sys/bus/w1/devices/DEVICE_ID_FOLDER, 
 and the temperature value is available in the file "w1_slave". The Thing needs full path to the w1_slave file.
+Note the values in sysfs are in Celsius.
 
 In the thing file, this looks e.g. like
 
@@ -40,10 +41,10 @@ sample onewiregpio.things file content:
 Thing onewiregpio:sensor:livingroom "Living room" [gpio_bus_file="/sys/bus/w1/devices/28-0000061b587b/w1_slave",refresh_time=30]
 ```
 
-sample onewiregpio.items file content:
+sample onewiregpio.items file content (implements QuantityType for unit conversion):
 
 ``` 
-Number LivingRoomTemperature      "Temperature: [%.2f °C]" <temperature>  { channel="onewiregpio:sensor:livingroom:temperature" }
+Number:Temperature LivingRoomTemperature      "Temperature: [%.2f %unit%]" <temperature>  { channel="onewiregpio:sensor:livingroom:temperature" }
 ```
 
 sample demo.sitemap file content:

--- a/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
+++ b/addons/binding/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
@@ -23,7 +23,8 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -126,7 +127,7 @@ public class OneWireGPIOHandler extends BaseThingHandler {
     private void publishTemperatureSensorState(ChannelUID channelUID) {
         BigDecimal temp = readSensorTemperature(gpioBusFile);
         if (temp != null) {
-            updateState(channelUID, new DecimalType(temp));
+            updateState(channelUID, new QuantityType<>(temp, SIUnits.CELSIUS));
         }
     }
 


### PR DESCRIPTION
I have configured Fahrenheit as my unit of temperature. The onewire sysfs uses Celsius. When reading the temperature, it was being assumed Fahrenheit. I updated it to use QuantityType instead of DecimalType. Built a jar and loaded the bundle. Worked!

`10:54:19.217 [INFO ] [smarthome.event.ItemStateChangedEvent] - Air_East_Supply changed from 23.5 °F to 74.4116 °F`
`10:54:19.373 [INFO ] [smarthome.event.ItemStateChangedEvent] - Air_West_Supply changed from 58.812 °F to 97.1366 °F`

(Note the math doesn't work out on the change for Air_West_Supply - this is okay, it was cooling down between unloading the old bundle and loading the new one.)