### PR TITLE
removed patch folder from classpath

### DIFF
--- a/addons/ui/org.openhab.ui.basic/META-INF/MANIFEST.MF
+++ b/addons/ui/org.openhab.ui.basic/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-Activator: org.openhab.ui.basic.internal.WebAppActivator
-Bundle-ClassPath: patch/,.
+Bundle-ClassPath: .
 Bundle-License: https://www.eclipse.org/legal/epl-2.0/
 Bundle-ManifestVersion: 2
 Bundle-Name: Basic UI

--- a/addons/ui/org.openhab.ui.paper/META-INF/MANIFEST.MF
+++ b/addons/ui/org.openhab.ui.paper/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Bundle-ClassPath: patch/,.
+Bundle-ClassPath: .
 Bundle-License: https://www.eclipse.org/legal/epl-2.0/
 Bundle-ManifestVersion: 2
 Bundle-Name: Paper UI


### PR DESCRIPTION
This fixes those exceptions that I found in my log:
```
org.osgi.framework.BundleException: The bundle class path entry "patch/" could not be found for the bundle "osgi.identity; osgi.identity="org.openhab.ui.basic"; type="osgi.bundle"; version:Version="2.5.0.201902092017""
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findClassPathEntry(ClasspathManager.java:174) ~[?:?]
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.buildClasspath(ClasspathManager.java:152) ~[?:?]
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.<init>(ClasspathManager.java:81) ~[?:?]
```

Signed-off-by: Kai Kreuzer <kai@openhab.org>
