### PR TITLE
[enocean] Add validation for new values for channel "totalusage"

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
@@ -153,9 +153,10 @@
 		<description>Used energy in Kilowatt hours</description>
 		<state pattern="%d %unit%" readOnly="true" />
 		<config-description>
-			<parameter name="validate" type="boolean">
+			<parameter name="validateValue" type="boolean">
 				<label>Validate value</label>
 				<description>Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh</description>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</channel-type>

--- a/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
@@ -152,6 +152,12 @@
 		<label>Total Usage</label>
 		<description>Used energy in Kilowatt hours</description>
 		<state pattern="%d %unit%" readOnly="true" />
+		<config-description>
+			<parameter name="validate" type="boolean">
+				<label>Validate value</label>
+				<description>Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh</description>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="batteryVoltage">

--- a/addons/binding/org.openhab.binding.enocean/README.md
+++ b/addons/binding/org.openhab.binding.enocean/README.md
@@ -246,6 +246,7 @@ Some channels can be configured with parameters.
 | dimmer        | rampingTime    | Duration of dimming                                                  | A5-38-08: Ramping Time (in seconds), 0 = default ramping, 1..255 = seconds to 100%; D2-01-01: 0 = switch, 1-3 = timer 1-3, 4 = stop |
 | teachInCMD    | manufacturerId | Id is used for 4BS teach in with EEP                                 | HEX                                                                                                                                 |
 |               | teachInMSG     | Use this message if teach in type and/or manufacturer id are unknown | HEX                                                                                                                                 |
+|  totalusage   | validateValue  | Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh | true / false                                                                                                                        |
 
 Possible declaration in Thing DSL:
 

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
@@ -17,5 +17,5 @@ package org.openhab.binding.enocean.internal.config;
  * @author Dominik Vorreiter - Initial contribution
  */
 public class EnOceanChannelTotalusageConfig {
-    public boolean validate = false;
+    public boolean validateValue = false;
 }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
@@ -17,10 +17,5 @@ package org.openhab.binding.enocean.internal.config;
  * @author Dominik Vorreiter - Initial contribution
  */
 public class EnOceanChannelTotalusageConfig {
-
-    public Boolean validate;
-
-    public EnOceanChannelTotalusageConfig() {
-        validate = false;
-    }
+    public boolean validate = false;
 }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTotalusageConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.enocean.internal.config;
+
+/**
+ *
+ * @author Dominik Vorreiter - Initial contribution
+ */
+public class EnOceanChannelTotalusageConfig {
+
+    public Boolean validate;
+
+    public EnOceanChannelTotalusageConfig() {
+        validate = false;
+    }
+}

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_11/A5_11_04.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_11/A5_11_04.java
@@ -151,9 +151,9 @@ public class A5_11_04 extends _4BSMessage {
                 case WATT:
                     factor = 1;
                     break;
-                case KILOWATT:
-                    factor *= 1000;
                 case MEGAWATT:
+                    factor *= 1000;
+                case KILOWATT:
                     factor *= 1000;
                     break;
                 default:

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_11/A5_11_04.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_11/A5_11_04.java
@@ -14,8 +14,6 @@ package org.openhab.binding.enocean.internal.eep.A5_11;
 
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
 
-import javax.measure.quantity.Energy;
-
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -25,7 +23,7 @@ import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.util.HexUtils;
-import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
+import org.openhab.binding.enocean.internal.eep.EEPHelper;
 import org.openhab.binding.enocean.internal.eep.Base._4BSMessage;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
 import org.slf4j.Logger;
@@ -195,37 +193,7 @@ public class A5_11_04 extends _4BSMessage {
             case CHANNEL_TOTALUSAGE:
                 State value = getEnergyMeasurementData();
 
-                EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
-
-                if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> newValue = value.as(QuantityType.class);
-
-                    if (newValue != null) {
-                        newValue = newValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> oldValue = currentState.as(QuantityType.class);
-
-                    if (oldValue != null) {
-                        oldValue = oldValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    if ((newValue != null) && (oldValue != null)) {
-                        if (newValue.compareTo(oldValue) < 0) {
-                            if ((oldValue.subtract(newValue).doubleValue() < 1.0)) {
-                                return UnDefType.UNDEF;
-                            }
-                        } else {
-                            if (newValue.subtract(oldValue).doubleValue() > 10.0) {
-                                return UnDefType.UNDEF;
-                            }
-                        }
-                    }
-                }
-
-                return value;
+                return EEPHelper.validateTotalUsage(value, currentState, config);
             case CHANNEL_COUNTER:
                 return getOperatingHours();
         }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_12/A5_12.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_12/A5_12.java
@@ -14,15 +14,13 @@ package org.openhab.binding.enocean.internal.eep.A5_12;
 
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
 
-import javax.measure.quantity.Energy;
-
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.util.HexUtils;
-import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
+import org.openhab.binding.enocean.internal.eep.EEPHelper;
 import org.openhab.binding.enocean.internal.eep.Base._4BSMessage;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
 
@@ -123,37 +121,7 @@ public abstract class A5_12 extends _4BSMessage {
             case CHANNEL_TOTALUSAGE:
                 State value = getCumulativeValue();
 
-                EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
-
-                if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> newValue = value.as(QuantityType.class);
-
-                    if (newValue != null) {
-                        newValue = newValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> oldValue = currentState.as(QuantityType.class);
-
-                    if (oldValue != null) {
-                        oldValue = oldValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    if ((newValue != null) && (oldValue != null)) {
-                        if (newValue.compareTo(oldValue) < 0) {
-                            if ((oldValue.subtract(newValue).doubleValue() < 1.0)) {
-                                return UnDefType.UNDEF;
-                            }
-                        } else {
-                            if (newValue.subtract(oldValue).doubleValue() > 10.0) {
-                                return UnDefType.UNDEF;
-                            }
-                        }
-                    }
-                }
-
-                return value;
+                return EEPHelper.validateTotalUsage(value, currentState, config);
             case CHANNEL_TOTALCUBICMETRE:
             case CHANNEL_COUNTER:
                 return getCumulativeValue();

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
@@ -144,7 +144,7 @@ public abstract class D2_01 extends _VLDMessage {
 
             switch (bytes[1] >>> 5) {
                 case 0:
-                    factor /= 3600.0;
+                    factor /= (3600 * 1000);
                     break;
                 case 1:
                     factor /= 1000;

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
@@ -141,13 +141,14 @@ public abstract class D2_01 extends _VLDMessage {
             float factor = 1;
 
             switch (bytes[1] >>> 5) {
-                case 0:
+                case 0: // value is given as watt seconds, so divide it by 3600 to get watt hours, and 1000 to get
+                        // kilowatt hours
                     factor /= (3600 * 1000);
                     break;
-                case 1:
+                case 1: // value is given as watt hours, so divide it by 1000 to get kilowatt hours
                     factor /= 1000;
                     break;
-                case 2:
+                case 2: // value is given as kilowatt hours
                     factor = 1;
                     break;
                 default:
@@ -167,10 +168,10 @@ public abstract class D2_01 extends _VLDMessage {
             float factor = 1;
 
             switch (bytes[1] >>> 5) {
-                case 3:
+                case 3: // value is given as watt
                     factor = 1;
                     break;
-                case 4:
+                case 4: // value is given as kilowatt
                     factor /= 1000;
                     break;
                 default:

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
@@ -14,6 +14,8 @@ package org.openhab.binding.enocean.internal.eep.D2_01;
 
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
 
+import javax.measure.quantity.Energy;
+
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -27,6 +29,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.util.HexUtils;
 import org.openhab.binding.enocean.internal.config.EnOceanChannelDimmerConfig;
+import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
 import org.openhab.binding.enocean.internal.eep.Base._VLDMessage;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
 
@@ -242,7 +245,39 @@ public abstract class D2_01 extends _VLDMessage {
             case CHANNEL_INSTANTPOWER:
                 return getPowerMeasurementData();
             case CHANNEL_TOTALUSAGE:
-                return getEnergyMeasurementData();
+                State value = getEnergyMeasurementData();
+
+                EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
+
+                if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
+                    @SuppressWarnings("unchecked")
+                    QuantityType<Energy> newValue = value.as(QuantityType.class);
+
+                    if (newValue != null) {
+                        newValue = newValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    QuantityType<Energy> oldValue = currentState.as(QuantityType.class);
+
+                    if (oldValue != null) {
+                        oldValue = oldValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
+                    }
+
+                    if ((newValue != null) && (oldValue != null)) {
+                        if (newValue.compareTo(oldValue) < 0) {
+                            if ((oldValue.subtract(newValue).doubleValue() < 1.0)) {
+                                return UnDefType.UNDEF;
+                            }
+                        } else {
+                            if (newValue.subtract(oldValue).doubleValue() > 10.0) {
+                                return UnDefType.UNDEF;
+                            }
+                        }
+                    }
+                }
+
+                return value;
         }
 
         return UnDefType.UNDEF;

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_01/D2_01.java
@@ -14,8 +14,6 @@ package org.openhab.binding.enocean.internal.eep.D2_01;
 
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
 
-import javax.measure.quantity.Energy;
-
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -29,7 +27,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.util.HexUtils;
 import org.openhab.binding.enocean.internal.config.EnOceanChannelDimmerConfig;
-import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
+import org.openhab.binding.enocean.internal.eep.EEPHelper;
 import org.openhab.binding.enocean.internal.eep.Base._VLDMessage;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
 
@@ -247,37 +245,7 @@ public abstract class D2_01 extends _VLDMessage {
             case CHANNEL_TOTALUSAGE:
                 State value = getEnergyMeasurementData();
 
-                EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
-
-                if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> newValue = value.as(QuantityType.class);
-
-                    if (newValue != null) {
-                        newValue = newValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    @SuppressWarnings("unchecked")
-                    QuantityType<Energy> oldValue = currentState.as(QuantityType.class);
-
-                    if (oldValue != null) {
-                        oldValue = oldValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
-                    }
-
-                    if ((newValue != null) && (oldValue != null)) {
-                        if (newValue.compareTo(oldValue) < 0) {
-                            if ((oldValue.subtract(newValue).doubleValue() < 1.0)) {
-                                return UnDefType.UNDEF;
-                            }
-                        } else {
-                            if (newValue.subtract(oldValue).doubleValue() > 10.0) {
-                                return UnDefType.UNDEF;
-                            }
-                        }
-                    }
-                }
-
-                return value;
+                return EEPHelper.validateTotalUsage(value, currentState, config);
         }
 
         return UnDefType.UNDEF;

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
+ * information.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
@@ -13,7 +13,7 @@ public abstract class EEPHelper {
     public static State validateTotalUsage(State value, State currentState, Configuration config) {
         EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
 
-        if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
+        if (c.validateValue && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
             @SuppressWarnings("unchecked")
             QuantityType<Energy> newValue = value.as(QuantityType.class);
 

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.enocean.internal.eep;
 
 import javax.measure.quantity.Energy;
@@ -9,6 +21,11 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
 
+/**
+ *
+ * @author Dominik Vorreiter - initial contribution
+ *
+ */
 public abstract class EEPHelper {
     public static State validateTotalUsage(State value, State currentState, Configuration config) {
         EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPHelper.java
@@ -1,0 +1,46 @@
+package org.openhab.binding.enocean.internal.eep;
+
+import javax.measure.quantity.Energy;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.enocean.internal.config.EnOceanChannelTotalusageConfig;
+
+public abstract class EEPHelper {
+    public static State validateTotalUsage(State value, State currentState, Configuration config) {
+        EnOceanChannelTotalusageConfig c = config.as(EnOceanChannelTotalusageConfig.class);
+
+        if (c.validate && (value instanceof QuantityType) && (currentState instanceof QuantityType)) {
+            @SuppressWarnings("unchecked")
+            QuantityType<Energy> newValue = value.as(QuantityType.class);
+
+            if (newValue != null) {
+                newValue = newValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
+            }
+
+            @SuppressWarnings("unchecked")
+            QuantityType<Energy> oldValue = currentState.as(QuantityType.class);
+
+            if (oldValue != null) {
+                oldValue = oldValue.toUnit(SmartHomeUnits.KILOWATT_HOUR);
+            }
+
+            if ((newValue != null) && (oldValue != null)) {
+                if (newValue.compareTo(oldValue) < 0) {
+                    if ((oldValue.subtract(newValue).doubleValue() < 1.0)) {
+                        return UnDefType.UNDEF;
+                    }
+                } else {
+                    if (newValue.subtract(oldValue).doubleValue() > 10.0) {
+                        return UnDefType.UNDEF;
+                    }
+                }
+            }
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Dominik Vorreiter <dominikkv@gmx.de>

Add new channel config for channel "totalusage" to enable value validation, defaulting to false.
Validation is done in all EEPs receiving values for this channel.
If value decreases by less than 1 kWh, discard value.
If value increases by more than 10 kWh, discard value.

Closes #5052