### PR TITLE
Update skeleton binding and archetype versions to 2.5.0, 0.11.0

### DIFF
--- a/addons/binding/create_openhab_binding_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_skeleton.cmd
@@ -10,8 +10,8 @@ IF %ARGC% NEQ 2 (
 	exit /B 1
 )
 
-SET BindingVersion="2.4.0-SNAPSHOT"
-SET ArchetypeVersion="0.10.0-SNAPSHOT"
+SET BindingVersion="2.5.0-SNAPSHOT"
+SET ArchetypeVersion="0.11.0-SNAPSHOT"
 
 SET BindingIdInCamelCase=%~1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/addons/binding/create_openhab_binding_skeleton.sh
+++ b/addons/binding/create_openhab_binding_skeleton.sh
@@ -2,8 +2,8 @@
 
 [ $# -lt 2 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author>"; exit 1; }
 
-bindingVersion=2.4.0-SNAPSHOT
-archetypeVersion=0.10.0-SNAPSHOT
+bindingVersion=2.5.0-SNAPSHOT
+archetypeVersion=0.11.0-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`

--- a/addons/binding/create_openhab_binding_test_skeleton.cmd
+++ b/addons/binding/create_openhab_binding_test_skeleton.cmd
@@ -10,8 +10,8 @@ IF %ARGC% NEQ 2 (
 	exit /B 1
 )
 
-SET BindingVersion="2.4.0-SNAPSHOT" 
-SET ArchetypeVersion="0.10.0-SNAPSHOT"
+SET BindingVersion="2.5.0-SNAPSHOT" 
+SET ArchetypeVersion="0.11.0-SNAPSHOT"
 
 SET BindingIdInCamelCase=%1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/addons/binding/create_openhab_binding_test_skeleton.sh
+++ b/addons/binding/create_openhab_binding_test_skeleton.sh
@@ -2,8 +2,8 @@
 
 [ $# -lt 2 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author>"; exit 1; }
 
-bindingVersion=2.4.0-SNAPSHOT
-archetypeVersion=0.10.0-SNAPSHOT
+bindingVersion=2.5.0-SNAPSHOT
+archetypeVersion=0.11.0-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`


### PR DESCRIPTION
Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

The skeleton generators create a new binding with version 2.4.0. Fixed.