### PR TITLE
Hue emulation: Fixes (user creation, storage service, turn light white)

### DIFF
--- a/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
+++ b/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
@@ -14,7 +14,8 @@ package org.openhab.io.hueemulation.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -27,8 +28,13 @@ import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.smarthome.core.events.EventPublisher;
+import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.items.events.ItemCommandEvent;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.service.ReadyMarker;
 import org.eclipse.smarthome.core.service.ReadyService;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
@@ -38,9 +44,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.openhab.io.hueemulation.internal.dto.HueDataStore.UserAuth;
 import org.openhab.io.hueemulation.internal.dto.HueDevice;
+import org.openhab.io.hueemulation.internal.dto.HueStateColorBulb;
 import org.openhab.io.hueemulation.internal.dto.HueUnauthorizedConfig;
+import org.openhab.io.hueemulation.internal.dto.HueUserAuth;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 import com.google.gson.Gson;
@@ -58,6 +65,12 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
     @Mock
     ConfigurationAdmin configurationAdmin;
 
+    @Mock
+    EventPublisher eventPublisher;
+
+    @Mock
+    Item item;
+
     String host;
 
     @SuppressWarnings("null")
@@ -73,6 +86,10 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
         assertThat(readyService, notNullValue());
         hueService = getService(HueEmulationService.class, HueEmulationService.class);
         assertThat(hueService, notNullValue());
+
+        when(item.getName()).thenReturn("itemname");
+
+        hueService.setEventPublisher(eventPublisher);
 
         readyService.markReady(new ReadyMarker("fake", "org.eclipse.smarthome.model.core"));
         waitFor(() -> hueService.discovery != null, 5000, 100);
@@ -154,6 +171,19 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
         body = read(c);
         assertThat(body, containsString("success"));
         assertThat(hueService.ds.config.whitelist.get("testuser").name, is("label"));
+        hueService.ds.config.whitelist.clear();
+
+        // Add user name without proposing one (the bridge generates one)
+        body = "{'devicetype':'label'}";
+        c = (HttpURLConnection) new URL(host + "/api").openConnection();
+        c.setRequestProperty("Content-Type", "application/json");
+        c.setRequestMethod("POST");
+        c.setDoOutput(true);
+        c.getOutputStream().write(body.getBytes(), 0, body.getBytes().length);
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("success"));
+        assertThat(body, containsString(hueService.ds.config.whitelist.keySet().iterator().next()));
     }
 
     @Test
@@ -161,14 +191,13 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
         HttpURLConnection c;
         String body;
 
-        hueService.ds.config.whitelist.put("testuser", new UserAuth("testUserLabel"));
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
 
         c = (HttpURLConnection) new URL(host + "/api/testuser/lights").openConnection();
         assertThat(c.getResponseCode(), is(200));
         body = read(c);
         assertThat(body, containsString("{}"));
 
-        Item item = mock(Item.class);
         hueService.ds.lights.put(1, new HueDevice(item, "switch", DeviceType.SwitchType));
         hueService.ds.lights.put(2, new HueDevice(item, "color", DeviceType.ColorType));
         hueService.ds.lights.put(3, new HueDevice(item, "white", DeviceType.WhiteTemperatureType));
@@ -186,5 +215,118 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
         assertThat(c.getResponseCode(), is(200));
         body = read(c);
         assertThat(body, containsString("color"));
+    }
+
+    @Test
+    public void LightGroupItemSwitchTest()
+            throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        HttpURLConnection c;
+        String body;
+
+        GroupItem gitem = new GroupItem("group", item);
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
+        hueService.ds.lights.put(7, new HueDevice(gitem, "switch", DeviceType.SwitchType));
+
+        body = "{'on':true}";
+        c = (HttpURLConnection) new URL(host + "/api/testuser/lights/7/state").openConnection();
+        c.setRequestProperty("Content-Type", "application/json");
+        c.setRequestMethod("PUT");
+        c.setDoOutput(true);
+        c.getOutputStream().write(body.getBytes(), 0, body.getBytes().length);
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("success"));
+        assertThat(body, containsString("on"));
+
+        verify(eventPublisher).post(argThat(ce -> assertOnValue((ItemCommandEvent) ce, true)));
+    }
+
+    @Test
+    public void LightHueTest() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        HttpURLConnection c;
+        String body;
+
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
+        hueService.ds.lights.put(2, new HueDevice(item, "color", DeviceType.ColorType));
+
+        body = "{'hue':1000}";
+        c = (HttpURLConnection) new URL(host + "/api/testuser/lights/2/state").openConnection();
+        c.setRequestProperty("Content-Type", "application/json");
+        c.setRequestMethod("PUT");
+        c.setDoOutput(true);
+        c.getOutputStream().write(body.getBytes(), 0, body.getBytes().length);
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("success"));
+        assertThat(body, containsString("hue"));
+
+        verify(eventPublisher).post(argThat(ce -> assertHueValue((ItemCommandEvent) ce, 1000)));
+    }
+
+    @Test
+    public void LightSaturationTest() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        HttpURLConnection c;
+        String body;
+
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
+        hueService.ds.lights.put(2, new HueDevice(item, "color", DeviceType.ColorType));
+
+        body = "{'sat':50}";
+        c = (HttpURLConnection) new URL(host + "/api/testuser/lights/2/state").openConnection();
+        c.setRequestProperty("Content-Type", "application/json");
+        c.setRequestMethod("PUT");
+        c.setDoOutput(true);
+        c.getOutputStream().write(body.getBytes(), 0, body.getBytes().length);
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("success"));
+        assertThat(body, containsString("sat"));
+
+        verify(eventPublisher).post(argThat(ce -> assertSatValue((ItemCommandEvent) ce, 50)));
+    }
+
+    /**
+     * Amazon echos are setting ct only, if commanded to turn a light white.
+     */
+    @Test
+    public void LightToWhiteTest() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        HttpURLConnection c;
+        String body;
+
+        // We start with a coloured state
+        when(item.getState()).thenReturn(new HSBType("100,100,100"));
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
+        hueService.ds.lights.put(2, new HueDevice(item, "color", DeviceType.ColorType));
+
+        body = "{'ct':500}";
+        c = (HttpURLConnection) new URL(host + "/api/testuser/lights/2/state").openConnection();
+        c.setRequestProperty("Content-Type", "application/json");
+        c.setRequestMethod("PUT");
+        c.setDoOutput(true);
+        c.getOutputStream().write(body.getBytes(), 0, body.getBytes().length);
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("success"));
+        assertThat(body, containsString("sat"));
+        assertThat(body, containsString("ct"));
+
+        // Saturation is expected to be 0 -> white light
+        verify(eventPublisher).post(argThat(ce -> assertSatValue((ItemCommandEvent) ce, 0)));
+    }
+
+    private boolean assertHueValue(ItemCommandEvent ce, int hueValue) {
+        assertThat(((HSBType) ce.getItemCommand()).getHue().intValue(), is(hueValue * 360 / HueStateColorBulb.MAX_HUE));
+        return true;
+    }
+
+    private boolean assertSatValue(ItemCommandEvent ce, int satValue) {
+        assertThat(((HSBType) ce.getItemCommand()).getSaturation().intValue(),
+                is(satValue * 100 / HueStateColorBulb.MAX_SAT));
+        return true;
+    }
+
+    private boolean assertOnValue(ItemCommandEvent ce, boolean value) {
+        assertThat(ce.getItemCommand(), is(OnOffType.from(value)));
+        return true;
     }
 }

--- a/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/LightItemsTest.java
+++ b/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/LightItemsTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.hueemulation.internal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.smarthome.core.items.GroupItem;
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.storage.Storage;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openhab.io.hueemulation.internal.dto.HueDataStore;
+import org.openhab.io.hueemulation.internal.dto.HueDevice;
+import org.openhab.io.hueemulation.internal.dto.HueStatePlug;
+
+import com.google.gson.Gson;
+
+/**
+ * Tests for {@link LightItems}.
+ *
+ * @author David Graeff - Initial contribution
+ */
+public class LightItemsTest {
+    private Gson gson;
+    private HueDataStore ds;
+    private LightItems lightItems;
+
+    @Mock
+    private ItemRegistry itemRegistry;
+
+    @Mock
+    Storage<Integer> storage;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(itemRegistry.getItems()).thenReturn(Collections.emptyList());
+        gson = new Gson();
+        ds = new HueDataStore();
+        lightItems = spy(new LightItems(ds));
+        lightItems.setItemRegistry(itemRegistry);
+        lightItems.setFilterTags(Collections.singleton("Switchable"), Collections.singleton("ColorLighting"),
+                Collections.singleton("Lighting"));
+        verify(itemRegistry).getItems();
+    }
+
+    @Test
+    public void loadStorage() throws IOException {
+        Map<String, Integer> itemUIDtoHueID = new TreeMap<>();
+        itemUIDtoHueID.put("switch1", 12);
+        when(storage.getKeys()).thenReturn(itemUIDtoHueID.keySet());
+        when(storage.get(eq("switch1"))).thenReturn(itemUIDtoHueID.get("switch1"));
+        lightItems.loadMappingFromFile(storage);
+    }
+
+    @Test
+    public void addSwitchableByCategory() throws IOException {
+        SwitchItem item = new SwitchItem("switch1");
+        item.setCategory("Light");
+        lightItems.added(item);
+        HueDevice device = ds.lights.get(lightItems.itemUIDtoHueID.get("switch1"));
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+
+    }
+
+    @Test
+    public void addSwitchableByTag() throws IOException {
+        SwitchItem item = new SwitchItem("switch1");
+        item.addTag("Switchable");
+        lightItems.added(item);
+        HueDevice device = ds.lights.get(lightItems.itemUIDtoHueID.get("switch1"));
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+    }
+
+    @Test
+    public void addGroupSwitchableByTag() throws IOException {
+        GroupItem item = new GroupItem("group1", new SwitchItem("switch1"));
+        item.addTag("Switchable");
+        lightItems.added(item);
+        HueDevice device = ds.lights.get(lightItems.itemUIDtoHueID.get("group1"));
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+    }
+
+    @Test
+    public void updateSwitchable() throws IOException {
+        SwitchItem item = new SwitchItem("switch1");
+        item.setLabel("labelOld");
+        item.addTag("Switchable");
+        lightItems.added(item);
+        Integer hueID = lightItems.itemUIDtoHueID.get("switch1");
+        HueDevice device = ds.lights.get(hueID);
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+        assertThat(device.name, is("labelOld"));
+
+        SwitchItem newitem = new SwitchItem("switch1");
+        newitem.setLabel("labelNew");
+        newitem.addTag("Switchable");
+        lightItems.updated(item, newitem);
+        device = ds.lights.get(hueID);
+        assertThat(device.item, is(newitem));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+        assertThat(device.name, is("labelNew"));
+
+        // Update with an item that has no tags anymore -> should be removed
+        SwitchItem newitemWithoutTag = new SwitchItem("switch1");
+        newitemWithoutTag.setLabel("labelNew2");
+        lightItems.updated(newitem, newitemWithoutTag);
+
+        device = ds.lights.get(hueID);
+        assertThat(device, nullValue());
+        assertThat(lightItems.itemUIDtoHueID.get("switch1"), nullValue());
+    }
+}

--- a/addons/io/org.openhab.io.hueemulation/README.md
+++ b/addons/io/org.openhab.io.hueemulation/README.md
@@ -1,6 +1,10 @@
 # openHAB Hue Emulation Service
 
-Hue Emulation exposes openHAB items as Hue devices to other Hue HTTP API compatible applications like an Amazon Echo.  
+Hue Emulation exposes openHAB items as Hue devices to other Hue HTTP API compatible applications like an Amazon Echo, Google Home or
+any Hue compatible application.
+
+Because Amazon Echo and Google Home control openHAB locally this way, it is a fast and reliable way
+to voice control your installation. See the Troubleshoot section down below though.
 
 ## Discovery:
 
@@ -8,6 +12,7 @@ As soon as the binding is enabled, it will announce the presence of an (emulated
 Hue bridges are using the Universal Plug and Play (UPnP) protocol for discovery.
 
 Like the real HUE bridge the service must be put into pairing mode before other applications can access it. 
+By default the pairing mode disables itself after 1 minute (can be configured).
 
 ## Exposed devices
 
@@ -23,24 +28,26 @@ This service can emulate 3 different devices:
 The exposed Hue-type depends on some criteria:
 
 * If the item has the category "ColorLight": It will be exposed as a color bulb
-* If the item has the category "Light": It will be exposed as a dimmable white bulb.
+* If the item has the category "Light": It will be exposed as a switch.
 
-This initial type determination is overriden if the item is tagged.
+This initial type determination is overridden if the item is tagged.
 Tags can be configured in Paper UI, please refer to the next section.
 
 The following default tags are setup:
-* "Switchable": Item will be exposed as a switchable
+* "Switchable": Item will be exposed as an OSRAM SMART+ Plug
 * "Lighting": Item will be exposed as a dimmable white bulb
 * "ColorLighting": Item will be exposed as a color bulb
 
 It is the responsibility of binding developers to categories and default tag their
 available *Channels*, so that linked Items are automatically exposed with this service.
 
+You can tag items manually though as well.
+
 ## Exposed names
 
 Your items labels are used for exposing! The default naming schema in Paper UI
 for automatically linked items unfortunately names *Items* like their Channel names,
-so usually "Brightness" or "Color". You want to rename those!
+so usually "Brightness" or "Color". You want to rename those.
 
 ## Configuration:
 
@@ -59,14 +66,26 @@ After that timeout, the `pairingEnabled` is automatically set to `false`.
 org.openhab.hueemulation:pairingTimeout=60
 ```
 
-For systems with multiple IP addresses the IP to use for UPNP may optionally be specified.
-Otherwise the first non loopback address will be used.
+To create an api key on the fly, you can set the following option.
+
+Necessary for Amazon Echos and other devices where the API key cannot be reset.
+After a new installation of openHAB or a configuration pruning the old
+API keys are gone but the Echos will keep trying with their invalid keys.
+
+```
+org.openhab.hueemulation:createNewUserOnEveryEndpoint=false
+```
+
+For systems with multiple IP addresses the IP to expose via UPNP may optionally be specified.
+Otherwise the openHAB configured primary address will be used.
+Usually you do not want to set this option, but change the primary address configuration of openHAB.
 
 ```
 org.openhab.hueemulation:discoveryIp=192.168.1.100
 ```
 
-One of the comma separated tags must match for the item to be exposed. Can be empty to match every item.
+One of the comma separated tags must match for the item to be exposed.
+Can be empty to match an item based on the other criteria.
 
 ```
 org.openhab.hueemulation:restrictToTagsSwitches=Switchable
@@ -74,6 +93,19 @@ org.openhab.hueemulation:restrictToTagsWhiteLights=Lighting
 org.openhab.hueemulation:restrictToTagsColorLights=ColorLighting
 ```
 
+## Troubleshooting
+
+Some devices like the Amazon Echo, Google Home and all Philips devices expect a Hue bridge to
+run on port 80. You must either port forward your openHAB installation to port 80, install
+a reverse proxy on port 80 or let openHAB run on port 80.
+
+You can test if the hue emulation does its job by enabling pairing mode including the option
+"Amazon Echo device discovery fix".
+
+1. Navigate with your browser to "http://your-openhab-ip/description.xml" to check the discovery
+   response. Check the IP address in there.
+2. Navigate with your browser to "http://your-openhab-ip/api/testuser/lights?debug=true"
+   to check all exposed lights and switches.
 
 ## Text configuration example
 

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/LightItems.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/LightItems.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.storage.Storage;
-import org.eclipse.smarthome.core.types.StateDescription;
 import org.openhab.io.hueemulation.internal.dto.HueDataStore;
 import org.openhab.io.hueemulation.internal.dto.HueDevice;
 import org.openhab.io.hueemulation.internal.dto.HueGroup;
@@ -30,20 +29,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Listens to the ItemRegistry for items that fulfill the criteria
- * (type is any of SWITCH, DIMMER, COLOR and it is tagged or has a category)
- * and creates {@link HueDevice} instances for every found item.
+ * Listens to the ItemRegistry for items that fulfill one of these criteria:
+ * <ul>
+ * <li>Type is any of SWITCH, DIMMER, COLOR (or Group type with one of the mentioned base item types)
+ * <li>The category is "ColorLight" for coloured lights or "Light" for switchables.
+ * <li>The item is tagged, according to what is set with {@link #setFilterTags(Set, Set, Set)}.
+ * </ul>
  *
  * <p>
- * The {@link HueDevice} instances are kept in the given {@link HueDataStore}.
+ * A {@link HueDevice} instances is created for each found item.
+ * Those are kept in the given {@link HueDataStore}.
  * </p>
  *
  * <p>
- * Implementing groups or scenes should be done here as well by filtering for GroupItems.
- * At the moment only the artificial Group 0 is provided.
+ * Implementing scenes should be done here as well.
  * </p>
  *
- * The HUE Rest API requires a unique integer ID for every listed device.
+ * <p>
+ * The HUE Rest API requires a unique integer ID for every listed device. A storage service
+ * is used to store and load this mapping. A storage is not required for this class to work,
+ * but without it the mapping will be temporary only and ids may change on every boot up.
+ * </p>
+ *
+ * <p>
+ * </p>
  *
  * @author David Graeff - Initial contribution
  */
@@ -54,19 +63,25 @@ public class LightItems implements RegistryChangeListener<Item> {
             .of(CoreItemFactory.COLOR, CoreItemFactory.DIMMER, CoreItemFactory.SWITCH).collect(Collectors.toSet());
 
     // deviceMap maps a unique Item id to a Hue numeric id
-    private final TreeMap<String, Integer> itemUIDtoHueID = new TreeMap<>();
+    final TreeMap<String, Integer> itemUIDtoHueID = new TreeMap<>();
     private final HueDataStore dataStore;
     private Set<String> switchFilter = Collections.emptySet();
     private Set<String> colorFilter = Collections.emptySet();
     private Set<String> whiteFilter = Collections.emptySet();
     private @Nullable Storage<Integer> storage;
+    private boolean initDone = false;
+    private @NonNullByDefault({}) ItemRegistry itemRegistry;
 
     public LightItems(HueDataStore ds) {
         dataStore = ds;
     }
 
     /**
-     * Set filter tags. Empty sets are allowed, items will not be filtered then.
+     * Set filter tags. Empty sets are allowed, items will not be filtered by tags but other criteria then.
+     *
+     * <p>
+     * Calling this method will reset the {@link HueDataStore} and parse items from the item registry again.
+     * </p>
      *
      * @param switchFilter The switch filter tags
      * @param colorFilter The color filter tags
@@ -76,14 +91,38 @@ public class LightItems implements RegistryChangeListener<Item> {
         this.switchFilter = switchFilter;
         this.colorFilter = colorFilter;
         this.whiteFilter = whiteFilter;
+        fetchItems();
     }
 
     /**
-     * Load the {@link #itemUIDtoHueID} mapping.
+     * Sets the item registry. Used to load up items and register to changes
+     *
+     * @param itemRegistry The item registry
      */
-    public void loadMappingFromFile(Storage<Integer> storage) {
+    public void setItemRegistry(@Nullable ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
+
+    /**
+     * Load the {@link #itemUIDtoHueID} mapping from the given storage.
+     * This method can also be called when the storage service changes.
+     * A changed storage causes an immediately write request.
+     * <p>
+     * Because storage services are dynamically bound and may appear late,
+     * it may happen that the mapping is only loaded after items have been parsed already.
+     * In that case the {@link HueDataStore} is reset and items from the item registry are parsed again.
+     * It is important to keep the once exposed ids though.
+     * </p>
+     *
+     * @param storage A storage service
+     */
+    public void loadMappingFromFile(@Nullable Storage<Integer> storage) {
         boolean storageChanged = this.storage != null && this.storage != storage;
         this.storage = storage;
+        if (storage == null) {
+            return;
+        }
+
         for (String itemUID : storage.getKeys()) {
             Integer hueID = storage.get(itemUID);
             if (hueID == null) {
@@ -91,8 +130,11 @@ public class LightItems implements RegistryChangeListener<Item> {
             }
             itemUIDtoHueID.put(itemUID, hueID);
         }
+
         if (storageChanged) {
             writeToFile();
+        } else if (initDone) { // storage comes late to the game -> reassign all items
+            fetchItems();
         }
     }
 
@@ -101,19 +143,26 @@ public class LightItems implements RegistryChangeListener<Item> {
      * Call {@link #close(ItemRegistry)} when you are done with this object.
      *
      * Only call this after you have set the filter tags with {@link #setFilterTags(Set, Set, Set)}.
-     *
-     * @param itemRegistry The item registry
      */
-    public void fetchItemsAndWatchRegistry(ItemRegistry itemRegistry) {
+    public synchronized void fetchItems() {
+        initDone = false;
+
+        dataStore.resetGroupsAndLights();
+
+        itemRegistry.removeRegistryChangeListener(this);
         itemRegistry.addRegistryChangeListener(this);
 
+        boolean changed = false;
         for (Item item : itemRegistry.getItems()) {
-            added(item);
+            changed |= addItem(item);
         }
-    }
+        initDone = true;
 
-    private int generateNextHueID() {
-        return dataStore.lights.size() == 0 ? 1 : new Integer(dataStore.lights.lastKey().intValue() + 1);
+        logger.debug("Added items: {}",
+                dataStore.lights.values().stream().map(l -> l.name).collect(Collectors.joining(", ")));
+        if (changed) {
+            writeToFile();
+        }
     }
 
     /**
@@ -124,6 +173,7 @@ public class LightItems implements RegistryChangeListener<Item> {
         if (storage == null) {
             return;
         }
+        storage.getKeys().forEach(key -> storage.remove(key));
         itemUIDtoHueID.forEach((itemUID, hueID) -> storage.put(itemUID, hueID));
     }
 
@@ -134,23 +184,16 @@ public class LightItems implements RegistryChangeListener<Item> {
     /**
      * Unregisters from the {@link ItemRegistry}.
      */
-    public void close(ItemRegistry itemRegistry) {
+    public void close() {
         writeToFile();
         itemRegistry.removeRegistryChangeListener(this);
     }
 
-    private @Nullable DeviceType determineTargetType(Item element) {
+    private @Nullable DeviceType determineTargetType(@Nullable String category, String type, Set<String> tags) {
         // Determine type, heuristically
         DeviceType t = null;
 
-        // No read only states
-        StateDescription stateDescription = element.getStateDescription();
-        if (stateDescription != null && stateDescription.isReadOnly()) {
-            return t;
-        }
-
         // First consider the category
-        String category = element.getCategory();
         if (category != null) {
             switch (category) {
                 case "ColorLight":
@@ -162,19 +205,19 @@ public class LightItems implements RegistryChangeListener<Item> {
         }
 
         // Then the tags
-        if (switchFilter.stream().anyMatch(element.getTags()::contains)) {
+        if (switchFilter.stream().anyMatch(tags::contains)) {
             t = DeviceType.SwitchType;
         }
-        if (whiteFilter.stream().anyMatch(element.getTags()::contains)) {
+        if (whiteFilter.stream().anyMatch(tags::contains)) {
             t = DeviceType.WhiteTemperatureType;
         }
-        if (colorFilter.stream().anyMatch(element.getTags()::contains)) {
+        if (colorFilter.stream().anyMatch(tags::contains)) {
             t = DeviceType.ColorType;
         }
 
         // Last but not least, the item type
         if (t == null) {
-            switch (element.getType()) {
+            switch (type) {
                 case CoreItemFactory.COLOR:
                     if (colorFilter.size() == 0) {
                         t = DeviceType.ColorType;
@@ -195,26 +238,43 @@ public class LightItems implements RegistryChangeListener<Item> {
         return t;
     }
 
-    @SuppressWarnings({ "unused", "null" })
     @Override
-    public void added(Item element) {
+    public synchronized void added(Item element) {
+        addItem(element);
+    }
+
+    String getType(Item element) {
+        if (element instanceof GroupItem) {
+            Item baseItem = ((GroupItem) element).getBaseItem();
+            if (baseItem != null) {
+                return baseItem.getType();
+            } else {
+                return "";
+            }
+        } else {
+            return element.getType();
+        }
+    }
+
+    @SuppressWarnings({ "unused", "null" })
+    public boolean addItem(Item element) {
         // Only allowed types
-        if (!ALLOWED_ITEM_TYPES.contains(element.getType())) {
-            return;
+        String type = getType(element);
+
+        if (!ALLOWED_ITEM_TYPES.contains(type)) {
+            return false;
         }
 
-        DeviceType t = determineTargetType(element);
+        DeviceType t = determineTargetType(element.getCategory(), type, element.getTags());
         if (t == null) {
-            return;
+            return false;
         }
-
-        logger.debug("Add item {}", element.getUID());
 
         Integer hueID = itemUIDtoHueID.get(element.getUID());
 
         boolean itemAssociationCreated = false;
         if (hueID == null) {
-            hueID = generateNextHueID();
+            hueID = dataStore.generateNextLightHueID();
             itemAssociationCreated = true;
         }
 
@@ -229,9 +289,13 @@ public class LightItems implements RegistryChangeListener<Item> {
         }
         updateGroup0();
         itemUIDtoHueID.put(element.getUID(), hueID);
-        if (itemAssociationCreated) {
-            writeToFile();
+        if (initDone) {
+            logger.debug("Add item {}", element.getUID());
+            if (itemAssociationCreated) {
+                writeToFile();
+            }
         }
+        return itemAssociationCreated;
     }
 
     /**
@@ -244,7 +308,7 @@ public class LightItems implements RegistryChangeListener<Item> {
 
     @SuppressWarnings({ "null", "unused" })
     @Override
-    public void removed(Item element) {
+    public synchronized void removed(Item element) {
         Integer hueID = itemUIDtoHueID.get(element.getUID());
         if (hueID == null) {
             return;
@@ -262,7 +326,7 @@ public class LightItems implements RegistryChangeListener<Item> {
      */
     @SuppressWarnings({ "null", "unused" })
     @Override
-    public void updated(Item oldElement, Item element) {
+    public synchronized void updated(Item oldElement, Item element) {
         Integer hueID = itemUIDtoHueID.get(element.getUID());
         if (hueID == null) {
             // If the correct tags got added -> use the logic within added()
@@ -287,7 +351,7 @@ public class LightItems implements RegistryChangeListener<Item> {
         }
 
         // Check if type can still be determined (tags and category is still sufficient)
-        DeviceType t = determineTargetType(element);
+        DeviceType t = determineTargetType(element.getCategory(), getType(element), element.getTags());
         if (t == null) {
             removed(element);
             return;

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/UserManagement.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/UserManagement.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.openhab.io.hueemulation.internal.dto.HueDataStore;
-import org.openhab.io.hueemulation.internal.dto.HueDataStore.UserAuth;
+import org.openhab.io.hueemulation.internal.dto.HueUserAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class UserManagement {
     private final Logger logger = LoggerFactory.getLogger(UserManagement.class);
     private final HueDataStore dataStore;
-    private @Nullable Storage<UserAuth> storage;
+    private @Nullable Storage<HueUserAuth> storage;
 
     public UserManagement(HueDataStore ds) {
         dataStore = ds;
@@ -38,11 +38,11 @@ public class UserManagement {
     /**
      * Load users from disk
      */
-    public void loadUsersFromFile(Storage<UserAuth> storage) {
+    public void loadUsersFromFile(Storage<HueUserAuth> storage) {
         boolean storageChanged = this.storage != null && this.storage != storage;
         this.storage = storage;
         for (String id : storage.getKeys()) {
-            UserAuth userAuth = storage.get(id);
+            HueUserAuth userAuth = storage.get(id);
             if (userAuth == null) {
                 continue;
             }
@@ -58,7 +58,7 @@ public class UserManagement {
      */
     @SuppressWarnings("null")
     public boolean authorizeUser(String userName) throws IOException {
-        UserAuth userAuth = dataStore.config.whitelist.get(userName);
+        HueUserAuth userAuth = dataStore.config.whitelist.get(userName);
         if (userAuth != null) {
             userAuth.lastUseDate = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         }
@@ -72,14 +72,14 @@ public class UserManagement {
     public synchronized void addUser(String apiKey, String label) throws IOException {
         if (!dataStore.config.whitelist.containsKey(apiKey)) {
             logger.debug("APIKey {} added", apiKey);
-            dataStore.config.whitelist.put(apiKey, new UserAuth(label));
+            dataStore.config.whitelist.put(apiKey, new HueUserAuth(label));
             writeToFile();
         }
     }
 
     @SuppressWarnings("null")
     public synchronized void removeUser(String apiKey) {
-        UserAuth userAuth = dataStore.config.whitelist.remove(apiKey);
+        HueUserAuth userAuth = dataStore.config.whitelist.remove(apiKey);
         if (userAuth != null) {
             logger.debug("APIKey {} removed", apiKey);
             writeToFile();
@@ -90,10 +90,11 @@ public class UserManagement {
      * Persist users to storage.
      */
     void writeToFile() {
-        Storage<UserAuth> storage = this.storage;
+        Storage<HueUserAuth> storage = this.storage;
         if (storage == null) {
             return;
         }
+        storage.getKeys().forEach(key -> storage.remove(key));
         dataStore.config.whitelist.forEach((id, userAuth) -> storage.put(id, userAuth));
     }
 

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueAuthorizedConfig.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueAuthorizedConfig.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.io.hueemulation.internal.dto.HueDataStore.UserAuth;
 
 /**
  * Hue API config object
@@ -48,5 +47,5 @@ public class HueAuthorizedConfig extends HueUnauthorizedConfig {
     public String proxyaddress = "none";
     public int proxyport = 0;
 
-    public final Map<String, UserAuth> whitelist = new TreeMap<>();
+    public final Map<String, HueUserAuth> whitelist = new TreeMap<>();
 }

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDataStore.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDataStore.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.io.hueemulation.internal.dto;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
@@ -28,7 +26,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class HueDataStore {
     public HueAuthorizedConfig config = new HueAuthorizedConfig();
     public TreeMap<Integer, HueDevice> lights = new TreeMap<>();
-    public Map<Integer, HueGroup> groups = new TreeMap<>();
+    public TreeMap<Integer, HueGroup> groups = new TreeMap<>();
     public Map<Integer, Dummy> scenes = new TreeMap<>();
     public Map<Integer, Dummy> rules = new TreeMap<>();
     public Map<Integer, Dummy> sensors = new TreeMap<>();
@@ -36,32 +34,24 @@ public class HueDataStore {
     public Map<Integer, Dummy> resourcelinks = Collections.emptyMap();
 
     public HueDataStore() {
+        resetGroupsAndLights();
+    }
+
+    public void resetGroupsAndLights() {
+        groups.clear();
+        lights.clear();
         // There must be a group 0 all the time!
         groups.put(0, new HueGroup("All lights", null, Collections.emptyMap()));
     }
 
-    public static class Dummy {
+    public int generateNextLightHueID() {
+        return lights.size() == 0 ? 1 : new Integer(lights.lastKey().intValue() + 1);
     }
 
-    public static class UserAuth {
-        public String name = "";
-        public String createDate = "";
-        public String lastUseDate = "";
+    public int generateNextGroupHueID() {
+        return groups.size() == 0 ? 1 : new Integer(groups.lastKey().intValue() + 1);
+    }
 
-        /**
-         * For de-serialization.
-         */
-        public UserAuth() {
-        }
-
-        /**
-         * Create a new user
-         *
-         * @param name Visible name
-         */
-        public UserAuth(String name) {
-            this.name = name;
-            this.createDate = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        }
+    public static class Dummy {
     }
 }

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
@@ -39,7 +39,7 @@ public class HueStateBulb extends HueStatePlug {
      * Create a hue state with the given brightness percentage
      *
      * @param brightness Brightness percentage
-     * @param on         On value
+     * @param on On value
      */
     public HueStateBulb(PercentType brightness, boolean on) {
         super(on);
@@ -48,6 +48,6 @@ public class HueStateBulb extends HueStatePlug {
 
     @Override
     public String toString() {
-        return "[on: " + on + " bri: " + bri + " reachable: " + reachable;
+        return "on: " + on + ", brightness: " + bri + ", reachable: " + reachable;
     }
 }

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
@@ -32,7 +32,14 @@ public class HueStateColorBulb extends HueStateBulb {
 
     /** time for transition in centiseconds. */
     public int transitiontime;
-    public String colormode = "ct";
+
+    public static enum ColorMode {
+        ct,
+        hs,
+        xy
+    }
+
+    public ColorMode colormode = ColorMode.ct;
 
     protected HueStateColorBulb() {
     }
@@ -40,6 +47,7 @@ public class HueStateColorBulb extends HueStateBulb {
     public HueStateColorBulb(boolean on) {
         super(on);
         this.bri = on ? MAX_BRI : 0;
+        colormode = ColorMode.ct;
     }
 
     /**
@@ -50,6 +58,7 @@ public class HueStateColorBulb extends HueStateBulb {
      */
     public HueStateColorBulb(PercentType brightness, boolean on) {
         super(brightness, on);
+        colormode = ColorMode.ct;
     }
 
     /**
@@ -62,6 +71,7 @@ public class HueStateColorBulb extends HueStateBulb {
         this.hue = hsb.getHue().intValue() * MAX_HUE / 360;
         this.sat = hsb.getSaturation().intValue() * MAX_SAT / 100;
         this.bri = hsb.getBrightness().intValue() * MAX_BRI / 100;
+        colormode = this.sat > 0 ? ColorMode.hs : ColorMode.ct;
     }
 
     /**
@@ -70,13 +80,15 @@ public class HueStateColorBulb extends HueStateBulb {
     public HSBType toHSBType() {
         int bri = this.bri * 100 / MAX_BRI;
         int sat = this.sat * 100 / MAX_SAT;
-        int hue = this.sat * 360 / MAX_HUE;
+        int hue = this.hue * 360 / MAX_HUE;
 
         if (!this.on) {
-            return new HSBType(new DecimalType(hue), new PercentType(sat), new PercentType(0));
-        } else {
-            return new HSBType(new DecimalType(hue), new PercentType(sat), new PercentType(bri));
+            bri = 0;
         }
+        if (colormode == ColorMode.ct) {
+            sat = 0;
+        }
+        return new HSBType(new DecimalType(hue), new PercentType(sat), new PercentType(bri));
     }
 
     @Override
@@ -86,7 +98,8 @@ public class HueStateColorBulb extends HueStateBulb {
             xyString += d + " ";
         }
         xyString += "}";
-        return "[on: " + on + " bri: " + bri + " hue: " + hue + " sat: " + sat + " xy: " + xyString + " ct: " + ct
-                + " alert: " + alert + " effect: " + effect + " colormode: " + colormode + " reachable: " + reachable;
+        return "on: " + on + ", brightness: " + bri + ", hue: " + hue + ", sat: " + sat + ", xy: " + xyString + ", ct: "
+                + ct + ", alert: " + alert + ", effect: " + effect + ", colormode: " + colormode + ", reachable: "
+                + reachable;
     }
 }

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStatePlug.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStatePlug.java
@@ -26,6 +26,6 @@ public class HueStatePlug extends AbstractHueState {
 
     @Override
     public String toString() {
-        return "[on: " + on + " reachable: " + reachable;
+        return "on: " + on + ", reachable: " + reachable;
     }
 }

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueUserAuth.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueUserAuth.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.hueemulation.internal.dto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Hue user object. Used by {@link HueAuthorizedConfig}.
+ *
+ * @author David Graeff - Initial contribution
+ */
+public class HueUserAuth {
+    public String name = "";
+    public String createDate = "";
+    public String lastUseDate = "";
+
+    /**
+     * For de-serialization.
+     */
+    public HueUserAuth() {
+    }
+
+    /**
+     * Create a new user
+     *
+     * @param name Visible name
+     */
+    public HueUserAuth(String name) {
+        this.name = name;
+        this.createDate = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+}

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/response/HueSuccessCreateGroup.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/response/HueSuccessCreateGroup.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.hueemulation.internal.dto.response;
+
+/**
+ * This object describes the right hand side of "success".
+ * The response looks like this:
+ *
+ * <pre>
+ * {
+ *   "success":{
+ *      "id": "-the-id-"
+ *   }
+ * }
+ * </pre>
+ *
+ * @author David Graeff - Initial contribution
+ */
+public class HueSuccessCreateGroup implements HueSuccessResponse {
+    public int id;
+
+    public HueSuccessCreateGroup(int id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
Fixes:
* Fix user creation without a proposed username in the request. Incl. test
* Fix: The hue value was wrongly applied to the saturation field. Incl. test
* Fix usage of StorageService: Set the classloader
* Set the saturation to 0 if a ct (color temperature) value is set.
  This is because Alexa only sets "ct" if you command her to turn the light white.
* Only call writeToFile in LightItems once, after all items have been
  loaded up from the registry.
* Don't load items twice from the registry.
* Reload items whenever the tags configuration has changed.
* Allow group items

Features:
* Add troubleshoot section to readme.
  Allow a pretty printed output for /api/{username}/lights?debug=true.

Tests:
* Add LightItems class unit tests for adding/updating items and group items
  by category and tags.
* Add tests for setting the hue and saturation and turn a light from color to white

Refactor:
* Move UserAuth class out of DataStore into own HueUserAuth class

Fixes #4293
Fixes #4307

Signed-off-by: David Graeff <david.graeff@web.de>