### PR TITLE
[MiHome] fixed Update of magnet sensorStatus from heartbeat's

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorMagnetHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorMagnetHandler.java
@@ -56,7 +56,7 @@ public class XiaomiSensorMagnetHandler extends XiaomiSensorBaseHandlerWithTimer 
                 }
             }
         }
-        super.parseReport(data);
+        parseDefault(data);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorMagnetHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorMagnetHandler.java
@@ -47,16 +47,8 @@ public class XiaomiSensorMagnetHandler extends XiaomiSensorBaseHandlerWithTimer 
     void parseReport(JsonObject data) {
         if (data.has(STATUS)) {
             String sensorStatus = data.get(STATUS).getAsString();
-            boolean isOpen = OPEN.equals(sensorStatus);
-            if (isOpen) {
-                updateState(CHANNEL_IS_OPEN, OpenClosedType.OPEN);
-            } else if (CLOSED.equals(sensorStatus)) {
-                updateState(CHANNEL_IS_OPEN, OpenClosedType.CLOSED);
-            } else {
-                updateState(CHANNEL_IS_OPEN, UnDefType.UNDEF);
-            }
             synchronized (this) {
-                if (isOpen) {
+                if (OPEN.equals(sensorStatus)) {
                     updateState(CHANNEL_LAST_OPENED, new DateTimeType());
                     startTimer();
                 } else {
@@ -64,6 +56,22 @@ public class XiaomiSensorMagnetHandler extends XiaomiSensorBaseHandlerWithTimer 
                 }
             }
         }
+        super.parseReport(data);
+    }
+
+    @Override
+    void parseDefault(JsonObject data) {
+        if (data.has(STATUS)) {
+            String sensorStatus = data.get(STATUS).getAsString();
+            if (OPEN.equals(sensorStatus)) {
+                updateState(CHANNEL_IS_OPEN, OpenClosedType.OPEN);
+            } else if (CLOSED.equals(sensorStatus)) {
+                updateState(CHANNEL_IS_OPEN, OpenClosedType.CLOSED);
+            } else {
+                updateState(CHANNEL_IS_OPEN, UnDefType.UNDEF);
+            }
+        }
+        super.parseDefault(data);
     }
 
     @Override


### PR DESCRIPTION
When using the MiHome addon and a Door / Windows Sensors, then when openhab2 is restart the status of the sensors remain empty, until the Door / Windows sensor is triggered.

The status information is available and using be other sensors by parsing the heartbeat data.
I have update the XiaomiSensorMagnetHandler to also parse this data, so the state is update.
