### PR TITLE
[onkyo] Fix error with album art not displaying correctly on Onkyo TX-NR686 models

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoAlbumArt.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoAlbumArt.java
@@ -153,7 +153,7 @@ public class OnkyoAlbumArt {
                         int bodyLength = data.length;
                         int i = new String(data).indexOf("image/");
                         if (i > 0) {
-                            while (i < bodyLength && data[i] != '\r') {
+                            while (i < bodyLength && (data[i] != '\r' && data[i] != '\n')) {
                                 i++;
                             }
                             while (i < bodyLength && (data[i] == '\r' || data[i] == '\n')) {


### PR DESCRIPTION
This push request fixes an error with the **Onkyo TX-NR686** receiver displaying no image for the _albumArt_ channel (a broken image icon appears under Paper UI).

When parsing the _incorrect page headers_ that appear in the content of the album art page, the parser only looks for carriage returns after searching for the `image/` string; however on the **Onkyo TX-NR686** receiver, the headers are terminated with _Line Feeds_ instead of _Carriage Returns_.

The code has been modified to check for line feeds as well as carriage returns.

This has been built and tested locally and the fix successfully displays the artwork in the _albumArt_ channel correctly.