### PR TITLE
[exec] State default setting for interval

### DIFF
--- a/addons/binding/org.openhab.binding.exec/README.md
+++ b/addons/binding/org.openhab.binding.exec/README.md
@@ -28,7 +28,7 @@ Optionally one can specify:
 
 
 - `transform` - A [transformation](https://www.openhab.org/docs/configuration/transformations.html) to apply on the execution result,
-- `interval` - An interval, in seconds, the command will be repeatedly executed,
+- `interval` - An interval, in seconds, the command will be repeatedly executed. Default is 60 seconds, set to 0 to avoid repetition.
 - `timeout` - A time-out, in seconds, the execution of the command will time out, and lastly,
 - `autorun` - A boolean parameter to make the command execute immediately every time the state of the input channel has changed.
 
@@ -95,7 +95,7 @@ Thing exec:command:yourcommand [ command="<YOUR COMMAND> %2$s", interval=0, auto
 
 ```java
 Switch YourTrigger
-Number YourNumber "Your Number [%.1f °C]"
+Number YourNumber "Your Number [%.1f Â°C]"
 
 // state of the execution, is running or finished
 Switch yourcommand {channel="exec:command:yourcommand:run"}


### PR DESCRIPTION
The default setting for `interval` is missing in the documentation for the exec-biniding, insert this.

(github has also converted encoding from ISO-8859-1 to UTF-8)