### PR TITLE
[enocean] Remove unused and deprecated ExtendedDiscoveryService implementation

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/discovery/EnOceanDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/discovery/EnOceanDeviceDiscoveryService.java
@@ -15,8 +15,6 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.util.HexUtils;
@@ -37,12 +35,10 @@ import org.slf4j.LoggerFactory;
  * @author Daniel Weber - Initial contribution
  */
 
-public class EnOceanDeviceDiscoveryService extends AbstractDiscoveryService
-        implements ESP3PacketListener, ExtendedDiscoveryService {
+public class EnOceanDeviceDiscoveryService extends AbstractDiscoveryService implements ESP3PacketListener {
     private final Logger logger = LoggerFactory.getLogger(EnOceanDeviceDiscoveryService.class);
 
     private EnOceanBridgeHandler bridgeHandler;
-    DiscoveryServiceCallback discoveryServiceCallback;
 
     public EnOceanDeviceDiscoveryService(EnOceanBridgeHandler bridgeHandler) {
         super(null, 60, false);
@@ -154,8 +150,4 @@ public class EnOceanDeviceDiscoveryService extends AbstractDiscoveryService
         return 0;
     }
 
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
-    }
 }


### PR DESCRIPTION
The `ExtendedDiscoveryService` implementation seems unused and is deprecated. So I've removed it in this PR.