### PR TITLE
[WifiLED] Read wrong value for White2 (CW) from byte array

### DIFF
--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
@@ -125,7 +125,7 @@ public abstract class AbstractWiFiLEDDriver {
 
             // Example response (14 Bytes):
             // 0x81 0x04 0x23 0x26 0x21 0x10 0x45 0x00 0x00 0x00 0x03 0x00 0x00 0x47
-            // ..........^--- On/Off.........R....G....B....WW..
+            // ..........^--- On/Off.........R....G....B....WW........CW
             // ...............^-- PGM...^---SPEED...............
 
             int state = statusBytes[2] & 0xFF; // On/Off
@@ -136,7 +136,7 @@ public abstract class AbstractWiFiLEDDriver {
             int green = statusBytes[7] & 0xFF;
             int blue = statusBytes[8] & 0xFF;
             int white = statusBytes[9] & 0xFF;
-            int white2 = protocol == Protocol.LD686 ? statusBytes[10] & 0xFF : 0;
+            int white2 = protocol == Protocol.LD686 ? statusBytes[11] & 0xFF : 0;
 
             logger.debug("RGBW: {},{},{},{}, {}", red, green, blue, white, white2);
 


### PR DESCRIPTION
The correct value for the White2 (CW) parameter is on index 11 of the byte array.

Signed-off-by: Jan Mollenhauer <janmo0904@gmail.com>