### PR TITLE
[deconz] Added util channels (e.g. 'battery')

### DIFF
--- a/addons/binding/org.openhab.binding.deconz/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.deconz/ESH-INF/thing/thing-types.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="deconz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="deconz"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -26,7 +27,8 @@
 		<label>Presence Sensor</label>
 		<description>A Presence sensor</description>
 		<channels>
-			<channel typeId="presence" id="presence"></channel>
+			<channel typeId="presence" id="presence" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -43,6 +45,14 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
+	<channel-type id="last_updated">
+		<item-type>DateTime</item-type>
+		<label>Last Updated</label>
+		<description>The date and time when the sensor was last updated.</description>
+		<category>Time</category>
+		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS" />
+	</channel-type>
+
 	<thing-type id="powersensor">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="deconz" />
@@ -50,7 +60,8 @@
 		<label>Power Sensor</label>
 		<description>A power sensor</description>
 		<channels>
-			<channel typeId="power" id="power"></channel>
+			<channel typeId="power" id="power" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -99,8 +110,9 @@
 		<label>Switch/Button</label>
 		<description>A switch or button</description>
 		<channels>
-			<channel typeId="buttonevent" id="buttonevent"></channel>
-			<channel typeId="button" id="button"></channel>
+			<channel typeId="buttonevent" id="buttonevent" />
+			<channel typeId="button" id="button" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -131,7 +143,11 @@
 		<label>Light Sensor</label>
 		<description>A light sensor</description>
 		<channels>
-			<channel typeId="lightlux" id="lightlux"></channel>
+			<channel typeId="lightlux" id="lightlux" />
+			<channel typeId="light_level" id="light_level" />
+			<channel typeId="dark" id="dark" />
+			<channel typeId="daylight" id="daylight" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -148,6 +164,27 @@
 		<state readOnly="true" pattern="%.1f %unit%"></state>
 	</channel-type>
 
+	<channel-type id="light_level" advanced="true">
+		<item-type>Number</item-type>
+		<label>Light Level</label>
+		<description>Current light level.</description>
+		<state readOnly="true" pattern="%d" />
+	</channel-type>
+
+	<channel-type id="dark">
+		<item-type>Switch</item-type>
+		<label>Dark</label>
+		<description>Light level is below the darkness threshold.</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="daylight">
+		<item-type>Switch</item-type>
+		<label>Daylight</label>
+		<description>Light level is above the daylight threshold.</description>
+		<state readOnly="true" />
+	</channel-type>
+
 	<thing-type id="temperaturesensor">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="deconz" />
@@ -155,7 +192,8 @@
 		<label>Temperature Sensor</label>
 		<description>A temperature sensor</description>
 		<channels>
-			<channel typeId="temperature" id="temperature"></channel>
+			<channel typeId="temperature" id="temperature" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -179,7 +217,8 @@
 		<label>Humidity Sensor</label>
 		<description>A humidity sensor</description>
 		<channels>
-			<channel typeId="humidity" id="humidity"></channel>
+			<channel typeId="humidity" id="humidity" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">
@@ -266,7 +305,8 @@
 		<label>Open/Close Sensor</label>
 		<description>A open/close sensor</description>
 		<channels>
-			<channel typeId="open" id="open"></channel>
+			<channel typeId="open" id="open" />
+			<channel typeId="last_updated" id="last_updated" />
 		</channels>
 		<config-description>
 			<parameter name="id" type="text" required="true">

--- a/addons/binding/org.openhab.binding.deconz/README.md
+++ b/addons/binding/org.openhab.binding.deconz/README.md
@@ -54,11 +54,13 @@ Bridge deconz:deconz:homeserver [ host="192.168.0.10" ]
 
 In this case, the API key is generated automatically as described above (the deCONZ bridge has to be unlocked). Please note that the generated key cannot be written automatically to the `.thing` file, and has to be set manually.
 The generated key can be queried from the configuration using the openHAB console. To do this log into the [console](https://www.openhab.org/docs/administration/console.html) and use the command `things show` to display the configuration parameters, e.g:
+
 ```
 things show deconz:deconz:homeserver
 ```
 
 Afterwards the displayed API key has to be inserted in the `.thing` file as `apikey` configuration value, e.g.:
+
 ```
 Bridge deconz:deconz:homeserver [ host="192.168.0.10", apikey="ABCDEFGHIJ" ]
 ```
@@ -67,29 +69,35 @@ Bridge deconz:deconz:homeserver [ host="192.168.0.10", apikey="ABCDEFGHIJ" ]
 
 The devices support some of the following channels:
 
-| Channel Type ID   | Item Type             | Access Mode   | Description                                                               | Thing types       |
-| :---------------- | :-------------------- | :-----------: | :------------------------------------------------------------------------ | :---------------- |
-| presence          | Switch                | R             | Status of presence: `ON` = presence; `OFF` = no-presence                  | presencesensor    |
-| power             | Number:Power          | R             | Current power usage in Watts                                              | powersensor       |
-| consumption       | Number:Energy         | R             | Current power usage in Watts/Hour                                         | consumptionsensor |
-| button            | Number                | R             | Last pressed button id on a switch                                        | switch            |
-| lightlux          | Number:Illuminance    | R             | Current light illuminance in Lux                                          | lightsensor       |
-| temperature       | Number:Temperature    | R             | Current temperature in ˚C                                                 | temperaturesensor |
-| humidity          | Number:Dimensionless  | R             | Current humidity in %                                                     | humiditysensor    |
-| pressure          | Number:Pressure       | R             | Current pressure in hPa                                                   | pressuresensor    |
-| open              | Contact               | R             | Status of contacts: `OPEN`; `CLOSED`                                      | openclosesensor   |
-| light             | String                | R             | Light level: `Daylight`,`Sunset`,`Dark`                                   | daylightsensor    |
-| value             | Number                | R             | Sun position: `130` = dawn; `140` = sunrise; `190` = sunset; `210` = dusk | daylightsensor    |
+| Channel Type ID | Item Type            | Access Mode | Description                                                               | Thing types                               |
+|-----------------|----------------------|:-----------:|---------------------------------------------------------------------------|-------------------------------------------|
+| presence        | Switch               |      R      | Status of presence: `ON` = presence; `OFF` = no-presence                  | presencesensor                            |
+| last_updated    | DateTime             |      R      | Timestamp when the sensor was last updated                                | all, except daylightsensor                |
+| power           | Number:Power         |      R      | Current power usage in Watts                                              | powersensor                               |
+| consumption     | Number:Energy        |      R      | Current power usage in Watts/Hour                                         | consumptionsensor                         |
+| button          | Number               |      R      | Last pressed button id on a switch                                        | switch                                    |
+| lightlux        | Number:Illuminance   |      R      | Current light illuminance in Lux                                          | lightsensor                               |
+| light_level     | Number               |      R      | Current light level                                                       | lightsensor                               |
+| dark            | Switch               |      R      | Light level is below the darkness threshold.                              | lightsensor, sometimes for presencesensor |
+| daylight        | Switch               |      R      | Light level is above the daylight threshold.                              | lightsensor                               |
+| temperature     | Number:Temperature   |      R      | Current temperature in ˚C                                                 | temperaturesensor                         |
+| humidity        | Number:Dimensionless |      R      | Current humidity in %                                                     | humiditysensor                            |
+| pressure        | Number:Pressure      |      R      | Current pressure in hPa                                                   | pressuresensor                            |
+| open            | Contact              |      R      | Status of contacts: `OPEN`; `CLOSED`                                      | openclosesensor                           |
+| light           | String               |      R      | Light level: `Daylight`,`Sunset`,`Dark`                                   | daylightsensor                            |
+| value           | Number               |      R      | Sun position: `130` = dawn; `140` = sunrise; `190` = sunset; `210` = dusk | daylightsensor                            |
+| battery_level   | Number               |      R      | Battery level (in %)                                                      | any battery-powered sensor                |
+| battery_low     | Switch               |      R      | Battery level low: `ON`; `OFF`                                            | any battery-powered sensor                |
+
+**NOTE:** The `battery_level` and `battery_low` channels will be added to the Thing during runtime if the sensor is battery-powered.
 
 ### Trigger Channels
 
 The dimmer switch additionally supports a trigger channel.
 
-| Channel Type ID   | Description                                                       | Thing types       |
-| :---------------- | :---------------------------------------------------------------- | :---------------- |
-| buttonevent       | Event for switch pressed.                                         | switch            |
-
-
+| Channel Type ID | Description               | Thing types |
+|-----------------|---------------------------|-------------|
+| buttonevent     | Event for switch pressed. | switch      |
 
 ## Full Example
 
@@ -100,9 +108,9 @@ Bridge deconz:deconz:homeserver [ host="192.168.0.10", apikey="ABCDEFGHIJ" ] {
     presencesensor      livingroom-presence     "Livingroom Presence"       [ id="1" ]
     temperaturesensor   livingroom-temperature  "Livingroom Temperature"    [ id="2" ]
     humiditysensor      livingroom-humidity     "Livingroom Humidity"       [ id="3" ]
-	pressuresensor      livingroom-pressure     "Livingroom Pressure"       [ id="4" ]
+    pressuresensor      livingroom-pressure     "Livingroom Pressure"       [ id="4" ]
     openclosesensor     livingroom-window       "Livingroom Window"         [ id="5" ]
-	switch              livingroom-hue-tap      "Livingroom Hue Tap"        [ id="6" ]
+    switch              livingroom-hue-tap      "Livingroom Hue Tap"        [ id="6" ]
 }
 ```
 

--- a/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
+++ b/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
@@ -19,7 +19,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  */
 public class BindingConstants {
 
-    private static final String BINDING_ID = "deconz";
+    public static final String BINDING_ID = "deconz";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID BRIDGE_TYPE = new ThingTypeUID(BINDING_ID, "deconz");
@@ -36,17 +36,23 @@ public class BindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_PRESENCE = "presence";
+    public static final String CHANNEL_LAST_UPDATED = "last_updated";
     public static final String CHANNEL_POWER = "power";
     public static final String CHANNEL_CONSUMPTION = "consumption";
     public static final String CHANNEL_VALUE = "value";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_PRESSURE = "pressure";
-    public static final String CHANNEL_DAYLIGHT = "light";
+    public static final String CHANNEL_LIGHT = "light";
     public static final String CHANNEL_LIGHT_LUX = "lightlux";
+    public static final String CHANNEL_LIGHT_LEVEL = "light_level";
+    public static final String CHANNEL_DARK = "dark";
+    public static final String CHANNEL_DAYLIGHT = "daylight";
     public static final String CHANNEL_BUTTON = "button";
     public static final String CHANNEL_BUTTONEVENT = "buttonevent";
     public static final String CHANNEL_OPENCLOSE = "open";
+    public static final String CHANNEL_BATTERY_LEVEL = "battery_level";
+    public static final String CHANNEL_BATTERY_LOW = "battery_low";
 
     // Thing configuration
     public static final String CONFIG_HOST = "host";

--- a/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/SensorState.java
+++ b/addons/binding/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/SensorState.java
@@ -24,8 +24,10 @@ import org.eclipse.jdt.annotation.Nullable;
 public class SensorState {
     /** Some presence sensors, the daylight sensor and all light sensors provide the "dark" boolean. */
     public @Nullable Boolean dark;
-    /** The daylight sensor provides the "daylight" boolean. */
+    /** The daylight sensor and all light sensors provides the "daylight" boolean. */
     public @Nullable Boolean daylight;
+    /** Light sensors provide a light level value. */
+    public @Nullable Integer lightlevel;
     /** Light sensors provide a lux value. */
     public @Nullable Integer lux;
     /** Temperature sensors provide a degrees value. */


### PR DESCRIPTION
- Added util channels (e.g. `battery_level`, `battery_low` and `last_updated`)
- Added more light sensor channels (e.g. `lightlevel`, `dark` and `daylight`)
- Added check for the optional `dark` channel on presence sensors

Test version:
[org.openhab.binding.deconz-2.5.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab2-addons/files/2746191/org.openhab.binding.deconz-2.5.0-SNAPSHOT.jar.zip)

~I did not find the time to do a real test. Just threw in the code.~

Closes #4538
Closes #4524

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>