### PR TITLE
[WifiLED] Missing WHITE2 parameter while updating item

### DIFF
--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/WiFiLEDHandler.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/WiFiLEDHandler.java
@@ -209,6 +209,7 @@ public class WiFiLEDHandler extends BaseThingHandler {
             updateState(WiFiLEDBindingConstants.CHANNEL_POWER, ledState.getPower());
             updateState(WiFiLEDBindingConstants.CHANNEL_COLOR, color);
             updateState(WiFiLEDBindingConstants.CHANNEL_WHITE, ledState.getWhite());
+            updateState(WiFiLEDBindingConstants.CHANNEL_WHITE2, ledState.getWhite2());
             updateState(WiFiLEDBindingConstants.CHANNEL_PROGRAM, ledState.getProgram());
             updateState(WiFiLEDBindingConstants.CHANNEL_PROGRAM_SPEED, ledState.getProgramSpeed());
 


### PR DESCRIPTION
The White2 channel of an item with two white channels (CW and WW) was always NULL because of missing line for reading the actual White2 value and updating the item state.

Signed-off-by: Jan Mollenhauer <janmo0904@gmail.com> (github: t1lt3rr0r)