### PR TITLE
[lutron] Add new output device types to RA2 auto-discovery code

### DIFF
--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -186,7 +186,11 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
             switch (type) {
                 case INC:
                 case MLV:
+                case ECO_SYSTEM_FLUORESCENT:
+                case FLUORESCENT_DB:
+                case ZERO_TO_TEN:
                 case AUTO_DETECT:
+                case CEILING_FAN_TYPE:
                     notifyDiscovery(THING_TYPE_DIMMER, output.getIntegrationId(), label);
                     break;
 

--- a/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
+++ b/addons/binding/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
@@ -16,15 +16,22 @@ package org.openhab.binding.lutron.internal.discovery.project;
  * Type of output device in a Lutron system.
  *
  * @author Allan Tong - Initial contribution
+ * @author Bob Adair - Added additional output types
  */
 public enum OutputType {
     AUTO_DETECT,
     CCO_MAINTAINED,
     CCO_PULSED,
+    CEILING_FAN_TYPE,
+    ECO_SYSTEM_FLUORESCENT,
+    FLUORESCENT_DB,
     INC,
     MLV,
     NON_DIM,
     NON_DIM_ELV,
     NON_DIM_INC,
+    SHEER_BLIND,
     SYSTEM_SHADE,
+    VENETIAN_BLIND,
+    ZERO_TO_TEN,
 }


### PR DESCRIPTION
Hi. This PR contains a small commit which enhances RadioRA 2 device auto-discovery support by adding several new output device types. Note that output types SHEER_BLIND and VENETIAN_BLIND do not yet map to a handler, but are added to OutputType for completeness.

Regards,
Bob
