### PR TITLE
[OneWire] fix digital I/O and initialization

### DIFF
--- a/addons/binding/org.openhab.binding.onewire.test/src/test/java/org/openhab/binding/onewire/test/AbstractThingHandlerTest.java
+++ b/addons/binding/org.openhab.binding.onewire.test/src/test/java/org/openhab/binding/onewire/test/AbstractThingHandlerTest.java
@@ -116,11 +116,7 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
         }).when(bridgeHandler).readBitSet(any(), any());
 
         Mockito.doAnswer(answer -> {
-            Thing thing = thingHandler.getThing();
-            Map<String, String> properties = new HashMap<String, String>();
-            properties.putAll(thing.getProperties());
-            properties.putAll(thingHandler.updateSensorProperties(secondBridgeHandler));
-            thing.setProperties(properties);
+            thingHandler.updateSensorProperties(secondBridgeHandler);
             thingHandler.initialize();
             return null;
         }).when(bridgeHandler).scheduleForPropertiesUpdate(any());

--- a/addons/binding/org.openhab.binding.onewire/README.md
+++ b/addons/binding/org.openhab.binding.onewire/README.md
@@ -23,7 +23,8 @@ The thing types `ms-th` and `ms-tv` have been marked deprecated and will be upda
 The thing types `counter2`, `digitalio`, `digitalio2`, `digitalio8`, `ibutton`, `temperature` have been marked deprecated and will be updated to `basic` automatically. 
 Please note that auto-upgraded things keep their thing UID _including the deprecated thing type_.
 
-Manually (via textual configuration) defined things need to be changed to `ms-tx` or `basic` respectively. 
+Manually (via textual configuration) defined things need to be changed to `ms-tx` or `basic` respectively.
+The thing UID changes and the item links need to be adjusted to the new UID.
 
 Deprecated thing types will will be removed with the next official release.
 

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/DigitalIoConfig.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/DigitalIoConfig.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.CHANNEL_DI
 import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -37,7 +38,8 @@ public class DigitalIoConfig {
     private DigitalIoMode ioMode = DigitalIoMode.INPUT;
     private DigitalIoLogic ioLogic = DigitalIoLogic.NORMAL;
 
-    public DigitalIoConfig(Thing thing, Integer channelIndex, OwDeviceParameterMap inParam, OwDeviceParameterMap outParam) {
+    public DigitalIoConfig(Thing thing, Integer channelIndex, OwDeviceParameterMap inParam,
+            OwDeviceParameterMap outParam) {
         this.channelUID = new ChannelUID(thing.getUID(), String.format("%s%d", CHANNEL_DIGITAL, channelIndex));
         this.channelID = String.format("%s%d", CHANNEL_DIGITAL, channelIndex);
         this.inParam = inParam;
@@ -85,6 +87,14 @@ public class DigitalIoConfig {
             return rawValue ? OnOffType.ON : OnOffType.OFF;
         } else {
             return rawValue ? OnOffType.OFF : OnOffType.ON;
+        }
+    }
+
+    public DecimalType convertState(OnOffType command) {
+        if (ioLogic == DigitalIoLogic.NORMAL) {
+            return command.equals(OnOffType.ON) ? new DecimalType(1) : DecimalType.ZERO;
+        } else {
+            return command.equals(OnOffType.ON) ? DecimalType.ZERO : new DecimalType(1);
         }
     }
 

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/device/AbstractDigitalOwDevice.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/device/AbstractDigitalOwDevice.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -130,11 +129,8 @@ public abstract class AbstractDigitalOwDevice extends AbstractOwDevice {
         if (ioChannel < getChannelCount()) {
             try {
                 if (ioConfig.get(ioChannel).isOutput()) {
-                    DecimalType value = ((OnOffType) command).as(DecimalType.class);
-                    if (value == null) {
-                        throw new OwException("command is null");
-                    }
-                    bridgeHandler.writeDecimalType(sensorId, ioConfig.get(ioChannel).getParameter(), value);
+                    bridgeHandler.writeDecimalType(sensorId, ioConfig.get(ioChannel).getParameter(),
+                            ioConfig.get(ioChannel).convertState((OnOffType) command));
                     return true;
                 } else {
                     return false;

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
@@ -38,9 +38,9 @@ import org.openhab.binding.onewire.internal.SensorId;
 import org.openhab.binding.onewire.internal.device.DS18x20;
 import org.openhab.binding.onewire.internal.device.DS2406_DS2413;
 import org.openhab.binding.onewire.internal.device.DS2438;
+import org.openhab.binding.onewire.internal.device.DS2438.LightSensorType;
 import org.openhab.binding.onewire.internal.device.OwChannelConfig;
 import org.openhab.binding.onewire.internal.device.OwSensorType;
-import org.openhab.binding.onewire.internal.device.DS2438.LightSensorType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,8 +214,8 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
     }
 
     @Override
-    public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
-        Map<String, String> properties = new HashMap<String, String>();
+    public void updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
+        Map<String, String> properties = editProperties();
         DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorId);
 
         sensorType = DS2438Configuration.getMultisensorType(ds2438configuration.getSensorSubType(),
@@ -247,7 +247,7 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
                 throw new OwException("sensorType " + sensorType.toString() + " not supported by this thing handler");
         }
 
-        return properties;
+        updateProperties(properties);
     }
 
     /**

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.onewire.internal.handler;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,9 +28,9 @@ import org.openhab.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.device.DS1923;
 import org.openhab.binding.onewire.internal.device.DS2438;
-import org.openhab.binding.onewire.internal.device.OwSensorType;
 import org.openhab.binding.onewire.internal.device.DS2438.CurrentSensorType;
 import org.openhab.binding.onewire.internal.device.DS2438.LightSensorType;
+import org.openhab.binding.onewire.internal.device.OwSensorType;
 
 /**
  * The {@link BasicMultisensorThingHandler} is responsible for handling DS2438/DS1923 based multisensors (single
@@ -94,8 +93,8 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
     }
 
     @Override
-    public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
-        Map<String, String> properties = new HashMap<String, String>();
+    public void updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
+        Map<String, String> properties = editProperties();
         sensorType = bridgeHandler.getType(sensorId);
 
         if (sensorType == OwSensorType.DS1923) {
@@ -111,6 +110,6 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
             properties.put(PROPERTY_VENDOR, vendor);
         }
 
-        return properties;
+        updateProperties(properties);
     }
 }

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/EDSSensorThingHandler.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/EDSSensorThingHandler.java
@@ -16,7 +16,6 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -63,8 +62,8 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
     }
 
     @Override
-    public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
-        Map<String, String> properties = new HashMap<String, String>();
+    public void updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
+        Map<String, String> properties = editProperties();
 
         OwPageBuffer pages = bridgeHandler.readPages(sensorId);
 
@@ -86,6 +85,6 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
         properties.put(PROPERTY_VENDOR, "Embedded Data Systems");
         properties.put(PROPERTY_HW_REVISION, String.valueOf(fwRevision));
 
-        return properties;
+        updateProperties(properties);
     }
 }

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/OwBaseBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/OwBaseBridgeHandler.java
@@ -13,10 +13,8 @@
 package org.openhab.binding.onewire.internal.handler;
 
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
@@ -99,12 +97,8 @@ public abstract class OwBaseBridgeHandler extends BaseBridgeHandler {
                 OwBaseThingHandler owHandler = (OwBaseThingHandler) updateThing.getHandler();
                 if (owHandler != null) {
                     try {
-                        Map<String, String> properties = new HashMap<String, String>();
-                        properties.putAll(updateThing.getProperties());
-                        properties.putAll(owHandler.updateSensorProperties(this));
-                        updateThing.setProperties(properties);
+                        owHandler.updateSensorProperties(this);
                         owHandler.initialize();
-
                         logger.debug("{} sucessfully updated properties, removing from property update list",
                                 updateThing.getUID());
                     } catch (OwException e) {
@@ -117,8 +111,7 @@ public abstract class OwBaseBridgeHandler extends BaseBridgeHandler {
                 }
             }
         }
-
-    };
+    }
 
     @Override
     public void initialize() {

--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/OwBaseThingHandler.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/handler/OwBaseThingHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -321,7 +320,9 @@ public abstract class OwBaseThingHandler extends BaseThingHandler {
             return;
         }
 
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "required properties missing");
         bridgeHandler.scheduleForPropertiesUpdate(thing);
+        
     }
 
     /**
@@ -333,14 +334,15 @@ public abstract class OwBaseThingHandler extends BaseThingHandler {
      * @return properties to be added to the properties map
      * @throws OwException
      */
-    public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
-        Map<String, String> properties = new HashMap<String, String>();
+    public void updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
+        Map<String, String> properties = editProperties();
         OwSensorType sensorType = bridgeHandler.getType(sensorId);
         properties.put(PROPERTY_MODELID, sensorType.toString());
         properties.put(PROPERTY_VENDOR, "Dallas/Maxim");
-        logger.trace("updated modelid/vendor to {} / {}", sensorType.name(), "Dallas/Maxim");
 
-        return properties;
+        updateProperties(properties);
+
+        logger.trace("updated modelid/vendor to {} / {}", sensorType.name(), "Dallas/Maxim");
     }
 
     /**


### PR DESCRIPTION
This will fix the "digital I/O does not respect inverted setting on write" bug, reported [here](https://community.openhab.org/t/solved-onewire-binding-digitalio-output-is-inverted/65171) and a thing initialization problem found in the same thread. Also makes documentation more clear for upgrading thing-types.