### PR TITLE
[chromecast] Use device ID as representational property

### DIFF
--- a/addons/binding/org.openhab.binding.chromecast.test/src/test/java/org/openhab/binding/chromecast/internal/handler/ChromecastOSGiTest.java
+++ b/addons/binding/org.openhab.binding.chromecast.test/src/test/java/org/openhab/binding/chromecast/internal/handler/ChromecastOSGiTest.java
@@ -15,7 +15,7 @@ package org.openhab.binding.chromecast.internal.handler;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.openhab.binding.chromecast.internal.ChromecastBindingConstants.THING_TYPE_CHROMECAST;
+import static org.openhab.binding.chromecast.internal.ChromecastBindingConstants.*;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
@@ -28,7 +28,6 @@ import org.eclipse.smarthome.test.storage.VolatileStorageService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.openhab.binding.chromecast.internal.ChromecastBindingConstants;
 
 /**
  * Tests for {@link ChromecastHandler}.
@@ -59,7 +58,7 @@ public class ChromecastOSGiTest extends JavaOSGiTest {
         assertThat(handler, is(nullValue()));
 
         Configuration configuration = new Configuration();
-        configuration.put(ChromecastBindingConstants.HOST, "hostname");
+        configuration.put(HOST, "hostname");
 
         Thing thing = ThingBuilder.create(THING_TYPE_CHROMECAST, "tv").withConfiguration(configuration).build();
         managedThingProvider.add(thing);
@@ -68,5 +67,4 @@ public class ChromecastOSGiTest extends JavaOSGiTest {
         assertThat(thing.getConfiguration(), is(notNullValue()));
         assertThat(thing.getHandler(), is(instanceOf(ChromecastHandler.class)));
     }
-
 }

--- a/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
@@ -48,6 +48,8 @@
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
 
+		<representation-property>deviceId</representation-property>
+
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>
 
@@ -95,6 +97,8 @@
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
 
+		<representation-property>deviceId</representation-property>
+
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>
 
@@ -141,6 +145,8 @@
 			<channel id="title" typeId="system.media-title" />
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
+
+		<representation-property>deviceId</representation-property>
 
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>

--- a/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.chromecast/ESH-INF/thing/thing-types.xml
@@ -48,8 +48,6 @@
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
 
-		<representation-property>ipAddress</representation-property>
-
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>
 
@@ -97,8 +95,6 @@
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
 
-		<representation-property>ipAddress</representation-property>
-
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>
 
@@ -145,8 +141,6 @@
 			<channel id="title" typeId="system.media-title" />
 			<channel id="trackNumber" typeId="trackNumber" />
 		</channels>
-
-		<representation-property>ipAddress</representation-property>
 
 		<config-description-ref uri="thing-type:chromecast:device" />
 	</thing-type>

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastBindingConstants.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastBindingConstants.java
@@ -48,6 +48,7 @@ public class ChromecastBindingConstants {
     public static final String HOST = "ipAddress";
     public static final String PORT = "port";
     public static final String REFRESH_RATE_SECONDS = "refreshRate";
+    public static final String DEVICE_ID = "deviceId";
 
     // Channel IDs
     public static final String CHANNEL_CONTROL = "control";

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -66,7 +66,7 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
         String friendlyName = service.getPropertyString("fn"); // friendly name;
 
         final DiscoveryResult result = DiscoveryResultBuilder.create(uid).withThingType(getThingType(service))
-                .withProperties(properties).withRepresentationProperty(HOST).withLabel(friendlyName).build();
+                .withProperties(properties).withLabel(friendlyName).build();
 
         return result;
     }
@@ -96,5 +96,4 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
             return null;
         }
     }
-
 }

--- a/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
  */
 @Component(immediate = true)
 public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant {
+    private static final String PROPERTY_MODEL = "md";
+    private static final String PROPERTY_FRIENDLY_NAME = "fn";
+    private static final String PROPERTY_DEVICE_ID = "id";
     private static final String SERVICE_TYPE = "_googlecast._tcp.local.";
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -63,16 +66,18 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
         int port = service.getPort();
         properties.put(PORT, port);
         logger.debug("Chromecast Found: {} {}", host, port);
-        String friendlyName = service.getPropertyString("fn"); // friendly name;
+        String id = service.getPropertyString(PROPERTY_DEVICE_ID);
+        properties.put(DEVICE_ID, id);
+        String friendlyName = service.getPropertyString(PROPERTY_FRIENDLY_NAME); // friendly name;
 
         final DiscoveryResult result = DiscoveryResultBuilder.create(uid).withThingType(getThingType(service))
-                .withProperties(properties).withLabel(friendlyName).build();
+                .withProperties(properties).withRepresentationProperty(DEVICE_ID).withLabel(friendlyName).build();
 
         return result;
     }
 
     private ThingTypeUID getThingType(final ServiceInfo service) {
-        String model = service.getPropertyString("md"); // model
+        String model = service.getPropertyString(PROPERTY_MODEL); // model
         logger.debug("Chromecast Type: {}", model);
         if (model == null) {
             return null;
@@ -90,7 +95,7 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
     public ThingUID getThingUID(ServiceInfo service) {
         ThingTypeUID thingTypeUID = getThingType(service);
         if (thingTypeUID != null) {
-            String id = service.getPropertyString("id"); // device id
+            String id = service.getPropertyString(PROPERTY_DEVICE_ID); // device id
             return new ThingUID(thingTypeUID, id);
         } else {
             return null;


### PR DESCRIPTION
- Removed representational property

> The way the groups work is they are virtual on the audio. So the same ip will be listed multiple times under different things.

See https://community.openhab.org/t/chromecast-binding-how-to-send-stopmovetype/63547/16

Fixed #4186 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>