### PR TITLE
Update pom.xml / adding generic Xbee devices / Connect to linky smartmeter

### DIFF
--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -130,6 +130,7 @@
     <module>org.openhab.binding.smaenergymeter</module>
     <module>org.openhab.binding.smartmeter</module>
     <module>org.openhab.binding.smartmeter.test</module>
+    <module>org.openhab.binding.snavxbee2</module>
     <module>org.openhab.binding.solaredge</module>
     <module>org.openhab.binding.solarlog</module>
     <module>org.openhab.binding.somfytahoma</module>


### PR DESCRIPTION
<!--
This binding will let you use Xbee devices from DigiInternational. 
It will also support to connect to linky devices using Xbee
-->

<!-- SnavXbee2 -->

<!--
"[snavxbee2] using XBee devices "
-->

<!-- DESCRIPTION -->

<!--
This  binding will let you use xbee devices and new discovery processes. 
It can connect to the French Linky meter that will be soon in all french houses. 
It also support DIY devices connected by Xbee. 

-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
