### PR TITLE
Add missing Automatic-Module-Name manifest entries

### DIFF
--- a/addons/binding/org.openhab.binding.evohome/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.evohome/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.evohome
 Bundle-ManifestVersion: 2
 Bundle-Name: evohome Binding
 Bundle-SymbolicName: org.openhab.binding.evohome;singleton:=true

--- a/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.groheondus
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: ., lib/ondus-api-0.0.2.jar
 Bundle-ManifestVersion: 2

--- a/addons/binding/org.openhab.binding.nibeuplink/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.nibeuplink/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.nibeuplink
 Bundle-ManifestVersion: 2
 Bundle-Name: NibeUplink Binding
 Bundle-SymbolicName: org.openhab.binding.nibeuplink;singleton:=true

--- a/addons/binding/org.openhab.binding.smartmeter/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.smartmeter/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.smartmeter
 Bundle-ManifestVersion: 2
 Bundle-Name: Smartmeter Binding
 Bundle-SymbolicName: org.openhab.binding.smartmeter;singleton:=true

--- a/addons/binding/org.openhab.binding.somfytahoma/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.somfytahoma/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.somfytahoma
 Bundle-ManifestVersion: 2
 Bundle-Name: SomfyTahoma Binding
 Bundle-SymbolicName: org.openhab.binding.somfytahoma;singleton:=true


### PR DESCRIPTION
Fixes warnings shown in Eclipse caused by bindings that were recently merged.