### PR TITLE
[tplinksmarthome] Adding support for TP-Link HS103 Smart Wi-Fi Plug Mini

### DIFF
--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="tplinksmarthome"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <thing-type id="hs103">
-        <label>HS103</label>
-        <description>TP-Link HS103 Smart Wi-Fi Plug Mini</description>
-        <category>PowerOutlet</category>
+	<thing-type id="hs103">
+		<label>HS103</label>
+		<description>TP-Link HS103 Smart Wi-Fi Plug Mini</description>
+		<category>PowerOutlet</category>
 
-        <channels>
-            <channel id="switch" typeId="system.power" />
-            <channel id="led" typeId="led" />
-            <channel id="rssi" typeId="rssi" />
-        </channels>
+		<channels>
+			<channel id="switch" typeId="system.power" />
+			<channel id="led" typeId="led" />
+			<channel id="rssi" typeId="rssi" />
+		</channels>
 
-        <representation-property>deviceId</representation-property>
+		<representation-property>deviceId</representation-property>
 
-        <config-description-ref uri="thing-type:device:plug" />
-    </thing-type>
+		<config-description-ref uri="thing-type:device:plug" />
+	</thing-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
@@ -6,7 +6,7 @@
 
 	<thing-type id="hs103">
 		<label>HS103</label>
-		<description>TP-Link HS103 Smart Wi-Fi Plug Mini</description>
+		<description>TP-Link HS103 Smart Wi-Fi Plug Lite</description>
 		<category>PowerOutlet</category>
 
 		<channels>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/ESH-INF/thing/HS103.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tplinksmarthome"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="hs103">
+        <label>HS103</label>
+        <description>TP-Link HS103 Smart Wi-Fi Plug Mini</description>
+        <category>PowerOutlet</category>
+
+        <channels>
+            <channel id="switch" typeId="system.power" />
+            <channel id="led" typeId="led" />
+            <channel id="rssi" typeId="rssi" />
+        </channels>
+
+        <representation-property>deviceId</representation-property>
+
+        <config-description-ref uri="thing-type:device:plug" />
+    </thing-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.tplinksmarthome/README.md
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/README.md
@@ -126,6 +126,11 @@ Switching, Brightness and Color is done using the `color` channel.
 * Switch On/Off
 * Wi-Fi signal strength (rssi)
 
+### HS103 Smart Wi-Fi Plug Mini
+
+* Switch On/Off
+* Wi-Fi signal strength (rssi)
+
 ### HS105 Smart Wi-Fi Plug
 
 * Switch On/Off
@@ -215,7 +220,7 @@ All devices support some of the following channels:
 
 | Channel Type ID  | Item Type | Description                                        | Thing types supporting this channel                           |
 |------------------|-----------|----------------------------------------------------|---------------------------------------------------------------|
-| switch           | Switch    | Switch the Smart Home device on or off.            | KP100, HS100, HS105, HS110, HS200, HS210, RE270K, RE370K      |
+| switch           | Switch    | Switch the Smart Home device on or off.            | KP100, HS100, HS103, HS105, HS110, HS200, HS210, RE270K, RE370K      |
 | brightness       | Dimmer    | Set the brightness of Smart Home device or dimmer. | HS220, KB100, LB100, LB110, LB120, LB200, HS220, KL110, KL120 |
 | colorTemperature | Dimmer    | Set the color temperature of Smart Home light.     | KB130, LB120, LB130, LB230, KL120, KL130                      |
 | color            | Color     | Set the color of the Smart Home light.             | KB130, LB130, LB230, KL130                                    |

--- a/addons/binding/org.openhab.binding.tplinksmarthome/README.md
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/README.md
@@ -126,7 +126,7 @@ Switching, Brightness and Color is done using the `color` channel.
 * Switch On/Off
 * Wi-Fi signal strength (rssi)
 
-### HS103 Smart Wi-Fi Plug Mini
+### HS103 Smart Wi-Fi Plug Lite
 
 * Switch On/Off
 * Wi-Fi signal strength (rssi)

--- a/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/addons/binding/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -44,6 +44,7 @@ enum TPLinkSmartHomeThingType {
 
     // Plug Thing Type UIDs
     HS100("hs100", DeviceType.PLUG),
+    HS103("hs103", DeviceType.PLUG),
     HS105("hs105", DeviceType.PLUG),
     HS110("hs110", DeviceType.PLUG),
     KP100("kp100", DeviceType.PLUG),


### PR DESCRIPTION
This plug (thing) is simply a smaller version of the existing HS105 module (12A versus 15A). It follows the same protocol.

Follow up to #5001

First PR, still getting my head wrapped around this build system.

Signed-off-by: Gus Grubba gus@grubba.com (github: dogmaphobic)