### PR TITLE
[gpstracker] Location accuracy threshold for distance channels

### DIFF
--- a/addons/binding/org.openhab.binding.gpstracker/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.gpstracker/ESH-INF/config/config.xml
@@ -30,5 +30,11 @@
 			<description>Location of the region center</description>
 			<advanced>false</advanced>
 		</parameter>
+		<parameter name="accuracyThreshold" type="decimal" required="true" min="0">
+			<label>Accuracy Threshold</label>
+			<description>Location accuracy threshold in m or yd (0 to disable)</description>
+			<default>0</default>
+			<advanced>false</advanced>
+		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.gpstracker/README.md
+++ b/addons/binding/org.openhab.binding.gpstracker/README.md
@@ -101,8 +101,9 @@ These dynamic channels require the following parameters:
 | Region Name   | String   | Region name. If the region is configured in the tracker app as well use the same name. Distance channels can also be defined as binding only regions (not configured in trackers) |
 | Region center | Location | Region center location                                                                                                                                                            |
 | Region Radius | Integer  | Geofence radius                                                                                                                                                                   |
+| Accuracy Threshold | Integer  | Location accuracy threshold (0 to disable)                                                                                                                                                                 |
 
-Distance values will be updated each time a GPS location log record is received from the tracker.
+Distance values will be updated each time a GPS location log record is received from the tracker if the accuracy is below the threshold or if the threshold is disabled.
 
 When this calculated distance is less than the defined geofence radius the binding also fires event on Region Trigger channel.
 
@@ -145,7 +146,8 @@ Thing gpstracker:tracker:EX   "EX tracker" [trackerId="EX"] {
             Type regionDistance : homeDistance "Distance from Home" [
                 regionName="Home",
                 regionCenterLocation="11.1111,22.2222",
-                regionRadius=100
+                regionRadius=100,
+                accuracyThreshold=30
             ]
 }
 ```

--- a/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/config/ConfigHelper.java
+++ b/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/config/ConfigHelper.java
@@ -24,6 +24,7 @@ public class ConfigHelper {
     public static final String CONFIG_REGION_NAME = "regionName";
     public static final String CONFIG_REGION_RADIUS = "regionRadius";
     public static final String CONFIG_REGION_CENTER_LOCATION = "regionCenterLocation";
+    public static final String CONFIG_ACCURACY_THRESHOLD = "accuracyThreshold";
 
     /**
      * Constructor.
@@ -32,6 +33,11 @@ public class ConfigHelper {
 
     public static double getRegionRadius(Configuration config) {
         return ((BigDecimal) config.get(CONFIG_REGION_RADIUS)).doubleValue();
+    }
+
+    public static double getAccuracyThreshold(Configuration config) {
+        Object value = config.get(CONFIG_ACCURACY_THRESHOLD);
+        return value != null ? ((BigDecimal) value).doubleValue(): 0;
     }
 
     public static String getRegionName(Configuration config) {


### PR DESCRIPTION
Each distance channel now has an accuracyThreshold parameter. If the accuracy of the received GPS log record is above this threshold the binding skips the distance calculation and firing enter/leave event on the region trigger channel.
Setting 0 as threshold disables this check.

Closes #4362

Signed-off-by: Gabor Bicskei <gbicskei@gmail.com>
