### PR TITLE
[Hue Emulation] Made corrections for integer arithmetic

### DIFF
--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
@@ -237,7 +237,7 @@ public class HueDevice {
                 if (newBri < 0 || newBri > HueStateBulb.MAX_BRI) {
                     throw new IllegalArgumentException();
                 }
-                command = new PercentType((int) newBri * 100.0 / HueStateBulb.MAX_BRI + 0.5));
+                command = new PercentType((int) (newBri * 100.0 / HueStateBulb.MAX_BRI + 0.5));
                 successApplied.put("bri", newState.bri);
             } catch (ClassCastException e) {
                 errorApplied.add("bri_inc");

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueDevice.java
@@ -223,7 +223,7 @@ public class HueDevice {
             try {
                 if (as(HueStateBulb.class).bri != newState.bri) {
                     as(HueStateBulb.class).bri = newState.bri;
-                    command = new PercentType(newState.bri * 100 / HueStateBulb.MAX_BRI);
+                    command = new PercentType((int) (newState.bri * 100.0 / HueStateBulb.MAX_BRI + 0.5));
                 }
                 successApplied.put("bri", newState.bri);
             } catch (ClassCastException e) {
@@ -237,7 +237,7 @@ public class HueDevice {
                 if (newBri < 0 || newBri > HueStateBulb.MAX_BRI) {
                     throw new IllegalArgumentException();
                 }
-                command = new PercentType(newBri * 100 / HueStateBulb.MAX_BRI);
+                command = new PercentType((int) newBri * 100.0 / HueStateBulb.MAX_BRI + 0.5));
                 successApplied.put("bri", newState.bri);
             } catch (ClassCastException e) {
                 errorApplied.add("bri_inc");

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
@@ -43,7 +43,7 @@ public class HueStateBulb extends HueStatePlug {
      */
     public HueStateBulb(PercentType brightness, boolean on) {
         super(on);
-        this.bri = brightness.intValue() * MAX_BRI / 100;
+        this.bri = (int) (brightness.intValue() * MAX_BRI / 100.0 + 0.5);
     }
 
     @Override

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
@@ -69,9 +69,9 @@ public class HueStateColorBulb extends HueStateBulb {
      */
     public HueStateColorBulb(HSBType hsb) {
         super(hsb.getBrightness().intValue() > 0);
-        this.hue = hsb.getHue().intValue() * MAX_HUE / 360;
-        this.sat = hsb.getSaturation().intValue() * MAX_SAT / 100;
-        this.bri = hsb.getBrightness().intValue() * MAX_BRI / 100;
+        this.hue = (int) (hsb.getHue().intValue() * MAX_HUE / 360.0 + 0.5);
+        this.sat = (int) (hsb.getSaturation().intValue() * MAX_SAT / 100.0 + 0.5);
+        this.bri = (int) (hsb.getBrightness().intValue() * MAX_BRI / 100.0 + 0.5);
         colormode = this.sat > 0 ? ColorMode.hs : ColorMode.ct;
     }
 


### PR DESCRIPTION
This PR corrects #3171, which was flagged as resolved in #4216, but it was not. This change corrects errors introduced when doing arithmetic with integers. I have tested sending values to lights, by having Alexa set a dimmers level (0-10, 100). I have not tested the changes with colored lights, or states received by Alexa. @davidgraeff , please review!

Signed-off-by: Scott Rushworth openhab@5iver.com (github: openhab-5iver)

