### PR TITLE
[milight] Fix timeout for V3 bridges which are slow to respond

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
@@ -119,7 +119,7 @@ public class BridgeV3Handler extends AbstractBridgeHandler {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Bridge did not respond!");
                         timeoutsCounter = 0;
                     } else {
-                        socket.setSoTimeout(300);
+                        socket.setSoTimeout(1000);
                         ++timeoutsCounter;
                         socket.send(discoverPacketV3);
                     }


### PR DESCRIPTION
A change in the 2.4 binding resulted in the timeout for V3 keep-alive discovery packets changing from 1000ms to 300ms. In certain environments the response to a discovery packet is often greater than 300ms which resulted in the V3 bridge constantly going offline. This PR sets the timeout back to 1000ms. 

Signed-off-by: Mike Major <mike_j_major@hotmail.com>
