### PR TITLE
[squeezebox] Synchronize on squeezeBoxPlayerListeners iteration

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -987,8 +987,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
      */
     private void updatePlayer(PlayerUpdateEvent event) {
         // update listeners like disco services
-        for (SqueezeBoxPlayerEventListener listener : squeezeBoxPlayerListeners) {
-            event.updateListener(listener);
+        synchronized (squeezeBoxPlayerListeners) {
+            for (SqueezeBoxPlayerEventListener listener : squeezeBoxPlayerListeners) {
+                event.updateListener(listener);
+            }
         }
         // update our children
         Bridge bridge = getThing();


### PR DESCRIPTION
Fixes #4253 

Add synchronization to `squeezeBoxPlayerListeners` iteration as required [here](https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#synchronizedList-java.util.List-).

Signed-off-by: Mark Hilbush <mark@hilbush.com>
