### PR TITLE
Update CODEOWNERS for Astro and AVM Fritz bnd migrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,12 +10,8 @@
 /addons/binding/org.openhab.binding.allplay/ @dominicdesu
 /addons/binding/org.openhab.binding.amazondashbutton/ @OLibutzki
 /addons/binding/org.openhab.binding.amazonechocontrol/ @mgeramb
-/addons/binding/org.openhab.binding.astro/ @gerrieg
-/addons/binding/org.openhab.binding.astro.test/ @gerrieg
 /addons/binding/org.openhab.binding.atlona/ @tmrobert8
 /addons/binding/org.openhab.binding.autelis/ @digitaldan
-/addons/binding/org.openhab.binding.avmfritz/ @cweitkamp
-/addons/binding/org.openhab.binding.avmfritz.test/ @cweitkamp
 /addons/binding/org.openhab.binding.bigassfan/ @mhilbush
 /addons/binding/org.openhab.binding.bluetooth/ @cdjackson @kaikreuzer
 /addons/binding/org.openhab.binding.bluetooth.bluegiga/ @cdjackson @kaikreuzer
@@ -230,5 +226,9 @@
 /addons/voice/org.openhab.voice.picotts/ @FlorianSW
 /addons/voice/org.openhab.voice.pollytts/ @hillmanr
 /addons/voice/org.openhab.voice.voicerss/ @JochenHiller
+/bundles/org.openhab.binding.astro/ @gerrieg
+/bundles/org.openhab.binding.avmfritz/ @cweitkamp
+/itests/org.openhab.binding.astro.tests/ @gerrieg
+/itests/org.openhab.binding.avmfritz.tests/ @cweitkamp
 
 # PLEASE HELP ADDING FURTHER LINES HERE!


### PR DESCRIPTION
Updates the CODEOWNERS file for the migrations in #5018 and #5050.