### PR TITLE
[mcp23017] Added hint to the wiringPi library

### DIFF
--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -1,7 +1,7 @@
 # MCP23017 Binding
 
 This binding allows you to have native access for MCP23017 I/O expander on I2C bus.
-It was tested with Raspberry PI 2 and Raspberry PI 3, but probably should work with other devices supported by [pi4j] (http://pi4j.com/) library.
+It was tested with Raspberry Pi 2 and Raspberry Pi 3, but probably should work with other devices supported by [Pi4J](http://pi4j.com/) library.
 
 On Raspberry PI the user on which openHAB is running (default user name is "openhab") needs to be added to groups "i2c" and  "gpio".
 

--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -1,9 +1,15 @@
 # MCP23017 Binding
 
 This binding allows you to have native access for MCP23017 I/O expander on I2C bus.
-It was tested with Raspberry PI 2 and Raspberry PI 3, but probably should work with other devices supported by pi4j library.
+It was tested with Raspberry PI 2 and Raspberry PI 3, but probably should work with other devices supported by [pi4j] (http://pi4j.com/) library.
 
-On Raspberry PI user on which openHAB is running (default user name is "openhab") needs to be added to groups "i2c" and  "gpio".
+On Raspberry PI the user on which openHAB is running (default user name is "openhab") needs to be added to groups "i2c" and  "gpio".
+
+## Dependencies
+
+Make sure that the [wiringPi](http://wiringpi.com/) library has been installed and that the `gpio` command line tool is available to openHAB.
+The shared library `libwiringPi.so` is required by the [pi4j](http://pi4j.com/) Java library to access the GPIO ports.
+Without satisfying this dependency you will see strange `NoClassDefFoundError: Could not initialize class ...` errors in the openHAB logs.
 
 ## Supported Things
 

--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -3,7 +3,7 @@
 This binding allows you to have native access for MCP23017 I/O expander on I2C bus.
 It was tested with Raspberry Pi 2 and Raspberry Pi 3, but probably should work with other devices supported by [Pi4J](http://pi4j.com/) library.
 
-On Raspberry PI the user on which openHAB is running (default user name is "openhab") needs to be added to groups "i2c" and  "gpio".
+On Raspberry Pi the user on which openHAB is running (default user name is "openhab") needs to be added to groups "i2c" and  "gpio".
 
 ## Dependencies
 

--- a/addons/binding/org.openhab.binding.mcp23017/README.md
+++ b/addons/binding/org.openhab.binding.mcp23017/README.md
@@ -8,7 +8,7 @@ On Raspberry Pi the user on which openHAB is running (default user name is "open
 ## Dependencies
 
 Make sure that the [wiringPi](http://wiringpi.com/) library has been installed and that the `gpio` command line tool is available to openHAB.
-The shared library `libwiringPi.so` is required by the [pi4j](http://pi4j.com/) Java library to access the GPIO ports.
+The shared library `libwiringPi.so` is required by the [Pi4J](http://pi4j.com/) Java library to access the GPIO ports.
 Without satisfying this dependency you will see strange `NoClassDefFoundError: Could not initialize class ...` errors in the openHAB logs.
 
 ## Supported Things


### PR DESCRIPTION
Without this dependency the pi4j library did not work on my Raspberry Pi Model 3 B+.
Unfortunately there is another issue Pi4J/pi4j#319 which can be resolved by updating to pi4j release 1.2 (not yet released).

Supersedes #4806.

// CC @mrumpf 

Also-by: Michael Rumpf <michael@rumpfonline.de> (github: mrumpf)
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>