### PR TITLE
[enocean] Dimmer not updated after openhab restart

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
@@ -8,15 +8,12 @@
  */
 package org.openhab.binding.enocean.internal.eep.A5_38;
 
-import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_DIMMER;
-
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.enocean.internal.eep.Base._4BSMessage;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
 
@@ -58,18 +55,11 @@ public class A5_38_08_Dimming extends _4BSMessage {
 
     @Override
     public State convertToStateImpl(String channelId, String channelTypeId, State currentState, Configuration config) {
-        if (!isValid()) {
-            return UnDefType.UNDEF;
-        }
 
-        if (channelId == CHANNEL_DIMMER) {
-            if (getDB_0() == (TeachInBit | SwitchOff)) {
-                return new PercentType(0);
-            } else {
-                return new PercentType(getDB_2Value());
-            }
+        if (getDB_0() == (TeachInBit | SwitchOff)) {
+            return new PercentType(0);
+        } else {
+            return new PercentType(getDB_2Value());
         }
-
-        return UnDefType.UNDEF;
     }
 }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/transceiver/EnOceanTransceiver.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/transceiver/EnOceanTransceiver.java
@@ -421,9 +421,10 @@ public abstract class EnOceanTransceiver {
 
     public void addPacketListener(ESP3PacketListener listener) {
 
-        listeners.computeIfAbsent(listener.getSenderIdToListenTo(), k -> new HashSet<ESP3PacketListener>())
-                .add(listener);
-        logger.debug("Listener added: {}", listener.getSenderIdToListenTo());
+        if (listeners.computeIfAbsent(listener.getSenderIdToListenTo(), k -> new HashSet<ESP3PacketListener>())
+                .add(listener)) {
+            logger.debug("Listener added: {}", listener.getSenderIdToListenTo());
+        }
     }
 
     public void removePacketListener(ESP3PacketListener listener) {


### PR DESCRIPTION
 * Dimmer profile EEP A5_38_08 checks channelId not longer by reference, fixes #4541
 * Message about adding an EnOcean listener is just posted if it is really added

Signed-off-by: Daniel Weber <uni@fruggy.de>
