### PR TITLE
[openuv] Fix openUV addon name and installation instructions

### DIFF
--- a/addons/binding/org.openhab.binding.openuv/README.md
+++ b/addons/binding/org.openhab.binding.openuv/README.md
@@ -1,10 +1,11 @@
-# Open UV Binding
+# OpenUV Binding
 
 This binding uses the [OpenUV Index API service](https://www.openuv.io/) for providing UV Index information for any location worldwide.
 
 To use this binding, you first need to [register and get your API token](https://www.openuv.io/auth/google).
 
-## Supported Things
+## Binding Installation
+This binding can be installed via the Add-ons section of the Paper UI. Go to Bindings and search for `OpenUV`. Click on install. 
 
 ## Discovery
 

--- a/addons/binding/org.openhab.binding.openuv/README.md
+++ b/addons/binding/org.openhab.binding.openuv/README.md
@@ -5,7 +5,10 @@ This binding uses the [OpenUV Index API service](https://www.openuv.io/) for pro
 To use this binding, you first need to [register and get your API token](https://www.openuv.io/auth/google).
 
 ## Binding Installation
-This binding can be installed via the Add-ons section of the Paper UI. Go to Bindings and search for `OpenUV`. Click on install. 
+
+This binding can be installed via the Add-ons section of the Paper UI. 
+
+Go to Bindings and search for `OpenUV`. Click on install. 
 
 ## Discovery
 

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -447,7 +447,7 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.opensprinkler/${project.version}</bundle>
     </feature>
 
-    <feature name="openhab-binding-openuv" description="OpenSprinkler Binding" version="${project.version}">
+    <feature name="openhab-binding-openuv" description="OpenUV Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.openuv/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
Hi,

I've tried yesterday to install the openUV addon. I could not find the addon from the list of add-ons and according to the [current documentation](https://www.openhab.org/addons/bindings/openuv/) it should be sufficient to just add the Bridge and the Items and the addon is configured.

The values were still empty and I found this discussion which pointed me into the right direction:
https://community.openhab.org/t/solved-location-of-openuv-binding/49200/3

The plugin can be found if you search for `opensprinkler`. Therefore it seems to be a copy&paste error when the `feature.xml` was touched. 

Here's a screenshot of how it currently looks in openHAB 2.4:

![openuv-opensprinkler](https://user-images.githubusercontent.com/1426140/50526587-5156ae80-0ae3-11e9-93ea-846aace89c97.png)


I've updated now the `feature.xml` to show the correct name of the addon "openUV" and also updated the binding's `readme.md` to make the installation instruction clear.

I assume I don't need to sign off the changes, since it is a spelling correction as well as changes to the documentation, please correct me if I'm wrong.
