### PR TITLE
Add missing Automatic-Module-Name manifest entries

### DIFF
--- a/addons/binding/org.openhab.binding.km200/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.km200/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.km200
 Bundle-ManifestVersion: 2
 Bundle-Name: KM200 Binding
 Bundle-SymbolicName: org.openhab.binding.km200;singleton:=true

--- a/addons/binding/org.openhab.binding.unifi/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.unifi/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.binding.unifi
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
Adds the missing Automatic-Module-Name manifest entries to the KM200 and UniFi bindings.