### PR TITLE
Update NetworkUtils.java

### DIFF
--- a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -200,7 +200,7 @@ public class NetworkUtils {
         if (StringUtils.isBlank(result)) {
             return ArpPingUtilEnum.UNKNOWN_TOOL;
         } else if (result.contains("Thomas Habets")) {
-            if (result.matches("(?s)(.*)w sec(\\s*)Specify a timeout(.*)")) {
+            if (result.matches("(?s)(.*)w sec Specify a timeout(.*)")) {
                 return ArpPingUtilEnum.THOMAS_HABERT_ARPING;
             } else {
                 return ArpPingUtilEnum.THOMAS_HABERT_ARPING_WITHOUT_TIMEOUT;


### PR DESCRIPTION
Removed "(\s*)" from RegExp expression as "\s" not present in the current tool help output and it will fail RegExp, current tool output looks like this (as of version 2.19):

-w sec Specify a timeout before ping exits regardless of how many
packets have been sent or received.

Signed-off-by: Konstantin Panchenko <kpanchen@konstantech.com>

[network] Fix to Thomas Harbet ARP tool detection