### PR TITLE
[airvisualnode] Replace "Greek Small Letter Mu" with "Micro sign"

### DIFF
--- a/addons/binding/org.openhab.binding.airvisualnode/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.airvisualnode/ESH-INF/thing/thing-types.xml
@@ -86,7 +86,7 @@
 	<channel-type id="Pm_25">
 		<item-type>Number:Density</item-type>
 		<label>PM2.5</label>
-		<description>PM2.5 level, μg/m&#179;</description>
+		<description>PM2.5 level, µg/m&#179;</description>
 		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 

--- a/addons/binding/org.openhab.binding.airvisualnode/README.md
+++ b/addons/binding/org.openhab.binding.airvisualnode/README.md
@@ -40,7 +40,7 @@ The binding supports the following channels:
 | co2             | Number:Dimensionless  | CO2 level, ppm              |
 | humidity        | Number:Dimensionless  | Relative humidity, %        |
 | aqi             | Number:Dimensionless  | Air Quality Index (US)      |
-| pm_25           | Number:Density        | PM2.5 level, μg/m³          |
+| pm_25           | Number:Density        | PM2.5 level, µg/m³          |
 | temperature     | Number:Temperature    | Temperature                 |
 | used_memory     | Number                | Used memory                 |
 | timestamp       | DateTime              | Timestamp                   |


### PR DESCRIPTION
The binding has a few occurrences of the "Greek Small Letter Mu" (U+03BC) which may cause issues when copy/pasted. The "Micro sign" (U+00B5) should be used instead. 

See https://github.com/eclipse/smarthome/pull/6818.