### PR TITLE
[globalcache] Fix dependency on map transform in feature.xml

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -219,7 +219,7 @@
 
     <feature name="openhab-binding-globalcache" description="GlobalCache Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>esh-transform-map</feature>
+        <feature>openhab-transformation-map</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.globalcache/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
As a result of the move of the ESH addons to openhab, the map transform dependency needs to be updated.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
