### PR TITLE
-handle channel type of switch as OnOffType

### DIFF
--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -7,7 +7,7 @@
 	<config-description uri="thing-type:konnected:module">
 		<parameter-group name="actions">
 			<label>Actions</label>
-			<description></description>
+			<description />
 		</parameter-group>
 		<parameter name="blink" type="boolean">
 			<label>blink</label>
@@ -17,25 +17,22 @@
 		</parameter>
 		<parameter name="discovery" type="boolean">
 			<label>discovery</label>
-			<description>If set to true the device will not respond to discovery requests via UPnP.  Make sure you have statically assigned an IP address to the module before applying this setting. See https://help.konnected.io/support/solutions/articles/32000023968-disabling-device-discovery</description>
-			<default>false</default>
+			<description>If set to false the device will not respond to discovery requests via UPnP.  Make sure you have statically assigned an IP address to the module before turning this setting off. See https://help.konnected.io/support/solutions/articles/32000023968-disabling-device-discovery</description>
+			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
-
 		<parameter name="controller_softreset" type="boolean" groupName="actions">
 			<label>Soft Reset Module</label>
 			<description>Send A Restart Command to the Module.</description>
 			<advanced>true</advanced>
 			<default>false</default>
 		</parameter>
-
 		<parameter name="controller_removewifi" type="boolean" groupName="actions">
 			<label>Factory Reset</label>
 			<description>Resets the module to Factory Conditions.</description>
 			<advanced>true</advanced>
 			<default>false</default>
 		</parameter>
-
 		<parameter name="controller_sendConfig" type="boolean" groupName="actions">
 			<label>Update Settings</label>
 			<description>Manually sends the settings to the module.  The binding will send settings on every restart and if there are any configuration changes but this can be used to manually update the settings as needed.</description>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
@@ -28,6 +28,7 @@
 			<parameter name="zone" type="text" required="true">
 				<label>Zone Number</label>
 				<description>The Zone Number of the channel.</description>
+				<default>6</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>
@@ -49,7 +50,6 @@
 			<parameter name="zone" type="text">
 				<label>Zone Number</label>
 				<description>The Zone Number of the channel.</description>
-				<default>6</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>

--- a/addons/binding/org.openhab.binding.konnected/README.md
+++ b/addons/binding/org.openhab.binding.konnected/README.md
@@ -21,7 +21,7 @@ The auto-discovery service of the binding will detect the ip address and port of
 But once it is added you will need to provide an Auth Token to secure communication between the module and openHAB.  
 As discussed above the binding will attempt to discover the ip address of your openHAB server.  However, if it is unable to determine the ip address you can manually define the ip address and port in the thing configuration.
 In addition you can also turn off discovery which when this setting is synced to the module will cause the device to no longer respond to UPnP requests as documented. https://help.konnected.io/support/solutions/articles/32000023968-disabling-device-discovery
-Please use this setting with caution and do not enable until a static ip address has been provided for your Konnected Alarm Panel via DHCP, router or otherwise.
+Please use this setting with caution and do not disable until a static ip address has been provided for your Konnected Alarm Panel via DHCP, router or otherwise.
 The blink setting will disable the transmission LED on the Konnected Alarm Panel.
 
 
@@ -41,7 +41,7 @@ For zones 1-5, you will need to add channels for the remaining zones that you ha
 
 | Channel Type  | ItemType | ConfigParameters| Description |
 | ------------- | ------------- |-------------| -------------| 
-|Switch|Contact|Zone Number| This is the channel type for sensors or other read only devices   |
+|Switch|Switch|Zone Number| This is the channel type for sensors or other read only devices   |
 |Actuator|Switch|Zone Number, Momentary, Pause, Times| This is the channel type for devices whose state can be turned on an off by the Konnected Alarm Panel |
 |Temperature|Number:Temperature|Zone Number, DHT22, Poll Interval, DS18b20 Address| This is the channel for sensors which measure temperature (DHT22 and DS18B20). The DHT22 setting should be set to true when the channel is monitoring a zone connected to a DHT22 sensor and false if the zone is connected to a DS1820B sensor |
 |Humidity|Number:Dimonsionless|Zone Number| This is the channel type for the humidity sensor on a connected DHT22 sensor |

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -93,7 +93,7 @@ public class KonnectedHandler extends BaseThingHandler {
                 logger.debug("A command was sent to a sensor type so we are ignoring the command");
             } else {
                 int sendCommand = (OnOffType.OFF.compareTo((OnOffType) command));
-                logger.debug("The command being sent to pin {} for channel:  is {}", channelUID.getAsString(), pin,
+                logger.debug("The command being sent to pin {} for channel:{}  is {}", pin, channelUID.getAsString(),
                         sendCommand);
                 sendActuatorCommand(Integer.toString(sendCommand), pin, channelUID);
             }

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -23,7 +23,6 @@ import javax.measure.quantity.Temperature;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
@@ -82,6 +81,7 @@ public class KonnectedHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         // get the zone number in integer form
         Channel channel = this.getThing().getChannel(channelUID.getId());
+        String channelType = channel.getChannelTypeUID().getAsString();
         String zoneNumber = (String) channel.getConfiguration().get(CHANNEL_ZONE);
         Integer zone = Integer.parseInt(zoneNumber);
         logger.debug("The channelUID is: {} and the zone is :", channelUID.getAsString(), zone);
@@ -89,12 +89,14 @@ public class KonnectedHandler extends BaseThingHandler {
         Integer pin = Arrays.asList(PIN_TO_ZONE).get(zone);
         // if the command is OnOfftype
         if (command instanceof OnOffType) {
-            int sendCommand = (OnOffType.OFF.compareTo((OnOffType) command));
-            logger.debug("The command being sent to pin {} for channel:  is {}", channelUID.getAsString(), pin,
-                    sendCommand);
-            sendActuatorCommand(Integer.toString(sendCommand), pin, channelUID);
-        } else if (command instanceof OpenClosedType) {
-            logger.debug("A command was sent to a sensor type so we are ignoring the command");
+            if (channelType.equalsIgnoreCase(CHANNEL_SWITCH)) {
+                logger.debug("A command was sent to a sensor type so we are ignoring the command");
+            } else {
+                int sendCommand = (OnOffType.OFF.compareTo((OnOffType) command));
+                logger.debug("The command being sent to pin {} for channel:  is {}", channelUID.getAsString(), pin,
+                        sendCommand);
+                sendActuatorCommand(Integer.toString(sendCommand), pin, channelUID);
+            }
         } else if (command instanceof RefreshType) {
             getSwitchState(pin, channelUID);
         }
@@ -121,16 +123,11 @@ public class KonnectedHandler extends BaseThingHandler {
                 logger.debug(
                         "The configrued zone of channelID: {}  was a match for the zone sent by the alarm panel: {} on thing: {}",
                         channelId, sentZone, this.getThing().getUID().getId());
-
                 String channelType = channel.getChannelTypeUID().getAsString();
                 logger.debug("The channeltypeID is: {}", channelType);
                 // check if the itemType has been defined for the zone received
                 // check the itemType of the Zone, if Contact, send the State if Temp send Temp, etc.
-                if (channelType.equalsIgnoreCase(CHANNEL_SWITCH)) {
-                    OpenClosedType openClosedType = event.getState().equalsIgnoreCase("1") ? OpenClosedType.OPEN
-                            : OpenClosedType.CLOSED;
-                    updateState(channelId, openClosedType);
-                } else if (channelType.equalsIgnoreCase(CHANNEL_ACTUATOR)) {
+                if (channelType.equalsIgnoreCase(CHANNEL_SWITCH) || channelType.equalsIgnoreCase(CHANNEL_ACTUATOR)) {
                     OnOffType onOffType = event.getState().equalsIgnoreCase("1") ? OnOffType.ON : OnOffType.OFF;
                     updateState(channelId, onOffType);
                 } else if (channelType.equalsIgnoreCase(CHANNEL_HUMIDITY)) {


### PR DESCRIPTION
Signed-off-by: Zachary Christiansen <volfan6415@gmail.com> (github: volfan6415)

@kaikreuzer When i changed the thing type of the switch per #3702 (comment) i neglected to correct the handling of the states in the handler.

This pull request corrects that so that the states are properly updated as OnOffType instead of OpenClosed type.

This also adds checking in the handle command section to check the channel type and ignores commands for the channel type of switch (previously i was ignoring based on command type but since they are both OnOffType now that needed to change)