### PR TITLE
[network] Use refreshInterval in thing type definitions

### DIFF
--- a/addons/binding/org.openhab.binding.network/ESH-INF/i18n/network_de.properties
+++ b/addons/binding/org.openhab.binding.network/ESH-INF/i18n/network_de.properties
@@ -19,8 +19,8 @@ thing-type.config.network.pingdevice.retry.label = Wiederholen
 thing-type.config.network.pingdevice.retry.description = Gibt an, wie oft der PING wiederholt werden soll, bevor das Gerät als offline markiert wird.
 thing-type.config.network.pingdevice.timeout.label = Zeitlimit
 thing-type.config.network.pingdevice.timeout.description = Gibt an, wie lange maximal gewartet wird (in ms), bevor ein Gerät als nicht vorhanden gekennzeichnet wird.
-thing-type.config.network.pingdevice.refresh_interval.label = Aktualisierungsintervall
-thing-type.config.network.pingdevice.refresh_interval.description = Spezifiziert den Aktualisierungsintervall (in ms)
+thing-type.config.network.pingdevice.refreshInterval.label = Aktualisierungsintervall
+thing-type.config.network.pingdevice.refreshInterval.description = Spezifiziert den Aktualisierungsintervall (in ms)
 
 thing-type.network.servicedevice.label = Netzwerkgerät mit Dienst
 thing-type.network.servicedevice.description = Die Verfügbarkeit des Geräts wird durch einen Verbindungsversuch mit dem angegeben TCP Dienst festgestellt.
@@ -30,8 +30,8 @@ thing-type.config.network.servicedevice.retry.label = Wiederholen
 thing-type.config.network.servicedevice.retry.description = Gibt an, wie oft der Verbindungsversuch wiederholt werden soll, bevor das Gerät als offline markiert wird.
 thing-type.config.network.servicedevice.timeout.label = Zeitlimit
 thing-type.config.network.servicedevice.timeout.description = Gibt an, wie lange maximal gewartet wird (in ms), bevor ein Gerät als nicht vorhanden gekennzeichnet wird.
-thing-type.config.network.servicedevice.refresh_interval.label = Aktualisierungsintervall
-thing-type.config.network.servicedevice.refresh_interval.description = Spezifiziert das Aktualisierungsintervall (in ms)
+thing-type.config.network.servicedevice.refreshInterval.label = Aktualisierungsintervall
+thing-type.config.network.servicedevice.refreshInterval.description = Spezifiziert das Aktualisierungsintervall (in ms)
 thing-type.config.network.servicedevice.port.label = Port
 thing-type.config.network.servicedevice.port.description = Der TCP Port an dem das Gerät erreichbar ist. Muss größer 0 sein.
 

--- a/addons/binding/org.openhab.binding.network/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.network/ESH-INF/thing/thing-types.xml
@@ -27,7 +27,7 @@
 				<description>Hostname or IP of the device</description>
 			</parameter>
 
-			<parameter name="refresh_interval" type="integer">
+			<parameter name="refreshInterval" type="integer">
 				<label>Refresh Interval</label>
 				<description>States how long to wait after a device state update before the next refresh shall occur (in ms)</description>
 				<default>60000</default>
@@ -90,7 +90,7 @@
 				<default>5000</default>
 			</parameter>
 
-			<parameter name="refresh_interval" type="integer">
+			<parameter name="refreshInterval" type="integer">
 				<label>Refresh Interval</label>
 				<description>States how long to wait after a device state update before the next refresh shall occur (in ms)</description>
 				<default>60000</default>


### PR DESCRIPTION
Fixes #3761.

Updates to the refresh interval in the UI are ignored because the thing type definitions were not updated after the configuration parameter variable names were renamed in #2580.

The affected Network Binding Things need to be removed/readded for the fix to work.