### PR TITLE
Remove static "for the next 3 hours" text

### DIFF
--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
@@ -266,7 +266,7 @@
 	<channel-type id="rain">
 		<item-type>Number:Length</item-type>
 		<label>Rain</label>
-		<description>Rain volume for the last 3 hours.</description>
+		<description>Rain volume.</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -274,7 +274,7 @@
 	<channel-type id="forecasted-rain">
 		<item-type>Number:Length</item-type>
 		<label>Forecasted Rain</label>
-		<description>Forecasted rain volume for the next 3 hours.</description>
+		<description>Forecasted rain volume.</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -282,7 +282,7 @@
 	<channel-type id="snow">
 		<item-type>Number:Length</item-type>
 		<label>Snow</label>
-		<description>Snow volume for the last 3 hours.</description>
+		<description>Snow volume.</description>
 		<category>Snow</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -290,7 +290,7 @@
 	<channel-type id="forecasted-snow">
 		<item-type>Number:Length</item-type>
 		<label>Forecasted Snow</label>
-		<description>Forecasted snow volume for the next 3 hours.</description>
+		<description>Forecasted snow volume.</description>
 		<category>Snow</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
@@ -266,7 +266,7 @@
 	<channel-type id="rain">
 		<item-type>Number:Length</item-type>
 		<label>Rain</label>
-		<description>Rain volume.</description>
+		<description>Rain volume for the last 3 hours.</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -282,7 +282,7 @@
 	<channel-type id="snow">
 		<item-type>Number:Length</item-type>
 		<label>Snow</label>
-		<description>Snow volume.</description>
+		<description>Snow volume for the last 3 hours.</description>
 		<category>Snow</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>

--- a/addons/binding/org.openhab.binding.openweathermap/README.md
+++ b/addons/binding/org.openhab.binding.openweathermap/README.md
@@ -112,8 +112,8 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 | forecastHours03, forecastHours06, ... forecastHours120 | wind-direction | Number:Angle         | Forecasted wind direction.                                                 |
 | forecastHours03, forecastHours06, ... forecastHours120 | gust-speed     | Number:Speed         | Forecasted gust speed. **Advanced**                                        |
 | forecastHours03, forecastHours06, ... forecastHours120 | cloudiness     | Number:Dimensionless | Forecasted cloudiness.                                                     |
-| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volume for the next 3 hours.                                 |
-| forecastHours03, forecastHours06, ... forecastHours120 | snow           | Number:Length        | Expected snow volume for the next 3 hours.                                 |
+| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volum.                                                      |
+| forecastHours03, forecastHours06, ... forecastHours120 | snow           | Number:Length        | Expected snow volume.                                                      |
 
 ### Daily Forecast
 

--- a/addons/binding/org.openhab.binding.openweathermap/README.md
+++ b/addons/binding/org.openhab.binding.openweathermap/README.md
@@ -112,7 +112,7 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 | forecastHours03, forecastHours06, ... forecastHours120 | wind-direction | Number:Angle         | Forecasted wind direction.                                                 |
 | forecastHours03, forecastHours06, ... forecastHours120 | gust-speed     | Number:Speed         | Forecasted gust speed. **Advanced**                                        |
 | forecastHours03, forecastHours06, ... forecastHours120 | cloudiness     | Number:Dimensionless | Forecasted cloudiness.                                                     |
-| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volum.                                                      |
+| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volume.                                                      |
 | forecastHours03, forecastHours06, ... forecastHours120 | snow           | Number:Length        | Expected snow volume.                                                      |
 
 ### Daily Forecast


### PR DESCRIPTION
This is applied to every forecast, no matter how far in the future.