### PR TITLE
Deconz: Fix: Websocket connection is never established

### DIFF
--- a/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/netutils/WebSocketConnection.java
+++ b/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/netutils/WebSocketConnection.java
@@ -50,7 +50,7 @@ public class WebSocketConnection {
     }
 
     public void start(String ip) {
-        if (client.isRunning()) {
+        if (connected) {
             return;
         }
         try {
@@ -67,6 +67,7 @@ public class WebSocketConnection {
 
     public void close() {
         try {
+            connected = false;
             client.stop();
         } catch (Exception e) {
             logger.debug("Error while closing connection: {}", e);


### PR DESCRIPTION
The introduced "connected" flag was not used at all.
This worked in the very first version of the binding, because a new Websocket connection was established.
Now that a framework connection is used, the `client.isRunning()` will always return true.

Fixes #4355

Signed-off-by: davidgraeff <david.graeff@web.de>