### PR TITLE
[chromecast] Added dedicated channel to stop playback

### DIFF
--- a/addons/binding/org.openhab.binding.chromecast/ESH-INF/i18n/chromecast_de.properties
+++ b/addons/binding/org.openhab.binding.chromecast/ESH-INF/i18n/chromecast_de.properties
@@ -19,6 +19,8 @@ thing-type.config.chromecast.device.port.label = Port
 thing-type.config.chromecast.device.port.description = Port des Chromecast Gerätes.
 
 # channel types
+channel-type.kodi.stop.label = Stop
+channel-type.kodi.stop.description = Ermöglicht das Stoppen der Wiedergabe.
 channel-type.chromecast.playuri.label = URI abspielen
 channel-type.chromecast.playuri.description = Ermöglicht das Abspielen einer URI.
 channel-type.chromecast.metadataType.label = Medientyp

--- a/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
@@ -11,6 +11,7 @@
 
 		<channels>
 			<channel id="control" typeId="system.media-control" />
+			<channel id="stop" typeId="stop" />
 			<channel id="volume" typeId="system.volume" />
 			<channel id="mute" typeId="system.mute" />
 			<channel id="playuri" typeId="playuri" />
@@ -60,6 +61,7 @@
 
 		<channels>
 			<channel id="control" typeId="system.media-control" />
+			<channel id="stop" typeId="stop" />
 			<channel id="volume" typeId="system.volume" />
 			<channel id="mute" typeId="system.mute" />
 			<channel id="playuri" typeId="playuri" />
@@ -109,6 +111,7 @@
 
 		<channels>
 			<channel id="control" typeId="system.media-control" />
+			<channel id="stop" typeId="stop" />
 			<channel id="volume" typeId="system.volume" />
 			<channel id="mute" typeId="system.mute" />
 			<channel id="playuri" typeId="playuri" />
@@ -150,6 +153,12 @@
 
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>
+
+	<channel-type id="stop">
+		<item-type>Switch</item-type>
+		<label>Stop</label>
+		<description>Stops the player. ON if the player is stopped.</description>
+	</channel-type>
 
 	<channel-type id="playuri" advanced="true">
 		<item-type>String</item-type>

--- a/addons/binding/org.openhab.binding.chromecast/README.md
+++ b/addons/binding/org.openhab.binding.chromecast/README.md
@@ -23,7 +23,7 @@ Configure a Callback URL when the Chromecast cannot connect using the Primary Ad
 | Things           | Description                                                                  | Thing Type |
 |------------------|------------------------------------------------------------------------------|------------|
 | Chromecast       | Classic HDMI video Chromecasts and Google Homes                              | chromecast |
-| Chromecast Audio | The Chromecast whichonly does audio streaming and offers a headphone jack    | audio      |
+| Chromecast Audio | The Chromecast which only does audio streaming and offers a headphone jack   | audio      |
 | Audio Group      | A Chromecast audio group for multi-room audio defined via the Chromecast app | audiogroup |
 
 ## Discovery
@@ -41,6 +41,7 @@ The only configuration parameter is the `ipAddress`.
 | Channel Type ID | Item Type   | Description                                                                                                                                                                           |
 |-----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | control         | Player      | Player control; currently only supports play/pause and does not correctly update, if the state changes on the device itself                                                           |
+| stop            | Switch      | Send `ON` to this channel: Stops the Chromecast. If this channel is `ON`, the Chromecast is stopped, otherwise it is in another state (see control channel)                           |
 | volume          | Dimmer      | Control the volume, this is also updated if the volume is changed by another app                                                                                                      |
 | mute            | Switch      | Mute the audio                                                                                                                                                                        |
 | playuri         | String      | Can be used to tell the Chromecast to play media from a given url                                                                                                                     |

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastBindingConstants.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastBindingConstants.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.chromecast.internal;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,12 +36,8 @@ public class ChromecastBindingConstants {
     public static final ThingTypeUID THING_TYPE_AUDIO = new ThingTypeUID(BINDING_ID, "audio");
     public static final ThingTypeUID THING_TYPE_AUDIOGROUP = new ThingTypeUID(BINDING_ID, "audiogroup");
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();
-    static {
-        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_AUDIO);
-        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_AUDIOGROUP);
-        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CHROMECAST);
-    }
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            Stream.of(THING_TYPE_AUDIO, THING_TYPE_AUDIOGROUP, THING_TYPE_CHROMECAST).collect(Collectors.toSet()));
 
     // Config Parameters
     public static final String HOST = "ipAddress";
@@ -51,6 +46,7 @@ public class ChromecastBindingConstants {
 
     // Channel IDs
     public static final String CHANNEL_CONTROL = "control";
+    public static final String CHANNEL_STOP = "stop";
     public static final String CHANNEL_VOLUME = "volume";
     public static final String CHANNEL_MUTE = "mute";
     public static final String CHANNEL_PLAY_URI = "playuri";

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -176,7 +176,6 @@ public class ChromecastCommander {
         if (command == OnOffType.ON) {
             try {
                 chromeCast.stopApp();
-                statusUpdater.updateMediaStatus(null);
                 statusUpdater.updateStatus(ThingStatus.ONLINE);
             } catch (final IOException ex) {
                 logger.debug("{} command failed: {}", command, ex.getMessage());

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.core.library.types.NextPreviousType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.PlayPauseType;
-import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -69,6 +68,9 @@ public class ChromecastCommander {
         switch (channelUID.getId()) {
             case CHANNEL_CONTROL:
                 handleControl(command);
+                break;
+            case CHANNEL_STOP:
+                handleStop(command);
                 break;
             case CHANNEL_VOLUME:
                 handleVolume(command);
@@ -146,15 +148,6 @@ public class ChromecastCommander {
                 return;
             }
 
-            if (command instanceof StopMoveType) {
-                final StopMoveType stopMoveType = (StopMoveType) command;
-                if (stopMoveType == StopMoveType.STOP) {
-                    chromeCast.stopApp();
-                    statusUpdater.updateMediaStatus(null);
-                }
-                return;
-            }
-
             if (command instanceof PlayPauseType) {
                 MediaStatus mediaStatus = chromeCast.getMediaStatus();
                 logger.debug("mediaStatus {}", mediaStatus);
@@ -173,9 +166,22 @@ public class ChromecastCommander {
                     logger.info("{} command not supported by current media", command);
                 }
             }
-        } catch (final Exception e) {
+        } catch (final IOException e) {
             logger.debug("{} command failed: {}", command, e.getMessage());
             statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    private void handleStop(final Command command) {
+        if (command == OnOffType.ON) {
+            try {
+                chromeCast.stopApp();
+                statusUpdater.updateMediaStatus(null);
+                statusUpdater.updateStatus(ThingStatus.ONLINE);
+            } catch (final IOException ex) {
+                logger.debug("{} command failed: {}", command, ex.getMessage());
+                statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, ex.getMessage());
+            }
         }
     }
 

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastEventReceiver.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastEventReceiver.java
@@ -55,6 +55,9 @@ public class ChromecastEventReceiver implements ChromeCastSpontaneousEventListen
     @Override
     public void spontaneousEventReceived(final ChromeCastSpontaneousEvent event) {
         switch (event.getType()) {
+            case CLOSE:
+                statusUpdater.updateMediaStatus(null);
+                break;
             case MEDIA_STATUS:
                 statusUpdater.updateMediaStatus(event.getData(MediaStatus.class));
                 break;
@@ -65,7 +68,7 @@ public class ChromecastEventReceiver implements ChromeCastSpontaneousEventListen
                 logger.debug("Received an 'UNKNOWN' event (class={})", event.getType().getDataClass());
                 break;
             default:
-                logger.debug("Unhandled event type: {}", event.getData());
+                logger.debug("Unhandled event type: {}", event.getType());
                 break;
         }
     }

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
@@ -137,6 +137,7 @@ public class ChromecastStatusUpdater {
 
         // In-between songs? It's thinking? It's not doing anything
         if (mediaStatus == null) {
+            callback.updateState(CHANNEL_CONTROL, PlayPauseType.PAUSE);
             callback.updateState(CHANNEL_CURRENT_TIME, UNDEF);
             updateMediaInfoStatus(null);
             return;
@@ -147,10 +148,12 @@ public class ChromecastStatusUpdater {
                 break;
             case PAUSED:
                 callback.updateState(CHANNEL_CONTROL, PlayPauseType.PAUSE);
+                callback.updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
             case BUFFERING:
             case PLAYING:
                 callback.updateState(CHANNEL_CONTROL, PlayPauseType.PLAY);
+                callback.updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
             default:
                 logger.debug("Unknown mediaStatus: {}", mediaStatus.playerState);

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
@@ -138,6 +138,7 @@ public class ChromecastStatusUpdater {
         // In-between songs? It's thinking? It's not doing anything
         if (mediaStatus == null) {
             callback.updateState(CHANNEL_CONTROL, PlayPauseType.PAUSE);
+            callback.updateState(CHANNEL_STOP, OnOffType.ON);
             callback.updateState(CHANNEL_CURRENT_TIME, UNDEF);
             updateMediaInfoStatus(null);
             return;
@@ -156,7 +157,7 @@ public class ChromecastStatusUpdater {
                 callback.updateState(CHANNEL_STOP, OnOffType.OFF);
                 break;
             default:
-                logger.debug("Unknown mediaStatus: {}", mediaStatus.playerState);
+                logger.debug("Unknown media status: {}", mediaStatus.playerState);
                 break;
         }
 

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
@@ -235,7 +235,6 @@ public class ChromecastHandler extends BaseThingHandler implements AudioSink {
         private final ChromecastStatusUpdater statusUpdater;
         private final ChromecastScheduler scheduler;
 
-        private final Runnable connectRunnable = this::connect;
         private final Runnable refreshRunnable = new Runnable() {
             @Override
             public void run() {
@@ -247,7 +246,7 @@ public class ChromecastHandler extends BaseThingHandler implements AudioSink {
                 AudioHTTPServer audioHttpServer, String callbackURL) {
             this.chromeCast = chromeCast;
 
-            this.scheduler = new ChromecastScheduler(handler.scheduler, CONNECT_DELAY, connectRunnable, refreshRate,
+            this.scheduler = new ChromecastScheduler(handler.scheduler, CONNECT_DELAY, this::connect, refreshRate,
                     refreshRunnable);
             this.statusUpdater = new ChromecastStatusUpdater(thing, handler);
 
@@ -278,6 +277,7 @@ public class ChromecastHandler extends BaseThingHandler implements AudioSink {
         private void connect() {
             try {
                 chromeCast.connect();
+                statusUpdater.updateMediaStatus(null);
                 statusUpdater.updateStatus(ThingStatus.ONLINE);
             } catch (final Exception e) {
                 statusUpdater.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,


### PR DESCRIPTION
- Added dedicated channel to stop playback
- Removed handling of `StopMoveType` from `control` channel

Closes #1783
Closes #4794

Test version:
[org.openhab.binding.chromecast-2.5.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab2-addons/files/2855457/org.openhab.binding.chromecast-2.5.0-SNAPSHOT.jar.zip)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>