### PR TITLE
[smartmeter] Fix test build path

### DIFF
--- a/addons/binding/org.openhab.binding.smartmeter.test/.classpath
+++ b/addons/binding/org.openhab.binding.smartmeter.test/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/binding/org.openhab.binding.smartmeter.test/build.properties
+++ b/addons/binding/org.openhab.binding.smartmeter.test/build.properties
@@ -1,5 +1,4 @@
-source.. = src/test/java/,\
-				src/test/resources/
+source.. = src/test/java/
 output.. = target/classes
 bin.includes = META-INF/,\
                .,\


### PR DESCRIPTION
Fixes the following warnings shown in Eclipse:

* Project 'org.openhab.binding.smartmeter.test' is missing required source folder: 'src/test/resources'
* The project cannot be built until build path errors are resolved