### PR TITLE
[Keba] Removed check of firmware version

### DIFF
--- a/addons/binding/org.openhab.binding.keba/README.md
+++ b/addons/binding/org.openhab.binding.keba/README.md
@@ -30,7 +30,7 @@ All devices support the following channels (non exhaustive):
 | Channel Type ID  | Item Type | Description                                                                                       |   |   |
 |------------------|-----------|---------------------------------------------------------------------------------------------------|---|---|
 | state            | Number    | This channel indicates the current operational state of the wallbox                               |   |   |
-| maxpresetcurrent | Number    | This channel supports adjusting the maximim current the charging station should deliver to the EV |   |   |
+| maxpresetcurrent | Number    | This channel supports adjusting the maximum current the charging station should deliver to the EV |   |   |
 | power            | Number    | This channel indicates the active power delivered by the charging station                         |   |   |
 | I1/2/3           | Number    | This channel indicates the current for the given phase                                            |   |   |
 | U1/2/3           | Number    | This channel indicates the voltage for the given phase                                            |   |   |

--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -100,38 +100,4 @@ public class KebaBindingConstants {
             throw new IllegalArgumentException("Not a valid series");
         }
     };
-
-    public enum KebaFirmware {
-        V201M21("2.01m21"),
-        V22A1("2.2a1"),
-        V23A2("2.3a2"),
-        V23A3("2.3a3"),
-        V25A3("2.5a3"),
-        V3042A1("3.04.2a1"),
-        V3062A5("3.06.2a5"),
-        V3071A1("3.07.1a1"),
-        V3084("3.08.4");
-
-        private final String id;
-
-        private KebaFirmware(final String id) {
-            this.id = id;
-        }
-
-        @Override
-        public String toString() {
-            return id;
-        }
-
-        public static KebaFirmware getFirmware(String text) throws IllegalArgumentException {
-            for (KebaFirmware c : KebaFirmware.values()) {
-                if (text.contains(c.id)) {
-                    return c;
-                }
-            }
-
-            throw new IllegalArgumentException("Not a valid firmware");
-        }
-
-    };
 }

--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -74,7 +74,7 @@ class KeContactTransceiver {
                 selector = Selector.open();
 
                 if (transceiverThread == null) {
-                    transceiverThread = new Thread(transceiverRunnable, "ESH-Keba-Transceiver");
+                    transceiverThread = new Thread(transceiverRunnable, "openHAB-Keba-Transceiver");
                     transceiverThread.start();
                 }
 

--- a/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/addons/binding/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -196,7 +196,7 @@ class KeContactTransceiver {
                         logger.trace("{} waiting on handerLock {}", Thread.currentThread().getName(),
                                 handlerLock.toString());
                     }
-                    handlerLock.wait();
+                    handlerLock.wait(KeContactHandler.REPORT_INTERVAL);
                 }
 
                 return buffers.remove(handler);


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab2-addons/issues/3328

Note that this PR only removes the check for specific firmware versions (which imho does not make much sense as this info is nowhere used and in general it is better to assume that Keba does not break backward compatibility when releasing newer firmwares).
I cannot say whether or not this binding works correctly with newer firmwares, though, but if there are problems, we should open dedicated issues about them.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
