### PR TITLE
[enocean] Parse SwitchingState messages of D2_01 EEPs correctly

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
@@ -75,7 +75,7 @@ public abstract class D2_01 extends _VLDMessage {
 
     protected State getSwitchingData() {
         if (getCMD() == CMD_ACTUATOR_STATUS_RESPONE) {
-            return (bytes[bytes.length - 1] & outputValueMask) == STATUS_SWITCHING_ON ? OnOffType.OFF : OnOffType.ON;
+            return (bytes[bytes.length - 1] & outputValueMask) == STATUS_SWITCHING_OFF ? OnOffType.OFF : OnOffType.ON;
         }
 
         return UnDefType.UNDEF;


### PR DESCRIPTION
This PR fixes the parsing of SwitchingState messages of D2_01 EEPs.

Signed-off-by: Daniel Weber <uni@fruggy.de>