### PR TITLE
[Onkyo] Thing action to send raw eISCP commands

### DIFF
--- a/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-Version: 2.5.0.qualifier
 Import-Package: 
  org.apache.commons.io,
  org.apache.commons.lang,
+ org.openhab.core.automation.annotation;resolution:=optional,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,

--- a/addons/binding/org.openhab.binding.onkyo/README.md
+++ b/addons/binding/org.openhab.binding.onkyo/README.md
@@ -155,6 +155,25 @@ The Onkyo AVR supports the following channels (some channels are model specific)
 | netmenu#item8             | String    | The text of USB/Net Menu entry 8                                                                                 |
 | netmenu#item9             | String    | The text of USB/Net Menu entry 9                                                                                 |
 
+## Rule Actions
+
+This binding includes a rule action which allows to send raw eISCP messages to the receiver. The rule action can be used to send commands to the receiver that are not supported by channels.
+There is a separate instance for each receiver, which can be retrieved through
+
+```
+val onkyoActions = getActions("onkyo","onkyo:onkyoAVR:avr-livingroom")
+```
+
+where the first parameter always has to be `onkyo` and the second (`onkyo:onkyoAVR:avr-livingroom`) is the Thing UID of the broker that should be used.
+Once this action instance is retrieved, you can invoke the `onkyoActions.sendRawCommand(String action, String value)` method on it:
+
+```
+onkyoActions.sendRawCommand("CTL", "UP")
+```
+This command for instance increases the volume for the center channel. For a description of all commands you can e.g. search [this GitHub project](https://github.com/miracle2k/onkyo-eiscp/tree/master/commands/main).
+
+Also note that when sending multiple commands there has to be a `Thread::sleep(100)` in between the commands because the action does not wait for a response from the receiver.
+
 ## Input Source Mapping
 
 Here after are the ID values of the input sources:

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/automation/modules/OnkyoThingActionsService.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/automation/modules/OnkyoThingActionsService.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.onkyo.internal.automation.modules;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.binding.ThingActions;
+import org.eclipse.smarthome.core.thing.binding.ThingActionsScope;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.onkyo.internal.handler.OnkyoHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Some automation actions to be used with a {@link OnkyoThingActionsService}
+ *
+ * @author David Masshardt - initial contribution
+ *
+ */
+@ThingActionsScope(name = "onkyo")
+@NonNullByDefault
+public class OnkyoThingActionsService implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(OnkyoThingActionsService.class);
+
+    private @Nullable OnkyoHandler handler;
+
+    @SuppressWarnings("null")
+    @RuleAction(label = "Onkyo sendRawCommand", description = "Action that sends raw command to the receiver")
+    public void sendRawCommand(@ActionInput(name = "command") @Nullable String command,
+            @ActionInput(name = "command") @Nullable String value) {
+        logger.debug("sendRawCommand called with raw command: {} value: {}", command, value);
+        if (handler == null) {
+            logger.warn("Onkyo Action service ThingHandler is null!");
+            return;
+        }
+        handler.sendRawCommand(command, value);
+    }
+
+    public static void sendRawCommand(@Nullable ThingActions actions, @Nullable String command,
+            @Nullable String value) {
+        if (actions instanceof OnkyoThingActionsService) {
+            ((OnkyoThingActionsService) actions).sendRawCommand(command, value);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OnkyoThingActionsService class.");
+        }
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof OnkyoHandler) {
+            this.handler = (OnkyoHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return this.handler;
+    }
+}

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -670,7 +670,7 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
         if (connection != null) {
             connection.send(command, value);
         } else {
-            logger.debug("Connect send command to onkyo receiver since the onkyo binding is not initialized");
+            logger.debug("Cannot send command to onkyo receiver since the onkyo binding is not initialized");
         }
     }
 

--- a/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/addons/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.onkyo.internal.handler;
 import static org.openhab.binding.onkyo.internal.OnkyoBindingConstants.*;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +36,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerService;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -44,6 +47,7 @@ import org.openhab.binding.onkyo.internal.OnkyoAlbumArt;
 import org.openhab.binding.onkyo.internal.OnkyoConnection;
 import org.openhab.binding.onkyo.internal.OnkyoEventListener;
 import org.openhab.binding.onkyo.internal.ServiceType;
+import org.openhab.binding.onkyo.internal.automation.modules.OnkyoThingActionsService;
 import org.openhab.binding.onkyo.internal.config.OnkyoDeviceConfiguration;
 import org.openhab.binding.onkyo.internal.eiscp.EiscpCommand;
 import org.openhab.binding.onkyo.internal.eiscp.EiscpMessage;
@@ -662,6 +666,14 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
         return state;
     }
 
+    public void sendRawCommand(String command, String value) {
+        if (connection != null) {
+            connection.send(command, value);
+        } else {
+            logger.debug("Connect send command to onkyo receiver since the onkyo binding is not initialized");
+        }
+    }
+
     private void sendCommand(EiscpCommand deviceCommand) {
         if (connection != null) {
             connection.send(deviceCommand.getCommand(), deviceCommand.getValue());
@@ -828,5 +840,10 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
         }
         logger.debug("Mime type: {}", mimeType);
         return mimeType;
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singletonList(OnkyoThingActionsService.class);
     }
 }


### PR DESCRIPTION
I've added a thing action to the Onkyo binding to send raw eISCP commands to the receiver to support commands that are not built in as channels. I e.g. use this to adjust the volume of the center speaker.

Here is the link to the forum thread I created for this: https://community.openhab.org/t/onkyo-testers-for-thing-action-to-send-raw-eiscp-commands/68446

Please see the chapter “Rule Actions” in the readme how to use this: https://github.com/TheNetStriker/openhab2-addons/tree/OnkyoThingAction/addons/binding/org.openhab.binding.onkyo

Signed-off-by: David Masshardt <david@masshardt.ch>