### PR TITLE
[squeezebox] Fix for Jetty insufficient threads

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -420,6 +420,10 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                     } catch (IllegalArgumentException e) {
                         logger.debug("IllegalArgumentException when downloading image from {}", url, e);
                         return null;
+                    } catch (IllegalStateException e) {
+                        // Jetty throws this when it doesn't have enough threads
+                        logger.debug("IllegalStateException when downloading image from {}", url, e);
+                        return null;
                     }
                 });
                 if (image == null) {


### PR DESCRIPTION
Fixes #4260 

Squeezebox listener should not die silently if it cannot download the cover art due to Jetty not having a sufficient number of threads.

See these two forum posts for more information.
https://community.openhab.org/t/solved-no-contact-to-squeeze-server-with-error-message-could-not-start-jetty-http-client/57348
https://community.openhab.org/t/fix-for-jetty-error-when-running-on-host-with-many-cores/57449

Unless you would rather deal with the exception further upstream, say in HttpUtil.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
