### PR TITLE
[KNX] replace spaces in GA config string

### DIFF
--- a/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelType.java
+++ b/addons/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/channel/KNXChannelType.java
@@ -64,7 +64,7 @@ public abstract class KNXChannelType {
         if (fancy == null) {
             return null;
         }
-        Matcher matcher = PATTERN.matcher(fancy);
+        Matcher matcher = PATTERN.matcher(fancy.replace(" ", ""));
 
         if (matcher.matches()) {
 


### PR DESCRIPTION
There are no spaces allowed in the GA configuration. And many users are
irritated because no errors or warnings are displayed but errors occur.
This little patch erases any spaces.

"7 .001 : 7/0/209 + < 7 / 0 / 208" -> "7.001:7/0/209+<7/0/208"


