### PR TITLE
Remove base type restriction from group items

### DIFF
--- a/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/LightItemsTest.java
+++ b/addons/io/org.openhab.io.hueemulation.test/src/test/java/org/openhab/io/hueemulation/internal/LightItemsTest.java
@@ -102,6 +102,16 @@ public class LightItemsTest {
     }
 
     @Test
+    public void addGroupWithoutTypeByTag() throws IOException {
+        GroupItem item = new GroupItem("group1", null);
+        item.addTag("Switchable");
+        lightItems.added(item);
+        HueDevice device = ds.lights.get(lightItems.itemUIDtoHueID.get("group1"));
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+    }
+
+    @Test
     public void updateSwitchable() throws IOException {
         SwitchItem item = new SwitchItem("switch1");
         item.setLabel("labelOld");

--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/LightItems.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/LightItems.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Listens to the ItemRegistry for items that fulfill one of these criteria:
  * <ul>
- * <li>Type is any of SWITCH, DIMMER, COLOR (or Group type with one of the mentioned base item types)
+ * <li>Type is any of SWITCH, DIMMER, COLOR, or Group
  * <li>The category is "ColorLight" for coloured lights or "Light" for switchables.
  * <li>The item is tagged, according to what is set with {@link #setFilterTags(Set, Set, Set)}.
  * </ul>
@@ -55,12 +55,15 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * @author David Graeff - Initial contribution
+ * @author Florian Schmidt - Removed base type restriction from Group items
  */
 @NonNullByDefault
 public class LightItems implements RegistryChangeListener<Item> {
     private final Logger logger = LoggerFactory.getLogger(LightItems.class);
+    private static final String ITEM_TYPE_GROUP = "Group";
     private static final Set<String> ALLOWED_ITEM_TYPES = Stream
-            .of(CoreItemFactory.COLOR, CoreItemFactory.DIMMER, CoreItemFactory.SWITCH).collect(Collectors.toSet());
+            .of(CoreItemFactory.COLOR, CoreItemFactory.DIMMER, CoreItemFactory.SWITCH, ITEM_TYPE_GROUP)
+            .collect(Collectors.toSet());
 
     // deviceMap maps a unique Item id to a Hue numeric id
     final TreeMap<String, Integer> itemUIDtoHueID = new TreeMap<>();
@@ -84,8 +87,8 @@ public class LightItems implements RegistryChangeListener<Item> {
      * </p>
      *
      * @param switchFilter The switch filter tags
-     * @param colorFilter The color filter tags
-     * @param whiteFilter The white bulb filter tags
+     * @param colorFilter  The color filter tags
+     * @param whiteFilter  The white bulb filter tags
      */
     public void setFilterTags(Set<String> switchFilter, Set<String> colorFilter, Set<String> whiteFilter) {
         this.switchFilter = switchFilter;
@@ -245,15 +248,9 @@ public class LightItems implements RegistryChangeListener<Item> {
 
     String getType(Item element) {
         if (element instanceof GroupItem) {
-            Item baseItem = ((GroupItem) element).getBaseItem();
-            if (baseItem != null) {
-                return baseItem.getType();
-            } else {
-                return "";
-            }
-        } else {
-            return element.getType();
+            return ITEM_TYPE_GROUP;
         }
+        return element.getType();
     }
 
     @SuppressWarnings({ "unused", "null" })


### PR DESCRIPTION
Given that this is not documented anywhere and given that the user already
understands what they're doing when adding one of the hueemulation-used
tags, restricting them to add a base type to a group doesn't seem to be
reasonable. As this restriction makes debugging more complicated ("Why
does my group with the Lighting tag does not get discovered by
hueemulation?") this commit removes this restriction completely. As a
result, all groups with one of the supported tags, will be added to
hueemulation discovery document.

Fixes #4379

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>