### PR TITLE
[squeezebox] Fix local cover art download failure when auth enabled

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/README.md
+++ b/addons/binding/org.openhab.binding.squeezebox/README.md
@@ -202,3 +202,6 @@ Therefore, it is recommended that the LMS be on a more current version than 7.7.
 
 -   There have been reports that the LMS does not play some WAV files reliably.
 If you're using a TTS service that produces WAV files, and the notifications are not playing, try using an MP3-formatted TTS notification.
+
+-   The LMS treats player MAC addresses as case-sensitive.
+Therefore, the case of MAC addresses in the Squeeze Player thing configuration must match the case displayed on the *Information* tab in the LMS Settings.

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -450,7 +450,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
             if (userInfo != null) {
                 String[] userInfoParts = userInfo.split(":");
                 if (userInfoParts.length == 2) {
-                    sanitizedUrl = url.replace(userInfoParts[1], "password");
+                    sanitizedUrl = url.replace(userInfoParts[1], "**********");
                 }
             }
         } catch (URISyntaxException e) {

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -14,6 +14,8 @@ package org.openhab.binding.squeezebox.internal.handler;
 
 import static org.openhab.binding.squeezebox.internal.SqueezeBoxBindingConstants.*;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,8 +70,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Convert sound notification volume from channel to config parameter
  */
 public class SqueezeBoxPlayerHandler extends BaseThingHandler implements SqueezeBoxPlayerEventListener {
-
-    private Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerHandler.class);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .singleton(SQUEEZEBOXPLAYER_THING_TYPE);
@@ -417,17 +418,18 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         // Only get the image if this is my PlayerHandler instance
         if (isMe(mac)) {
             if (StringUtils.isNotEmpty(url)) {
+                String sanitizedUrl = sanitizeUrl(url);
                 RawType image = IMAGE_CACHE.putIfAbsentAndGet(url, () -> {
-                    logger.debug("Trying to download the content of URL {}", url);
+                    logger.debug("Trying to download the content of URL {}", sanitizedUrl);
                     try {
                         return HttpUtil.downloadImage(url);
                     } catch (IllegalArgumentException e) {
-                        logger.debug("IllegalArgumentException when downloading image from {}", url, e);
+                        logger.debug("IllegalArgumentException when downloading image from {}", sanitizedUrl, e);
                         return null;
                     }
                 });
                 if (image == null) {
-                    logger.debug("Failed to download the content of URL {}", url);
+                    logger.debug("Failed to download the content of URL {}", sanitizedUrl);
                     return null;
                 } else {
                     return image;
@@ -435,6 +437,26 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
             }
         }
         return null;
+    }
+
+    /*
+     * Replaces the password in the URL, if present
+     */
+    private String sanitizeUrl(String url) {
+        String sanitizedUrl = url;
+        try {
+            URI uri = new URI(url);
+            String userInfo = uri.getUserInfo();
+            if (userInfo != null) {
+                String[] userInfoParts = userInfo.split(":");
+                if (userInfoParts.length == 2) {
+                    sanitizedUrl = url.replace(userInfoParts[1], "password");
+                }
+            }
+        } catch (URISyntaxException e) {
+            // Just return what was passed in
+        }
+        return sanitizedUrl;
     }
 
     /**

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerState.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerState.java
@@ -22,20 +22,21 @@ import org.slf4j.LoggerFactory;
  * @author Patrik Gfeller - Moved class to its own file.
  */
 class SqueezeBoxPlayerState {
-    boolean savedMute;
-    boolean savedPower;
-    boolean savedStop;
-    boolean savedControl;
+    private final Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerState.class);
 
-    int savedVolume;
-    int savedShuffle;
-    int savedRepeat;
-    int savedPlaylistIndex;
-    int savedNumberPlaylistTracks;
-    int savedPlayingTime;
+    private boolean savedMute;
+    private boolean savedPower;
+    private boolean savedStop;
+    private boolean savedControl;
+
+    private int savedVolume;
+    private int savedShuffle;
+    private int savedRepeat;
+    private int savedPlaylistIndex;
+    private int savedNumberPlaylistTracks;
+    private int savedPlayingTime;
 
     private SqueezeBoxPlayerHandler playerHandler;
-    private Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerState.class);
 
     public SqueezeBoxPlayerState(SqueezeBoxPlayerHandler playerHandler) {
         this.playerHandler = playerHandler;

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -340,7 +340,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     String sanitizeCommand(String command) {
         String sanitizedCommand = command;
         if (command.startsWith("login")) {
-            sanitizedCommand = command.replace(password, "password");
+            sanitizedCommand = command.replace(password, "**********");
         }
         return sanitizedCommand;
     }

--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Hilbush - Get favorites from LMS; update channel and send to players
  */
 public class SqueezeBoxServerHandler extends BaseBridgeHandler {
-    private Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .singleton(SQUEEZEBOXSERVER_THING_TYPE);
@@ -324,14 +324,25 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             return;
         }
 
-        logger.debug("Sending command: {}", command);
+        logger.debug("Sending command: {}", sanitizeCommand(command));
         try {
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(clientSocket.getOutputStream()));
             writer.write(command + NEW_LINE);
             writer.flush();
         } catch (IOException e) {
-            logger.error("Error while sending command to Squeeze Server ({}) ", command, e);
+            logger.error("Error while sending command to Squeeze Server ({}) ", sanitizeCommand(command), e);
         }
+    }
+
+    /*
+     * Remove password from login command to prevent it from being logged
+     */
+    String sanitizeCommand(String command) {
+        String sanitizedCommand = command;
+        if (command.startsWith("login")) {
+            sanitizedCommand = command.replace(password, "password");
+        }
+        return sanitizedCommand;
     }
 
     /**
@@ -789,7 +800,12 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
 
         private String constructCoverArtUrl(String mac, boolean coverart, String coverid, String artwork_url) {
-            String hostAndPort = "http://" + host + ":" + webport;
+            String hostAndPort;
+            if (StringUtils.isNotEmpty(userId)) {
+                hostAndPort = "http://" + userId + ":" + password + "@" + host + ":" + webport;
+            } else {
+                hostAndPort = "http://" + host + ":" + webport;
+            }
 
             // Default to using the convenience artwork URL (should be rare)
             String url = hostAndPort + "/music/current/cover.jpg?player=" + encode(mac);
@@ -812,7 +828,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     url = hostAndPort + "/" + decode(artwork_url);
                 }
             }
-            logger.trace("{}: URL for cover art is {}", mac, url);
             return url;
         }
 


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

Fixes #4653

- Add basic authentication to the download URL for LMS-served covert art images when LMS authentication is enabled. 
- Ensure that the password is not logged in the openHAB log file.
- Add private to SqueezeBoxPlayerState fields.

Note that there are now a number of new SAT warnings, which were not there before. I presume this is because new SAT checks were added. I will fix these in a separate PR.
