### PR TITLE
[tplinksmarthome] Discovery package timeout gets more time, clear cache before discovery

### DIFF
--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeDiscoveryService.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 public class TPLinkSmartHomeDiscoveryService extends AbstractDiscoveryService implements TPLinkIpAddressService {
 
     private static final String BROADCAST_IP = "255.255.255.255";
-    private static final int DISCOVERY_TIMEOUT_SECONDS = 30;
-    private static final int UDP_PACKET_TIMEOUT_MS = 3000;
+    private static final int DISCOVERY_TIMEOUT_SECONDS = 8;
+    private static final int UDP_PACKET_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(DISCOVERY_TIMEOUT_SECONDS - 1);
     private static final long REFRESH_INTERVAL_MINUTES = 1;
 
     private final Logger logger = LoggerFactory.getLogger(TPLinkSmartHomeDiscoveryService.class);
@@ -94,6 +94,7 @@ public class TPLinkSmartHomeDiscoveryService extends AbstractDiscoveryService im
         logger.debug("Start scan for TP-Link Smart devices.");
         synchronized (this) {
             try {
+                idInetAddressCache.clear();
                 discoverSocket = sendDiscoveryPacket();
                 // Runs until the socket call gets a time out and throws an exception. When a time out is triggered it
                 // means no data was present and nothing new to discover.


### PR DESCRIPTION
Timeout of discovery was very short. For devices with a low connection rssi this seems to give them some more time to react.
Also reduced to overall time because if the packet timeout triggers discovery is over anyway, so no need to keep it longer.
Also cleared the idINet cache to avoid having old results. It keeps the cache clean.