### PR TITLE
Revert 4685 modbus internal

### DIFF
--- a/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Vendor: openHAB
 Bundle-Version: 2.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
-Import-Package: 
- org.apache.commons.lang,
+Import-Package: org.apache.commons.lang,
  org.apache.commons.lang.builder,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.library.items,
@@ -18,10 +17,14 @@ Import-Package:
  org.eclipse.smarthome.core.transform,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.config.core,
+ org.openhab.binding.modbus,
+ org.openhab.binding.modbus.handler,
  org.openhab.io.transport.modbus,
  org.openhab.io.transport.modbus.endpoint,
  org.openhab.io.transport.modbus.json,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Export-Package: org.openhab.binding.modbus,
+ org.openhab.binding.modbus.handler
 Bundle-ActivationPolicy: lazy

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingConstants.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingConstants.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.modbus.internal;
+package org.openhab.binding.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/EndpointNotInitializedException.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/EndpointNotInitializedException.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.modbus.internal.handler;
+package org.openhab.binding.modbus.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusEndpointThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusEndpointThingHandler.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.modbus.internal.handler;
+package org.openhab.binding.modbus.handler;
 
 import java.util.function.Supplier;
 

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstantsInternal.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBindingConstantsInternal.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.modbus.internal;
 
-import static org.openhab.binding.modbus.internal.ModbusBindingConstants.BINDING_ID;
+import static org.openhab.binding.modbus.ModbusBindingConstants.BINDING_ID;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.ModbusConfigurationException;
 import org.openhab.io.transport.modbus.ModbusManager;
 import org.openhab.io.transport.modbus.ModbusManagerListener;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -53,6 +53,8 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.ModbusConfigurationException;
 import org.openhab.binding.modbus.internal.Transformation;

--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusPollerThingHandlerImpl.java
@@ -33,6 +33,8 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
 import org.openhab.binding.modbus.internal.AtomicStampedKeyValue;
 import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
 import org.openhab.binding.modbus.internal.config.ModbusPollerConfiguration;


### PR DESCRIPTION
Reverts #4685.

As @mrbig [pointed out](https://github.com/openhab/openhab2-addons/pull/4685#issuecomment-457407781) the exported packages are there so they can be used in https://github.com/openhab/openhab2-addons/pull/4220. Sorry for making them internal again! 

We'd best review/merge https://github.com/openhab/openhab2-addons/pull/4220 so whenever we make them internal it results in build errors. :wink: 