### PR TITLE
[onewire] fix NumberFormatException

### DIFF
--- a/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/owserver/OwserverConnection.java
+++ b/addons/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/owserver/OwserverConnection.java
@@ -172,7 +172,11 @@ public class OwserverConnection {
 
         OwserverPacket returnPacket = request(requestPacket);
         if ((returnPacket.getReturnCode() != -1) && returnPacket.hasPayload()) {
-            returnState = DecimalType.valueOf(returnPacket.getPayloadString().trim());
+            try {
+                returnState = DecimalType.valueOf(returnPacket.getPayloadString().trim());
+            } catch (NumberFormatException e) {
+                throw new OwException("could not parse '" + returnPacket.getPayloadString().trim() + "' to a number");
+            }
         } else {
             throw new OwException("invalid or empty packet");
         }


### PR DESCRIPTION
Fixes a NumberFormatException if the string returned from the owserver could not be parsed to a DecimalType.

Reported [in the forum](https://community.openhab.org/t/new-onewire-binding-bms-sensor-working-for-a-few-hours-seperate-temperature-sensor-dss18x20-not-initializing/64203/24).

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
