### PR TITLE
[onkyo] Add volume scaling variants

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
 		http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
@@ -33,12 +34,12 @@
 			<default>100</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="volumeScale" type="integer" min="0" max="100">
-            <label>Volume Scale</label>
-            <description>Select volume scale (0 = 0-100, 1 = 0-100 in 0.5 steps, 2 = 0-80, 3 = 0-50)</description>
-            <default>0</default>
-            <advanced>true</advanced>
-        </parameter>
+		<parameter name="volumeScale" type="decimal">
+			<label>Volume Scale</label>
+			<description>Applies a scale to the volume.</description>
+			<default>1</default>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
@@ -39,6 +39,12 @@
 			<description>Applies a scale to the volume.</description>
 			<default>1</default>
 			<advanced>true</advanced>
+			<options>
+				<option value="1">0-100</option>
+				<option value="2">0-100 in 0.5 steps</option>
+				<option value="0.8">0-80</option>
+				<option value="0.5">0-50</option>
+			</options>
 		</parameter>
 	</config-description>
 

--- a/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.onkyo/ESH-INF/config/config.xml
@@ -29,10 +29,16 @@
 		</parameter>
 		<parameter name="volumeLimit" type="integer" min="0" max="100">
 			<label>Volume Limit</label>
-			<description>Limit maximum volume level to defined value.</description>
+			<description>Limit maximum volume level to defined percentage.</description>
 			<default>100</default>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="volumeScale" type="integer" min="0" max="100">
+            <label>Volume Scale</label>
+            <description>Select volume scale (0 = 0-100, 1 = 0-100 in 0.5 steps, 2 = 0-80, 3 = 0-50)</description>
+            <default>0</default>
+            <advanced>true</advanced>
+        </parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -90,20 +90,22 @@ onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, volumeLimi
 
 Binding then automatically scale the volume level in both directions (100% = 50 = 100%).
 
-You can also change the way volume scaling works. This can be necessary if your receiver uses a different scaling system than 0-100.
-The following values are available:
+You can also change the way volume scaling works.
+This can be necessary if your receiver uses a different scaling system than 0-100.
+You can specify a decimal number that acts as the coefficient for scaling.
+See below for a few examples:
 
 | Value  | Description                                          | Value for 100%   |
 |--------|------------------------------------------------------|------------------|
-| 0      | Default, don't scale                                 |              100 |
-| 1      | For receivers that support 0.5 increments in volume  |              200 |
-| 2      | For receivers that go from 0-80                      |               80 |
-| 3      | For receivers that go from 0-50                      |               50 |
+| 1      | Default, don't scale                                 |              100 |
+| 2      | For receivers that support 0.5 increments in volume  |              200 |
+| 0.8    | For receivers that go from 0-80                      |               80 |
+| 0.5    | For receivers that go from 0-50                      |               50 |
 
 Note that this is applied after the volume limiting took place.
 
 ```text
-onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, scale=1]
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, volumeScale=2]
 ```
 
 The binding will send value 200 for maximum volume to the receiver.

--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -90,6 +90,24 @@ onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, volumeLimi
 
 Binding then automatically scale the volume level in both directions (100% = 50 = 100%).
 
+You can also change the way volume scaling works. This can be necessary if your receiver uses a different scaling system than 0-100.
+The following values are available:
+
+| Value  | Description                                          | Value for 100%   |
+|--------|------------------------------------------------------|------------------|
+| 0      | Default, don't scale                                 |              100 |
+| 1      | For receivers that support 0.5 increments in volume  |              200 |
+| 2      | For receivers that go from 0-80                      |               80 |
+| 3      | For receivers that go from 0-50                      |               50 |
+
+Note that this is applied after the volume limiting took place.
+
+```text
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, scale=1]
+```
+
+The binding will send value 200 for maximum volume to the receiver.
+
 ## Channels
 
 The Onkyo AVR supports the following channels (some channels are model specific):

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
@@ -20,7 +20,7 @@ public class OnkyoDeviceConfiguration {
     public String udn;
     public int refreshInterval;
     public int volumeLimit;
-    public int volumeScale;
+    public double volumeScale = 1.0d;
 
     @Override
     public String toString() {

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/config/OnkyoDeviceConfiguration.java
@@ -20,6 +20,7 @@ public class OnkyoDeviceConfiguration {
     public String udn;
     public int refreshInterval;
     public int volumeLimit;
+    public int volumeScale;
 
     @Override
     public String toString() {
@@ -30,6 +31,7 @@ public class OnkyoDeviceConfiguration {
         str += ", udn = " + udn;
         str += ", refreshInterval = " + refreshInterval;
         str += ", volumeLimit = " + volumeLimit;
+        str += ", volumeScale = " + volumeScale;
 
         return str;
     }

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -795,24 +795,11 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
     }
 
     private DecimalType scaleVolumeForReceiver(PercentType volume) {
-        return new DecimalType(((Double) (volume.doubleValue() * getScaleCoefficient())).intValue());
+        return new DecimalType(((Double) (volume.doubleValue() * configuration.volumeScale)).intValue());
     }
 
     private PercentType scaleVolumeFromReceiver(DecimalType volume) {
-        return new PercentType(((Double) (volume.intValue() / getScaleCoefficient())).intValue());
-    }
-
-    private double getScaleCoefficient() {
-        switch (configuration.volumeScale) {
-            case 1:
-                return 2d;
-            case 2:
-                return 0.8d;
-            case 3:
-                return 0.5d;
-            default:
-                return 1d;
-        }
+        return new PercentType(((Double) (volume.intValue() / configuration.volumeScale)).intValue());
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -359,7 +359,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                     break;
                 case ZONE2_VOLUME:
                     volumeLevelZone2 = handleReceivedVolume(
-                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
                     updateState(CHANNEL_VOLUMEZONE2, volumeLevelZone2);
                     break;
                 case ZONE2_SOURCE:
@@ -378,7 +378,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                     break;
                 case ZONE3_VOLUME:
                     volumeLevelZone3 = handleReceivedVolume(
-                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
                     updateState(CHANNEL_VOLUMEZONE3, volumeLevelZone3);
                     break;
                 case ZONE3_SOURCE:

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -337,7 +337,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                     break;
                 case VOLUME:
                     volumeLevelZone1 = handleReceivedVolume(
-                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
                     updateState(CHANNEL_VOLUME, volumeLevelZone1);
                     break;
                 case SOURCE:
@@ -763,34 +763,56 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
     }
 
     private State handleReceivedVolume(State volume) {
-        if (volume instanceof PercentType) {
-            return upScaleVolume(((PercentType) volume));
+        if (volume instanceof DecimalType) {
+            return upScaleVolume(((DecimalType) volume));
         }
         return volume;
     }
 
-    private PercentType upScaleVolume(PercentType volume) {
-        PercentType newVolume = volume;
+    private PercentType upScaleVolume(DecimalType volume) {
+        PercentType newVolume = scaleVolumeFromReceiver(volume);
 
         if (configuration.volumeLimit < 100) {
             double scaleCoefficient = 100d / configuration.volumeLimit;
-            newVolume = new PercentType(((Double) (volume.doubleValue() * scaleCoefficient)).intValue());
-            logger.debug("Up scaled volume level '{}' to '{}'", volume, newVolume);
+            PercentType unLimitedVolume = newVolume;
+            newVolume = new PercentType(((Double) (newVolume.doubleValue() * scaleCoefficient)).intValue());
+            logger.debug("Up scaled volume level '{}' to '{}'", unLimitedVolume, newVolume);
         }
 
         return newVolume;
     }
 
-    private PercentType downScaleVolume(PercentType volume) {
-        PercentType newVolume = volume;
+    private DecimalType downScaleVolume(PercentType volume) {
+        PercentType limitedVolume = volume;
 
         if (configuration.volumeLimit < 100) {
             double scaleCoefficient = configuration.volumeLimit / 100d;
-            newVolume = new PercentType(((Double) (volume.doubleValue() * scaleCoefficient)).intValue());
-            logger.debug("Down scaled volume level '{}' to '{}'", volume, newVolume);
+            limitedVolume = new PercentType(((Double) (volume.doubleValue() * scaleCoefficient)).intValue());
+            logger.debug("Limited volume level '{}' to '{}'", volume, limitedVolume);
         }
 
-        return newVolume;
+        return scaleVolumeForReceiver(limitedVolume);
+    }
+
+    private DecimalType scaleVolumeForReceiver(PercentType volume) {
+        return new DecimalType(((Double) (volume.doubleValue() * getScaleCoefficient())).intValue());
+    }
+
+    private PercentType scaleVolumeFromReceiver(DecimalType volume) {
+        return new PercentType(((Double) (volume.intValue() / getScaleCoefficient())).intValue());
+    }
+
+    private double getScaleCoefficient() {
+        switch (configuration.volumeScale) {
+            case 1:
+                return 2d;
+            case 2:
+                return 0.8d;
+            case 3:
+                return 0.5d;
+            default:
+                return 1d;
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

This adds a configuration parameter to the onkyo receiver thing that allows to control volume scaling. The following 4 variants are supported:

- 0-100 -> no scaling
- 0-200 -> 0.5 increments for volume, scale by 2
- 0-80  -> volume goes from 0-80, scale by 0.8
- 0-50  -> volume goes from 0-50, scale by 0.5

The default behavior remains unchanged. Volume limiting is applied before the scaling, so should still be ok.

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
