### PR TITLE
[amazonechocontrol] Fix for the startRoutine channel if more than 20 routines are defined

### DIFF
--- a/addons/binding/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/addons/binding/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -1223,7 +1223,7 @@ public class Connection {
     }
 
     public JsonAutomation[] getRoutines() throws IOException, URISyntaxException {
-        String json = makeRequestAndReturnString(alexaServer + "/api/behaviors/automations");
+        String json = makeRequestAndReturnString(alexaServer + "/api/behaviors/automations?limit=2000");
         JsonAutomation[] result = parseJson(json, JsonAutomation[].class);
         return result;
     }


### PR DESCRIPTION
This PR fixes a problem where routines can not be started, if the user have more than 20 routines defined in alexa app.