### PR TITLE
[Konnected]- Updates,  Tweaks,  add retry count and request timeout config parameter to thing

### DIFF
--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -21,7 +21,7 @@
 			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="retry_count" type="text">
+		<parameter name="retry_count" type="integer">
 			<label>Retry Count</label>
 			<description>The number of times the binding attempts to send http requests to the Konnected Alarm Panel.  Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Network.  This will allow the binding to attempt more retries before it considers the connection a failure and marks the thing as offline.</description>
 			<default>2</default>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -21,6 +21,18 @@
 			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="retry_count" type="text">
+			<label>Retry Count</label>
+			<description> The number of times the binding will attempt to send http requests to the Konnected Alarm Panel.  Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Netork.  This will allow the binding to attempt more retries before it considers the connection and failure and sets the thing as offline.</description>
+			<default>2</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="request_timeout" type="text">
+			<label>Request Timeout</label>
+			<description> The timout period in seconds for HTTP requets to the Konnected Alarm Panel.  The default is 30.  Adjusting this setting can help in networks situations with high laency where the binding is erroneously reporting the thing as offline.</description>
+			<default>30</default>
+			<advanced>true</advanced>
+		</parameter>
 		<parameter name="controller_softreset" type="boolean" groupName="actions">
 			<label>Soft Reset Module</label>
 			<description>Send A Restart Command to the Module.</description>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -27,7 +27,7 @@
 			<default>2</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="request_timeout" type="text">
+		<parameter name="request_timeout" type="integer">
 			<label>Request Timeout</label>
 			<description>The timeout period in seconds for HTTP requests to the Konnected Alarm Panel.  The default is 30.  Adjusting this setting can help in networks situations with high latency where the binding is erroneously reporting the thing as offline.</description>
 			<default>30</default>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -29,7 +29,7 @@
 		</parameter>
 		<parameter name="request_timeout" type="text">
 			<label>Request Timeout</label>
-			<description> The timout period in seconds for HTTP requets to the Konnected Alarm Panel.  The default is 30.  Adjusting this setting can help in networks situations with high laency where the binding is erroneously reporting the thing as offline.</description>
+			<description>The timeout period in seconds for HTTP requests to the Konnected Alarm Panel.  The default is 30.  Adjusting this setting can help in networks situations with high latency where the binding is erroneously reporting the thing as offline.</description>
 			<default>30</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/config/config.xml
@@ -23,7 +23,7 @@
 		</parameter>
 		<parameter name="retry_count" type="text">
 			<label>Retry Count</label>
-			<description> The number of times the binding will attempt to send http requests to the Konnected Alarm Panel.  Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Netork.  This will allow the binding to attempt more retries before it considers the connection and failure and sets the thing as offline.</description>
+			<description>The number of times the binding attempts to send http requests to the Konnected Alarm Panel.  Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Network.  This will allow the binding to attempt more retries before it considers the connection a failure and marks the thing as offline.</description>
 			<default>2</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
@@ -125,7 +125,7 @@
 			</parameter>
 			<parameter name="onvalue" type="text">
 				<label>On Value</label>
-				<description>The value that will be treated by the binding as an on command.  For actuators that activate with a high command set to 1 and actuators that activate with a low value set to 0.</description>
+				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high command set to 1 and actuators that activate with a low value set to 0.</description>
 				<default>1</default>
 				<options>
 					<option value="0">0</option>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
@@ -41,7 +41,7 @@
 			</parameter>
 			<parameter name="onvalue" type="text">
 				<label>On Value</label>
-				<description>The value that will be treated by the binding as the on value.  For sensors that activate with a high value leave at the default of 1 and sensors that activate with a low value set to 0.</description>
+				<description>The value that will be treated by the binding as the on value. For sensors that activate with a high value leave at the default of 1 and sensors that activate with a low value set to 0.</description>
 				<default>1</default>
 				<options>
 					<option value="0">0</option>

--- a/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.konnected/ESH-INF/thing/thing-types.xml
@@ -39,6 +39,15 @@
 					<option value="7">Out</option>
 				</options>
 			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as the on value.  For sensors that activate with a high value leave at the default of 1 and sensors that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
 		</config-description>
 	</channel-type>
 	<channel-type id="temperature">
@@ -112,6 +121,15 @@
 					<option value="5">5</option>
 					<option value="6">6</option>
 					<option value="7">Out</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as an on command.  For actuators that activate with a high command set to 1 and actuators that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
 				</options>
 			</parameter>
 			<parameter name="momentary" type="integer">

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
@@ -25,10 +25,12 @@ public class KonnectedBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_MODULE = new ThingTypeUID(BINDING_ID, "module");
 
-    // Bridge config properties
+    // Thing config properties
     public static final String HOST = "ipAddress";
     public static final String MAC_ADDR = "macAddress";
     public static final String CALLBACK_PATH = "callBackPath";
+    public static final String REQUEST_TIMEOUT = "request_timeout";
+    public static final String RETRY_COUNT = "retry_count";
 
     // PIN_TO_ZONE array, this array maps an index location as a zone to the corresponding
     // pin location
@@ -36,7 +38,7 @@ public class KonnectedBindingConstants {
 
     public static final String WEBHOOK_APP = "app_security";
 
-    public static final String CHANNEL_ZONE = "channel_zone";
+    public static final String CHANNEL_ZONE = "zone";
 
     // channeltypeids
     public static final String CHANNEL_SWITCH = "konnected:switch";
@@ -51,5 +53,7 @@ public class KonnectedBindingConstants {
     public static final String CHANNEL_ACTUATOR_TIMES = "times";
     public static final String CHANNEL_ACTUATOR_MOMENTARY = "momentary";
     public static final String CHANNEL_ACTUATOR_PAUSE = "pause";
+
+    public static final String CHANNEL_ONVALUE = "onvalue";
 
 }

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
@@ -25,8 +25,16 @@ import org.slf4j.LoggerFactory;
  */
 public class KonnectedHTTPUtils {
     private final Logger logger = LoggerFactory.getLogger(KonnectedHTTPUtils.class);
-    private static final int REQUEST_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(30);
+    private int requestTimeout;
     private String logTest = "";
+
+    public KonnectedHTTPUtils(int requestTimeout) {
+        this.requestTimeout = (int) TimeUnit.SECONDS.toMillis(requestTimeout);
+    }
+
+    public void setRequestTimeout(int requestTimeout) {
+        this.requestTimeout = (int) TimeUnit.SECONDS.toMillis(requestTimeout);
+    }
 
     /**
      * Sends a {@link doPut} request with a timeout of 30 seconds
@@ -34,12 +42,11 @@ public class KonnectedHTTPUtils {
      * @param urlAddress the address to send the request
      * @param payload    the json payload to include with the request
      */
-    public String doPut(String urlAddress, String payload) throws IOException {
+    private String doPut(String urlAddress, String payload) throws IOException {
         logger.debug("The String url we want to put is : {}", urlAddress);
         logger.debug("The payload we want to put is: {}", payload);
         ByteArrayInputStream input = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
-        logTest = HttpUtil.executeUrl("PUT", urlAddress, getHttpHeaders(), input, "application/json",
-                KonnectedHTTPUtils.REQUEST_TIMEOUT);
+        logTest = HttpUtil.executeUrl("PUT", urlAddress, getHttpHeaders(), input, "application/json", requestTimeout);
         logger.debug(logTest);
         return logTest;
     }
@@ -56,9 +63,9 @@ public class KonnectedHTTPUtils {
      * @param urlAddress the address to send the request
      */
 
-    public synchronized String doGet(String urlAddress) throws IOException {
+    private synchronized String doGet(String urlAddress) throws IOException {
         logger.debug("The String url we want to get is : {}", urlAddress);
-        logTest = HttpUtil.executeUrl("GET", urlAddress, KonnectedHTTPUtils.REQUEST_TIMEOUT);
+        logTest = HttpUtil.executeUrl("GET", urlAddress, requestTimeout);
         logger.debug(logTest);
         return logTest;
     }
@@ -70,12 +77,68 @@ public class KonnectedHTTPUtils {
      * @param payload    the json payload you want to send as part of the request
      */
 
-    public synchronized String doGet(String urlAddress, String payload) throws IOException {
+    private synchronized String doGet(String urlAddress, String payload) throws IOException {
         logger.debug("The String url we want to get is : {}", urlAddress);
         ByteArrayInputStream input = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
-        logTest = HttpUtil.executeUrl("GET", urlAddress, getHttpHeaders(), input, "application/json",
-                KonnectedHTTPUtils.REQUEST_TIMEOUT);
+        logTest = HttpUtil.executeUrl("GET", urlAddress, getHttpHeaders(), input, "application/json", requestTimeout);
         logger.debug(logTest);
         return logTest;
+    }
+
+    /**
+     * Sends a {@link doGet} request with a timeout of 30 seconds
+     *
+     * @param urlAddress the address to send the request
+     * @param payload    the json payload you want to send as part of the request, may be null.
+     * @param retry      the number of retries before throwing the IOexpcetion back to the handler
+     */
+
+    public synchronized String doGet(String urlAddress, String payload, int retryCount)
+            throws KonnectedHttpRetryExceeded {
+        String response = null;
+        int x = 0;
+        Boolean loop = true;
+        while (loop) {
+            try {
+                if (payload == null) {
+                    response = doGet(urlAddress, payload);
+                } else {
+                    response = doGet(urlAddress);
+                }
+                loop = false;
+            } catch (IOException e) {
+                x++;
+                if (x > retryCount) {
+                    throw new KonnectedHttpRetryExceeded("The number of retry attempts was exceeded", e.getCause());
+                }
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Sends a {@link doPut} request with a timeout of 30 seconds
+     *
+     * @param urlAddress the address to send the request
+     * @param payload    the json payload you want to send as part of the request
+     * @param retry      the number of retries before throwing the IOexpcetion back to the handler
+     */
+    public synchronized String doPut(String urlAddress, String payload, int retryCount)
+            throws KonnectedHttpRetryExceeded {
+        String response = null;
+        int x = 0;
+        Boolean loop = true;
+        while (loop) {
+            try {
+                response = doPut(urlAddress, payload);
+                loop = false;
+            } catch (IOException e) {
+                x++;
+                if (x > retryCount) {
+                    throw new KonnectedHttpRetryExceeded("The number of retry attempts was exceeded", e.getCause());
+                }
+            }
+        }
+        return response;
     }
 }

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
@@ -92,7 +92,6 @@ public class KonnectedHTTPUtils {
      * @param payload    the json payload you want to send as part of the request, may be null.
      * @param retry      the number of retries before throwing the IOexpcetion back to the handler
      */
-
     public synchronized String doGet(String urlAddress, String payload, int retryCount)
             throws KonnectedHttpRetryExceeded {
         String response = null;

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHttpRetryExceeded.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHttpRetryExceeded.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.konnected.internal;
+
+/**
+ * Custom exception class to be thrown when number of retries is exceeded.
+ *
+ * @author Zachary Christiansen - Initial contribution
+ */
+@SuppressWarnings("serial")
+public class KonnectedHttpRetryExceeded extends Exception {
+    public KonnectedHttpRetryExceeded(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -177,7 +177,7 @@ public class KonnectedHandler extends BaseThingHandler {
 
     private void checkConfiguration() throws ConfigValidationException {
         KonnectedConfiguration testConfig = getConfigAs(KonnectedConfiguration.class);
-        String testRetryCount = (String) testConfig.get(RETRY_COUNT);
+        String testRetryCount = testConfig.get(RETRY_COUNT).toString();
         String testRequestTimeout = testConfig.get(REQUEST_TIMEOUT).toString();
 
         try {

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -10,7 +10,6 @@ package org.openhab.binding.konnected.internal.handler;
 
 import static org.openhab.binding.konnected.internal.KonnectedBindingConstants.*;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Map;
@@ -396,11 +395,11 @@ public class KonnectedHandler extends BaseThingHandler {
         return payloadString;
     }
 
-    /**
+    /*
      * Prepares and sends the {@link KonnectedModulePayload} via the {@link KonnectedHttpUtils}
      *
      * @return response obtained from sending the settings payload to Konnected module defined by the thing
-     * @throws IOException if unable to communicate with the Konnected module defined by the Thing
+     * @throws KonnectedHttpRetryExceeded if unable to communicate with the Konnected module defined by the Thing
      */
     private String updateKonnectedModule() throws KonnectedHttpRetryExceeded {
         String payload = constructSettingsPayload();

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.konnected.internal.KonnectedConfiguration;
 import org.openhab.binding.konnected.internal.KonnectedHTTPUtils;
+import org.openhab.binding.konnected.internal.KonnectedHttpRetryExceeded;
 import org.openhab.binding.konnected.internal.gson.KonnectedModuleGson;
 import org.openhab.binding.konnected.internal.gson.KonnectedModulePayload;
 import org.slf4j.Logger;
@@ -55,10 +56,11 @@ public class KonnectedHandler extends BaseThingHandler {
     private KonnectedConfiguration config;
 
     private final String konnectedServletPath;
-    private final KonnectedHTTPUtils http = new KonnectedHTTPUtils();
+    private final KonnectedHTTPUtils http = new KonnectedHTTPUtils(30);
     private String callbackIpAddress = null;
     private String moduleIpAddress;
     private Gson gson = new GsonBuilder().create();
+    private int retryCount;
 
     /**
      * This is the constructor of the Konnected Handler.
@@ -75,6 +77,7 @@ public class KonnectedHandler extends BaseThingHandler {
         this.konnectedServletPath = path;
         callbackIpAddress = hostAddress + ":" + port;
         logger.debug("The callback ip address is: {}", callbackIpAddress);
+        retryCount = 2;
     }
 
     @Override
@@ -121,6 +124,8 @@ public class KonnectedHandler extends BaseThingHandler {
         // get the zone number based off of the index location of the pin value
         String sentZone = Integer.toString(Arrays.asList(PIN_TO_ZONE).indexOf(event.getPin()));
         // check that the zone number is in one of the channelUID definitions
+        logger.debug("Looping Through all channels on thing: {} to find a match for {}", thing.getUID().getAsString(),
+                event.getAuthToken());
         getThing().getChannels().forEach(channel -> {
             ChannelUID channelId = channel.getUID();
             String zoneNumber = (String) channel.getConfiguration().get(CHANNEL_ZONE);
@@ -135,7 +140,8 @@ public class KonnectedHandler extends BaseThingHandler {
                 // check if the itemType has been defined for the zone received
                 // check the itemType of the Zone, if Contact, send the State if Temp send Temp, etc.
                 if (channelType.equalsIgnoreCase(CHANNEL_SWITCH) || channelType.equalsIgnoreCase(CHANNEL_ACTUATOR)) {
-                    OnOffType onOffType = event.getState().equalsIgnoreCase("1") ? OnOffType.ON : OnOffType.OFF;
+                    OnOffType onOffType = event.getState().equalsIgnoreCase(getOnState(channel)) ? OnOffType.ON
+                            : OnOffType.OFF;
                     updateState(channelId, onOffType);
                 } else if (channelType.equalsIgnoreCase(CHANNEL_HUMIDITY)) {
                     // if the state is of type number then this means it is the humidity channel of the dht22
@@ -171,6 +177,24 @@ public class KonnectedHandler extends BaseThingHandler {
 
     private void checkConfiguration() throws ConfigValidationException {
         KonnectedConfiguration testConfig = getConfigAs(KonnectedConfiguration.class);
+        String testRetryCount = (String) testConfig.get(RETRY_COUNT);
+        String testRequestTimeout = (String) testConfig.get(REQUEST_TIMEOUT);
+
+        try {
+            this.retryCount = Integer.parseInt(testRetryCount);
+        } catch (NumberFormatException e) {
+            logger.debug(
+                    "Please check your configuration of the Retry Count as it is not an Integer. It is configured as: {}, will contintue to configure the binding with the default of 2",
+                    testRetryCount);
+            this.retryCount = 2;
+        }
+        try {
+            this.http.setRequestTimeout(Integer.parseInt(testRequestTimeout));
+        } catch (NumberFormatException e) {
+            logger.debug(
+                    "Please check your configuration of the Request Timeout as it is not an Integer. It is configured as: {}, will contintue to configure the binding with the default of 30",
+                    testRequestTimeout);
+        }
 
         if ((callbackIpAddress == null)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -201,8 +225,8 @@ public class KonnectedHandler extends BaseThingHandler {
                 if (cfg[1].equals("softreset") && value instanceof Boolean && ((Boolean) value) == true) {
                     scheduler.execute(() -> {
                         try {
-                            http.doGet(moduleIpAddress + "/settings?restart=true");
-                        } catch (IOException e) {
+                            http.doGet(moduleIpAddress + "/settings?restart=true", null, retryCount);
+                        } catch (KonnectedHttpRetryExceeded e) {
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                         }
                     });
@@ -210,8 +234,8 @@ public class KonnectedHandler extends BaseThingHandler {
                 } else if (cfg[1].equals("removewifi") && value instanceof Boolean && ((Boolean) value) == true) {
                     scheduler.execute(() -> {
                         try {
-                            http.doGet(moduleIpAddress + "/settings?restore=true");
-                        } catch (IOException e) {
+                            http.doGet(moduleIpAddress + "/settings?restore=true", null, retryCount);
+                        } catch (KonnectedHttpRetryExceeded e) {
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                         }
                     });
@@ -228,10 +252,9 @@ public class KonnectedHandler extends BaseThingHandler {
                             } else {
                                 updateStatus(ThingStatus.ONLINE);
                             }
-                        } catch (IOException e) {
+                        } catch (KonnectedHttpRetryExceeded e) {
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                         }
-
                     });
                     value = false;
                 }
@@ -251,8 +274,8 @@ public class KonnectedHandler extends BaseThingHandler {
             } else {
                 updateStatus(ThingStatus.ONLINE);
             }
-        } catch (IOException e) {
-            logger.trace("There was an IOExcption Error thrown during HandleConfigurationUpdate()");
+        } catch (KonnectedHttpRetryExceeded e) {
+            logger.trace("The number of retries was exceeeded during the HandleConfigurationUpdate():", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
@@ -275,7 +298,7 @@ public class KonnectedHandler extends BaseThingHandler {
                 } else {
                     updateStatus(ThingStatus.ONLINE);
                 }
-            } catch (IOException e) {
+            } catch (KonnectedHttpRetryExceeded e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
         });
@@ -299,12 +322,13 @@ public class KonnectedHandler extends BaseThingHandler {
     private String constructSettingsPayload() {
         String hostPath = "";
         hostPath = callbackIpAddress + this.konnectedServletPath;
-        String authToken = this.getThing().getUID().getAsString();
+        String authToken = getThing().getUID().getAsString();
         logger.debug("The Auth_Token is: {}", authToken);
         KonnectedModulePayload payload = new KonnectedModulePayload(authToken, "http://" + hostPath);
         payload.setBlink(config.blink);
         payload.setDiscovery(config.discovery);
-        getThing().getChannels().forEach(channel -> {
+        this.getThing().getChannels().forEach(channel -> {
+            // ChannelUID channelId = channel.getUID();
             if (isLinked(channel.getUID())) {
                 // adds linked channels to list based on last value of Channel ID
                 // which is set to a number
@@ -378,9 +402,9 @@ public class KonnectedHandler extends BaseThingHandler {
      * @return response obtained from sending the settings payload to Konnected module defined by the thing
      * @throws IOException if unable to communicate with the Konnected module defined by the Thing
      */
-    private String updateKonnectedModule() throws IOException {
+    private String updateKonnectedModule() throws KonnectedHttpRetryExceeded {
         String payload = constructSettingsPayload();
-        String response = http.doPut(moduleIpAddress + "/settings", payload);
+        String response = http.doPut(moduleIpAddress + "/settings", payload, retryCount);
         logger.debug("The response of the put request was: {}", response);
         return response;
     }
@@ -401,40 +425,45 @@ public class KonnectedHandler extends BaseThingHandler {
                 KonnectedModuleGson payload = new KonnectedModuleGson();
                 payload.setState(scommand);
                 payload.setPin(pin);
-
-                if (configuration.get(CHANNEL_ACTUATOR_TIMES) == null) {
-                    logger.debug("The times configuration was not set for channelID: {}, not adding it to the payload.",
-                            channelId.toString());
-                } else {
-                    payload.setTimes(configuration.get(CHANNEL_ACTUATOR_TIMES).toString());
-                    logger.debug("The times configuration was set to: {} for channelID: {}.",
-                            configuration.get(CHANNEL_ACTUATOR_TIMES).toString(), channelId.toString());
-                }
-                if (configuration.get(CHANNEL_ACTUATOR_MOMENTARY) == null) {
-                    logger.debug(
-                            "The momentary configuration was not set for channelID: {}, not adding it to the payload.",
-                            channelId.toString());
-                } else {
-                    payload.setMomentary(configuration.get(CHANNEL_ACTUATOR_MOMENTARY).toString());
-                    logger.debug("The momentary configuration set to: {} channelID: {}.",
-                            configuration.get(CHANNEL_ACTUATOR_MOMENTARY).toString(), channelId.toString());
-                }
-                if (configuration.get(CHANNEL_ACTUATOR_PAUSE) == null) {
-                    logger.debug("The pause configuration was not set for channelID: {}, not adding it to the payload.",
-                            channelId.toString());
-                } else {
-                    payload.setPause(configuration.get(CHANNEL_ACTUATOR_PAUSE).toString());
-                    logger.debug("The pause configuration was set to: {} for channelID: {}.",
-                            configuration.get(CHANNEL_ACTUATOR_PAUSE).toString(), channelId.toString());
+                // check to see if this is an On Command type, if so add the momentary, pause, times to the payload if
+                // they exist on the configuration.
+                if (scommand.equals(getOnState(channel))) {
+                    if (configuration.get(CHANNEL_ACTUATOR_TIMES) == null) {
+                        logger.debug(
+                                "The times configuration was not set for channelID: {}, not adding it to the payload.",
+                                channelId.toString());
+                    } else {
+                        payload.setTimes(configuration.get(CHANNEL_ACTUATOR_TIMES).toString());
+                        logger.debug("The times configuration was set to: {} for channelID: {}.",
+                                configuration.get(CHANNEL_ACTUATOR_TIMES).toString(), channelId.toString());
+                    }
+                    if (configuration.get(CHANNEL_ACTUATOR_MOMENTARY) == null) {
+                        logger.debug(
+                                "The momentary configuration was not set for channelID: {}, not adding it to the payload.",
+                                channelId.toString());
+                    } else {
+                        payload.setMomentary(configuration.get(CHANNEL_ACTUATOR_MOMENTARY).toString());
+                        logger.debug("The momentary configuration set to: {} channelID: {}.",
+                                configuration.get(CHANNEL_ACTUATOR_MOMENTARY).toString(), channelId.toString());
+                    }
+                    if (configuration.get(CHANNEL_ACTUATOR_PAUSE) == null) {
+                        logger.debug(
+                                "The pause configuration was not set for channelID: {}, not adding it to the payload.",
+                                channelId.toString());
+                    } else {
+                        payload.setPause(configuration.get(CHANNEL_ACTUATOR_PAUSE).toString());
+                        logger.debug("The pause configuration was set to: {} for channelID: {}.",
+                                configuration.get(CHANNEL_ACTUATOR_PAUSE).toString(), channelId.toString());
+                    }
                 }
                 String payloadString = gson.toJson(payload);
                 logger.debug("The command payload  is: {}", payloadString);
-                http.doPut(moduleIpAddress + "/device", payloadString);
+                http.doPut(moduleIpAddress + "/device", payloadString, retryCount);
             } else {
                 logger.debug("The channel {} returned null for channelId.getID(): {}", channelId.toString(),
                         channelId.getId());
             }
-        } catch (IOException e) {
+        } catch (KonnectedHttpRetryExceeded e) {
             logger.debug("Attempting to set the state of the actuator on thing {} failed: {}",
                     this.thing.getUID().getId(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
@@ -453,13 +482,13 @@ public class KonnectedHandler extends BaseThingHandler {
             logger.debug("The command payload  is: {}", payloadString);
             try {
                 sendSetSwitchState(payloadString);
-            } catch (IOException e) {
+            } catch (KonnectedHttpRetryExceeded e) {
                 // try to get the state of the device one more time 30 seconds later. This way it can be confirmed if
                 // the device was simply in a reboot loop when device state was attempted the first time
                 scheduler.schedule(() -> {
                     try {
                         sendSetSwitchState(payloadString);
-                    } catch (IOException ex) {
+                    } catch (KonnectedHttpRetryExceeded ex) {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "Unable to communicate with Konnected Alarm Panel confirm settings, and that module is online.");
                         logger.debug("Attempting to get the state of the zone on thing {} failed for channel: {} : {}",
@@ -471,13 +500,21 @@ public class KonnectedHandler extends BaseThingHandler {
             logger.debug("The channel {} returned null for channelId.getID(): {}", channelId.toString(),
                     channelId.getId());
         }
-
     }
 
-    private void sendSetSwitchState(String payloadString) throws IOException {
-        String response = http.doGet(moduleIpAddress + "/device", payloadString);
+    private void sendSetSwitchState(String payloadString) throws KonnectedHttpRetryExceeded {
+        String response = http.doGet(moduleIpAddress + "/device", payloadString, retryCount);
         KonnectedModuleGson event = gson.fromJson(response, KonnectedModuleGson.class);
         this.handleWebHookEvent(event);
+    }
+
+    private String getOnState(Channel channel) {
+        String config = (String) channel.getConfiguration().get(CHANNEL_ONVALUE);
+        if (config == null) {
+            return "1";
+        } else {
+            return config;
+        }
     }
 
 }

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -178,7 +178,7 @@ public class KonnectedHandler extends BaseThingHandler {
     private void checkConfiguration() throws ConfigValidationException {
         KonnectedConfiguration testConfig = getConfigAs(KonnectedConfiguration.class);
         String testRetryCount = (String) testConfig.get(RETRY_COUNT);
-        String testRequestTimeout = (String) testConfig.get(REQUEST_TIMEOUT);
+        String testRequestTimeout = testConfig.get(REQUEST_TIMEOUT).toString();
 
         try {
             this.retryCount = Integer.parseInt(testRetryCount);

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
@@ -97,6 +97,7 @@ public class KonnectedHTTPServlet extends HttpServlet {
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
         try {
             String data = inputStreamToString(req);
+
             logger.debug("The raw json data is: {}", data);
             if (data != null && !(konnectedThingHandlers.size() == 0)) {
                 KonnectedModuleGson event = gson.fromJson(data, KonnectedModuleGson.class);


### PR DESCRIPTION
- add high/low onvalue config parameter to thing
- updates to httpUtils to use request timeout and retry count parameters with http requests
- addition of custom exception for retry timeout exceed exception
- updates to handler to utilize retry timeout config parameter and request timeout parameter or defaults of 30 seconds and 2 if none configured

So i have added a request timeout config parameter and a retry count parameter.  The binding now utilizes these instead to retry the http requests to the module and throws a custom exception when the retry count is exceed that sets the thing status to offline.  This allows the end user to better configure the thing to tailor the thing to their address network latency issues.

Also added high/low config option to the switch and actuator channel types so that the user can change whether a 0 or 1 received from the Alarm Panel is treated as the on or off by the binding.  In the absense of this setting the binding defaults to 0 as off and 1 as On.

Also added a bug fix to the actuator send command to not transmit the momentary, times and payload values for the off command as this means that the actuator does not properly turn off and instead "pulses" off.

Signed-off-by: Zachary Christiansen <volfan6415@gmail.com> (github: volfan6415)

