### PR TITLE
[smartmeter] Bugfix/4472 read timeout

### DIFF
--- a/addons/binding/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/sml/SmlSerialConnector.java
+++ b/addons/binding/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/sml/SmlSerialConnector.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.smartmeter.internal.sml;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -85,6 +87,7 @@ public final class SmlSerialConnector extends ConnectorBase<SmlFile> {
         // read out the whole buffer. We are only interested in the most recent SML file.
         Stack<SmlFile> smlFiles = new Stack<>();
         do {
+            logger.trace("Reading {}. SML message", smlFiles.size() + 1);
             smlFiles.push(TRANSPORT.getSMLFile(is));
         } while (is != null && is.available() > 0);
         if (smlFiles.isEmpty()) {
@@ -124,8 +127,8 @@ public final class SmlSerialConnector extends ConnectorBase<SmlFile> {
             }
             // serialPort.setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
             serialPort.notifyOnDataAvailable(true);
-            is = new DataInputStream(serialPort.getInputStream());
-            os = new DataOutputStream(serialPort.getOutputStream());
+            is = new DataInputStream(new BufferedInputStream(serialPort.getInputStream()));
+            os = new DataOutputStream(new BufferedOutputStream(serialPort.getOutputStream()));
         } else {
             throw new IllegalStateException(MessageFormat.format("No provider for port {0} found", getPortName()));
         }

--- a/addons/binding/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/sml/SmlSerialConnector.java
+++ b/addons/binding/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/sml/SmlSerialConnector.java
@@ -111,6 +111,12 @@ public final class SmlSerialConnector extends ConnectorBase<SmlFile> {
             try {
                 serialPort.setSerialPortParams(baudrateToUse, serialParameter.getDatabits(),
                         serialParameter.getStopbits(), serialParameter.getParity());
+                serialPort.setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
+                try {
+                    serialPort.enableReceiveTimeout(100);
+                } catch (UnsupportedCommOperationException e) {
+                    // doesn't matter (rfc2217 is not supporting this)
+                }
             } catch (UnsupportedCommOperationException e) {
                 throw new IOException(MessageFormat.format(
                         "Error at SerialConnector.openConnection: unable to set serial port parameters for port {0}.",


### PR DESCRIPTION
Final fix of timeout issue. Using a buffered stream fixes the performance issue. 
Fixes #4472

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
