### PR TITLE
[Konnected]- bugfix fix configuation check to properly pull the configurations and prev…

### DIFF
--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -175,10 +175,12 @@ public class KonnectedHandler extends BaseThingHandler {
     }
 
     private void checkConfiguration() throws ConfigValidationException {
-        KonnectedConfiguration testConfig = getConfigAs(KonnectedConfiguration.class);
+        logger.debug("Checking configurauon on thing {}", this.getThing().getUID().getAsString());
+        Configuration testConfig = this.getConfig();
         String testRetryCount = testConfig.get(RETRY_COUNT).toString();
         String testRequestTimeout = testConfig.get(REQUEST_TIMEOUT).toString();
-
+        logger.debug("The RequestTimeout Parameter is Configured as: {}", testRequestTimeout);
+        logger.debug("The Retry Count Parameter is Configured as: {}", testRetryCount);
         try {
             this.retryCount = Integer.parseInt(testRetryCount);
         } catch (NumberFormatException e) {
@@ -188,6 +190,7 @@ public class KonnectedHandler extends BaseThingHandler {
             this.retryCount = 2;
         }
         try {
+
             this.http.setRequestTimeout(Integer.parseInt(testRequestTimeout));
         } catch (NumberFormatException e) {
             logger.debug(
@@ -201,7 +204,7 @@ public class KonnectedHandler extends BaseThingHandler {
         }
 
         else {
-            this.config = testConfig;
+            this.config = getConfigAs(KonnectedConfiguration.class);
         }
     }
 
@@ -399,6 +402,7 @@ public class KonnectedHandler extends BaseThingHandler {
      * Prepares and sends the {@link KonnectedModulePayload} via the {@link KonnectedHttpUtils}
      *
      * @return response obtained from sending the settings payload to Konnected module defined by the thing
+     *
      * @throws KonnectedHttpRetryExceeded if unable to communicate with the Konnected module defined by the Thing
      */
     private String updateKonnectedModule() throws KonnectedHttpRetryExceeded {

--- a/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/addons/binding/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -175,7 +175,7 @@ public class KonnectedHandler extends BaseThingHandler {
     }
 
     private void checkConfiguration() throws ConfigValidationException {
-        logger.debug("Checking configurauon on thing {}", this.getThing().getUID().getAsString());
+        logger.debug("Checking configuration on thing {}", this.getThing().getUID().getAsString());
         Configuration testConfig = this.getConfig();
         String testRetryCount = testConfig.get(RETRY_COUNT).toString();
         String testRequestTimeout = testConfig.get(REQUEST_TIMEOUT).toString();


### PR DESCRIPTION
fix to  the check configuration method to properly pull configuration and prevent null pointer expception from being thrown.  Then if valid get the configutration as class and save to handler.

Signed-off-by: Zachary Christiansen <volfan6415@gmail.com> (github: volfan6415)

