### PR TITLE
renamed javasound back to enhancejavasound for compatibility reasons

### DIFF
--- a/addons/io/org.openhab.io.javasound/src/main/java/org/openhab/io/javasound/internal/JavaSoundAudioSink.java
+++ b/addons/io/org.openhab.io.javasound/src/main/java/org/openhab/io/javasound/internal/JavaSoundAudioSink.java
@@ -154,7 +154,7 @@ public class JavaSoundAudioSink implements AudioSink {
 
     @Override
     public String getId() {
-        return "javasound";
+        return "enhancedjavasound";
     }
 
     @Override


### PR DESCRIPTION
See https://community.openhab.org/t/1507-default-audiosink-service-enhancedjavasound-not-available/65730

Signed-off-by: Kai Kreuzer <kai@openhab.org>
