### PR TITLE
[dscalarm] Update README.md

### DIFF
--- a/addons/binding/org.openhab.binding.dscalarm/README.md
+++ b/addons/binding/org.openhab.binding.dscalarm/README.md
@@ -606,15 +606,14 @@ rule "SendKeystrokeStringCommand"
 when   
     Item SwitchItemName received command ON
 then   
-    sendCommand(SEND_DSC_ALARM_COMMAND, "071,1*101#")
+    SEND_DSC_ALARM_COMMAND.sendCommand("071,1*101#")
 end
 
 rule "SendPollingCommand"
-
 when   
     Item SwitchItemName received command ON
 then   
-    sendCommand(SEND_DSC_ALARM_COMMAND, "000")
+    SEND_DSC_ALARM_COMMAND.sendCommand("000")
 end
 ```
 


### PR DESCRIPTION
Please always use the object method instead of the static method. This is safer and less confusing for newcomers. See https://www.openhab.org/docs/configuration/rules-dsl.html#manipulating-item-states
