### PR TITLE
[milight] Fix issue with white mode commands being lost

### DIFF
--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV3RGBWHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV3RGBWHandler.java
@@ -66,7 +66,7 @@ public class MilightV3RGBWHandler extends AbstractLedV3Handler {
     public void whiteMode(MilightThingState state) {
         final byte cOn[] = { COMMAND_ON[config.zone], 0x00, 0x55 };
         final byte cWhite[] = { COMMAND_WHITEMODE[config.zone], 0x00, 0x55 };
-        sendQueue.queue(createRepeatable(uidc(ProtocolConstants.CAT_POWER_MODE), cOn).addRepeatable(cWhite));
+        sendQueue.queue(createRepeatable(uidc(ProtocolConstants.CAT_WHITEMODE), cOn).addRepeatable(cWhite));
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV3WhiteHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV3WhiteHandler.java
@@ -139,10 +139,10 @@ public class MilightV3WhiteHandler extends AbstractLedV3Handler {
         } else {
             oldLevel = (int) Math.ceil((state.brightness * BRIGHTNESS_LEVELS) / 100.0);
             skipFirst = true;
-        }
 
-        if (newLevel == oldLevel) {
-            return;
+            if (newLevel == oldLevel) {
+                return;
+            }
         }
 
         final int repeatCount = Math.abs(newLevel - oldLevel);

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBCWWWHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBCWWWHandler.java
@@ -39,7 +39,7 @@ public class MilightV6RGBCWWWHandler extends AbstractLedV6Handler {
 
     @Override
     public void whiteMode(MilightThingState state) {
-        sendRepeatableCat(ProtocolConstants.CAT_POWER_MODE, 5, state.colorTemperature);
+        sendRepeatableCat(ProtocolConstants.CAT_WHITEMODE, 5, state.colorTemperature);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBIBOXHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBIBOXHandler.java
@@ -40,7 +40,7 @@ public class MilightV6RGBIBOXHandler extends AbstractLedV6Handler {
 
     @Override
     public void whiteMode(MilightThingState state) {
-        sendRepeatableCat(ProtocolConstants.CAT_POWER_MODE, 3, 5);
+        sendRepeatableCat(ProtocolConstants.CAT_WHITEMODE, 3, 5);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBWHandler.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBWHandler.java
@@ -40,7 +40,7 @@ public class MilightV6RGBWHandler extends AbstractLedV6Handler {
 
     @Override
     public void whiteMode(MilightThingState state) {
-        sendRepeatableCat(ProtocolConstants.CAT_POWER_MODE, 3, 5);
+        sendRepeatableCat(ProtocolConstants.CAT_WHITEMODE, 3, 5);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/ProtocolConstants.java
+++ b/addons/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/ProtocolConstants.java
@@ -35,6 +35,7 @@ public abstract class ProtocolConstants {
     public static final int CAT_COLOR_SET = 12;
     public static final int CAT_POWER_MODE = 13;
     public static final int CAT_TEMPERATURE_SET = 14;
+    public static final int CAT_WHITEMODE = 17;
     public static final int CAT_MODE_SET = 18;
     public static final int CAT_SPEED_CHANGE = 19;
     public static final int CAT_LINK = 20;


### PR DESCRIPTION
This is a fix for an issue introduced in the 2.4
binding which changed the queue category for white mode to be the same
as power commands. This change broke rules which changed the bulb back
to white before turning it off (in case it was subsequently turned on by
a manual switch) since the white mode command would be removed from the
send queue by the power off command.

Also fixed a long standing issue with V3 white bulbs which would not
turn on to 98% from off.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>
