### PR TITLE
Removed stackoverflow from 'usage' template

### DIFF
--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -1,10 +1,9 @@
 ---
 name: "\U0001F914 Support/Usage Question"
-about: For usage questions, please use Stack Overflow or our community board!
+about: For usage questions, please use the openHAB community board!
 
 ---
 
-This is a bug tracker, not a support system. For usage questions, please use Stack Overflow or our community board where there are a lot more people ready to help you out. Thanks!
+This is an issue tracker for reporting problems and requesting new features. For usage questions, please use the openHAB community board where there are a lot more people ready to help you out. Thanks!
 
-https://stackoverflow.com/questions/tagged/openhab  
 https://community.openhab.org/


### PR DESCRIPTION
Stack Overflow is for a specific target group and for source code related questions: https://stackoverflow.com/help/on-topic So I would not advice people to visit stack overflow for 'usage' questions.