### PR TITLE
[tplinksmarthome] Use system-wide channel type ids.

### DIFF
--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS100.xml
@@ -10,7 +10,7 @@
 		<category>PowerOutlet</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="led" typeId="led" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS105.xml
@@ -10,7 +10,7 @@
 		<category>PowerOutlet</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="led" typeId="led" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS110.xml
@@ -10,7 +10,7 @@
 		<category>PowerOutlet</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="led" typeId="led" />
 			<channel id="rssi" typeId="rssi" />
 			<channel id="power" typeId="power" />

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS200.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS200.xml
@@ -10,7 +10,7 @@
 		<category>WallSwitch</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS210.xml
@@ -10,7 +10,7 @@
 		<category>WallSwitch</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS220.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS220.xml
@@ -10,7 +10,7 @@
 		<category>WallSwitch</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness" typeId="system.brightness" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB100.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness" typeId="system.brightness" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KB130.xml
@@ -10,8 +10,8 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="color" typeId="color" />
-			<channel id="colorTemperature" typeId="colorTemperature" />
+			<channel id="color" typeId="system.color" />
+			<channel id="colorTemperature" typeId="system.color-temperature" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>
 

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/KP100.xml
@@ -10,7 +10,7 @@
 		<category>PowerOutlet</category>
 
 		<channels>
-			<channel id="switch" typeId="switch" />
+			<channel id="switch" typeId="system.power" />
 			<channel id="led" typeId="led" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB100.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness" typeId="system.brightness" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB110.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness" typeId="system.brightness" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB120.xml
@@ -10,8 +10,8 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
-			<channel id="colorTemperature" typeId="colorTemperature" />
+			<channel id="brightness" typeId="system.brightness" />
+			<channel id="colorTemperature" typeId="system.color-temperature" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB130.xml
@@ -10,8 +10,8 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="color" typeId="color" />
-			<channel id="colorTemperature" typeId="colorTemperature" />
+			<channel id="color" typeId="system.color" />
+			<channel id="colorTemperature" typeId="system.color-temperature" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB200.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness" typeId="system.brightness" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/LB230.xml
@@ -10,8 +10,8 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="color" typeId="color" />
-			<channel id="colorTemperature" typeId="colorTemperature" />
+			<channel id="color" typeId="system.color" />
+			<channel id="colorTemperature" typeId="system.color-temperature" />
 			<channel id="power" typeId="power" />
 			<channel id="rssi" typeId="rssi" />
 		</channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/channels.xml
@@ -5,12 +5,6 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<!-- Primary Channel types -->
-	<channel-type id="switch">
-		<item-type>Switch</item-type>
-		<label>Switch</label>
-		<description>Switch the Smart Home device on or off.</description>
-		<category>Switch</category>
-	</channel-type>
 	<channel-type id="switchReadonly">
 		<item-type>Switch</item-type>
 		<label>Switch</label>
@@ -53,34 +47,6 @@
 		<description>Actual voltage usage.</description>
 		<category>Energy</category>
 		<state readOnly="true" pattern="%.0f V"></state>
-	</channel-type>
-
-	<!-- Bulb Channel types -->
-	<channel-type id="color">
-		<item-type>Color</item-type>
-		<label>Color</label>
-		<description>This channel supports adjusting the color of a light. </description>
-		<category>ColorLight</category>
-		<tags>
-			<tag>Lighting</tag>
-		</tags>
-	</channel-type>
-
-	<channel-type id="colorTemperature">
-		<item-type>Dimmer</item-type>
-		<label>Color Temperature</label>
-		<description>This channel supports adjusting the color temperature from cold (0%) to warm (100%).</description>
-		<category>ColorLight</category>
-	</channel-type>
-
-	<channel-type id="brightness">
-		<item-type>Dimmer</item-type>
-		<label>Brightness</label>
-		<description>This channel supports adjusting the brightness.</description>
-		<category>DimmableLight</category>
-		<tags>
-			<tag>Lighting</tag>
-		</tags>
 	</channel-type>
 
 	<!-- Misc Channel types -->


### PR DESCRIPTION
Changed channel type Id to system-wide channel type ids. See https://www.eclipse.org/smarthome/documentation/development/bindings/thing-definition.html#system-state-channel-types