### PR TITLE
[airquality] Added how to find the stationId to the documentation

### DIFF
--- a/addons/binding/org.openhab.binding.airquality/README.md
+++ b/addons/binding/org.openhab.binding.airquality/README.md
@@ -41,8 +41,10 @@ For the location parameter, the following syntax is allowed (comma separated lat
 37.8255,-122.456
 ```
 
-If you always want to receive data from specific station and you know its unique ID, you can enter it instead of the coordinates. This stationId can be found by using the following link:
-https://api.waqi.info/search/?token=TOKEN&keyword=NAME, replacing TOKEN by your apikey and NAME  by the station you are looking for.
+If you always want to receive data from specific station and you know its unique ID, you can enter it instead of the coordinates.
+
+This `stationId` can be found by using the following link:
+https://api.waqi.info/search/?token=TOKEN&keyword=NAME, replacing TOKEN by your apikey and NAME by the station you are looking for.
 
 ## Channels
 

--- a/addons/binding/org.openhab.binding.airquality/README.md
+++ b/addons/binding/org.openhab.binding.airquality/README.md
@@ -41,7 +41,8 @@ For the location parameter, the following syntax is allowed (comma separated lat
 37.8255,-122.456
 ```
 
-If you always want to receive data from specific station and you know its unique ID, you can enter it instead of the coordinates.
+If you always want to receive data from specific station and you know its unique ID, you can enter it instead of the coordinates. This stationId can be found by using the following link:
+https://api.waqi.info/search/?token=TOKEN&keyword=NAME, replacing TOKEN by your apikey and NAME  by the station you are looking for.
 
 ## Channels
 


### PR DESCRIPTION
Added how to find the stationId to the Air Quality Binding documentation. After a long search and a question on the community forum. 

Only a single line of the documentation changed, but it will sure help others save time :-)