### PR TITLE
removed superfluous "openHAB" in name and fixed typos

### DIFF
--- a/addons/binding/org.openhab.binding.keba/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.keba/ESH-INF/binding/binding.xml
@@ -4,7 +4,7 @@
 		xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
 		xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
-	<name>openHAB Keba Binding</name>
+	<name>Keba Binding</name>
 	<description>This is the binding for Keba EV Charging Stations</description>
 	<author>Karel Goderis</author>
 

--- a/addons/binding/org.openhab.binding.tesla/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.tesla/ESH-INF/binding/binding.xml
@@ -4,8 +4,8 @@
 		xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
 		xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
-	<name>openHAB Tesla Binding</name>
-	<description>This is the binding for Tesla Electrical Vehicles.</description>
+	<name>Tesla Binding</name>
+	<description>This is the binding for Tesla Electric Vehicles.</description>
 	<author>Karel Goderis</author>
 
 </binding:binding>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>
