### PR TITLE
[Network] fix oom bug

### DIFF
--- a/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.network/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Import-Package:
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.cache,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -163,8 +163,6 @@ public class NetworkUtils {
                 try {
                     // gets every ip which can be assigned on the given network
                     SubnetUtils utils = new SubnetUtils(string);
-                    // TODO: remove logging
-                    logger.info("resolved to network: {}", utils.getInfo());
                     String[] addresses = utils.getInfo().getAllAddresses();
                     int len = addresses.length;
                     if (maximumPerInterface != 0 && maximumPerInterface < len) {

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -32,7 +32,6 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
@@ -54,8 +53,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class NetworkUtils {
     private final Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
-    private static final Pattern IP4_ADDRESS = Pattern
-            .compile("^(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\/(\\d+)$");
 
     /**
      * Gets every IPv4 Address on each Interface except the loopback

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -40,6 +40,8 @@ import org.apache.commons.net.util.SubnetUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.net.exec.ExecUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Network utility functions for pinging and for determining all interfaces and assigned IP addresses.
@@ -48,6 +50,8 @@ import org.eclipse.smarthome.io.net.exec.ExecUtil;
  */
 @NonNullByDefault
 public class NetworkUtils {
+    private final Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
+
     /**
      * Gets every IPv4 Address on each Interface except the loopback
      * The Address format is ip/subnet
@@ -132,10 +136,14 @@ public class NetworkUtils {
     public Set<String> getNetworkIPs(Set<String> interfaceIPs, int maximumPerInterface) {
         LinkedHashSet<String> networkIPs = new LinkedHashSet<>();
 
+        logger.info("{} interface IPs found: {}", interfaceIPs.size(), interfaceIPs);
+
         for (String string : interfaceIPs) {
+            logger.info("processing IP: {}", string);
             try {
                 // gets every ip which can be assigned on the given network
                 SubnetUtils utils = new SubnetUtils(string);
+                logger.info("resolved to network: {}", utils.getInfo());
                 String[] addresses = utils.getInfo().getAllAddresses();
                 int len = addresses.length;
                 if (maximumPerInterface != 0 && maximumPerInterface < len) {


### PR DESCRIPTION
Fixes #3145 

Large networks (like /8) caused an OOM exception because 16 million IP addresses were cconstructed during network discovery. This reduces the network size to the number of requested addresses (usually 255 which results in /24).

Verified locally.