### PR TITLE
[Network] Fix regex for tool recognition

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -208,7 +208,7 @@ public class NetworkUtils {
         if (StringUtils.isBlank(result)) {
             return ArpPingUtilEnum.UNKNOWN_TOOL;
         } else if (result.contains("Thomas Habets")) {
-            if (result.matches("(.*)w sec(\\s*)Specify a timeout(.*)")) {
+            if (result.matches("(?s)(.*)w sec(\\s*)Specify a timeout(.*)")) {
                 return ArpPingUtilEnum.THOMAS_HABERT_ARPING;
             } else {
                 return ArpPingUtilEnum.THOMAS_HABERT_ARPING_WITHOUT_TIMEOUT;


### PR DESCRIPTION
The content of the arping tool result is a multi line string. matches() returns true, when the whole
string matches against the regex, thus we need to switch to DOTALL mode by using (?s)
inside the regex.

Signed-off-by: davidgraeff <david.graeff@web.de>