### PR TITLE
[milight] Fix issue with commands being lost when using multiple bridges.

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/MilightHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/MilightHandlerFactory.java
@@ -55,6 +55,8 @@ public class MilightHandlerFactory extends BaseThingHandlerFactory {
     // each other (user report!).
     private @Nullable QueuedSend queuedSend;
 
+    private int bridgeOffset;
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -69,9 +71,9 @@ public class MilightHandlerFactory extends BaseThingHandlerFactory {
         }
 
         if (thingTypeUID.equals(BRIDGEV3_THING_TYPE)) {
-            return new BridgeV3Handler((Bridge) thing);
+            return new BridgeV3Handler((Bridge) thing, bridgeOffset += 100);
         } else if (thingTypeUID.equals(BRIDGEV6_THING_TYPE)) {
-            return new BridgeV6Handler((Bridge) thing);
+            return new BridgeV6Handler((Bridge) thing, bridgeOffset += 100);
         } else if (thing.getThingTypeUID().equals(MilightBindingConstants.RGB_IBOX_THING_TYPE)) {
             return new MilightV6RGBIBOXHandler(thing, queuedSend);
         } else if (thing.getThingTypeUID().equals(MilightBindingConstants.RGB_CW_WW_THING_TYPE)) {
@@ -94,6 +96,7 @@ public class MilightHandlerFactory extends BaseThingHandlerFactory {
         super.activate(componentContext);
         queuedSend = new QueuedSend();
         queuedSend.start();
+        bridgeOffset = 0;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/AbstractBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/AbstractBridgeHandler.java
@@ -37,9 +37,11 @@ public abstract class AbstractBridgeHandler extends BaseBridgeHandler {
     protected BridgeHandlerConfig config = new BridgeHandlerConfig();
     protected @Nullable InetAddress address;
     protected @NonNullByDefault({}) DatagramSocket socket;
+    protected int bridgeOffset;
 
-    public AbstractBridgeHandler(Bridge bridge) {
+    public AbstractBridgeHandler(Bridge bridge, int bridgeOffset) {
         super(bridge);
+        this.bridgeOffset = bridgeOffset;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/AbstractLedHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/AbstractLedHandler.java
@@ -59,6 +59,8 @@ public abstract class AbstractLedHandler extends BaseThingHandler implements Led
     protected int delayTimeMS = 50;
     protected int repeatTimes = 3;
 
+    protected int bridgeOffset;
+
     /**
      * A bulb always belongs to a zone in the milight universe and we need a way to queue commands for being send.
      *
@@ -245,7 +247,7 @@ public abstract class AbstractLedHandler extends BaseThingHandler implements Led
     }
 
     /**
-     * Generates a unique command id for the {@see QueuedSend}. It incorporates the zone, bulb type and command
+     * Generates a unique command id for the {@see QueuedSend}. It incorporates the bridge, zone, bulb type and command
      * category.
      *
      * @param commandCategory The category of the command.
@@ -253,7 +255,7 @@ public abstract class AbstractLedHandler extends BaseThingHandler implements Led
      * @return
      */
     public int uidc(int commandCategory) {
-        return (config.zone + typeOffset + 1) * 64 + commandCategory;
+        return (bridgeOffset + config.zone + typeOffset + 1) * 64 + commandCategory;
     }
 
     protected void start(AbstractBridgeHandler handler) {
@@ -303,6 +305,7 @@ public abstract class AbstractLedHandler extends BaseThingHandler implements Led
         this.socket = h.socket;
         this.delayTimeMS = h.config.delayTime;
         this.repeatTimes = h.config.repeat;
+        this.bridgeOffset = h.bridgeOffset;
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV3Handler.java
@@ -38,8 +38,8 @@ public class BridgeV3Handler extends AbstractBridgeHandler {
     protected final DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
     private boolean running = false;
 
-    public BridgeV3Handler(Bridge bridge) {
-        super(bridge);
+    public BridgeV3Handler(Bridge bridge, int bridgeOffset) {
+        super(bridge, bridgeOffset);
         discoverPacketV3 = new DatagramPacket(MilightBindingConstants.DISCOVER_MSG_V3,
                 MilightBindingConstants.DISCOVER_MSG_V3.length);
     }

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV6Handler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/BridgeV6Handler.java
@@ -42,8 +42,8 @@ public class BridgeV6Handler extends AbstractBridgeHandler implements ISessionSt
     private String offlineReason = "";
     private @Nullable ScheduledFuture<?> scheduledFuture;
 
-    public BridgeV6Handler(Bridge bridge) {
-        super(bridge);
+    public BridgeV6Handler(Bridge bridge, int bridgeOffset) {
+        super(bridge, bridgeOffset);
     }
 
     /**
@@ -127,8 +127,9 @@ public class BridgeV6Handler extends AbstractBridgeHandler implements ISessionSt
             default:
                 // Delay putting the session offline
                 offlineReason = state.name();
-                scheduledFuture = scheduler.schedule(() -> updateStatus(ThingStatus.OFFLINE,
-                        ThingStatusDetail.CONFIGURATION_PENDING, offlineReason), 1000, TimeUnit.MILLISECONDS);
+                scheduledFuture = scheduler.schedule(
+                        () -> updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, offlineReason),
+                        1000, TimeUnit.MILLISECONDS);
                 break;
         }
     }


### PR DESCRIPTION
The unique command id generated for the global queue needs to take into
account the bridge. This is a fix for an issue introduced in the 2.4
binding when a single global queue was added.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>