### PR TITLE
[sonos] Added missing playlinein channel on Play1,Play3,One,ZonePlayer

### DIFF
--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/Beam.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/Beam.xml
@@ -30,6 +30,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -54,7 +55,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 			<channel id="nightmode" typeId="nightmode" />
 			<channel id="speechenhancement" typeId="speechenhancement" />
 		</channels>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -30,6 +30,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -54,7 +55,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 		</channels>
 
 		<properties>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -55,7 +56,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 		</channels>
 
 		<properties>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/One.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/One.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -55,7 +56,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 		</channels>
 
 		<properties>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -30,6 +30,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -54,7 +55,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 			<channel id="nightmode" typeId="nightmode" />
 			<channel id="speechenhancement" typeId="speechenhancement" />
 		</channels>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAYBASE.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/PLAYBASE.xml
@@ -30,6 +30,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
@@ -54,7 +55,6 @@
 			<channel id="currenttrackuri" typeId="currenttrackuri" />
 			<!-- Extended SONOS channels -->
 			<channel id="linein" typeId="linein" />
-			<channel id="playlinein" typeId="playlinein" />
 			<channel id="nightmode" typeId="nightmode" />
 			<channel id="speechenhancement" typeId="speechenhancement" />
 		</channels>

--- a/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/addons/binding/org.openhab.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -31,6 +31,7 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="playlist" typeId="playlist" />
 			<channel id="clearqueue" typeId="clearqueue" />
+			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playqueue" typeId="playqueue" />
 			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />


### PR DESCRIPTION
Added missing playlinein channel to things.xml for Play1,Play3, One & ZonePlayer. As this is no longer an extended channel the channel has been moved to the correct location in the xml on the other players
