### PR TITLE
[enocean] Fix auto detection of Eltako Rocker Switches.

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPFactory.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPFactory.java
@@ -63,7 +63,7 @@ public class EEPFactory {
     }
 
     public static EEP buildEEPFromTeachInERP1(ERP1Message msg) {
-        if (!msg.getIsTeachIn()) {
+        if (!msg.getIsTeachIn() && !(msg.getRORG() == RORG.RPS)) {
             return null;
         }
 


### PR DESCRIPTION
EnOceanTransceiver does check in line 398 if telegram is either teach-in
or RORG is RPS. Later EEPFactory in line 66 only checks if telegram is
teach-in and if not, it returns null. Changed method, it will now also
accept RORG == RPS.

I found this issue when playing with Enocean binding in OpenHAB 2.5.0-SNAPSHOT. In OpenHAB 2.4 it works correctly.