### PR TITLE
[Nibeuplink] extended available channels for different models

### DIFF
--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-groups.xml
@@ -40,6 +40,13 @@
 			<channel id="44298" typeId="base-type-44298" />
 			<channel id="48132" typeId="base-type-48132" />
 			<channel id="47041" typeId="base-type-47041" />
+			<channel id="47045" typeId="base-type-47045" />
+			<channel id="47049" typeId="base-type-47049" />
+			<channel id="47044" typeId="base-type-47044" />
+			<channel id="47048" typeId="base-type-47048" />
+			<channel id="47043" typeId="base-type-47043" />
+			<channel id="47047" typeId="base-type-47047" />
+			<channel id="47046" typeId="base-type-47046" />
 		</channels>
 	</channel-group-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-groups.xml
@@ -29,6 +29,7 @@
 			<channel id="44300" typeId="base-type-44300" />
 			<channel id="48043" typeId="base-type-48043" />
 			<channel id="10012" typeId="base-type-10012" />
+			<channel id="43437" typeId="base-type-43437" />		
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="base-hotwater">

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
@@ -183,7 +183,7 @@
 	<channel-type id="base-type-47043">
 		<item-type>Number:Temperature</item-type>
 		<label>Start temperature HW Luxury</label>
-		<description>Start temperature for heating water in Luxory mode</description>
+		<description>Start temperature for heating water in Luxury mode</description>
 		<state pattern="%.1f %unit%" readOnly="true">
 		</state>
 	</channel-type>
@@ -260,6 +260,13 @@
 		<label>Max int add. power, SG Ready</label>
 		<description></description>
 		<state min="0" max="4500" step="1" pattern="%.2f %unit%" readOnly="false">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-43437">
+		<item-type>Number</item-type>
+		<label>Supply Pump Speed EP14</label>
+		<description>Supply Pump Speed, EP14 (GP6)</description>
+		<state pattern="%d %%" readOnly="true">
 		</state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
@@ -180,6 +180,55 @@
 			</options>
 		</state>
 	</channel-type>
+	<channel-type id="base-type-47043">
+		<item-type>Number:Temperature</item-type>
+		<label>Start temperature HW Luxury</label>
+		<description>Start temperature for heating water in Luxory mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47044">
+		<item-type>Number:Temperature</item-type>
+		<label>Start temperature HW Normal</label>
+		<description>Start temperature for heating water in Normal mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47045">
+		<item-type>Number:Temperature</item-type>
+		<label>Start temperature HW Economy</label>
+		<description>Start temperature for heating water in Economy mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47046">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop temperature Periodic HW</label>
+		<description>Stop temperature for heating water in periodic heating</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47047">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop temperature HW Luxury</label>
+		<description>Stop temperature for heating water in Luxory mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47048">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop temperature HW Normal</label>
+		<description>Stop temperature for heating water in Normal mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="base-type-47049">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop temperature HW Economy</label>
+		<description>Stop temperature for heating water in Economy mode</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
 	<channel-type id="base-type-47212">
 		<item-type>Number:Power</item-type>
 		<label>Max int add. power</label>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/base-channel-types.xml
@@ -133,6 +133,13 @@
 		<description></description>
 		<state readOnly="true"></state>
 	</channel-type>
+	<channel-type id="base-type-43437">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Supply Pump Speed EP14</label>
+		<description>Supply Pump Speed, EP14 (GP6)</description>
+		<state pattern="%d %%" readOnly="true">
+		</state>
+	</channel-type>
 	<channel-type id="base-type-44298">
 		<item-type>Number:Energy</item-type>
 		<label>Heat Meter - HW Cpr and Add EP14</label>
@@ -260,13 +267,6 @@
 		<label>Max int add. power, SG Ready</label>
 		<description></description>
 		<state min="0" max="4500" step="1" pattern="%.2f %unit%" readOnly="false">
-		</state>
-	</channel-type>
-	<channel-type id="base-type-43437">
-		<item-type>Number</item-type>
-		<label>Supply Pump Speed EP14</label>
-		<description>Supply Pump Speed, EP14 (GP6)</description>
-		<state pattern="%d %%" readOnly="true">
 		</state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-groups.xml
@@ -7,6 +7,8 @@
 		<label>General Channels</label>
 		<channels>
 			<channel id="44302" typeId="f1145-type-44302" />
+			<channel id="44270" typeId="f1145-type-44270" />
+			<channel id="43103" typeId="f1145-type-43103" />
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="f1145-compressor">
@@ -19,6 +21,9 @@
 			<channel id="40019" typeId="f1145-type-40019" />
 			<channel id="40018" typeId="f1145-type-40018" />
 			<channel id="40017" typeId="f1145-type-40017" />
+			<channel id="40015" typeId="f1145-type-40015" />
+			<channel id="40016" typeId="f1145-type-40016" />
+			<channel id="43439" typeId="f1145-type-43439" />
 		</channels>
 	</channel-group-type>
 

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1145-channel-types.xml
@@ -45,11 +45,55 @@
 		<state pattern="%.1f %unit%" readOnly="true">
 		</state>
 	</channel-type>
+	<channel-type id="f1145-type-40015">
+		<item-type>Number:Temperature</item-type>
+		<label>EB100-EP14-BT10 Brine In Temperature</label>
+		<description>Brine in temperature, BT10</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="f1145-type-40016">
+		<item-type>Number:Temperature</item-type>
+		<label>EB100-EP14-BT11 Brine Out Temperature</label>
+		<description>Brine out temperature, BT11</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="f1145-type-44270">
+		<item-type>Number:Temperature</item-type>
+		<label>Calculated Cooling Supply Temperature S1</label>
+		<description>Calculated supply temperature in cooling mode for the climate system</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
 	<channel-type id="f1145-type-43416">
 		<item-type>Number</item-type>
 		<label>Compressor starts EB100-EP14</label>
 		<description>Number of compressor starts</description>
 		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="f1145-type-43103">
+		<item-type>Number</item-type>
+		<label>HPAC state</label>
+		<description>State of the HPAC accessory</description>
+		<state pattern="%d" readOnly="true">
+			<options>
+				<option value="10">Off</option>
+				<option value="20">Wait</option>
+				<option value="30">Passive</option>
+				<option value="40">PassiveWait</option>
+				<option value="50">Active</option>
+				<option value="60">ActiveWait</option>
+				<option value="70">ActiveProtWait</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="f1145-type-43439">
+		<item-type>Number:Dimensionless</item-type>
+		<label>EP14-GP2 Brine Pump Speed</label>
+		<description>Brine pump speed EP14 (GP2)</description>
+		<state pattern="%d %%" readOnly="true">
 		</state>
 	</channel-type>
 	<channel-type id="f1145-type-43420">

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-groups.xml
@@ -22,6 +22,9 @@
 			<channel id="43136" typeId="f1155-type-43136" />
 			<channel id="43122" typeId="f1155-type-43122" />
 			<channel id="43123" typeId="f1155-type-43123" />
+			<channel id="40015" typeId="f1155-type-40015" />
+			<channel id="40016" typeId="f1155-type-40016" />
+			<channel id="43439" typeId="f1155-type-43439" />
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="f1155-airsupply">

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/f1155-channel-types.xml
@@ -94,4 +94,25 @@
 		<state pattern="%.1f %unit%" readOnly="true">
 		</state>
 	</channel-type>
+		<channel-type id="f1155-type-43439">
+	<item-type>Number:Dimensionless</item-type>
+		<label>EP14-GP2 Brine Pump Speed</label>
+		<description>Brine pump speed EP14</description>
+		<state pattern="%d %%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="f1155-type-40015">
+		<item-type>Number:Temperature</item-type>
+		<label>EB100-EP14-BT10 Brine In Temperature</label>
+		<description>Brine in temperature, BT10</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="f1155-type-40016">
+		<item-type>Number:Temperature</item-type>
+		<label>EB100-EP14-BT11 Brine Out Temperature</label>
+		<description>Brine out temperature, BT11</description>
+		<state pattern="%.1f %unit%" readOnly="true">
+		</state>
+	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm310-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm310-channel-groups.xml
@@ -8,7 +8,6 @@
 		<channels>
 			<channel id="44270" typeId="vvm310-type-44270" />
 			<channel id="40121" typeId="vvm310-type-40121" />
-			<channel id="43437" typeId="vvm310-type-43437" />
 			<channel id="44302" typeId="vvm310-type-44302" />
 			<channel id="47011" typeId="vvm310-type-47011" />
 			<channel id="47394" typeId="vvm310-type-47394" />

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm310-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm310-channel-types.xml
@@ -72,13 +72,6 @@
 		<description>Indicates if the ERS accessory is externaly blocked.</description>
 		<state readOnly="true"></state>
 	</channel-type>
-	<channel-type id="vvm310-type-43437">
-		<item-type>Number:Dimensionless</item-type>
-		<label>Supply Pump Speed EP14</label>
-		<description>Supply Pump Speed EP14 (GP6)</description>
-		<state pattern="%d %%" readOnly="true">
-		</state>
-	</channel-type>
 	<channel-type id="vvm310-type-44055">
 		<item-type>Number:Temperature</item-type>
 		<label>EB101-EP14-BT3 Return Temp.</label>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-groups.xml
@@ -14,6 +14,10 @@
 			<channel id="47394" typeId="vvm320-type-47394" />
 			<channel id="47402" typeId="vvm320-type-47402" />
 			<channel id="48793" typeId="vvm320-type-48793" />
+			<channel id="47374" typeId="vvm320-type-47374" />
+			<channel id="47375" typeId="vvm320-type-47375" />
+			<channel id="47376" typeId="vvm320-type-47376" />
+			<channel id="47377" typeId="vvm320-type-47377" />
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="vvm320-compressor">

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-groups.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-groups.xml
@@ -8,7 +8,6 @@
 		<channels>
 			<channel id="44270" typeId="vvm320-type-44270" />
 			<channel id="40121" typeId="vvm320-type-40121" />
-			<channel id="43437" typeId="vvm320-type-43437" />
 			<channel id="44302" typeId="vvm320-type-44302" />
 			<channel id="47011" typeId="vvm320-type-47011" />
 			<channel id="47394" typeId="vvm320-type-47394" />

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
@@ -231,28 +231,28 @@
 		</state>
 	</channel-type>
 	<channel-type id="vvm320-type-47374">
-		<item-type>Number:Temperature</item-type>
+		<item-type>Number</item-type>
 		<label>Start Temperature Cooling</label>
 		<description>Start Temperature Cooling in Auto mode</description>
 		<state min="10" max="40" step="1" pattern="%d °C" readOnly="false">
 		</state>
 	</channel-type>
 	<channel-type id="vvm320-type-47375">
-		<item-type>Number:Temperature</item-type>
+		<item-type>Number</item-type>
 		<label>Stop Temperature Heating</label>
 		<description>Stop Temperature Heating in Auto mode</description>
 		<state min="0" max="30" step="1" pattern="%d °C" readOnly="false">
 		</state>
 	</channel-type>
 	<channel-type id="vvm320-type-47376">
-		<item-type>Number:Temperature</item-type>
+		<item-type>Number</item-type>
 		<label>Stop Temperature Additive</label>
 		<description>Stop Temperature Additive heater in Auto mode</description>
 		<state min="-20" max="10" step="1" pattern="%d °C" readOnly="false">
 		</state>
 	</channel-type>
 	<channel-type id="vvm320-type-47377">
-		<item-type>Number:Time</item-type>
+		<item-type>Number</item-type>
 		<label>Outdoor Filter Time</label>
 		<description>Outdoor Filter Time in Auto mode</description>
 		<state min="1" max="48" step="1" pattern="%d h" readOnly="false">

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
@@ -72,13 +72,6 @@
 		<description>Indicates if the ERS accessory is externaly blocked.</description>
 		<state readOnly="true"></state>
 	</channel-type>
-	<channel-type id="vvm320-type-43437">
-		<item-type>Number:Dimensionless</item-type>
-		<label>Supply Pump Speed EP14</label>
-		<description>Supply Pump Speed EP14 (GP6)</description>
-		<state pattern="%d %%" readOnly="true">
-		</state>
-	</channel-type>
 	<channel-type id="vvm320-type-44055">
 		<item-type>Number:Temperature</item-type>
 		<label>EB101-EP14-BT3 Return Temp.</label>

--- a/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
+++ b/addons/binding/org.openhab.binding.nibeuplink/ESH-INF/thing/vvm320-channel-types.xml
@@ -237,6 +237,34 @@
 			</options>
 		</state>
 	</channel-type>
+	<channel-type id="vvm320-type-47374">
+		<item-type>Number:Temperature</item-type>
+		<label>Start Temperature Cooling</label>
+		<description>Start Temperature Cooling in Auto mode</description>
+		<state min="10" max="40" step="1" pattern="%d °C" readOnly="false">
+		</state>
+	</channel-type>
+	<channel-type id="vvm320-type-47375">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop Temperature Heating</label>
+		<description>Stop Temperature Heating in Auto mode</description>
+		<state min="0" max="30" step="1" pattern="%d °C" readOnly="false">
+		</state>
+	</channel-type>
+	<channel-type id="vvm320-type-47376">
+		<item-type>Number:Temperature</item-type>
+		<label>Stop Temperature Additive</label>
+		<description>Stop Temperature Additive heater in Auto mode</description>
+		<state min="-20" max="10" step="1" pattern="%d °C" readOnly="false">
+		</state>
+	</channel-type>
+	<channel-type id="vvm320-type-47377">
+		<item-type>Number:Time</item-type>
+		<label>Outdoor Filter Time</label>
+		<description>Outdoor Filter Time in Auto mode</description>
+		<state min="1" max="48" step="1" pattern="%d h" readOnly="false">
+		</state>
+	</channel-type>
 	<channel-type id="vvm320-type-47394">
 		<item-type>Switch</item-type>
 		<label>Use room sensor S1</label>
@@ -247,14 +275,14 @@
 		<item-type>Number</item-type>
 		<label>Room sensor factor S1</label>
 		<description>Setting of how much the difference between set and actual room temperature should affect the supply temperature.</description>
-		<state min="0" max="60" step="1" pattern="%.1f" readOnly="false">
+		<state min="0" max="6" step="1" pattern="%.1f" readOnly="false">
 		</state>
 	</channel-type>
 	<channel-type id="vvm320-type-48793">
 		<item-type>Number</item-type>
 		<label>Room sensor cool factor S1</label>
 		<description>Setting of how much the difference between set and actual room temperature should affect the supply temperature in cooling mode.</description>
-		<state min="0" max="60" step="1" pattern="%.1f" readOnly="false">
+		<state min="0" max="6" step="1" pattern="%.1f" readOnly="false">
 		</state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -114,6 +114,13 @@ Available channels depend on the specific heatpump model. Following models/chann
 | hotwater#44298  | Number:Energy          | 0      | 9999999    | No       | Heat Meter - HW Cpr and Add EP14           |                                               |
 | hotwater#48132  | Number                 | ---    | ---        | Yes      | Temporary Lux                              | 0=Off, 1=3h, 2=6h, 3=12h, 4=One time increase |
 | hotwater#47041  | Number                 | ---    | ---        | Yes      | Hot water mode                             | 0=Economy, 1=Normal, 2=Luxury                 |
+| hotwater#47045  | Number                 | 5      | 70         | No       | Start temperature HW Economy               |                                               |
+| hotwater#47049  | Number                 | 5      | 70         | No       | Stop temperature HW Economy                |                                               |
+| hotwater#47044  | Number                 | 5      | 70         | No       | Start temperature HW Normal                |                                               |
+| hotwater#47048  | Number                 | 5      | 70         | No       | Stop temperature HW Normal                 |                                               |
+| hotwater#47043  | Number                 | 5      | 70         | No       | Start temperature HW Luxury                |                                               |
+| hotwater#47047  | Number                 | 5      | 70         | No       | Stop temperature HW Luxury                 |                                               |
+| hotwater#47046  | Number                 | 55     | 70         | No       | Stop temperature Periodic HW               |                                               |
 
 ### F730
 

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -193,21 +193,24 @@ Available channels depend on the specific heatpump model. Following models/chann
 	
 ### F1155 / 1255
 
-| Channel Type ID  | Item Type          | Min    | Max     | Writable | Description                       | Allowed Values (write access) |
-|------------------|--------------------|--------|---------|----------|-----------------------------------|-------------------------------|
-| general#44302    | Number:Energy      | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14     |                               |
-| compressor#43424 | Number:Time        | 0      | 9999999 | No       | Tot. HW op.time compr. EB100-EP14 |                               |
-| compressor#43420 | Number:Time        | 0      | 9999999 | No       | Tot. op.time compr. EB100-EP14    |                               |
-| compressor#43416 | Number             | 0      | 9999999 | No       | Compressor starts EB100-EP14      |                               |
-| compressor#40022 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT17 Suction           |                               |
-| compressor#40019 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT15 Liquid Line       |                               |
-| compressor#40018 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT14 Hot Gas Temp      |                               |
-| compressor#40017 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT12 Condensor Out     |                               |
-| compressor#43136 | Number:Frequency   | 0      | 65535   | No       | Compressor Frequency, Actual      |                               |
-| compressor#43122 | Number:Frequency   | -32767 | 32767   | No       | Compr. current min.freq.          |                               |
-| compressor#43123 | Number:Frequency   | -32767 | 32767   | No       | Compr. current max.freq.          |                               |
-| airsupply#40025  | Number:Temperature | -32767 | 32767   | No       | BT20 Exhaust air temp. 1          |                               |
-| airsupply#40026  | Number:Temperature | -32767 | 32767   | No       | BT21 Vented air temp. 1           |                               |
+| Channel Type ID  | Item Type            | Min    | Max     | Writable | Description                           | Allowed Values (write access) |
+|------------------|----------------------|--------|---------|----------|---------------------------------------|-------------------------------|
+| general#44302    | Number:Energy        | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14         |                               |
+| compressor#43424 | Number:Time          | 0      | 9999999 | No       | Tot. HW op.time compr. EB100-EP14     |                               |
+| compressor#43420 | Number:Time          | 0      | 9999999 | No       | Tot. op.time compr. EB100-EP14        |                               |
+| compressor#43416 | Number               | 0      | 9999999 | No       | Compressor starts EB100-EP14          |                               |
+| compressor#40022 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT17 Suction               |                               |
+| compressor#40019 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT15 Liquid Line           |                               |
+| compressor#40018 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT14 Hot Gas Temp          |                               |
+| compressor#40017 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT12 Condensor Out         |                               |
+| compressor#43136 | Number:Frequency     | 0      | 65535   | No       | Compressor Frequency, Actual          |                               |
+| compressor#43122 | Number:Frequency     | -32767 | 32767   | No       | Compr. current min.freq.              |                               |
+| compressor#43123 | Number:Frequency     | -32767 | 32767   | No       | Compr. current max.freq.              |                               |
+| compressor#40015 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT10 Brine In Temperature  |                               |
+| compressor#40016 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT11 Brine Out Temperature |                               |
+| compressor#43439 | Number:Dimensionless | 0      | 100     | No       | EP14-GP2 Brine Pump Speed             |                               |
+| airsupply#40025  | Number:Temperature   | -32767 | 32767   | No       | BT20 Exhaust air temp. 1              |                               |
+| airsupply#40026  | Number:Temperature   | -32767 | 32767   | No       | BT21 Vented air temp. 1               |                               |
 
 ### VVM310 / VVM 500
 

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -249,6 +249,10 @@ Available channels depend on the specific heatpump model. Following models/chann
 | general#47394    | Switch               | ---    | ---     | Yes      | Use room sensor S1                                 | 0=off, 1=on                                          |
 | general#47402    | Number               | 0      | 60      | Yes      | Room sensor factor S1                              | Values between 0 and 6                               |
 | general#48793    | Number               | 0      | 60      | Yes      | Room sensor cool factor S1                         | Values between 0 and 6                               |
+| general#47374    | Number:Temperature   | 10     | 40      | Yes      | Start temperature cooling                          | Values between 10 and 40                             |
+| general#47375    | Number:Temperature   | 0      | 30      | Yes      | Stop temperature heating                           | Values between 0 and 30                              |
+| general#47376    | Number:Temperature   | -20    | 10      | Yes      | Stop temperature additive                          | Values between -20 and 10                            |
+| general#47377    | Number:Time          | 1      | 48      | Yes      | Outdoor Filter Time                                | Values between 1 and 48                              |
 | compressor#44362 | Number:Temperature   | -32767 | 32767   | No       | EB101-EP14-BT28 Outdoor Temp                       |                                                      |
 | compressor#44396 | Number:Dimensionless | 0      | 255     | No       | EB101 Speed charge pump                            |                                                      |
 | compressor#44703 | Number               | ---    | ---     | No       | EB101-EP14 Defrosting Outdoor Unit                 | 0=No, 1=Active, 2=Passive                            |

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -95,6 +95,7 @@ Available channels depend on the specific heatpump model. Following models/chann
 | base#40008      | Number:Temperature     | -32767 | 32767      | No       | BT2 Supply temp S1                         |                                               |
 | base#40012      | Number:Temperature     | -32767 | 32767      | No       | EB100-EP14-BT3 Return temp                 |                                               |
 | base#40072      | Number:Dimensionless   | -32767 | 32767      | No       | BF1 EP14 Flow                              |                                               |
+| base#43437      | Number:Dimensionless   | 0      | 100        | No       | Supply Pump Speed EP14                     |                                               |
 | base#40079      | Number:ElectricCurrent | 0      | 4294967295 | No       | EB100-BE3 Current                          |                                               |
 | base#40081      | Number:ElectricCurrent | 0      | 4294967295 | No       | EB100-BE2 Current                          |                                               |
 | base#40083      | Number:ElectricCurrent | 0      | 4294967295 | No       | EB100-BE1 Current                          |                                               |
@@ -172,20 +173,24 @@ Available channels depend on the specific heatpump model. Following models/chann
 
 ### F1145 / 1245
 
-| Channel Type ID  | Item Type          | Min    | Max     | Writable | Description                       | Allowed Values (write access) |
-|------------------|--------------------|--------|---------|----------|-----------------------------------|-------------------------------|
-| general#44302    | Number:Energy      | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14     |                               |
-| compressor#43424 | Number:Time        | 0      | 9999999 | No       | Tot. HW op.time compr. EB100-EP14 |                               |
-| compressor#43420 | Number:Time        | 0      | 9999999 | No       | Tot. op.time compr. EB100-EP14    |                               |
-| compressor#43416 | Number             | 0      | 9999999 | No       | Compressor starts EB100-EP14      |                               |
-| compressor#40022 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT17 Suction           |                               |
-| compressor#40019 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT15 Liquid Line       |                               |
-| compressor#40018 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT14 Hot Gas Temp      |                               |
-| compressor#40017 | Number:Temperature | -32767 | 32767   | No       | EB100-EP14-BT12 Condensor Out     |                               |
-| airsupply#40025  | Number:Temperature | -32767 | 32767   | No       | BT20 Exhaust air temp. 1          |                               |
-| airsupply#40026  | Number:Temperature | -32767 | 32767   | No       | BT21 Vented air temp. 1           |                               |
-
-
+| Channel Type ID  | Item Type            | Min    | Max     | Writable | Description                              | Allowed Values (write access) |
+|------------------|----------------------|--------|---------|----------|------------------------------------------|-------------------------------|
+| general#44302    | Number:Energy        | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14            |                               |
+| general#44270    | Number:Temperature   | -32767 | 32767   | No       | Calculated Cooling Supply Temperature S1 |                               |
+| general#43103    | Number               | 10     | 70      | No       | HPAC state                               |                               |
+| compressor#43424 | Number:Time          | 0      | 9999999 | No       | Tot. HW op.time compr. EB100-EP14        |                               |
+| compressor#43420 | Number:Time          | 0      | 9999999 | No       | Tot. op.time compr. EB100-EP14           |                               |
+| compressor#43416 | Number               | 0      | 9999999 | No       | Compressor starts EB100-EP14             |                               |
+| compressor#40022 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT17 Suction                  |                               |
+| compressor#40019 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT15 Liquid Line              |                               |
+| compressor#40018 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT14 Hot Gas Temp             |                               |
+| compressor#40017 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT12 Condensor Out            |                               |
+| compressor#40015 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT10 Brine In Temperature     |                               |
+| compressor#40016 | Number:Temperature   | -32767 | 32767   | No       | EB100-EP14-BT11 Brine Out Temperature    |                               |
+| compressor#43439 | Number:Dimensionless | 0      | 100     | No       | EP14-GP2 Brine Pump Speed                |                               |
+| airsupply#40025  | Number:Temperature   | -32767 | 32767   | No       | BT20 Exhaust air temp. 1                 |                               |
+| airsupply#40026  | Number:Temperature   | -32767 | 32767   | No       | BT21 Vented air temp. 1                  |                               |
+	
 ### F1155 / 1255
 
 | Channel Type ID  | Item Type          | Min    | Max     | Writable | Description                       | Allowed Values (write access) |
@@ -210,7 +215,6 @@ Available channels depend on the specific heatpump model. Following models/chann
 |------------------|----------------------|--------|---------|----------|----------------------------------------------------|------------------------------------------------------|
 | general#44270    | Number:Temperature   | -32767 | 32767   | No       | Calc. Cooling Supply S1                            |                                                      |
 | general#40121    | Number:Temperature   | -32767 | 32767   | No       | BT63 Add Supply Temp                               |                                                      |
-| general#43437    | Number:Dimensionless | 0      | 255     | No       | Supply Pump Speed EP14                             |                                                      |
 | general#44302    | Number:Energy        | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14                      |                                                      |
 | general#47011    | Number               | -10    | 10      | Yes      | Heat Offset S1                                     | values between -10 and 10                            |
 | general#47394    | Switch               | ---    | ---     | Yes      | Use room sensor S1                                 | 0=off, 1=on                                          |
@@ -250,7 +254,6 @@ Available channels depend on the specific heatpump model. Following models/chann
 |------------------|----------------------|--------|---------|----------|----------------------------------------------------|------------------------------------------------------|
 | general#44270    | Number:Temperature   | -32767 | 32767   | No       | Calc. Cooling Supply S1                            |                                                      |
 | general#40121    | Number:Temperature   | -32767 | 32767   | No       | BT63 Add Supply Temp                               |                                                      |
-| general#43437    | Number:Dimensionless | 0      | 255     | No       | Supply Pump Speed EP14                             |                                                      |
 | general#44302    | Number:Energy        | 0      | 9999999 | No       | Heat Meter - Cooling Cpr EP14                      |                                                      |
 | general#47011    | Number               | -10    | 10      | Yes      | Heat Offset S1                                     | values between -10 and 10                            |
 | general#47394    | Switch               | ---    | ---     | Yes      | Use room sensor S1                                 | 0=off, 1=on                                          |

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -2,7 +2,7 @@
 
 The NibeUplink binding is used to get "live data" from from Nibe heat pumps without plugging any custom devices into your heat pump.
 This avoids the risk of losing your warranty. Instead data is retrieved from Nibe Uplink. This binding should in general be compatible with heat pump models that support Nibe Uplink.
-In general read access is supported for all channels. Write access is only supported for a small subset of channels.
+In general read access is supported for all channels. Write access is only supported for a small subset of channels. Write access will only be available with a paid subscription for "manage" at NibeUplink.
 
 ## Supported Things
 

--- a/addons/binding/org.openhab.binding.nibeuplink/README.md
+++ b/addons/binding/org.openhab.binding.nibeuplink/README.md
@@ -1,12 +1,17 @@
 # NibeUplink Binding
 
 The NibeUplink binding is used to get "live data" from from Nibe heat pumps without plugging any custom devices into your heat pump.
-This avoids the risk of losing your warranty. Instead data is retrieved from Nibe Uplink. This binding should in general be compatible with heat pump models that support Nibe Uplink.
-In general read access is supported for all channels. Write access is only supported for a small subset of channels. Write access will only be available with a paid subscription for "manage" at NibeUplink.
+This avoids the risk of losing your warranty.
+Instead data is retrieved from Nibe Uplink.
+This binding should in general be compatible with heat pump models that support Nibe Uplink.
+In general read access is supported for all channels.
+Write access is only supported for a small subset of channels.
+Write access will only be available with a paid subscription for "manage" at NibeUplink.
 
 ## Supported Things
 
-This binding provides only one thing type: The Nibe heat pump. Create one Nibe heat pump thing per physical heat pump installation available in your home(s).
+This binding provides only one thing type: The Nibe heat pump.
+Create one Nibe heat pump thing per physical heat pump installation available in your home(s).
 If your setup contains an outdoor unit such as F2030 or F2040 and an indoor unit such as VVM320 this is one installation where the indoor unit is the master that has access to all data produced by the outdoor unit (slave).
 
 ## Discovery
@@ -48,13 +53,17 @@ password used to login on NibeUplink
 Id of your heatpump in NibeUplink (can be found in the URL after successful login: https://www.nibeuplink.com/System/**<nibeId>>**/Status/Overview)
 
 - **pollingInterval**  
-interval (seconds) in which values are retrieved from NibeUplink. Setting less than 60 seconds does not make any sense as the heat pump only provides periodic updates to NibeUplink. (default = 60). 
+interval (seconds) in which values are retrieved from NibeUplink.
+Setting less than 60 seconds does not make any sense as the heat pump only provides periodic updates to NibeUplink.
+(default = 60)
 
 - **houseKeepingInterval**  
-interval (seconds) in which list of "dead channels" (channels that do not return any data or invalid data) should be purged (default = 3600). Usually this settings should not be changed.
+interval (seconds) in which list of "dead channels" (channels that do not return any data or invalid data) should be purged (default = 3600).
+Usually this settings should not be changed.
 
 - **customChannel01 - customChannel08**  
-allows to define up to 8 custom channels which are not covered in the basic channel list of your model. Any number between 10000 and 50000 is allowed. 
+allows to define up to 8 custom channels which are not covered in the basic channel list of your model.
+Any number between 10000 and 50000 is allowed. 
 
 ### Examples
 
@@ -79,7 +88,8 @@ nibeuplink:vvm320:home2  [ user="...", password="...", nibeId="..."]
 
 ## Channels
 
-Available channels depend on the specific heatpump model. Following models/channels are currently available
+Available channels depend on the specific heatpump model.
+Following models/channels are currently available:
 
 ### All Models
 
@@ -305,7 +315,8 @@ nibeuplink:vvm320:mynibe     [ user="nibe@my-domain.de", password="secret123", n
 
 ### Items
 
-As the binding supports UoM you might define units in the item's label. An automatic conversion is applied e.g. from °C to °F then.
+As the binding supports UoM you might define units in the item's label.
+An automatic conversion is applied e.g. from °C to °F then.
 Channels which represent two states (such as on/off) are represented as Switch.
 Channels which have more than two states are internally represented as number.
 You need to define a map file which also gives you the opportunity to translate the state into your preferred language.
@@ -334,7 +345,9 @@ Please define each state as integer.
 
 ### Sitemaps
 
-Please take care of the status channels. If you use selection items an automatic mapping will be applied. If you prefer switch items a mapping must be applied like this:
+Please take care of the status channels.
+If you use selection items an automatic mapping will be applied.
+If you prefer switch items a mapping must be applied like this:
 
 ```
 Switch item=NIBE_HW_MODE mappings=[0="Eco", 1="Norm"]

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/BaseChannels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/BaseChannels.java
@@ -153,6 +153,20 @@ public class BaseChannels extends AbstractChannels {
             .addChannel(new Channel("48132", "Temporary Lux", ChannelGroup.HOTWATER, "/Manage/2.1", "[01234]"));
     public static final Channel CH_47041 = INSTANCE
             .addChannel(new Channel("47041", "Hot water mode", ChannelGroup.HOTWATER, "/Manage/2.2", "[012]"));
+    public static final Channel CH_47045 = INSTANCE.addChannel(new QuantityChannel("47045",
+            "Start temperature HW Economy", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47049 = INSTANCE.addChannel(new QuantityChannel("47049",
+            "Stop temperature HW Economy", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47044 = INSTANCE.addChannel(new QuantityChannel("47044",
+            "Start temperature HW Normal", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47048 = INSTANCE.addChannel(new QuantityChannel("47048",
+            "Stop temperature HW Normal", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47043 = INSTANCE.addChannel(new QuantityChannel("47043",
+            "Start temperature HW Luxury", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47047 = INSTANCE.addChannel(new QuantityChannel("47047",
+            "Stop temperature HW Luxury", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_47046 = INSTANCE.addChannel(new QuantityChannel("47046",
+            "Stop temperature periodic HW", ChannelGroup.HOTWATER, ScaleFactor.DIV_10, SIUnits.CELSIUS));
 
     // Compressor
     public static final Channel CH_10012 = INSTANCE

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/BaseChannels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/BaseChannels.java
@@ -105,6 +105,8 @@ public class BaseChannels extends AbstractChannels {
             "EB100-EP14-BT3 Return temp", ChannelGroup.BASE, ScaleFactor.DIV_10, SIUnits.CELSIUS));
     public static final Channel CH_40072 = INSTANCE.addChannel(new QuantityChannel("40072", "BF1 EP14 Flow",
             ChannelGroup.BASE, ScaleFactor.DIV_10, SIUnits.LITRE.divide(SIUnits.METRE)));
+    public static final Channel CH_43437 = INSTANCE.addChannel(
+            new QuantityChannel("43437", "Supply Pump Speed EP14", ChannelGroup.BASE, SmartHomeUnits.PERCENT));
     public static final Channel CH_40079 = INSTANCE.addChannel(new QuantityChannel("40079", "EB100-BE3 Current",
             ChannelGroup.BASE, ScaleFactor.DIV_10, SmartHomeUnits.AMPERE));
     public static final Channel CH_40081 = INSTANCE.addChannel(new QuantityChannel("40081", "EB100-BE2 Current",

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1145Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1145Channels.java
@@ -48,6 +48,11 @@ public final class F1145Channels extends BaseChannels {
     public static final Channel CH_44302 = INSTANCE
             .addChannel(new QuantityChannel("44302", "Heat Meter - Cooling Cpr EP14", ChannelGroup.GENERAL,
                     ScaleFactor.DIV_10, MetricPrefix.KILO(SmartHomeUnits.WATT_HOUR)));
+    public static final Channel CH_44270 = INSTANCE
+            .addChannel(new QuantityChannel("44270", "Calculated Cooling Supply Temperature S1", ChannelGroup.GENERAL,
+                    ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_43103 = INSTANCE
+            .addChannel(new Channel("43103", "HPAC state", ChannelGroup.GENERAL));
 
     // Compressor
     public static final Channel CH_43424 = INSTANCE.addChannel(
@@ -64,6 +69,12 @@ public final class F1145Channels extends BaseChannels {
             "EB100-EP14-BT14 Hot Gas Temp", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
     public static final Channel CH_40017 = INSTANCE.addChannel(new QuantityChannel("40017",
             "EB100-EP14-BT12 Condensor Out", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_40015 = INSTANCE.addChannel(new QuantityChannel("40015",
+            "EB100-EP14-BT10 Brine In Temperature", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_40016 = INSTANCE.addChannel(new QuantityChannel("40016",
+            "EB100-EP14-BT11 Brine Out Temperature", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_43439 = INSTANCE.addChannel(new QuantityChannel("43439",
+            "EP14-GP2 Brine Pump Speed", ChannelGroup.COMPRESSOR, SmartHomeUnits.PERCENT));
 
     // Airsupply
     public static final Channel CH_40025 = INSTANCE.addChannel(new QuantityChannel("40025", "BT20 Exhaust air temp. 1",

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1155Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/F1155Channels.java
@@ -70,6 +70,12 @@ public final class F1155Channels extends BaseChannels {
             ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SmartHomeUnits.HERTZ));
     public static final Channel CH_43123 = INSTANCE.addChannel(new QuantityChannel("43123", "Compr. current max.freq.",
             ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SmartHomeUnits.HERTZ));
+    public static final Channel CH_40015 = INSTANCE.addChannel(new QuantityChannel("40015",
+            "EB100-EP14-BT10 Brine In Temperature", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_40016 = INSTANCE.addChannel(new QuantityChannel("40016",
+            "EB100-EP14-BT11 Brine Out Temperature", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));
+    public static final Channel CH_43439 = INSTANCE.addChannel(new QuantityChannel("43439",
+            "EP14-GP2 Brine Pump Speed", ChannelGroup.COMPRESSOR, SmartHomeUnits.PERCENT));
 
     // Airsupply
     public static final Channel CH_40025 = INSTANCE.addChannel(new QuantityChannel("40025", "BT20 Exhaust air temp. 1",

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM310Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM310Channels.java
@@ -49,8 +49,6 @@ public final class VVM310Channels extends BaseChannels {
             ChannelGroup.GENERAL, ScaleFactor.DIV_10, SIUnits.CELSIUS));
     public static final Channel CH_40121 = INSTANCE.addChannel(new QuantityChannel("40121", "BT63 Add Supply Temp",
             ChannelGroup.GENERAL, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-    public static final Channel CH_43437 = INSTANCE.addChannel(
-            new QuantityChannel("43437", "Supply Pump Speed EP14", ChannelGroup.GENERAL, SmartHomeUnits.PERCENT));
 
     public static final Channel CH_44302 = INSTANCE
             .addChannel(new QuantityChannel("44302", "Heat Meter - Cooling Cpr EP14", ChannelGroup.GENERAL,

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM320Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM320Channels.java
@@ -49,8 +49,6 @@ public final class VVM320Channels extends BaseChannels {
             ChannelGroup.GENERAL, ScaleFactor.DIV_10, SIUnits.CELSIUS));
     public static final Channel CH_40121 = INSTANCE.addChannel(new QuantityChannel("40121", "BT63 Add Supply Temp",
             ChannelGroup.GENERAL, ScaleFactor.DIV_10, SIUnits.CELSIUS));
-    public static final Channel CH_43437 = INSTANCE.addChannel(
-            new QuantityChannel("43437", "Supply Pump Speed EP14", ChannelGroup.GENERAL, SmartHomeUnits.PERCENT));
 
     public static final Channel CH_44302 = INSTANCE
             .addChannel(new QuantityChannel("44302", "Heat Meter - Cooling Cpr EP14", ChannelGroup.GENERAL,

--- a/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM320Channels.java
+++ b/addons/binding/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/VVM320Channels.java
@@ -65,6 +65,15 @@ public final class VVM320Channels extends BaseChannels {
     public static final Channel CH_48793 = INSTANCE.addChannel(new ScaledChannel("48793", "Room sensor cool factor",
             ChannelGroup.GENERAL, ScaleFactor.DIV_10, "/Manage/1.9.4", "[0123456]*[0-9]"));
 
+    public static final Channel CH_47374 = INSTANCE.addChannel(new ScaledChannel("47374", "Start Temperature Cooling",
+            ChannelGroup.GENERAL, ScaleFactor.DIV_10, "/Manage/4.9.2", "[0-9]*[0-9]"));
+    public static final Channel CH_47375 = INSTANCE.addChannel(new ScaledChannel("47375", "Stop Temperature Heating",
+            ChannelGroup.GENERAL, ScaleFactor.DIV_10, "/Manage/4.9.2", "[0-9]*[0-9]"));
+    public static final Channel CH_47376 = INSTANCE.addChannel(new ScaledChannel("47376", "Stop Temperature Additive",
+            ChannelGroup.GENERAL, ScaleFactor.DIV_10, "/Manage/4.9.2", "[0-9]*[0-9]"));
+    public static final Channel CH_47377 = INSTANCE.addChannel(
+            new Channel("47377", "Outdoor Filter Time", ChannelGroup.GENERAL, "/Manage/4.9.2", "[0-4]*[0-9]"));
+
     // Compressor
     public static final Channel CH_44362 = INSTANCE.addChannel(new QuantityChannel("44362",
             "EB101-EP14-BT28 Outdoor Temp", ChannelGroup.COMPRESSOR, ScaleFactor.DIV_10, SIUnits.CELSIUS));


### PR DESCRIPTION
added new channels for different models:

all models: 43437, 47043, 47044, 47045, 47046, 47047, 47048, 47049
removed channel 43437 from VVM310/VVM320 as it is now a base channel available for all models

F1145: 44270, 43103, 40015, 40016, 43439
F1155: 40015, 40016, 43439
VVM320: 47374, 47375, 47376, 47377

