### PR TITLE
[enocean] Support Eltako TF-FGB

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/MechanicalHandle.xml
+++ b/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/MechanicalHandle.xml
@@ -11,7 +11,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Mechanical Handle</label>
-		<description>Mechanical handle sensor for window/door handles (EEP: F6-10)</description>
+		<description>Mechanical handle sensor for window/door handles</description>
 
 		<config-description>
 			<parameter name="enoceanId" type="text">
@@ -25,6 +25,7 @@
 				<options>
 					<option value="F6_10_00">F6-10-00</option>
 					<option value="F6_10_01">F6-10-01</option>
+					<option value="A5_14_09">A5-14-09</option>
 				</options>
 				<limitToOptions>true</limitToOptions>
 				<required>true</required>

--- a/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
@@ -147,6 +147,13 @@
 		<description>Used energy in Kilowatt hours</description>
 		<state pattern="%d %unit%" readOnly="true" />
 	</channel-type>
+	
+    <channel-type id="batteryVoltage">
+        <item-type>Number:ElectricPotential</item-type>
+        <label>Battery Voltage</label>
+        <description>Voltage of the battery</description>
+        <state pattern="%f %unit%" readOnly="true" />
+    </channel-type>
 
 	<!-- Teach in Channel -->
 	<channel-type id="teachInCMD" advanced="true">

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
@@ -101,6 +101,7 @@ public class EnOceanBindingConstants {
     public final static String CHANNEL_TOTALUSAGE = "totalusage";
     public final static String CHANNEL_INSTANTLITRE = "amrLitre";
     public final static String CHANNEL_TOTALCUBICMETRE = "amrCubicMetre";
+    public final static String CHANNEL_BATTERY_VOLTAGE = "batteryVoltage";
 
     public final static String CHANNEL_AUTOOFF = "autoOFF";
     public final static String CHANNEL_DELAYRADIOOFF = "delayRadioOFF";

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
@@ -160,6 +160,8 @@ public class EnOceanBindingConstants {
                             CoreItemFactory.CONTACT));
                     put(CHANNEL_WINDOWHANDLESTATE, new EnOceanChannelDescription(
                             new ChannelTypeUID(BINDING_ID, CHANNEL_WINDOWHANDLESTATE), CoreItemFactory.STRING));
+                    put(CHANNEL_BATTERY_VOLTAGE, new EnOceanChannelDescription(
+                            new ChannelTypeUID(BINDING_ID, CHANNEL_BATTERY_VOLTAGE), CoreItemFactory.NUMBER));
                     put(CHANNEL_TEACHINCMD, new EnOceanChannelDescription(
                             new ChannelTypeUID(BINDING_ID, CHANNEL_TEACHINCMD), CoreItemFactory.SWITCH));
 

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14.java
@@ -28,14 +28,14 @@ public abstract class A5_14 extends _4BSMessage {
     }
 
     private State getBatteryVoltage() {
-        byte db3 = getDB_3();
+        int db3 = getDB_3Value();
 
         if (db3 > 250) {
             logger.warn("EEP A5-14 error code {}", db3);
             return UnDefType.UNDEF;
         }
 
-        float voltage = db3 / 50; // 0..250 = 0.0..5.0V
+        double voltage = db3 / 50.0; // 0..250 = 0.0..5.0V
 
         return new QuantityType<>(voltage, SmartHomeUnits.VOLT);
     }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enocean.internal.eep.A5_14;
+
+import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_BATTERY_VOLTAGE;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.enocean.internal.eep.Base._4BSMessage;
+import org.openhab.binding.enocean.internal.messages.ERP1Message;
+
+/**
+ *
+ * @author Dominik Krickl-Vorreiter - Initial contribution
+ */
+public abstract class A5_14 extends _4BSMessage {
+    public A5_14(ERP1Message packet) {
+        super(packet);
+    }
+
+    private State getBatteryVoltage() {
+        byte db3 = getDB_3();
+
+        if (db3 > 250) {
+            logger.warn("EEP A5-14 error code {}", db3);
+            return UnDefType.UNDEF;
+        }
+
+        float voltage = db3 / 50; // 0..250 = 0.0..5.0V
+
+        return new QuantityType<>(voltage, SmartHomeUnits.VOLT);
+    }
+
+    @Override
+    protected State convertToStateImpl(String channelId, String channelTypeId, State currentState,
+            Configuration config) {
+        switch (channelId) {
+            case CHANNEL_BATTERY_VOLTAGE:
+                return getBatteryVoltage();
+        }
+
+        return UnDefType.UNDEF;
+    }
+}

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14_09.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14_09.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enocean.internal.eep.A5_14;
+
+import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.enocean.internal.messages.ERP1Message;
+
+/**
+ * Window/Door-Sensor with States Open/Closed/Tilt, Supply voltage monitor
+ *
+ * @author Dominik Krickl-Vorreiter - Initial contribution
+ */
+public class A5_14_09 extends A5_14 {
+    public final byte CLOSED = (byte) 0x00;
+    public final byte TILTED = (byte) 0x01;
+    public final byte OPEN = (byte) 0x03;
+
+    public A5_14_09(ERP1Message packet) {
+        super(packet);
+    }
+
+    private State getWindowhandleState() {
+        byte ct = (byte) ((getDB_0() & 0x06) >> 1);
+
+        switch (ct) {
+            case CLOSED:
+                return new StringType("CLOSED");
+            case OPEN:
+                return new StringType("OPEN");
+            case TILTED:
+                return new StringType("TILTED");
+        }
+
+        return UnDefType.UNDEF;
+    }
+
+    private State getContact() {
+        byte ct = (byte) ((getDB_0() & 0x06) >> 1);
+
+        switch (ct) {
+            case CLOSED:
+                return OpenClosedType.CLOSED;
+            case OPEN:
+            case TILTED:
+                return OpenClosedType.OPEN;
+        }
+
+        return UnDefType.UNDEF;
+    }
+
+    @Override
+    protected State convertToStateImpl(String channelId, String channelTypeId, State currentState,
+            Configuration config) {
+        switch (channelId) {
+            case CHANNEL_WINDOWHANDLESTATE:
+                return getWindowhandleState();
+            case CHANNEL_CONTACT:
+                return getContact();
+        }
+
+        return super.convertToStateImpl(channelId, channelTypeId, currentState, config);
+    }
+}

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
@@ -90,6 +90,7 @@ import org.openhab.binding.enocean.internal.eep.A5_12.A5_12_00;
 import org.openhab.binding.enocean.internal.eep.A5_12.A5_12_01;
 import org.openhab.binding.enocean.internal.eep.A5_12.A5_12_02;
 import org.openhab.binding.enocean.internal.eep.A5_12.A5_12_03;
+import org.openhab.binding.enocean.internal.eep.A5_14.A5_14_09;
 import org.openhab.binding.enocean.internal.eep.A5_38.A5_38_08_Blinds;
 import org.openhab.binding.enocean.internal.eep.A5_38.A5_38_08_Dimming;
 import org.openhab.binding.enocean.internal.eep.A5_38.A5_38_08_Switching;
@@ -167,6 +168,8 @@ public enum EEPType {
             CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT, CHANNEL_RECEIVINGSTATE),
     MechanicalHandle01(RORG.RPS, 0x10, 0x01, false, F6_10_01.class, THING_TYPE_MECHANICALHANDLE,
             CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT, CHANNEL_RECEIVINGSTATE),
+    MechanicalHandle02(RORG._4BS, 0x14, 0x09, false, A5_14_09.class, THING_TYPE_MECHANICALHANDLE,
+            CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT, CHANNEL_BATTERY_VOLTAGE, CHANNEL_RECEIVINGSTATE),
 
     ContactAndSwitch(RORG._1BS, 0x00, 0x01, false, D5_00_01.class, THING_TYPE_CONTACT, CHANNEL_CONTACT,
             CHANNEL_RECEIVINGSTATE),


### PR DESCRIPTION
Signed-off-by: Dominik Krickl-Vorreiter <dominikkv@gmx.de> (github: dominikkv)

Eltako TF-FGB is a window handle addon that can detect the handle position: OPEN, CLOSED and TILT. It is powered by a battery. The EEP is A5-14-09 which contains two pieces of information: the handle position and battery voltage.

This PR adds the said EEP and enables the user to use the device.

Example DSLs:

    Thing mechanicalHandle 05818C61 "Balkontüre" @ "Wohnzimmer" [ enoceanId="11223344", receivingEEPId="A5_14_09" ]

    String c_handle_door_balkon_state "Balkontürgriff [%s]" <door> {channel="enocean:mechanicalHandle:usb300:11223344:windowHandleState"}
    Contact c_handle_door_balkon_contact "Balkontür [%s]" <door> {channel="enocean:mechanicalHandle:usb300:11223344:contact"}
    Number:ElectricPotential c_handle_door_balkon_battery "Balkontür Batterie [%.1f V]" <power>  {channel="enocean:mechanicalHandle:usb300:11223344:batteryVoltage"}

Fixes #4380