### PR TITLE
[miio] Reflect deviceId being required as in the actual implementation

### DIFF
--- a/addons/binding/org.openhab.binding.miio/README.md
+++ b/addons/binding/org.openhab.binding.miio/README.md
@@ -163,7 +163,7 @@ However, for devices that are unsupported, you may override the value and try to
 |-----------------|---------|----------|-------------------------------------------------------------------|
 | host            | text    | true     | Device IP address                                                 |
 | token           | text    | true     | Token for communication (in Hex)                                  |
-| deviceId        | text    | false    | Device ID number for communication (in Hex)                       |
+| deviceId        | text    | true     | Device ID number for communication (in Hex)                       |
 | model           | text    | false    | Device model string, used to determine the subtype                |
 | refreshInterval | integer | false    | Refresh interval for refreshing the data in seconds. (0=disabled) |
 | timeout         | integer | false    | Timeout time in milliseconds                                      |


### PR DESCRIPTION
According to the commit https://github.com/openhab/openhab2-addons/commit/5465eb2b90eb03421c07b0ca2b7df68a40419647#diff-eee65336c9e776e03bb70f74aecedddc the deviceId is required. Unfortunately, the parameter is an advanced one, which makes it not that obvious, that this one is missing (when configured in textual configuration at least). Marking it as required in the documentation seems reasonable here.

Signed-Off-By: Florian Schmidt <florian.schmidt.welzow@t-online.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
