### PR TITLE
[webaudio] Readme

### DIFF
--- a/addons/io/org.openhab.io.webaudio/README.md
+++ b/addons/io/org.openhab.io.webaudio/README.md
@@ -1,0 +1,4 @@
+# Web Audio
+
+This IO bundle provides an `AudioSink` that is capable of accepting "FixedLengthAudioStreams" and "URLAudioStreams".
+It defines and registers a new `Event` called `PlayURLEvent` to let eventbus consumers know that an audio stream should be played.


### PR DESCRIPTION
Initiative to provide a Readme to all addon directories. Sometimes you really don't know what they are for.

Signed-off-by: davidgraeff <david.graeff@web.de>