### PR TITLE
Hue emulation: Don't use getParameter on a HttpServletRequest

### DIFF
--- a/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
+++ b/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
@@ -218,6 +218,20 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
     }
 
     @Test
+    public void DebugTest() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        HttpURLConnection c;
+        String body;
+
+        hueService.ds.config.whitelist.put("testuser", new HueUserAuth("testUserLabel"));
+        hueService.ds.lights.put(2, new HueDevice(item, "color", DeviceType.ColorType));
+
+        c = (HttpURLConnection) new URL(host + "/api/testuser/lights?debug=true").openConnection();
+        assertThat(c.getResponseCode(), is(200));
+        body = read(c);
+        assertThat(body, containsString("Exposed lights"));
+    }
+
+    @Test
     public void LightGroupItemSwitchTest()
             throws InterruptedException, ExecutionException, TimeoutException, IOException {
         HttpURLConnection c;

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
@@ -382,9 +382,6 @@ public class HueDevice {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(name).append(": ").append(type).append("\n\t");
-        b.append("State: ").append(state.toString());
-
-        return b.toString();
+        return b.append(name).append(": ").append(type).append("\n\t").append(state.toString()).toString();
     }
 }


### PR DESCRIPTION
* Add test that the troubleshoot view with ?debug=true works
* Use switch construct for HttpMethod if/else-branches.
* RestApi: Throw JSonException with proper error message instead of just
  returning a 400 error. That way HueEmulationService can
  return the exact error to the user and log a proper warning.
  (400-errors only happen if the user is sending errornous json.)

I'm pretty sure, backed by the test suits, with this commit the hue emulation is in release quality now.

Signed-off-by: David Graeff <david.graeff@web.de>