### PR TITLE
[avmfritz] Changed trigger channel type to 'system.rawbutton'

### DIFF
--- a/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.avmfritz/ESH-INF/thing/thing-types.xml
@@ -210,7 +210,7 @@
 		<description>HAN-FUN switch (e.g. SmartHome Wandtaster).</description>
 
 		<channels>
-			<channel id="press" typeId="system.trigger">
+			<channel id="press" typeId="system.rawbutton">
 				<label>Button press</label>
 				<description>Triggered when a button was pressed.</description>
 			</channel>

--- a/addons/binding/org.openhab.binding.avmfritz/README.md
+++ b/addons/binding/org.openhab.binding.avmfritz/README.md
@@ -126,9 +126,11 @@ If correct credentials are set in the bridge configuration, connected AHA device
 
 ### Triggers
 
-| Channel Type ID | Item Type | Description                          | Available on thing                                      |
-|-----------------|-----------|--------------------------------------|---------------------------------------------------------|
-| press           | Trigger   | Dispatched when a button is pressed. | HAN-FUN switch (e.g. SmartHome Wandtaster) - FRITZ!OS 7 |
+| Channel Type ID | Item Type | Description                                            | Available on thing                                      |
+|-----------------|-----------|--------------------------------------------------------|---------------------------------------------------------|
+| press           | Trigger   | Dispatches a `PRESSED` event when a button is pressed. | HAN-FUN switch (e.g. SmartHome Wandtaster) - FRITZ!OS 7 |
+
+The trigger channel `press` is of type `system.rawbutton` to allow the usage of the `rawbutton-toggle-switch` profile.
 
 ## Full Example
 

--- a/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.avmfritz.internal.handler;
 
 import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
+import static org.eclipse.smarthome.core.thing.CommonTriggerEvents.PRESSED;
 import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
 import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
 import static org.openhab.binding.avmfritz.internal.ahamodel.DeviceModel.ETSUnitInfo.*;
@@ -305,7 +306,7 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                 ZonedDateTime now = ZonedDateTime.now(zoneId);
                 Instant someSecondsEarlier = now.minusSeconds(refreshInterval).toInstant();
                 if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
-                    triggerThingChannel(thing, CHANNEL_PRESS);
+                    triggerThingChannel(thing, CHANNEL_PRESS, PRESSED);
                 }
                 updateThingChannelState(thing, CHANNEL_LAST_CHANGE, new DateTimeType(timestamp));
             }
@@ -337,11 +338,12 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
      *
      * @param thing Thing which channels should be triggered.
      * @param channelId ID of the channel to be triggered.
+     * @param event Event to emit
      */
-    private void triggerThingChannel(Thing thing, String channelId) {
+    private void triggerThingChannel(Thing thing, String channelId, String event) {
         Channel channel = thing.getChannel(channelId);
         if (channel != null) {
-            triggerChannel(channel.getUID());
+            triggerChannel(channel.getUID(), event);
         } else {
             logger.debug("Channel '{}' in thing '{}' does not exist.", channelId, thing.getUID());
         }


### PR DESCRIPTION
- Changed trigger channel type to `system.rawbutton` to allow the usage of the 'rawbutton-toggle-switch' profile

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>