### PR TITLE
Milight: Use any free port instead of fixed port on client-side for bridge communication

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/discovery/MilightBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/discovery/MilightBridgeDiscovery.java
@@ -232,7 +232,7 @@ public class MilightBridgeDiscovery extends AbstractDiscoveryService implements 
             datagramSocket = new DatagramSocket(null);
             datagramSocket.setBroadcast(true);
             datagramSocket.setReuseAddress(true);
-            datagramSocket.bind(new InetSocketAddress(receivePort));
+            datagramSocket.bind(null);
         } catch (SocketException e) {
             logger.error("Opening a socket for the milight discovery service failed. {}", e.getLocalizedMessage());
             return;

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
@@ -72,7 +72,7 @@ public class BridgeV3Handler extends AbstractBridgeHandler {
             socket = new DatagramSocket(null);
             socket.setReuseAddress(true);
             socket.setBroadcast(true);
-            socket.bind(new InetSocketAddress(MilightBindingConstants.PORT_DISCOVER));
+            socket.bind(new InetSocketAddress(0));
         } catch (SocketException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
         }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
@@ -72,7 +72,7 @@ public class BridgeV3Handler extends AbstractBridgeHandler {
             socket = new DatagramSocket(null);
             socket.setReuseAddress(true);
             socket.setBroadcast(true);
-            socket.bind(new InetSocketAddress(0));
+            socket.bind(null);
         } catch (SocketException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
         }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/MilightV6SessionManager.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -110,7 +109,7 @@ public class MilightV6SessionManager implements Runnable, Closeable {
          * SESSION_VALID_KEEP_ALIVE will be reported in the interval, given to the constructor of
          * {@link MilightV6SessionManager}.
          *
-         * @param state The new state
+         * @param state   The new state
          * @param address The remote IP address. Only guaranteed to be non null in the SESSION_VALID* states.
          */
         void sessionStateChanged(SessionState state, @Nullable InetAddress address);
@@ -536,7 +535,7 @@ public class MilightV6SessionManager implements Runnable, Closeable {
             datagramSocket.setBroadcast(true);
             datagramSocket.setReuseAddress(true);
             datagramSocket.setSoTimeout(150);
-            datagramSocket.bind(new InetSocketAddress(port));
+            datagramSocket.bind(null);
 
             if (ProtocolConstants.DEBUG_SESSION) {
                 logger.debug("MilightCommunicationV6 receive thread ready");


### PR DESCRIPTION
resolves #4232.

@TomaSpeed: I only tested it with emulated V3 bridges. Could you (or anybody else) test with the real ones? For convenience, I attached a snaphot build of the binding which contains the fix.

[org.openhab.binding.milight-2.4.0-SNAPSHOT.zip](https://github.com/openhab/openhab2-addons/files/2659957/org.openhab.binding.milight-2.4.0-SNAPSHOT.zip)


Signed-off-by: Patrick Fink <mail@pfink.de>
