### PR TITLE
[homekit] Fix Eclipse warnings and reduce bogus logger ERRORs to DEBUGs.

### DIFF
--- a/addons/io/org.openhab.io.homekit/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.homekit/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.openhab.io.homekit
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  .,
  lib/com.beowulfe.hap.hap-1.1.4.jar,
@@ -19,7 +20,6 @@ Bundle-Version: 2.5.0.qualifier
 Export-Package: org.openhab.io.homekit
 Import-Package: 
  com.google.common.collect,
- javax.jmdns,
  org.apache.commons.io,
  org.apache.commons.lang.builder,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -39,6 +39,7 @@ Import-Package:
  org.openhab.io.homekit,
  org.osgi.framework,
  org.osgi.service.component,
+ org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
@@ -85,12 +85,12 @@ class HomekitAccessoryRegistry {
         for (String group : item.getItem().getGroupNames()) {
             if (pendingGroupedAccessories.containsKey(group)) {
                 addCharacteristicToGroup(group, item);
-                logger.debug("Added {} to {}", item.getItem().getName(), group);
+                logger.debug("Added item {} to group {}", item.getItem().getName(), group);
                 return;
             }
         }
         pendingCharacteristics.add(item);
-        logger.debug("Stored {} until group is ready", item.getItem().getName());
+        logger.debug("Stored item{} until group is ready", item.getItem().getName());
     }
 
     private void addCharacteristicToGroup(String group, HomekitTaggedItem item) {
@@ -110,5 +110,4 @@ class HomekitAccessoryRegistry {
         }
         logger.debug("Added accessory {}", accessory.getId());
     }
-
 }

--- a/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
+++ b/addons/io/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
@@ -47,15 +47,16 @@ public class HomekitAccessoryUpdater {
         }
         ItemKey itemKey = new ItemKey(item, key);
         if (subscriptionsByName.containsKey(itemKey)) {
-            logger.error("Received duplicate subscription on {}", item.getName());
+            logger.debug("Received duplicate subscription on item {} for key {}", item.getName(), key);
         }
         subscriptionsByName.compute(itemKey, (k, v) -> {
             if (v != null) {
-                logger.error("Received duplicate subscription on {}", item.getName());
+                logger.debug("Compute: received duplicate subscription on item {} for key {}. Will unsubscribe.", item.getName(), key);
                 unsubscribe(item, key);
             }
             Subscription subscription = (changedItem, oldState, newState) -> callback.changed();
             item.addStateChangeListener(subscription);
+            logger.debug("Successfully added subscription for item '{}' using key '{}'", item.getName(), key);
             return subscription;
         });
     }
@@ -133,5 +134,4 @@ public class HomekitAccessoryUpdater {
             return true;
         }
     }
-
 }


### PR DESCRIPTION
Probably fixes #1258, since most of the descriptions given say the binding is functioning correctly in spite of seeing bogus duplicate subscription messages.

See also this [community thread](https://community.openhab.org/t/homekit-binding/37690/14).

Signed-off-by: Chris Carman <namraccr@gmail.com>

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
-->
