### PR TITLE
[paper] Fix missing maven-clean-plugin version warning

### DIFF
--- a/addons/ui/org.openhab.ui.paper/pom.xml
+++ b/addons/ui/org.openhab.ui.paper/pom.xml
@@ -18,6 +18,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <filesets>
             <fileset>


### PR DESCRIPTION
Fixes the following warning:

```
[WARNING] Some problems were encountered while building the effective model for org.openhab.ui:org.openhab.ui.paper:eclipse-plugin:2.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-clean-plugin is missing. @ org.openhab.ui:org.openhab.ui.paper:[unknown-version], /home/wouter/git/openhab/openhab2-addons/addons/ui/org.openhab.ui.paper/pom.xml, line 19, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```