### PR TITLE
[plugwise] Fix stability issues and some code improvements

### DIFF
--- a/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
@@ -9,9 +9,6 @@ Bundle-SymbolicName: org.openhab.binding.plugwise;singleton:=true
 Bundle-Vendor: openHAB
 Bundle-Version: 2.5.0.qualifier
 Import-Package: 
- com.google.common.base,
- com.google.common.collect,
- gnu.io,
  javax.measure.quantity,
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -26,6 +23,7 @@ Import-Package:
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.transport.serial,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBindingConstants.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBindingConstants.java
@@ -8,12 +8,14 @@
  */
 package org.openhab.binding.plugwise.internal;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-
-import com.google.common.collect.Sets;
 
 /**
  * The {@link PlugwiseBinding} class defines common constants, which are used across the whole binding.
@@ -59,8 +61,9 @@ public class PlugwiseBindingConstants {
     public static final ThingTypeUID THING_TYPE_STICK = new ThingTypeUID(BINDING_ID, "stick");
     public static final ThingTypeUID THING_TYPE_SWITCH = new ThingTypeUID(BINDING_ID, "switch");
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_CIRCLE,
-            THING_TYPE_CIRCLE_PLUS, THING_TYPE_SCAN, THING_TYPE_SENSE, THING_TYPE_STEALTH, THING_TYPE_STICK,
-            THING_TYPE_SWITCH);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .of(THING_TYPE_CIRCLE, THING_TYPE_CIRCLE_PLUS, THING_TYPE_SCAN, THING_TYPE_SENSE, THING_TYPE_STEALTH,
+                    THING_TYPE_STICK, THING_TYPE_SWITCH)
+            .collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
 
 }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
@@ -11,6 +11,7 @@ package org.openhab.binding.plugwise.internal;
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.plugwise.internal.config.PlugwiseStickConfig;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
 import org.openhab.binding.plugwise.internal.protocol.Message;
@@ -54,6 +55,10 @@ public class PlugwiseCommunicationHandler {
 
     public void setConfiguration(PlugwiseStickConfig configuration) {
         context.setConfiguration(configuration);
+    }
+
+    public void setSerialPortManager(SerialPortManager serialPortManager) {
+        context.setSerialPortManager(serialPortManager);
     }
 
     public void start() throws PlugwiseInitializationException {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseRelayDeviceHandler;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseScanHandler;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseSenseHandler;
@@ -31,6 +32,7 @@ import org.openhab.binding.plugwise.internal.handler.PlugwiseStickHandler;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseSwitchHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link PlugwiseHandlerFactory} is responsible for creating Plugwise things and thing handlers.
@@ -43,6 +45,8 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
 
     private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
 
+    private @NonNullByDefault({}) SerialPortManager serialPortManager;
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -53,7 +57,7 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_STICK)) {
-            PlugwiseStickHandler handler = new PlugwiseStickHandler((Bridge) thing);
+            PlugwiseStickHandler handler = new PlugwiseStickHandler((Bridge) thing, serialPortManager);
             registerDiscoveryService(handler);
             return handler;
         } else if (thingTypeUID.equals(THING_TYPE_CIRCLE) || thingTypeUID.equals(THING_TYPE_CIRCLE_PLUS)
@@ -89,4 +93,12 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
         }
     }
 
+    @Reference
+    protected void setSerialPortManager(SerialPortManager serialPortManager) {
+        this.serialPortManager = serialPortManager;
+    }
+
+    protected void unsetSerialPortManager(SerialPortManager serialPortManager) {
+        this.serialPortManager = null;
+    }
 }

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageSender.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageSender.java
@@ -19,12 +19,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.io.transport.serial.SerialPort;
 import org.openhab.binding.plugwise.internal.protocol.AcknowledgementMessage;
 import org.openhab.binding.plugwise.internal.protocol.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import gnu.io.SerialPort;
 
 /**
  * Sends messages to the Plugwise Stick using a serial connection.
@@ -167,6 +166,7 @@ public class PlugwiseMessageSender {
         }
     }
 
+    @SuppressWarnings("resource")
     public void start() throws PlugwiseInitializationException {
         SerialPort serialPort = context.getSerialPort();
         if (serialPort == null) {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
@@ -12,7 +12,7 @@ import static org.openhab.binding.plugwise.internal.PlugwiseBindingConstants.THI
 import static org.openhab.binding.plugwise.internal.protocol.field.DeviceType.STICK;
 
 import java.io.IOException;
-import java.util.Enumeration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -27,10 +27,9 @@ import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.plugwise.internal.config.PlugwiseStickConfig;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
 import org.openhab.binding.plugwise.internal.protocol.InformationRequestMessage;
@@ -43,12 +42,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Sets;
-
-import gnu.io.CommPortIdentifier;
 
 /**
  * Discovers Stick devices by periodically sending a {@link NetworkStatusRequestMessage} to unused serial ports.
@@ -57,10 +53,9 @@ import gnu.io.CommPortIdentifier;
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.plugwise")
-public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
-        implements ExtendedDiscoveryService, PlugwiseMessageListener {
+public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService implements PlugwiseMessageListener {
 
-    private static final Set<ThingTypeUID> DISCOVERED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_STICK);
+    private static final Set<ThingTypeUID> DISCOVERED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_STICK);
 
     private static final int DISCOVERY_INTERVAL = 180;
     private static final int SCAN_TIMEOUT = 5;
@@ -68,8 +63,8 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
     private final Logger logger = LoggerFactory.getLogger(PlugwiseStickDiscoveryService.class);
     private final PlugwiseCommunicationHandler communicationHandler = new PlugwiseCommunicationHandler();
 
-    private @Nullable DiscoveryServiceCallback discoveryServiceCallback;
     private @Nullable ScheduledFuture<?> discoveryJob;
+    private @NonNullByDefault({}) SerialPortManager serialPortManager;
 
     private boolean discovering;
     private final ReentrantLock discoveryLock = new ReentrantLock();
@@ -90,6 +85,7 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
     public void activate() {
         super.activate(new HashMap<>());
         communicationHandler.addMessageListener(this);
+        communicationHandler.setSerialPortManager(serialPortManager);
     }
 
     private DiscoveryResult createDiscoveryResult(MACAddress macAddress, Map<String, String> properties) {
@@ -112,18 +108,8 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
     }
 
     private void discoverNewStickDetails(MACAddress macAddress) {
-        if (!isAlreadyDiscovered(macAddress)) {
-            logger.debug("Discovered new Stick ({})", macAddress);
-            sendMessage(new InformationRequestMessage(macAddress));
-        } else {
-            try {
-                discoveryLock.lock();
-                logger.debug("Already discovered Stick ({})", macAddress);
-                continueDiscovery.signalAll();
-            } finally {
-                discoveryLock.unlock();
-            }
-        }
+        logger.debug("Discovered new Stick ({})", macAddress);
+        sendMessage(new InformationRequestMessage(macAddress));
     }
 
     private void discoverStick(String serialPort) {
@@ -160,16 +146,10 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
         } else {
             discovering = true;
 
-            @SuppressWarnings("unchecked")
-            Enumeration<CommPortIdentifier> portIdentifiers = CommPortIdentifier.getPortIdentifiers();
-
-            while (discovering && portIdentifiers.hasMoreElements()) {
-                CommPortIdentifier portIdentifier = portIdentifiers.nextElement();
-                if (portIdentifier.getPortType() == CommPortIdentifier.PORT_SERIAL
-                        && !portIdentifier.isCurrentlyOwned()) {
-                    discoverStick(portIdentifier.getName());
-                }
-            }
+            serialPortManager.getIdentifiers().filter(identifier -> !identifier.isCurrentlyOwned())
+                    .forEach(identifier -> {
+                        discoverStick(identifier.getName());
+                    });
 
             discovering = false;
             logger.debug("Finished discovering Sticks on serial ports");
@@ -211,23 +191,6 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
         }
     }
 
-    private boolean isAlreadyDiscovered(MACAddress macAddress) {
-        ThingUID thingUID = new ThingUID(THING_TYPE_STICK, macAddress.toString());
-        DiscoveryServiceCallback callback = discoveryServiceCallback;
-        if (callback == null) {
-            logger.debug("Assuming Stick ({}) has not yet been discovered (callback null)", macAddress);
-            return false;
-        } else if (callback.getExistingDiscoveryResult(thingUID) != null) {
-            logger.debug("Stick ({}) has existing discovery result: {}", macAddress, thingUID);
-            return true;
-        } else if (callback.getExistingThing(thingUID) != null) {
-            logger.debug("Stick ({}) has existing thing: {}", macAddress, thingUID);
-            return true;
-        }
-        logger.debug("Stick ({}) has not yet been discovered", macAddress);
-        return false;
-    }
-
     @Modified
     @Override
     protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
@@ -248,9 +211,13 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService
         }
     }
 
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
+    @Reference
+    protected void setSerialPortManager(SerialPortManager serialPortManager) {
+        this.serialPortManager = serialPortManager;
+    }
+
+    protected void unsetSerialPortManager(SerialPortManager serialPortManager) {
+        this.serialPortManager = null;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseUtils.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseUtils.java
@@ -17,6 +17,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.GregorianCalendar;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
@@ -73,6 +75,10 @@ public final class PlugwiseUtils {
         }
     }
 
+    public static String lowerCamelToUpperUnderscore(String text) {
+        return text.replaceAll("([a-z])([A-Z]+)", "$1_$2").toUpperCase();
+    }
+
     public static <T extends Comparable<T>> T minComparable(T first, T second) {
         return first.compareTo(second) <= 0 ? first : second;
     }
@@ -90,6 +96,11 @@ public final class PlugwiseUtils {
                 Thread.interrupted();
             }
         }
+    }
+
+    public static String upperUnderscoreToLowerCamel(String text) {
+        String upperCamel = StringUtils.remove(WordUtils.capitalizeFully(text, new char[] { '_' }), "_");
+        return upperCamel.substring(0, 1).toLowerCase() + upperCamel.substring(1);
     }
 
     @SuppressWarnings("null")

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseRelayConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseRelayConfig.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.plugwise.internal.config;
 
-import static com.google.common.base.CaseFormat.*;
+import static org.openhab.binding.plugwise.internal.PlugwiseUtils.*;
 import static org.openhab.binding.plugwise.internal.config.PlugwiseRelayConfig.PowerStateChanging.COMMAND_SWITCHING;
 
 import java.time.Duration;
@@ -32,7 +32,7 @@ public class PlugwiseRelayConfig {
     }
 
     private String macAddress = "";
-    private String powerStateChanging = UPPER_UNDERSCORE.to(LOWER_CAMEL, COMMAND_SWITCHING.name());
+    private String powerStateChanging = upperUnderscoreToLowerCamel(COMMAND_SWITCHING.name());
     private boolean suppliesPower = false;
     private int measurementInterval = 60; // minutes
     private boolean temporarilyNotInNetwork = false;
@@ -43,7 +43,7 @@ public class PlugwiseRelayConfig {
     }
 
     public PowerStateChanging getPowerStateChanging() {
-        return PowerStateChanging.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, powerStateChanging));
+        return PowerStateChanging.valueOf(lowerCamelToUpperUnderscore(powerStateChanging));
     }
 
     public boolean isSuppliesPower() {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseScanConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseScanConfig.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.plugwise.internal.config;
 
-import static com.google.common.base.CaseFormat.*;
+import static org.openhab.binding.plugwise.internal.PlugwiseUtils.*;
 import static org.openhab.binding.plugwise.internal.protocol.field.Sensitivity.MEDIUM;
 
 import java.time.Duration;
@@ -26,7 +26,7 @@ import org.openhab.binding.plugwise.internal.protocol.field.Sensitivity;
 public class PlugwiseScanConfig {
 
     private String macAddress = "";
-    private String sensitivity = UPPER_UNDERSCORE.to(LOWER_CAMEL, MEDIUM.name());
+    private String sensitivity = upperUnderscoreToLowerCamel(MEDIUM.name());
     private int switchOffDelay = 5; // minutes
     private boolean daylightOverride = false;
     private int wakeupInterval = 1440; // minutes (1 day)
@@ -39,7 +39,7 @@ public class PlugwiseScanConfig {
     }
 
     public Sensitivity getSensitivity() {
-        return Sensitivity.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, sensitivity));
+        return Sensitivity.valueOf(lowerCamelToUpperUnderscore(sensitivity));
     }
 
     public Duration getSwitchOffDelay() {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSenseConfig.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/config/PlugwiseSenseConfig.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.plugwise.internal.config;
 
-import static com.google.common.base.CaseFormat.*;
+import static org.openhab.binding.plugwise.internal.PlugwiseUtils.*;
 import static org.openhab.binding.plugwise.internal.protocol.field.BoundaryAction.OFF_BELOW_ON_ABOVE;
 import static org.openhab.binding.plugwise.internal.protocol.field.BoundaryType.NONE;
 
@@ -31,8 +31,8 @@ public class PlugwiseSenseConfig {
 
     private String macAddress = "";
     private int measurementInterval = 15; // minutes
-    private String boundaryType = UPPER_UNDERSCORE.to(LOWER_CAMEL, NONE.name());
-    private String boundaryAction = UPPER_UNDERSCORE.to(LOWER_CAMEL, OFF_BELOW_ON_ABOVE.name());
+    private String boundaryType = upperUnderscoreToLowerCamel(NONE.name());
+    private String boundaryAction = upperUnderscoreToLowerCamel(OFF_BELOW_ON_ABOVE.name());
     private int temperatureBoundaryMin = 15; // degrees Celsius
     private int temperatureBoundaryMax = 25; // degrees Celsius
     private int humidityBoundaryMin = 45; // relative humidity (RH)
@@ -50,11 +50,11 @@ public class PlugwiseSenseConfig {
     }
 
     public BoundaryType getBoundaryType() {
-        return BoundaryType.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, boundaryType));
+        return BoundaryType.valueOf(lowerCamelToUpperUnderscore(boundaryType));
     }
 
     public BoundaryAction getBoundaryAction() {
-        return BoundaryAction.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, boundaryAction));
+        return BoundaryAction.valueOf(lowerCamelToUpperUnderscore(boundaryAction));
     }
 
     public Temperature getTemperatureBoundaryMin() {

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseRelayDeviceHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseRelayDeviceHandler.java
@@ -8,13 +8,16 @@
  */
 package org.openhab.binding.plugwise.internal.handler;
 
+import static java.util.stream.Collectors.*;
 import static org.eclipse.smarthome.core.thing.ThingStatus.*;
 import static org.openhab.binding.plugwise.internal.PlugwiseBindingConstants.*;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -59,8 +62,6 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 import org.openhab.binding.plugwise.internal.protocol.field.PowerCalibration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 /**
  * <p>
@@ -217,8 +218,10 @@ public class PlugwiseRelayDeviceHandler extends AbstractPlugwiseThingHandler {
         }
     };
 
-    private final List<PlugwiseDeviceTask> recurringTasks = Lists.newArrayList(clockUpdateTask, currentPowerUpdateTask,
-            energyUpdateTask, informationUpdateTask, realTimeClockUpdateTask, setClockTask);
+    private final List<PlugwiseDeviceTask> recurringTasks = Stream
+            .of(clockUpdateTask, currentPowerUpdateTask, energyUpdateTask, informationUpdateTask,
+                    realTimeClockUpdateTask, setClockTask)
+            .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseRelayDeviceHandler.class);
     private final DeviceType deviceType;

--- a/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
+++ b/addons/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.plugwise.internal.handler;
 
 import static org.eclipse.smarthome.core.thing.ThingStatus.*;
+import static org.openhab.binding.plugwise.internal.PlugwiseBindingConstants.CONFIG_PROPERTY_MAC_ADDRESS;
 import static org.openhab.binding.plugwise.internal.protocol.field.DeviceType.STICK;
 
 import java.io.IOException;
@@ -21,10 +22,12 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.plugwise.internal.PlugwiseCommunicationHandler;
 import org.openhab.binding.plugwise.internal.PlugwiseDeviceTask;
 import org.openhab.binding.plugwise.internal.PlugwiseInitializationException;
@@ -78,6 +81,7 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseStickHandler.class);
     private final PlugwiseCommunicationHandler communicationHandler = new PlugwiseCommunicationHandler();
+    private final SerialPortManager serialPortManager;
     private final List<PlugwiseStickStatusListener> statusListeners = new CopyOnWriteArrayList<>();
 
     private @NonNullByDefault({}) PlugwiseStickConfig configuration;
@@ -85,8 +89,9 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     private @Nullable MACAddress circlePlusMAC;
     private @Nullable MACAddress stickMAC;
 
-    public PlugwiseStickHandler(Bridge bridge) {
+    public PlugwiseStickHandler(Bridge bridge, SerialPortManager serialPortManager) {
         super(bridge);
+        this.serialPortManager = serialPortManager;
     }
 
     public void addMessageListener(PlugwiseMessageListener listener) {
@@ -115,6 +120,17 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
 
     public @Nullable MACAddress getStickMAC() {
         return stickMAC;
+    }
+
+    public @Nullable Thing getThingByMAC(MACAddress macAddress) {
+        for (Thing thing : getThing().getThings()) {
+            String thingMAC = (String) thing.getConfiguration().get(CONFIG_PROPERTY_MAC_ADDRESS);
+            if (thingMAC != null && macAddress.equals(new MACAddress(thingMAC))) {
+                return thing;
+            }
+        }
+
+        return null;
     }
 
     private void handleAcknowledgement(AcknowledgementMessage acknowledge) {
@@ -171,6 +187,7 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     public void initialize() {
         configuration = getConfigAs(PlugwiseStickConfig.class);
         communicationHandler.setConfiguration(configuration);
+        communicationHandler.setSerialPortManager(serialPortManager);
         communicationHandler.addMessageListener(this);
 
         try {


### PR DESCRIPTION
In 2.4.0 an Inbox circular reference was fixed (https://github.com/eclipse/smarthome/issues/6216) by deprecating the `ExtendedDiscoveryService` and removing the functionality it provided.

As a result during background discovery the binding would request data from each and every node in the network instead of only the newly discovered nodes.

The increase in network traffic on the mesh resulted in Things going online/offline all the time. Also commands could be delayed or never executed.

Background discovery will now again skip existing Things registered with the associated Bridge to fix the stability issues. Other bindings using the `ExtendedDiscoveryService` may have similar issues.

Furthermore the code has been improved by:
* Removing the Guava dependency
* Replacing gnu.io with the Eclipse SmartHome Serial Transport

There's also a [org.openhab.binding.plugwise-2.5.0-SNAPSHOT.jar](https://github.com/wborn/openhab2-addons/releases/download/plugwise-fix-instability-and-improvements-tag/org.openhab.binding.plugwise-2.5.0-SNAPSHOT.jar) containing these changes.