### PR TITLE
Fixed usages of units.

### DIFF
--- a/addons/binding/org.openhab.binding.homematic.test/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
+++ b/addons/binding/org.openhab.binding.homematic.test/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
@@ -18,13 +18,9 @@ import static org.junit.Assert.assertThat;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
-import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
-import org.openhab.binding.homematic.internal.converter.ConverterException;
-import org.openhab.binding.homematic.internal.converter.ConverterFactory;
-import org.openhab.binding.homematic.internal.converter.TypeConverter;
 import org.openhab.binding.homematic.internal.converter.type.AbstractTypeConverter;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 
@@ -94,7 +90,7 @@ public class ConvertFromBindingTest extends BaseConverterTest {
         assertThat(((QuantityType<?>) convertedState).getDimension(),
                 is(QuantityDimension.NONE.divide(QuantityDimension.TIME)));
         assertThat(((QuantityType<?>) convertedState).intValue(), is(50000));
-        assertThat(((QuantityType<?>) convertedState).toUnit(SIUnits.HERTZ).intValue(), is(50));
+        assertThat(((QuantityType<?>) convertedState).toUnit(SmartHomeUnits.HERTZ).intValue(), is(50));
 
         floatQuantityDp.setValue(0.7);
         floatQuantityDp.setUnit("100%");


### PR DESCRIPTION
- Fixed wrong usage of HERTZ, should be from SmartHomeUnits.
- Added tec.uom.se to nest test. For some reasons with the changes in core units the compiler fails on NestThermostatHandlerTest. It's related to the static imports.

Related to https://github.com/openhab/openhab-core/pull/617