### PR TITLE
[Lutron] Add new model support and button hold fix to keypad handler

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.lutron/ESH-INF/thing/thing-types.xml
@@ -232,6 +232,13 @@
 					<option value="H4S">H4S</option>
 					<option value="H5BRL">H5BRL</option>
 					<option value="H6BRL">H6BRL</option>
+					<option value="HN1RLD">HN1RLD</option>
+					<option value="HN2RLD">HN2RLD</option>
+					<option value="HN3BSRL">HN3BSRL</option>
+					<option value="HN3S">HN3S</option>
+					<option value="HN4S">HN4S</option>
+					<option value="HN5BRL">HN5BRL</option>
+					<option value="HN6BRL">HN6BRL</option>
 					<option value="W1RLD">W1RLD</option>
 					<option value="W2RLD">W2RLD</option>
 					<option value="W3BD">W3BD</option>

--- a/addons/binding/org.openhab.binding.lutron/README.md
+++ b/addons/binding/org.openhab.binding.lutron/README.md
@@ -143,7 +143,7 @@ Note, however, that version 11.6 or higher of the RadioRA 2 software may be requ
 When using auto-discovery, remember to select the correct value for the `model` parameter after accepting the keypad thing from the inbox.
 The correct channels will then be automatically configured.
 
-Supported settings for `model` parameter: H1RLD, H3BSRL, H3S, H4S, H5BRL, H6BRL, W1RLD, W2RLD, W3BD, W3BRL, W3BSRL, W3S, W4S, W5BRL, W5BRLIR, W6BRL, W7B, Generic (default)
+Supported settings for `model` parameter: H1RLD, H2RLD, H3BSRL, H3S, H4S, H5BRL, H6BRL, HN1RLD, HN2RLD, HN3S, HN3BSRL, HN4S, HN5BRL, HN6BRL, W1RLD, W2RLD, W3BD, W3BRL, W3BSRL, W3S, W4S, W5BRL, W5BRLIR, W6BRL, W7B, Generic (default)
 
 Example:
 

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
@@ -43,6 +43,7 @@ public abstract class BaseKeypadHandler extends LutronHandler {
 
     protected static final Integer ACTION_PRESS = 3;
     protected static final Integer ACTION_RELEASE = 4;
+    protected static final Integer ACTION_HOLD = 5;
     protected static final Integer ACTION_LED_STATE = 9;
 
     protected static final Integer LED_OFF = 0;
@@ -335,6 +336,9 @@ public abstract class BaseKeypadHandler extends LutronHandler {
                     }
                 } else if (ACTION_RELEASE.toString().equals(parameters[1])) {
                     updateState(channelUID, OnOffType.OFF);
+                } else if (ACTION_HOLD.toString().equals(parameters[1])) {
+                    updateState(channelUID, OnOffType.OFF); // Signal a release if we receive a hold code as we will not
+                                                            // get a subsequent release.
                 }
             } else {
                 logger.warn("Unable to determine channel for component {} in keypad update event message",

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/KeypadHandler.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/KeypadHandler.java
@@ -100,6 +100,7 @@ public class KeypadHandler extends BaseKeypadHandler {
         switch (mod) {
             case "W1RLD":
             case "H1RLD":
+            case "HN1RLD":
                 buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
                         Component.BUTTON5, Component.BUTTON6));
                 buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
@@ -108,6 +109,7 @@ public class KeypadHandler extends BaseKeypadHandler {
                 break;
             case "W2RLD":
             case "H2RLD":
+            case "HN2RLD":
                 buttonList.addAll(
                         Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON5, Component.BUTTON6));
                 buttonList
@@ -116,6 +118,7 @@ public class KeypadHandler extends BaseKeypadHandler {
                 break;
             case "W3S":
             case "H3S":
+            case "HN3S":
                 buttonList.addAll(
                         Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON6));
                 buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
@@ -134,12 +137,14 @@ public class KeypadHandler extends BaseKeypadHandler {
                 break;
             case "W3BSRL":
             case "H3BSRL":
+            case "HN3BSRL":
                 buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5));
                 buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
                 ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5));
                 break;
             case "W4S":
             case "H4S":
+            case "HN4S":
                 buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
                         Component.BUTTON4, Component.BUTTON6));
                 buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
@@ -148,6 +153,7 @@ public class KeypadHandler extends BaseKeypadHandler {
                 break;
             case "W5BRL":
             case "H5BRL":
+            case "HN5BRL":
             case "W5BRLIR":
                 buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
                         Component.BUTTON4, Component.BUTTON5));
@@ -157,6 +163,7 @@ public class KeypadHandler extends BaseKeypadHandler {
                 break;
             case "W6BRL":
             case "H6BRL":
+            case "HN6BRL":
                 buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
                         Component.BUTTON4, Component.BUTTON5, Component.BUTTON6));
                 buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));


### PR DESCRIPTION
Hi.  This PR contains two minor changes to the Lutron keypad handler code.

The first adds support for Lutron seeTouch CL hybrid keypad models: HN1RLD, HN2RLD, HN3S, HN3BSRL, HN4S, HN5BRL, HN6BRL. Their configurations simply map to the corresponding older keypad models: H1RLD, H2RLD, H3S, H3BSRL, H4S, H5BRL, H6BRL.

The second fixes an issue reported by some users where with some keypad/system model combinations a keypad button channel can become stuck in the on (pressed) state when a user holds down a button.

Regards,
Bob

Closes #4484
Closes #4982
