### PR TITLE
[MiHome] add basic thing type for yet unsupported models

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/basic.xml
+++ b/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/basic.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="mihome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="basic">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+		<label>Basic Xiaomi MiHome Device</label>
+		<description>This device is not supported by the binding but you can still add it to your OpenHAB configuration. All messages from the device are available as channels providing values to String Items. Please open an issue on the openhab-addons2 github page to get this device added to the binding in the future. Meanwhile you can parse the messages with rules and/or JSONPATH transformations.</description>
+		<channels>
+			<channel id="reportMessage" typeId="rawMessage">
+				<label>Last report message</label>
+				<description>Report state or sensor values</description>
+			</channel>
+			<channel id="heartbeatMessage" typeId="rawMessage">
+				<label>Last heartbeat message</label>
+				<description>Alive signal (up to every 60 minutes)</description>
+			</channel>
+			<channel id="readAckMessage" typeId="rawMessage">
+				<label>Last read acknowledgement message</label>
+				<description>Answer to an active read request</description>
+			</channel>
+			<channel id="writeAckMessage" typeId="rawMessage">
+				<label>Last write acknowledgement message</label>
+				<description>Answer to a command</description>
+			</channel>
+			<channel id="lastMessage" typeId="rawMessage">
+				<label>Last raw message</label>
+				<description>Last raw message from the device</description>
+			</channel>
+			<channel id="writeMessage" typeId="rawMessage">
+				<label>Last command parameters</label>
+				<description>Channel to write command parameters - Example: \"join_permission\":\"yes\"</description>
+			</channel>
+		</channels>
+		<config-description-ref uri="thing-type:mihome:device" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/channel.xml
+++ b/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/channel.xml
@@ -16,6 +16,12 @@
 		<state max="100" min="0" step="1" pattern="%d %%" readOnly="false"></state>
 	</channel-type>
 
+	<channel-type id="rawMessage">
+		<item-type>String</item-type>
+		<label>Raw Message</label>
+		<description>Channel for raw messages. No parsing is done on these messages.</description>
+	</channel-type>
+
 	<channel-type id="brightness">
 		<item-type>Dimmer</item-type>
 		<label>Brightness</label>

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiGatewayBindingConstants.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiGatewayBindingConstants.java
@@ -27,6 +27,7 @@ public class XiaomiGatewayBindingConstants {
 
     public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
     public static final ThingTypeUID THING_TYPE_GATEWAY = new ThingTypeUID(BINDING_ID, "gateway");
+    public static final ThingTypeUID THING_TYPE_BASIC = new ThingTypeUID(BINDING_ID, "basic");
     // sensors
     public static final ThingTypeUID THING_TYPE_SENSOR_HT = new ThingTypeUID(BINDING_ID, "sensor_ht");
     public static final ThingTypeUID THING_TYPE_SENSOR_AQARA_WEATHER_V1 = new ThingTypeUID(BINDING_ID,
@@ -124,4 +125,12 @@ public class XiaomiGatewayBindingConstants {
 
     // Item config properties
     public static final String ITEM_ID = "itemId";
+
+    // Basic Device channels
+    public static final String CHANNEL_REPORT_MSG = "reportMessage";
+    public static final String CHANNEL_HEARTBEAT_MSG = "heartbeatMessage";
+    public static final String CHANNEL_READ_ACK_MSG = "readAckMessage";
+    public static final String CHANNEL_WRITE_ACK_MSG = "writeAckMessage";
+    public static final String CHANNEL_LAST_MSG = "lastMessage";
+    public static final String CHANNEL_WRITE_MSG = "writeMessage";
 }

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/XiaomiHandlerFactory.java
@@ -158,6 +158,8 @@ public class XiaomiHandlerFactory extends BaseThingHandlerFactory {
             return new XiaomiSensorVibrationHandler(thing);
         } else if (THING_TYPE_SENSOR_AQARA_LOCK.equals(thingTypeUID)) {
             return new XiaomiSensorLockHandler(thing);
+        } else if (THING_TYPE_BASIC.equals(thingTypeUID)) {
+            return new XiaomiDeviceBaseHandler(thing);
         } else {
             return null;
         }

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.mihome.internal.discovery;
 
 import static org.openhab.binding.mihome.internal.ModelMapper.*;
-import static org.openhab.binding.mihome.internal.XiaomiGatewayBindingConstants.ITEM_ID;
+import static org.openhab.binding.mihome.internal.XiaomiGatewayBindingConstants.*;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -87,9 +87,11 @@ public class XiaomiItemDiscoveryService extends AbstractDiscoveryService
             String model = data.get("model").getAsString();
 
             ThingTypeUID thingType = getThingTypeForModel(model);
+            String modelLabel = getLabelForModel(model);
             if (thingType == null) {
-                logger.debug("Unknown discovered model: {}", model);
-                return;
+                logger.warn("Discovered unsupported device with id \"{}\" -> Creating Basic Device Thing", model);
+                thingType = THING_TYPE_BASIC;
+                modelLabel = String.format("Unsupported Xiaomi MiHome Device \"%s\"", model);
             }
 
             Map<String, Object> properties = new HashMap<>(1);
@@ -99,10 +101,9 @@ public class XiaomiItemDiscoveryService extends AbstractDiscoveryService
 
             if (discoveryServiceCallback.getExistingThing(thingUID) == null) {
                 logger.debug("Detected Xiaomi smart device - sid: {} model: {}", sid, model);
-                thingDiscovered(
-                        DiscoveryResultBuilder.create(thingUID).withThingType(thingType).withProperties(properties)
-                                .withRepresentationProperty(ITEM_ID).withLabel(getLabelForModel(model))
-                                .withBridge(xiaomiBridgeHandler.getThing().getUID()).build());
+                thingDiscovered(DiscoveryResultBuilder.create(thingUID).withThingType(thingType)
+                        .withProperties(properties).withRepresentationProperty(ITEM_ID).withLabel(modelLabel)
+                        .withBridge(xiaomiBridgeHandler.getThing().getUID()).build());
             }
         }
     }

--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiBridgeHandler.java
@@ -297,6 +297,11 @@ public class XiaomiBridgeHandler extends ConfigStatusBridgeHandler implements Xi
                 new Object[] { itemId, createDataJsonString(keys, values) });
     }
 
+    void writeToDevice(String itemId, String command) {
+        sendCommandToBridge("write", new String[] { "sid", "data" },
+                new Object[] { itemId, "{" + command + ", \\\"key\\\": \\\"" + getEncryptedKey() + "\"}" });
+    }
+
     void writeToBridge(String[] keys, Object[] values) {
         sendCommandToBridge("write", new String[] { "model", "sid", "short_id", "data" },
                 new Object[] { "gateway", getGatewaySid(), "0", createDataJsonString(keys, values) });


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->
# Improvement
I just read of IKEA and Xiaomi partnering up on smart home solutions. As IKEA is also using Zigbee for it's current lineup, most likely in the future IKEA products will be able to speak to the Xiaomi gateway, adding more devices to the MiHome ecosystem and opening the chinese market for IKEA I guess. Also Xiaomi is expanding the MiHome lineup frequently.

Today, yet unsupported models have to be issued by users by searching through debug logs.
Also unsupported devices do not show up in the PaperUI inbox. So only advanced users can contribute with new model requests, even if there is a [tutorial how to do so](https://www.openhab.org/addons/bindings/mihome/#supporting-new-devices).
This PR is aiming to help discovering, analyzing and handling unsupported device models without the need to scan logs, so more users are able to issue new device types. Also while waiting for official support, users can already handle their unsupported devices, e.g. read sensor values and write commands.

If the binding does not have a thing type for the device model (so the model is unknown), then a new basic device is introduced. It shows up in the inbox of PaperUI with automatic discovery.

The user can add the basic thing and gets access to the device's communication channels:
- the user can read the __raw__ messages received from the device, showing identification and data
- the user can read the MiHome specific message types encapsulated in the raw message string, this is somehow redundant to the "whole" raw string above, but of most interest to users and binding developers, who then can implement parsing methods for the message types
  - report messages
  - heartbeat messages
  - read ack messages
  - write ack messages
- the user can send commands to the device by issueing the command parameters

To stay as generic as possible all channels bind to string Items. As the message format always is JSON, the inbound channels can be handled by JSONPATH transformations.
Example:
```JAVA
String GatewayHeartbeat {channel="mihome:basic:286c0788b407:heartbeatMessage"[profile="transform:JSONPATH", function="$.ip"]}
```

The outbound channel to write commands accepts a string formatted as JSON attributes. Instead of writing `{"attr":"value"}` the user only has to write `"attr":"value"` or `"channel_0":"on", "channel_1":"on"`.

In a rule the statement looks like that:
```JAVA
GatewayWrite.sendCommand("\"join_permission\":\"yes\"")
```
Or like that - you see it's possible to send more than one parameter:
```JAVA
GatewayWrite.sendCommand("\"rgb\":150000,\"join_permission\":\"yes\"")
```
Quotes have to be escaped, numbers don't need quotes, as with normal JSON.

I made some tests with the gateway, which is the only device I have to send commands to.
All features work as expected so far. As soon as the PR is approved this post will serve as template for the Readme.
<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
