### PR TITLE
[iCloud] Update readme for Mapview usage in applications (Android/iOS)

### DIFF
--- a/addons/binding/org.openhab.binding.icloud/README.md
+++ b/addons/binding/org.openhab.binding.icloud/README.md
@@ -97,7 +97,7 @@ sitemap icloud label="iCloud" {
         Text item=iPhone_LocationLastUpdate
         Switch item=iPhone_FindMyPhone mappings=[ ON="Find!" ]
         Switch item=iPhone_Refresh mappings=[ REFRESH='Refresh now' ]
-        // mapview for web UI, invisible in iOS client
+        // Mapview for BasicUI and Applications (Android/iOS)
         Mapview item=iPhone_Location height=10
     }
 }


### PR DESCRIPTION
Mapview is also available for Android and iOS applications.

Maybe another information that the parameter `height=X` is needed for Mapview to work in applications?

Signed-off-by: Michael Bredehorn <michael@bredehorn.nrw> (github: bredmich)