### PR TITLE
[SmartMeter] Fix typo in first README sentence

### DIFF
--- a/addons/binding/org.openhab.binding.smartmeter/README.md
+++ b/addons/binding/org.openhab.binding.smartmeter/README.md
@@ -1,6 +1,6 @@
 # SmartMeter Binding
 
-Retrieves and reads SML messages (PUSH) and supports IEC 62056-21 modes A,B,C (PULL) and D (PUSH).
+This binding retrieves and reads SML messages (PUSH) and supports IEC 62056-21 modes A,B,C (PULL) and D (PUSH).
 
 
 ## Supported Things

--- a/addons/binding/org.openhab.binding.smartmeter/README.md
+++ b/addons/binding/org.openhab.binding.smartmeter/README.md
@@ -1,6 +1,6 @@
 # SmartMeter Binding
 
-The Smartreader binding is able to read SML messages (PUSH) and supports IEC 62056-21 modes A,B,C (PULL) and D (PUSH).
+Retrieves and reads SML messages (PUSH) and supports IEC 62056-21 modes A,B,C (PULL) and D (PUSH).
 
 
 ## Supported Things


### PR DESCRIPTION
Not sure if "Smartreader" is correct here. The beginning of this sentence was anyhow redundant. Feel free to edit the PR content.

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de>