### PR TITLE
[zway] Update README.md

### DIFF
--- a/addons/binding/org.openhab.binding.zway/README.md
+++ b/addons/binding/org.openhab.binding.zway/README.md
@@ -190,4 +190,4 @@ Because textual configuration isn't useful, follow the instructions in the [Gett
 -   Only polling is available. Further versions will contain other mechanisms under usage of the WebSocket implementation of Z-Way or MQTT.
 
 <br>
-<img src="https://github.com/openhab/openhab2-addons/raw/master/addons/binding/org.openhab.binding.zway/doc/BMWi_4C_Gef_en.jpg" width="200">
+![BMWi](./doc/BMWi_4C_Gef_en.jpg)

--- a/addons/binding/org.openhab.binding.zway/README.md
+++ b/addons/binding/org.openhab.binding.zway/README.md
@@ -190,4 +190,4 @@ Because textual configuration isn't useful, follow the instructions in the [Gett
 -   Only polling is available. Further versions will contain other mechanisms under usage of the WebSocket implementation of Z-Way or MQTT.
 
 <br>
-<img src="doc/BMWi_4C_Gef_en.jpg" width="200">
+<img src="https://github.com/openhab/openhab2-addons/raw/master/addons/binding/org.openhab.binding.zway/doc/BMWi_4C_Gef_en.jpg" width="200">


### PR DESCRIPTION
Tried to fix the broken image on openhab.org by changing the relative path to image to an absolute one.