### PR TITLE
[enocean] Handle commands of virtualSwitchA channel correctly

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanClassicDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanClassicDeviceHandler.java
@@ -234,7 +234,7 @@ public class EnOceanClassicDeviceHandler extends EnOceanBaseActuatorHandler {
 
                 EEP eep = EEPFactory.createEEP(sendingEEPType);
                 ESP3Packet press = eep.setSenderId(senderId).setDestinationId(destinationId)
-                        .convertFromCommand(channelId, channel.getChannelTypeUID().getId(), command, currentState,
+                        .convertFromCommand(channelId, channel.getChannelTypeUID().getId(), result, currentState,
                                 channel.getConfiguration())
                         .setSuppressRepeating(getConfiguration().suppressRepeating).getERP1Message();
 


### PR DESCRIPTION
The switch command of the virtualSwitchA channels is already converted into a StringType. However this result is not passed to the EEP. Therefore the "PRESSED" messages are not send by the ClassicDevice thing. This PR fixes #4373.

Signed-off-by: Daniel Weber <uni@fruggy.de>