### PR TITLE
[groheondus] Export the waterconsumption value of the grohe sense guard

### DIFF
--- a/addons/binding/org.openhab.binding.groheondus/.classpath
+++ b/addons/binding/org.openhab.binding.groheondus/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="lib" path="lib/ondus-api-0.0.6.jar"/>
+	<classpathentry kind="lib" path="lib/ondus-api-0.0.7.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/binding/org.openhab.binding.groheondus/.classpath
+++ b/addons/binding/org.openhab.binding.groheondus/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="lib" path="lib/ondus-api-0.0.4.jar"/>
+	<classpathentry kind="lib" path="lib/ondus-api-0.0.6.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/binding/org.openhab.binding.groheondus/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.groheondus/ESH-INF/thing/thing-types.xml
@@ -125,22 +125,22 @@
 		<description>The humidity reported by the device</description>
 		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
-    <channel-type id="temperature">
-        <item-type>Number:Temperature</item-type>
-        <label>Temperature</label>
-        <description>The temperature reported by the device</description>
-        <state readOnly="true" pattern="%.1f %unit%" />
-    </channel-type>
-    <channel-type id="waterconsumption">
-        <item-type>Number</item-type>
-        <label>Water consumption</label>
-        <description>The amount of water consumed in the given time period.</description>
-        <state readOnly="true" />
-        <config-description>
-	        <parameter name="timeframe" type="integer" min="1" max="90" step="1" required="true">
-	            <label>Timeframe</label>
-	            <description>The timeframe in days to get the water consumption of</description>
-	        </parameter>
-	    </config-description>
-    </channel-type>
+	<channel-type id="temperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature</label>
+		<description>The temperature reported by the device</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
+	</channel-type>
+	<channel-type id="waterconsumption">
+		<item-type>Number</item-type>
+		<label>Water consumption</label>
+		<description>The amount of water consumed in the given time period.</description>
+		<state readOnly="true" />
+		<config-description>
+			<parameter name="timeframe" type="integer" min="1" max="90" step="1" required="true">
+				<label>Timeframe</label>
+				<description>The timeframe in days to get the water consumption of</description>
+			</parameter>
+		</config-description>
+	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.groheondus/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.groheondus/ESH-INF/thing/thing-types.xml
@@ -35,6 +35,7 @@
 			<channel id="name" typeId="name" />
 			<channel id="pressure" typeId="pressure" />
 			<channel id="temperature_guard" typeId="temperature_guard" />
+			<channel id="waterconsumption" typeId="waterconsumption" />
 			<channel id="valve_open" typeId="valve_open" />
 		</channels>
 
@@ -124,10 +125,22 @@
 		<description>The humidity reported by the device</description>
 		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
-	<channel-type id="temperature">
-		<item-type>Number:Temperature</item-type>
-		<label>Temperature</label>
-		<description>The temperature reported by the device</description>
-		<state readOnly="true" pattern="%.1f %unit%" />
-	</channel-type>
+    <channel-type id="temperature">
+        <item-type>Number:Temperature</item-type>
+        <label>Temperature</label>
+        <description>The temperature reported by the device</description>
+        <state readOnly="true" pattern="%.1f %unit%" />
+    </channel-type>
+    <channel-type id="waterconsumption">
+        <item-type>Number</item-type>
+        <label>Water consumption</label>
+        <description>The amount of water consumed in the given time period.</description>
+        <state readOnly="true" />
+        <config-description>
+	        <parameter name="timeframe" type="integer" min="1" max="90" step="1" required="true">
+	            <label>Timeframe</label>
+	            <description>The timeframe in days to get the water consumption of</description>
+	        </parameter>
+	    </config-description>
+    </channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.openhab.binding.groheondus
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: ., lib/ondus-api-0.0.6.jar
+Bundle-ClassPath: ., lib/ondus-api-0.0.7.jar
 Bundle-ManifestVersion: 2
 Bundle-Name: GROHE ONDUS Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.groheondus/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.openhab.binding.groheondus
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: ., lib/ondus-api-0.0.4.jar
+Bundle-ClassPath: ., lib/ondus-api-0.0.6.jar
 Bundle-ManifestVersion: 2
 Bundle-Name: GROHE ONDUS Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/addons/binding/org.openhab.binding.groheondus/README.md
+++ b/addons/binding/org.openhab.binding.groheondus/README.md
@@ -56,6 +56,7 @@ and the `locationId`. Once the account bridge is configured, the appliances in y
 | pressure                 | Number:Pressure          | The pressure of your water supply                     |
 | temperature_guard        | Number:Temperature       | The ambient temperature of the appliance              |
 | valve_open               | Switch                   | Valve switch                                          |
+| waterconsumption         | Number                   | The amount of water used in a specific timeframe      |
 
 ##### sense
 
@@ -72,7 +73,12 @@ Things file:
 
 ````
 Bridge groheondus:account:account1 [ username="user@example.com", password="YourStrongPasswordHere!" ] {
-    groheondus:senseguard:550e8400-e29b-11d4-a716-446655440000 [ applianceId="550e8400-e29b-11d4-a716-446655440000", roomId=456, locationId=123 ]
+    groheondus:senseguard:550e8400-e29b-11d4-a716-446655440000 [ applianceId="550e8400-e29b-11d4-a716-446655440000", roomId=456, locationId=123 ] {
+        Channels:
+            Type number : waterconsumption [
+               timeframe=3
+            ]
+    }
     groheondus:sense:550e8400-e29b-11d4-a716-446655440000 [ applianceId="444e8400-e29b-11d4-a716-446655440000", roomId=456, locationId=123 ]
 }
 ````

--- a/addons/binding/org.openhab.binding.groheondus/build.properties
+++ b/addons/binding/org.openhab.binding.groheondus/build.properties
@@ -5,4 +5,4 @@ bin.includes = META-INF/,\
                OSGI-INF/,\
                ESH-INF/,\
                NOTICE,\
-               lib/ondus-api-0.0.4.jar
+               lib/ondus-api-0.0.6.jar

--- a/addons/binding/org.openhab.binding.groheondus/build.properties
+++ b/addons/binding/org.openhab.binding.groheondus/build.properties
@@ -5,4 +5,4 @@ bin.includes = META-INF/,\
                OSGI-INF/,\
                ESH-INF/,\
                NOTICE,\
-               lib/ondus-api-0.0.6.jar
+               lib/ondus-api-0.0.7.jar

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
@@ -35,4 +35,6 @@ public class GroheOndusBindingConstants {
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_BATTERY = "battery";
+
+    public static final String CHANNEL_CONFIG_TIMEFRAME = "timeframe";
 }

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
@@ -31,6 +31,7 @@ public class GroheOndusBindingConstants {
     public static final String CHANNEL_PRESSURE = "pressure";
     public static final String CHANNEL_TEMPERATURE_GUARD = "temperature_guard";
     public static final String CHANNEL_VALVE_OPEN = "valve_open";
+    public static final String CHANNEL_WATERCONSUMPTION = "waterconsumption";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_BATTERY = "battery";

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBaseHandler.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBaseHandler.java
@@ -87,7 +87,7 @@ public abstract class GroheOndusBaseHandler<T extends BaseAppliance, M> extends 
         if (appliance == null) {
             return;
         }
-        updateChannel(channelUID, appliance, getLastMeasurement(appliance));
+        updateChannel(channelUID, appliance, getLastDataPoint(appliance));
     }
 
     public void updateChannels() {
@@ -104,13 +104,13 @@ public abstract class GroheOndusBaseHandler<T extends BaseAppliance, M> extends 
             return;
         }
 
-        M measurement = getLastMeasurement(appliance);
+        M measurement = getLastDataPoint(appliance);
         getThing().getChannels().forEach(channel -> updateChannel(channel.getUID(), appliance, measurement));
 
         updateStatus(ThingStatus.ONLINE);
     }
 
-    protected abstract M getLastMeasurement(T appliance);
+    protected abstract M getLastDataPoint(T appliance);
 
     protected abstract void updateChannel(ChannelUID channelUID, T appliance, M measurement);
 

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
@@ -51,6 +51,9 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<SenseGuardAppliance, Data> {
+    private static final int MIN_API_TIMEFRAME_DAYS = 1;
+    private static final int MAX_API_TIMEFRAME_DAYS = 90;
+    private static final int DEFAULT_TIMEFRAME_DAYS = 1;
 
     private final Logger logger = LoggerFactory.getLogger(GroheOndusSenseGuardHandler.class);
 
@@ -163,19 +166,19 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
     }
 
     private Instant fromTime() {
-        Instant from = Instant.now().minus(1, ChronoUnit.DAYS);
-        Channel waterconsumptionChannel = this.thing.getChannel("waterconsumption");
+        Instant from = Instant.now().minus(DEFAULT_TIMEFRAME_DAYS, ChronoUnit.DAYS);
+        Channel waterconsumptionChannel = this.thing.getChannel(CHANNEL_WATERCONSUMPTION);
         if (waterconsumptionChannel == null) {
             return from;
         }
 
-        Object timeframeConfig = waterconsumptionChannel.getConfiguration().get("timeframe");
+        Object timeframeConfig = waterconsumptionChannel.getConfiguration().get(CHANNEL_CONFIG_TIMEFRAME);
         if (!(timeframeConfig instanceof BigDecimal)) {
             return from;
         }
 
         int timeframe = ((BigDecimal) timeframeConfig).intValue();
-        if (timeframe < 1 && timeframe > 90) {
+        if (timeframe < MIN_API_TIMEFRAME_DAYS && timeframe > MAX_API_TIMEFRAME_DAYS) {
             logger.info(
                     "timeframe configuration of waterconsumption channel needs to be a number between 1 to 90, got {}",
                     timeframe);

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.groheondus.internal.handler;
 import static org.openhab.binding.groheondus.internal.GroheOndusBindingConstants.*;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -22,11 +23,13 @@ import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -38,6 +41,7 @@ import org.grohe.ondus.api.model.ApplianceCommand;
 import org.grohe.ondus.api.model.BaseApplianceData;
 import org.grohe.ondus.api.model.SenseGuardAppliance;
 import org.grohe.ondus.api.model.SenseGuardApplianceData;
+import org.grohe.ondus.api.model.SenseGuardApplianceData.Data;
 import org.grohe.ondus.api.model.SenseGuardApplianceData.Measurement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * @author Florian Schmidt and Arne Wohlert - Initial contribution
  */
 @NonNullByDefault
-public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<SenseGuardAppliance, Measurement> {
+public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<SenseGuardAppliance, Data> {
 
     private final Logger logger = LoggerFactory.getLogger(GroheOndusSenseGuardHandler.class);
 
@@ -63,7 +67,7 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
     }
 
     @Override
-    protected void updateChannel(ChannelUID channelUID, SenseGuardAppliance appliance, Measurement measurement) {
+    protected void updateChannel(ChannelUID channelUID, SenseGuardAppliance appliance, Data dataPoint) {
         String channelId = channelUID.getIdWithoutGroup();
         State newState;
         switch (channelId) {
@@ -71,13 +75,16 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
                 newState = new StringType(appliance.getName());
                 break;
             case CHANNEL_PRESSURE:
-                newState = new QuantityType<>(measurement.getPressure(), SmartHomeUnits.BAR);
+                newState = new QuantityType<>(getLastMeasurement(dataPoint).getPressure(), SmartHomeUnits.BAR);
                 break;
             case CHANNEL_TEMPERATURE_GUARD:
-                newState = new QuantityType<>(measurement.getTemperatureGuard(), SIUnits.CELSIUS);
+                newState = new QuantityType<>(getLastMeasurement(dataPoint).getTemperatureGuard(), SIUnits.CELSIUS);
                 break;
             case CHANNEL_VALVE_OPEN:
                 newState = getValveOpenType(appliance);
+                break;
+            case CHANNEL_WATERCONSUMPTION:
+                newState = sumWaterCosumption(dataPoint);
                 break;
             default:
                 throw new IllegalArgumentException("Channel " + channelUID + " not supported.");
@@ -85,6 +92,17 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
         if (newState != null) {
             updateState(channelUID, newState);
         }
+    }
+
+    private DecimalType sumWaterCosumption(Data dataPoint) {
+        Double waterConsumption = dataPoint.getWithdrawals().stream()
+                .mapToDouble(withdrawal -> withdrawal.getWaterconsumption()).sum();
+        return new DecimalType(waterConsumption);
+    }
+
+    private Measurement getLastMeasurement(Data dataPoint) {
+        List<Measurement> measurementList = dataPoint.getMeasurement();
+        return measurementList.isEmpty() ? new Measurement() : measurementList.get(measurementList.size() - 1);
     }
 
     @Nullable
@@ -107,32 +125,31 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
     }
 
     @Override
-    protected Measurement getLastMeasurement(SenseGuardAppliance appliance) {
+    protected Data getLastDataPoint(SenseGuardAppliance appliance) {
         if (getOndusService() == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
                     "No initialized OndusService available from bridge.");
-            return new Measurement();
+            return new Data();
         }
 
         SenseGuardApplianceData applianceData = getApplianceData(appliance);
         if (applianceData == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Could not load data from API.");
-            return new Measurement();
+            return new Data();
         }
-        List<Measurement> measurementList = applianceData.getData().getMeasurement();
-
-        return measurementList.isEmpty() ? new Measurement() : measurementList.get(measurementList.size() - 1);
+        return applianceData.getData();
     }
 
     private @Nullable SenseGuardApplianceData getApplianceData(SenseGuardAppliance appliance) {
-        Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS);
-        Instant today = Instant.now();
+        Instant from = fromTime();
+        Instant to = Instant.now();
+
         OndusService service = getOndusService();
         if (service == null) {
             return null;
         }
         try {
-            BaseApplianceData applianceData = service.getApplianceData(appliance, yesterday, today).orElse(null);
+            BaseApplianceData applianceData = service.getApplianceData(appliance, from, to).orElse(null);
             if (applianceData.getType() != SenseGuardAppliance.TYPE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Thing is not a GROHE SENSE Guard device.");
@@ -143,6 +160,29 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Sen
             logger.debug("Could not load appliance data", e);
         }
         return null;
+    }
+
+    private Instant fromTime() {
+        Instant from = Instant.now().minus(1, ChronoUnit.DAYS);
+        Channel waterconsumptionChannel = this.thing.getChannel("waterconsumption");
+        if (waterconsumptionChannel == null) {
+            return from;
+        }
+
+        Object timeframeConfig = waterconsumptionChannel.getConfiguration().get("timeframe");
+        if (!(timeframeConfig instanceof BigDecimal)) {
+            return from;
+        }
+
+        int timeframe = ((BigDecimal) timeframeConfig).intValue();
+        if (timeframe < 1 && timeframe > 90) {
+            logger.info(
+                    "timeframe configuration of waterconsumption channel needs to be a number between 1 to 90, got {}",
+                    timeframe);
+            return from;
+        }
+
+        return Instant.now().minus(timeframe, ChronoUnit.DAYS);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseHandler.java
+++ b/addons/binding/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseHandler.java
@@ -90,7 +90,7 @@ public class GroheOndusSenseHandler<T, M> extends GroheOndusBaseHandler<SenseApp
     }
 
     @Override
-    protected Measurement getLastMeasurement(SenseAppliance appliance) {
+    protected Measurement getLastDataPoint(SenseAppliance appliance) {
         if (getOndusService() == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
                     "No initialized OndusService available from bridge.");


### PR DESCRIPTION
The waterconsumption is a combined metric of the total consumed water
registered by the grohe sense guard. The channel allows you to get the
value of a specific timeframe (in days) from 1 to up to 90 days (the 90
days is a restriction of the api).

This also fixes (by an update of the api library) the issue of
deserializing an array to an actual appliance.

Fixes #4554

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
