### PR TITLE
[jeelink] Cancel cyclic status update task on disposal of Pca301SensorHandler

### DIFF
--- a/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
+++ b/addons/binding/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
@@ -69,6 +69,7 @@ public class Pca301SensorHandler extends JeeLinkSensorHandler<Pca301Reading> {
 
     @Override
     public void dispose() {
+        super.dispose();
         cancelRetry();
     }
 


### PR DESCRIPTION
Gets rid of the following warnings in the log:

> Handler Pca301SensorHandler tried updating the thing status although the handler was already disposed.

Signed-off-by: Volker Bier <volker.bier@web.de>
