### PR TITLE
[deconz] Remove results field from ThingDiscoveryService to fix OOM

### DIFF
--- a/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.deconz.internal.discovery;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -35,7 +33,7 @@ import org.openhab.binding.deconz.internal.handler.DeconzBridgeHandler;
  */
 @NonNullByDefault
 public class ThingDiscoveryService extends AbstractDiscoveryService implements ThingHandlerService {
-    private final List<DiscoveryResult> results = new ArrayList<>();
+
     private @NonNullByDefault({}) DeconzBridgeHandler handler;
 
     public ThingDiscoveryService() {
@@ -83,7 +81,6 @@ public class ThingDiscoveryService extends AbstractDiscoveryService implements T
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(uid).withBridge(handler.getThing().getUID())
                 .withLabel(sensor.name + " (" + sensor.manufacturername + ")").withProperty("id", sensorID)
                 .withProperty("uid", sensor.uniqueid).withRepresentationProperty("uid").build();
-        results.add(discoveryResult);
         thingDiscovered(discoveryResult);
     }
 


### PR DESCRIPTION
I don't use the deconz binding and don't even know what it does. But after briefly looking at the code I think this change may help with fixing the OOM reported in #4361. WDYT @davidgraeff?