### PR TITLE
[loxone] Bugfix Changing Min Max value of Dimmer inside Loxone Config

### DIFF
--- a/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
+++ b/addons/binding/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/core/LxControlDimmer.java
@@ -137,7 +137,7 @@ public class LxControlDimmer extends LxControl {
             Double max = getMax();
             Double min = getMin();
             if (max != null && min != null) {
-                return (loxoneValue - min) * ((max - min) / 100);
+                return loxoneValue;
             }
         }
         return null;
@@ -152,8 +152,7 @@ public class LxControlDimmer extends LxControl {
             Double max = getMax();
             Double min = getMin();
             if (max != null && min != null) {
-                double value = min + (ohValue / ((max - min) / 100));
-                return value; // no rounding to integer value is needed as loxone is accepting floating point values
+                return ohValue; // no rounding to integer value is needed as loxone is accepting floating point values
             }
         }
         return null;


### PR DESCRIPTION
When you changed the default Min and/or Max values (Min=0, Max=100) for a dimmer block inside Loxone Config, and you start moving the slider within OpenHAB or Loxone app, strange values appear. E.g.: If you changed the Max-value of the dimmer inside Loxone Config to 1000, and you set the slider to 69% in OpenHAB, the value in the Loxone App will be 6,9. I pinpointed the issue to be these two additional calculations. Therefore I would propose to delete the calculations and let the Min/Max value to be freely chosen from Loxone Config itself. This also has an additional advantage that someone is able to chose a range of 0-500 for example is he/she likes that.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
