### PR TITLE
[Tradfri] Force session resume after communication errors

### DIFF
--- a/addons/binding/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
+++ b/addons/binding/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
@@ -340,6 +340,14 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
 
     @Override
     public void setStatus(ThingStatus status, ThingStatusDetail statusDetail) {
+        // to fix connection issues after a gateway reboot, a session resume is forced for the next command
+        if (status == ThingStatus.OFFLINE && statusDetail == ThingStatusDetail.COMMUNICATION_ERROR) {
+            logger.debug("Gateway communication error. Forcing session resume on next command.");
+            TradfriGatewayConfig configuration = getConfigAs(TradfriGatewayConfig.class);
+            InetSocketAddress peerAddress = new InetSocketAddress(configuration.host, configuration.port);
+            this.dtlsConnector.forceResumeSessionFor(peerAddress);
+        }
+
         // are we still connected at all?
         if (endPoint != null) {
             updateStatus(status, statusDetail);


### PR DESCRIPTION
As discussed in eclipse/smarthome#6065 the tradfri gateway does not support a session resumption after a gateway reboot or other communcation errors.

@boaks implemented changes in californium scandium:
Californium 1.0.7 is able to force a full handshake instead.

This change calls "forceResumeSessionFor" after a communication error, so that a full handshake is done.

Related discussion: https://github.com/eclipse/smarthome/issues/6065#issuecomment-452752073
Californium 1.0.7 version bump: openhab/openhab-core#475