### PR TITLE
[squeezebox] Url encode userid and password in cover art URL

### DIFF
--- a/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/addons/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -802,7 +802,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         private String constructCoverArtUrl(String mac, boolean coverart, String coverid, String artwork_url) {
             String hostAndPort;
             if (StringUtils.isNotEmpty(userId)) {
-                hostAndPort = "http://" + userId + ":" + password + "@" + host + ":" + webport;
+                hostAndPort = "http://" + encode(userId) + ":" + encode(password) + "@" + host + ":" + webport;
             } else {
                 hostAndPort = "http://" + host + ":" + webport;
             }


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

My previous fix #4654 for retrieving cover art from LMS with authentication failed to deal with user ids and passwords that contain special characters. This PR encodes the userid and password parts of the cover art URL.
