### PR TITLE
[network] fixes excessive testing of arping method during discovery

### DIFF
--- a/addons/binding/org.openhab.binding.network.test/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/addons/binding/org.openhab.binding.network.test/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -78,7 +78,7 @@ public class PresenceDetectionTest {
         subject.setUseDhcpSniffing(false);
         subject.setIOSDevice(true);
         subject.setServicePorts(Collections.singleton(1010));
-        subject.setUseArpPing(true, "arping");
+        subject.setUseArpPing(true, "arping", ArpPingUtilEnum.IPUTILS_ARPING);
         subject.setUseIcmpPing(true);
 
         assertThat(subject.pingMethod, is(IpPingMethodEnum.WINDOWS_PING));

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
@@ -15,6 +15,9 @@ package org.openhab.binding.network.internal;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.network.internal.utils.NetworkUtils;
+import org.openhab.binding.network.internal.utils.NetworkUtils.ArpPingUtilEnum;
 
 /**
  * Contains the binding configuration and default values. The field names represent the configuration names,
@@ -29,10 +32,28 @@ public class NetworkBindingConfiguration {
     public BigDecimal cacheDeviceStateTimeInMS = BigDecimal.valueOf(2000);
     public String arpPingToolPath = "arping";
 
+    private @Nullable ArpPingUtilEnum arpPingUtilType = null;
+
     public void update(NetworkBindingConfiguration newConfiguration) {
         this.allowSystemPings = newConfiguration.allowSystemPings;
         this.allowDHCPlisten = newConfiguration.allowDHCPlisten;
         this.cacheDeviceStateTimeInMS = newConfiguration.cacheDeviceStateTimeInMS;
         this.arpPingToolPath = newConfiguration.arpPingToolPath;
+        arpPingUtilType = null;
+    }
+
+    /**
+     * get (or detect) the type of the arpping util
+     *
+     * @return the type of the arpping util
+     */
+    public ArpPingUtilEnum getArpPingUtilMethod() {
+        if (arpPingUtilType != null) {
+            return arpPingUtilType;
+        } else {
+            NetworkUtils networkUtils = new NetworkUtils();
+            arpPingUtilType = networkUtils.determineNativeARPpingMethod(arpPingToolPath);
+            return arpPingUtilType;
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
@@ -15,7 +15,6 @@ package org.openhab.binding.network.internal;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.network.internal.utils.NetworkUtils;
 import org.openhab.binding.network.internal.utils.NetworkUtils.ArpPingUtilEnum;
 
@@ -31,29 +30,15 @@ public class NetworkBindingConfiguration {
     public Boolean allowDHCPlisten = true;
     public BigDecimal cacheDeviceStateTimeInMS = BigDecimal.valueOf(2000);
     public String arpPingToolPath = "arping";
-
-    private @Nullable ArpPingUtilEnum arpPingUtilType = null;
+    public @NonNullByDefault({}) ArpPingUtilEnum arpPingUtilMethod;
 
     public void update(NetworkBindingConfiguration newConfiguration) {
         this.allowSystemPings = newConfiguration.allowSystemPings;
         this.allowDHCPlisten = newConfiguration.allowDHCPlisten;
         this.cacheDeviceStateTimeInMS = newConfiguration.cacheDeviceStateTimeInMS;
         this.arpPingToolPath = newConfiguration.arpPingToolPath;
-        arpPingUtilType = null;
-    }
 
-    /**
-     * get (or detect) the type of the arpping util
-     *
-     * @return the type of the arpping util
-     */
-    public ArpPingUtilEnum getArpPingUtilMethod() {
-        if (arpPingUtilType != null) {
-            return arpPingUtilType;
-        } else {
-            NetworkUtils networkUtils = new NetworkUtils();
-            arpPingUtilType = networkUtils.determineNativeARPpingMethod(arpPingToolPath);
-            return arpPingUtilType;
-        }
+        NetworkUtils networkUtils = new NetworkUtils();
+        this.arpPingUtilMethod = networkUtils.determineNativeARPpingMethod(arpPingToolPath);
     }
 }

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
@@ -58,8 +57,8 @@ public class PresenceDetection implements IPRequestReceivedCallback {
     private boolean useDHCPsniffing = false;
     private String arpPingState = "Disabled";
     private String ipPingState = "Disabled";
+    protected String arpPingUtilPath = "";
     protected ArpPingUtilEnum arpPingMethod = ArpPingUtilEnum.UNKNOWN_TOOL;
-    private String arpPingUtilPath = "arping";
     protected @Nullable IpPingMethodEnum pingMethod = null;
     private boolean iosDevice;
     private Set<Integer> tcpPorts = new HashSet<>();
@@ -112,7 +111,7 @@ public class PresenceDetection implements IPRequestReceivedCallback {
                 InetAddress destinationAddress = InetAddress.getByName(hostname);
                 if (!destinationAddress.equals(cachedDestination)) {
                     logger.trace("host name resolved to other address, (re-)setup presence detection");
-                    setUseArpPing(true, arpPingUtilPath, destinationAddress);
+                    setUseArpPing(true, destinationAddress);
                     if (useDHCPsniffing) {
                         if (cachedDestination != null) {
                             disableDHCPListen(cachedDestination);
@@ -179,9 +178,8 @@ public class PresenceDetection implements IPRequestReceivedCallback {
      * @param enable Enable or disable ARP ping
      * @param arpPingUtilPath c
      */
-    public void setUseArpPing(boolean enable, String arpPingUtilPath, @Nullable InetAddress destinationAddress) {
-        this.arpPingUtilPath = arpPingUtilPath;
-        if (!enable || StringUtils.isBlank(arpPingUtilPath)) {
+    public void setUseArpPing(boolean enable, @Nullable InetAddress destinationAddress) {
+        if (!enable || arpPingUtilPath.isEmpty()) {
             arpPingState = "Disabled";
             arpPingMethod = ArpPingUtilEnum.UNKNOWN_TOOL;
             return;
@@ -190,6 +188,7 @@ public class PresenceDetection implements IPRequestReceivedCallback {
             arpPingMethod = ArpPingUtilEnum.UNKNOWN_TOOL;
             return;
         }
+
         arpPingMethod = networkUtils.determineNativeARPpingMethod(arpPingUtilPath);
         switch (arpPingMethod) {
             case UNKNOWN_TOOL: {
@@ -217,8 +216,10 @@ public class PresenceDetection implements IPRequestReceivedCallback {
      * @param enable Enable or disable ARP ping
      * @param arpPingUtilPath enableDHCPListen(useDHCPsniffing);
      */
-    public void setUseArpPing(boolean enable, String arpPingUtilPath) {
-        setUseArpPing(enable, arpPingUtilPath, destination.getValue());
+    public void setUseArpPing(boolean enable, String arpPingUtilPath, ArpPingUtilEnum arpPingUtilMethod) {
+        setUseArpPing(enable, destination.getValue());
+        this.arpPingUtilPath = arpPingUtilPath;
+        this.arpPingMethod = arpPingUtilMethod;
     }
 
     public String getArpPingState() {

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
@@ -178,7 +178,7 @@ public class PresenceDetection implements IPRequestReceivedCallback {
      * @param enable Enable or disable ARP ping
      * @param arpPingUtilPath c
      */
-    public void setUseArpPing(boolean enable, @Nullable InetAddress destinationAddress) {
+    private void setUseArpPing(boolean enable, @Nullable InetAddress destinationAddress) {
         if (!enable || arpPingUtilPath.isEmpty()) {
             arpPingState = "Disabled";
             arpPingMethod = ArpPingUtilEnum.UNKNOWN_TOOL;
@@ -189,7 +189,6 @@ public class PresenceDetection implements IPRequestReceivedCallback {
             return;
         }
 
-        arpPingMethod = networkUtils.determineNativeARPpingMethod(arpPingUtilPath);
         switch (arpPingMethod) {
             case UNKNOWN_TOOL: {
                 arpPingState = "Unknown arping tool";

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -145,7 +145,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
             s.setTimeout(PING_TIMEOUT_IN_MS);
             // Ping devices
             s.setUseIcmpPing(true);
-            s.setUseArpPing(true, configuration.arpPingToolPath);
+            s.setUseArpPing(true, configuration.arpPingToolPath, configuration.getArpPingUtilMethod());
             // TCP devices
             s.setServicePorts(tcpServicePorts);
 

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -145,7 +145,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
             s.setTimeout(PING_TIMEOUT_IN_MS);
             // Ping devices
             s.setUseIcmpPing(true);
-            s.setUseArpPing(true, configuration.arpPingToolPath, configuration.getArpPingUtilMethod());
+            s.setUseArpPing(true, configuration.arpPingToolPath, configuration.arpPingUtilMethod);
             // TCP devices
             s.setServicePorts(tcpServicePorts);
 

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -177,7 +177,7 @@ public class NetworkHandler extends BaseThingHandler implements PresenceDetectio
             // Hand over binding configurations to the network service
             presenceDetection.setUseDhcpSniffing(configuration.allowDHCPlisten);
             presenceDetection.setUseIcmpPing(configuration.allowSystemPings);
-            presenceDetection.setUseArpPing(true, configuration.arpPingToolPath, configuration.getArpPingUtilMethod());
+            presenceDetection.setUseArpPing(true, configuration.arpPingToolPath, configuration.arpPingUtilMethod);
         }
 
         this.retries = handlerConfiguration.retry.intValue();

--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -177,7 +177,7 @@ public class NetworkHandler extends BaseThingHandler implements PresenceDetectio
             // Hand over binding configurations to the network service
             presenceDetection.setUseDhcpSniffing(configuration.allowDHCPlisten);
             presenceDetection.setUseIcmpPing(configuration.allowSystemPings);
-            presenceDetection.setUseArpPing(true, configuration.arpPingToolPath);
+            presenceDetection.setUseArpPing(true, configuration.arpPingToolPath, configuration.getArpPingUtilMethod());
         }
 
         this.retries = handlerConfiguration.retry.intValue();


### PR DESCRIPTION
Currently the arping method is determined for each address. This PR caches the method determination.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
