### PR TITLE
[denonmarantz] Refactors reconnection logic

### DIFF
--- a/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/DenonMarantzStateChangedListener.java
+++ b/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/DenonMarantzStateChangedListener.java
@@ -26,7 +26,7 @@ public interface DenonMarantzStateChangedListener {
      * Update was received.
      *
      * @param channelID the channel for which its state changed
-     * @param state the new state of the channel
+     * @param state     the new state of the channel
      */
     void stateChanged(String channelID, State state);
 

--- a/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/handler/DenonMarantzHandler.java
+++ b/addons/binding/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/handler/DenonMarantzHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -71,11 +72,13 @@ import org.xml.sax.SAXException;
 public class DenonMarantzHandler extends BaseThingHandler implements DenonMarantzStateChangedListener {
 
     private final Logger logger = LoggerFactory.getLogger(DenonMarantzHandler.class);
+    private static final int RETRY_TIME_SECONDS = 30;
     private HttpClient httpClient;
     private DenonMarantzConnector connector;
     private DenonMarantzConfiguration config;
     private DenonMarantzConnectorFactory connectorFactory = new DenonMarantzConnectorFactory();
     private DenonMarantzState denonMarantzState;
+    private ScheduledFuture<?> retryJob;
 
     public DenonMarantzHandler(Thing thing, HttpClient httpClient) {
         super(thing);
@@ -272,6 +275,7 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
 
     @Override
     public void initialize() {
+        cancelRetry();
         config = getConfigAs(DenonMarantzConfiguration.class);
 
         // Configure Connection type (Telnet/HTTP) and number of zones
@@ -291,8 +295,18 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
     }
 
     private void createConnection() {
+        if (connector != null) {
+            connector.dispose();
+        }
         connector = connectorFactory.getConnector(config, denonMarantzState, scheduler, httpClient);
         connector.connect();
+    }
+
+    private void cancelRetry() {
+        ScheduledFuture<?> localRetryJob = retryJob;
+        if (localRetryJob != null && !localRetryJob.isDone()) {
+            localRetryJob.cancel(false);
+        }
     }
 
     private void configureZoneChannels() {
@@ -367,6 +381,7 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
             connector.dispose();
             connector = null;
         }
+        cancelRetry();
         super.dispose();
     }
 
@@ -399,5 +414,7 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
             // Don't flood the log with thing 'updated: OFFLINE' when already offline
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
         }
+        connector.dispose();
+        retryJob = scheduler.schedule(this::createConnection, RETRY_TIME_SECONDS, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
I have experienced several issues with how the binding  is maintaining it's connection state and polling, the first issue is that the handler would create a new instance of its connection object when initalized without stopping or disposing the old one, this would create havac as the polling code would continue to run and conflict with the shared state model that is use between them.

Second is that the HTTP connection code did not handle exceptions well and would set the binding to offline on the first failed attempt but then continue to make more requests, once a request was successful, nothing would tell the binding to go back online if the state had not changed during the network outage (which is very likely) .

Signed-off-by: digitaldan <dan@digitaldan.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
