### PR TITLE
[gpstracker] Fixes the disablement of accuracy check

### DIFF
--- a/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
+++ b/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
@@ -297,9 +297,9 @@ public class TrackerHandler extends BaseThingHandler {
 
     private void updateDistanceChannelFromMessage(LocationMessage message, Channel c) {
         Configuration currentConfig = c.getConfiguration();
-        //convert into meters which is the unit of the threshold
-        double accuracyThreshold = convertToMeters(ConfigHelper.getAccuracyThreshold(currentConfig));
-        if (accuracyThreshold > message.getGpsAccuracy().doubleValue() || accuracyThreshold == 0) {
+        // convert into meters which is the unit of the threshold
+        Double accuracyThreshold = convertToMeters(ConfigHelper.getAccuracyThreshold(currentConfig));
+        if (accuracyThreshold > message.getGpsAccuracy().doubleValue() || accuracyThreshold.intValue() == 0) {
             if (accuracyThreshold > 0) {
                 logger.debug("Location accuracy is below required threshold: {}<{}", message.getGpsAccuracy(),
                         accuracyThreshold);

--- a/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
+++ b/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
@@ -8,6 +8,20 @@
  */
 package org.openhab.binding.gpstracker.internal.handler;
 
+import static org.openhab.binding.gpstracker.internal.GPSTrackerBindingConstants.*;
+import static org.openhab.binding.gpstracker.internal.config.ConfigHelper.CONFIG_REGION_CENTER_LOCATION;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.measure.Unit;
+import javax.measure.quantity.Length;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -37,16 +51,6 @@ import org.openhab.binding.gpstracker.internal.message.NotificationHandler;
 import org.openhab.binding.gpstracker.internal.message.TransitionMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.measure.Unit;
-import javax.measure.quantity.Length;
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static org.openhab.binding.gpstracker.internal.GPSTrackerBindingConstants.*;
-import static org.openhab.binding.gpstracker.internal.config.ConfigHelper.CONFIG_REGION_CENTER_LOCATION;
 
 /**
  * The {@link TrackerHandler} class is a tracker thing handler.
@@ -113,13 +117,14 @@ public class TrackerHandler extends BaseThingHandler {
     /**
      * Constructor.
      *
-     * @param thing Thing.
+     * @param thing              Thing.
      * @param notificationBroker Notification broker
-     * @param regions Global region set
-     * @param sysLocation Location of the system
-     * @param unitProvider Unit provider
+     * @param regions            Global region set
+     * @param sysLocation        Location of the system
+     * @param unitProvider       Unit provider
      */
-    public TrackerHandler(Thing thing, NotificationBroker notificationBroker, Set<String> regions, PointType sysLocation, UnitProvider unitProvider) {
+    public TrackerHandler(Thing thing, NotificationBroker notificationBroker, Set<String> regions,
+            PointType sysLocation, UnitProvider unitProvider) {
         super(thing);
 
         this.notificationBroker = notificationBroker;
@@ -159,15 +164,18 @@ public class TrackerHandler extends BaseThingHandler {
      * Create distance channel for measuring the distance between the tracker and the szstem.
      */
     private void createBasicDistanceChannel() {
-        @Nullable ThingHandlerCallback callback = getCallback();
+        @Nullable
+        ThingHandlerCallback callback = getCallback();
         if (callback != null) {
-            //find the system distance channel
+            // find the system distance channel
             ChannelUID systemDistanceChannelUID = new ChannelUID(thing.getUID(), CHANNEL_DISTANCE_SYSTEM_ID);
             Channel systemDistance = thing.getChannel(CHANNEL_DISTANCE_SYSTEM_ID);
             ChannelBuilder channelBuilder = null;
             if (systemDistance != null) {
-                if (!systemDistance.getConfiguration().get(CONFIG_REGION_CENTER_LOCATION).equals(sysLocation.toFullString())) {
-                    logger.trace("Existing distance channel for system. Changing system location config parameter: {}", sysLocation.toFullString());
+                if (!systemDistance.getConfiguration().get(CONFIG_REGION_CENTER_LOCATION)
+                        .equals(sysLocation.toFullString())) {
+                    logger.trace("Existing distance channel for system. Changing system location config parameter: {}",
+                            sysLocation.toFullString());
 
                     channelBuilder = callback.editChannel(thing, systemDistanceChannelUID);
                     Configuration configToUpdate = systemDistance.getConfiguration();
@@ -186,11 +194,10 @@ public class TrackerHandler extends BaseThingHandler {
                 config.put(ConfigHelper.CONFIG_ACCURACY_THRESHOLD, 0);
 
                 channelBuilder = callback.createChannelBuilder(systemDistanceChannelUID, CHANNEL_TYPE_DISTANCE)
-                        .withLabel("System Distance")
-                        .withConfiguration(config);
+                        .withLabel("System Distance").withConfiguration(config);
             }
 
-            //update the thing with system distance channel
+            // update the thing with system distance channel
             if (channelBuilder != null) {
                 List<Channel> channels = new ArrayList<>(thing.getChannels());
                 if (systemDistance != null) {
@@ -214,7 +221,7 @@ public class TrackerHandler extends BaseThingHandler {
         distanceChannelMap = thing.getChannels().stream()
                 .filter(c -> CHANNEL_TYPE_DISTANCE.equals(c.getChannelTypeUID()))
                 .collect(Collectors.toMap(c -> ConfigHelper.getRegionName(c.getConfiguration()), Function.identity()));
-        //register the collected regions
+        // register the collected regions
         regions.addAll(distanceChannelMap.keySet());
     }
 
@@ -235,8 +242,9 @@ public class TrackerHandler extends BaseThingHandler {
                 case CHANNEL_GPS_ACCURACY:
                     updateBaseChannels(lastMessage, CHANNEL_GPS_ACCURACY);
                     break;
-                default: //distance channels
-                    @Nullable Channel channel = thing.getChannel(channelId);
+                default: // distance channels
+                    @Nullable
+                    Channel channel = thing.getChannel(channelId);
                     if (channel != null) {
                         updateDistanceChannelFromMessage(lastMessage, channel);
                     }
@@ -258,7 +266,7 @@ public class TrackerHandler extends BaseThingHandler {
      * Fire trigger event with regionName/enter|leave payload but only if the event differs from the last event.
      *
      * @param regionName Region name
-     * @param event Occurred event
+     * @param event      Occurred event
      */
     private void triggerRegionChannel(@NonNull String regionName, @NonNull String event) {
         Boolean lastState = lastTriggeredStates.get(regionName);
@@ -273,17 +281,18 @@ public class TrackerHandler extends BaseThingHandler {
     }
 
     /**
-     * Update state channels from location message. This includes basic channel updates and recalculations of all distances.
+     * Update state channels from location message. This includes basic channel updates and recalculations of all
+     * distances.
      *
      * @param message Message.
      */
     private void updateChannelsWithLocation(LocationMessage message) {
-        updateBaseChannels(message, CHANNEL_BATTERY_LEVEL, CHANNEL_LAST_LOCATION, CHANNEL_LAST_REPORT, CHANNEL_GPS_ACCURACY);
+        updateBaseChannels(message, CHANNEL_BATTERY_LEVEL, CHANNEL_LAST_LOCATION, CHANNEL_LAST_REPORT,
+                CHANNEL_GPS_ACCURACY);
 
         String trackerId = message.getTrackerId();
         logger.debug("Updating distance channels tracker {}", trackerId);
-        distanceChannelMap.values()
-                .forEach(c -> updateDistanceChannelFromMessage(message, c));
+        distanceChannelMap.values().forEach(c -> updateDistanceChannelFromMessage(message, c));
     }
 
     private void updateDistanceChannelFromMessage(LocationMessage message, Channel c) {
@@ -292,7 +301,8 @@ public class TrackerHandler extends BaseThingHandler {
         double accuracyThreshold = convertToMeters(ConfigHelper.getAccuracyThreshold(currentConfig));
         if (accuracyThreshold > message.getGpsAccuracy().doubleValue() || accuracyThreshold == 0) {
             if (accuracyThreshold > 0) {
-                logger.debug("Location accuracy is below required threshold: {}<{}", message.getGpsAccuracy(), accuracyThreshold);
+                logger.debug("Location accuracy is below required threshold: {}<{}", message.getGpsAccuracy(),
+                        accuracyThreshold);
             } else {
                 logger.debug("Location accuracy threshold check is disabled.");
             }
@@ -303,11 +313,12 @@ public class TrackerHandler extends BaseThingHandler {
             if (center != null) {
                 double newDistance = newLocation.distanceFrom(center).doubleValue();
                 updateState(c.getUID(), new QuantityType<>(newDistance / 1000, MetricPrefix.KILO(SIUnits.METRE)));
-                logger.trace("Region {} center distance from tracker location {} is {}m", regionName, newLocation, newDistance);
+                logger.trace("Region {} center distance from tracker location {} is {}m", regionName, newLocation,
+                        newDistance);
 
-                //fire trigger based on distance calculation only in case of pure location message
+                // fire trigger based on distance calculation only in case of pure location message
                 if (!(message instanceof TransitionMessage)) {
-                    //convert into meters which is the unit of the calculated distance
+                    // convert into meters which is the unit of the calculated distance
                     double radiusMeter = convertToMeters(ConfigHelper.getRegionRadius(c.getConfiguration()));
                     if (radiusMeter > newDistance) {
                         triggerRegionChannel(regionName, EVENT_ENTER);
@@ -317,13 +328,15 @@ public class TrackerHandler extends BaseThingHandler {
                 }
             }
         } else {
-            logger.debug("Skip update as location accuracy is above required threshold: {}>={}", message.getGpsAccuracy(), accuracyThreshold);
+            logger.debug("Skip update as location accuracy is above required threshold: {}>={}",
+                    message.getGpsAccuracy(), accuracyThreshold);
         }
     }
 
     private double convertToMeters(double valueToConvert) {
         if (unitProvider != null) {
-            @Nullable Unit<Length> unit = unitProvider.getUnit(Length.class);
+            @Nullable
+            Unit<Length> unit = unitProvider.getUnit(Length.class);
             if (unit != null && !SIUnits.METRE.equals(unit)) {
                 double value = ImperialUnits.YARD.getConverterTo(SIUnits.METRE).convert(valueToConvert);
                 logger.trace("Value converted: {}yd->{}m", valueToConvert, value);

--- a/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/message/LocationMessage.java
+++ b/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/message/LocationMessage.java
@@ -113,4 +113,15 @@ public class LocationMessage {
     public BigDecimal getGpsAccuracy() {
         return gpsAccuracy;
     }
+
+    @Override
+    public String toString() {
+        return "LocationMessage [" + (type != null ? "type=" + type + ", " : "")
+                + (trackerId != null ? "trackerId=" + trackerId + ", " : "")
+                + (latitude != null ? "latitude=" + latitude + ", " : "")
+                + (longitude != null ? "longitude=" + longitude + ", " : "")
+                + (gpsAccuracy != null ? "gpsAccuracy=" + gpsAccuracy + ", " : "")
+                + (batteryLevel != null ? "batteryLevel=" + batteryLevel + ", " : "")
+                + (timestampMillis != null ? "timestampMillis=" + timestampMillis : "") + "]";
+    }
 }

--- a/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/message/LocationMessage.java
+++ b/addons/binding/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/message/LocationMessage.java
@@ -8,15 +8,16 @@
  */
 package org.openhab.binding.gpstracker.internal.message;
 
-import com.google.gson.annotations.SerializedName;
-import org.eclipse.smarthome.core.library.types.DateTimeType;
-import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.PointType;
-
 import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
+
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PointType;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * The {@link LocationMessage} is a POJO for location messages sent bz trackers.
@@ -24,6 +25,7 @@ import java.util.Date;
  * @author Gabor Bicskei - Initial contribution
  */
 public class LocationMessage {
+
     /**
      * Message type
      */
@@ -77,7 +79,7 @@ public class LocationMessage {
      */
     public DateTimeType getTimestamp() {
         if (timestampMillis != null) {
-            ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(new Date(timestampMillis*1000).toInstant(),
+            ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(new Date(timestampMillis * 1000).toInstant(),
                     ZoneId.systemDefault());
             return new DateTimeType(zonedDateTime);
         }


### PR DESCRIPTION
Having accuracy set to its default 0, the disablement didn't work for me as the comparison of a double value with 0 is not safe. This PR fixes that.

Note that the code formatting has been also applied by my IDE - I have therefore split the PR into two commits, to make clear what I have actually changed about the code.