### PR TITLE
[MQTT] fix typo in config example

### DIFF
--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -370,7 +370,7 @@ This converts to:
 ```xtend
 Bridge mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
 {
-    Thing topic mything "My Thing" {
+    Thing mqtt:topic:mything "My Thing" {
     Channels:
         Type switch : heatpumpChannel "Heatpump Power" [ stateTopic="heatpump/state1", commandTopic="heatpump/set" ]
         Type switch : heatpumpChannel2 "Heatpump Power" [ stateTopic="heatpump/state2" ]

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -247,7 +247,7 @@ demo.Things:
 ```xtend
 Bridge mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
 {
-    Thing topic mything {
+    Thing mqtt:topic:mything {
     Channels:
         Type switch : lamp "Kitchen Lamp" [ stateTopic="lamp/enabled", commandTopic="lamp/enabled/set" ]
         Type switch : fancylamp "Fancy Lamp" [ stateTopic="fancy/lamp/state", commandTopic="fancy/lamp/command", on="i-am-on", off="i-am-off" ]


### PR DESCRIPTION
changed line 250 from `Thing topic mything` to `Thing mqtt:topic:mything` 

Cost me an hour to figure out why my config wasn't working. 
I hope the pull request is in correct form, it's my first.

Signed-off-by: William Rother <menace_one@gmx.net> (github: menaceone)


