### PR TITLE
[nibeuplink] Change airsupply to watersupply for the ground water bas…

### DIFF
--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-groups.xml
@@ -22,11 +22,11 @@
 		</channels>
 	</channel-group-type>
 
-	<channel-group-type id="f1145-airsupply">
-		<label>Air Supply/Exhaust Channels</label>
+	<channel-group-type id="f1145-watersupply">
+		<label>Water In/Out Channels</label>
 		<channels>
-			<channel id="40025" typeId="f1145-type-40025" />
-			<channel id="40026" typeId="f1145-type-40026" />
+			<channel id="40015" typeId="f1145-type-40015" />
+			<channel id="40016" typeId="f1145-type-40016" />
 		</channels>
 	</channel-group-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-thing.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-thing.xml
@@ -5,13 +5,13 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 	<thing-type id="f1145">
 		<label>Nibe F1145</label>
-		<description>Nibe F1145 heat pump connected through Nibe UpLink</description>
+		<description>Nibe F1145/F1245 heat pump connected through Nibe UpLink</description>
 		<channel-groups>
 			<channel-group typeId="base-base" id="base" />
 			<channel-group typeId="base-hotwater" id="hotwater" />
 			<channel-group typeId="f1145-general" id="general" />
 			<channel-group typeId="f1145-compressor" id="compressor" />
-			<channel-group typeId="f1145-airsupply" id="airsupply" />
+			<channel-group typeId="f1145-watersupply" id="watersupply" />
 			<channel-group typeId="custom-custom" id="custom" />
 		</channel-groups>
 		<config-description-ref uri="thing-type:nibeuplink:web" />

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-groups.xml
@@ -24,11 +24,11 @@
 			<channel id="43123" typeId="f1155-type-43123" />
 		</channels>
 	</channel-group-type>
-	<channel-group-type id="f1155-airsupply">
-		<label>Air Supply/Exhaust Channels</label>
+	<channel-group-type id="f1155-watersupply">
+		<label>Water In/Out Channels</label>
 		<channels>
-			<channel id="40025" typeId="f1155-type-40025" />
-			<channel id="40026" typeId="f1155-type-40026" />
+			<channel id="40015" typeId="f1155-type-40015" />
+			<channel id="40016" typeId="f1155-type-40016" />
 		</channels>
 	</channel-group-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-thing.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-thing.xml
@@ -5,13 +5,13 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 	<thing-type id="f1155">
 		<label>Nibe F1155</label>
-		<description>Nibe F1155 heat pump connected through Nibe UpLink</description>
+		<description>Nibe F1155/F1255 heat pump connected through Nibe UpLink</description>
 		<channel-groups>
 			<channel-group typeId="base-base" id="base" />
 			<channel-group typeId="base-hotwater" id="hotwater" />
 			<channel-group typeId="f1155-general" id="general" />
 			<channel-group typeId="f1155-compressor" id="compressor" />
-			<channel-group typeId="f1155-airsupply" id="airsupply" />
+			<channel-group typeId="f1155-watersupply" id="watersupply" />
 			<channel-group typeId="custom-custom" id="custom" />
 		</channel-groups>
 		<config-description-ref uri="thing-type:nibeuplink:web" />

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -175,8 +175,8 @@ Available channels depend on the specific heatpump model. Following models/chann
 | compressor#40019 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT15 Liquid Line       |                               |
 | compressor#40018 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT14 Hot Gas Temp      |                               |
 | compressor#40017 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT12 Condensor Out     |                               |
-| airsupply#40025  | Number:Temperature | -32767 | 32767   | No       | BT20 Exhaust air temp. 1          |                               |
-| airsupply#40026  | Number:Temperature | -32767 | 32767   | No       | BT21 Vented air temp. 1           |                               |
+| watersupply#40015| Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT10 brine in temp     |                               |
+| watersupply#40016| Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT11 brine out temp    |                               |
 
 
 ### F1155 / 1255
@@ -194,8 +194,8 @@ Available channels depend on the specific heatpump model. Following models/chann
 | compressor#43136 | Number:Frequency   | 0      | 65535   | No       | Compressor Frequency, Actual      |                               |
 | compressor#43122 | Number:Frequency   | -32767 | 32767   | No       | Compr. current min.freq.          |                               |
 | compressor#43123 | Number:Frequency   | -32767 | 32767   | No       | Compr. current max.freq.          |                               |
-| airsupply#40025  | Number:Temperature | -32767 | 32767   | No       | BT20 Exhaust air temp. 1          |                               |
-| airsupply#40026  | Number:Temperature | -32767 | 32767   | No       | BT21 Vented air temp. 1           |                               |
+| watersupply#40015| Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT10 brine in temp     |                               |
+| watersupply#40016| Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT11 brine out temp    |                               |
 
 ### VVM310 / VVM 500
 

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/ChannelGroup.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/ChannelGroup.java
@@ -23,5 +23,6 @@ public enum ChannelGroup {
     COMPRESSOR,
     HOTWATER,
     AIRSUPPLY,
+    WATERSUPPLY,
     CUSTOM;
 }

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1145Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1145Channels.java
@@ -65,10 +65,9 @@ public final class F1145Channels extends BaseChannels {
     public static final Channel CH_40017 = INSTANCE.addChannel(new QuantityChannel("40017",
             "EB100-EP14-BT12 Condensor Out", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
 
-    // Airsupply
-    public static final Channel CH_40025 = INSTANCE.addChannel(new QuantityChannel("40025", "BT20 Exhaust air temp. 1",
-            ChannelGroup.AIRSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-    public static final Channel CH_40026 = INSTANCE.addChannel(new QuantityChannel("40026", "BT21 Vented air temp. 1",
-            ChannelGroup.AIRSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-
+    // Brine temp.
+    public static final Channel CH_40015 = INSTANCE.addChannel(new QuantityChannel("40015", "EB100-EP14-BT10 Brine in temp.",
+            ChannelGroup.WATERSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_40016 = INSTANCE.addChannel(new QuantityChannel("40016", "EB100-EP14-BT11 Brine out temp.",
+            ChannelGroup.WATERSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
 }

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1155Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1155Channels.java
@@ -71,10 +71,9 @@ public final class F1155Channels extends BaseChannels {
     public static final Channel CH_43123 = INSTANCE.addChannel(new QuantityChannel("43123", "Compr. current max.freq.",
             ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SmartHomeUnits.HERTZ));
 
-    // Airsupply
-    public static final Channel CH_40025 = INSTANCE.addChannel(new QuantityChannel("40025", "BT20 Exhaust air temp. 1",
-            ChannelGroup.AIRSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-    public static final Channel CH_40026 = INSTANCE.addChannel(new QuantityChannel("40026", "BT21 Vented air temp. 1",
-            ChannelGroup.AIRSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-
+    // Brine temp
+    public static final Channel CH_40015 = INSTANCE.addChannel(new QuantityChannel("40015", "EB100-EP14-BT10 Brine in temp.",
+            ChannelGroup.WATERSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_40016 = INSTANCE.addChannel(new QuantityChannel("40016", "EB100-EP14-BT11 Brine out temp.",
+            ChannelGroup.WATERSUPPLY, ScaleFactor.DIV_10, SIUnits.CELSIUS));
 }


### PR DESCRIPTION
…ed heat pumps

Air supply makes little sense on the F1145 to F1255 heat pump models.
They are ground source heat pumps, so add the temperature for the brine
in/out instead.

Note: we could change AIRSUPPLY to a more generic SUPPLY instead, let me
know if this is desired instead.

Signed-off-by: Ulrich Spörlein <uspoerlein@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
