### PR TITLE
Fix build path errors of Jinja addon by adapting build resource files

### DIFF
--- a/addons/transform/org.openhab.transform.jinja/.classpath
+++ b/addons/transform/org.openhab.transform.jinja/.classpath
@@ -9,7 +9,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry exported="true" kind="lib" path="lib/jinjava-2.4.12.jar" sourcepath="C:/Users/Jochen/.m2/repository/com/hubspot/jinjava/jinjava/2.4.12/jinjava-2.4.12-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jinjava-2.4.12.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/addons/transform/org.openhab.transform.jinja/build.properties
+++ b/addons/transform/org.openhab.transform.jinja/build.properties
@@ -11,5 +11,4 @@ bin.includes = META-INF/,\
                lib/jackson-annotations-2.9.8.jar,\
                lib/commons-lang3-3.8.1.jar,\
                ESH-INF/
-source.. = src/main/java/,\
-           src/main/resources/
+source.. = src/main/java/


### PR DESCRIPTION
After setting up the IDE for add-on development, I noticed some build path errors of the `org.openhab.transform.jinja` bundle in Eclipse. 

This PR is intended to solve these build path errors by adapting the `.classpath`/`build.properties` files so that the non-existing `src/main/resource` directory is no longer referenced.

Signed-off-by: Hannes Hofmann <hannes.hofmann92@gmail.com>

EDIT: Force-pushed to amend signed-off signature.
