### PR TITLE
[openweathermap] Consider "1h" property for precipitation

### DIFF
--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
@@ -220,13 +220,13 @@ channel-type.openweathermap.forecasted-cloudiness.label = Vorhergesagte Bewölkun
 channel-type.openweathermap.forecasted-cloudiness.description = Zeigt die vorhergesagte Bewölkung an.
 
 channel-type.openweathermap.rain.label = Regen
-channel-type.openweathermap.rain.description = Zeigt den kumulierten Regen der letzten Stunde / drei Stunden an.
+channel-type.openweathermap.rain.description = Zeigt den kumulierten Regen der letzten Stunde an.
 
 channel-type.openweathermap.forecasted-rain.label = Vorhergesagter Regen
 channel-type.openweathermap.forecasted-rain.description = Zeigt die vorhergesagte Regenmenge an.
 
 channel-type.openweathermap.snow.label = Schnee
-channel-type.openweathermap.snow.description = Zeigt den kumulierten Schnee der letzten Stunde / drei Stunden an.
+channel-type.openweathermap.snow.description = Zeigt den kumulierten Schnee der letzten Stunde an.
 
 channel-type.openweathermap.forecasted-snow.label = Vorhergesagter Schnee
 channel-type.openweathermap.forecasted-snow.description = Zeigt die vorhergesagte Schneemenge an.

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
@@ -220,13 +220,13 @@ channel-type.openweathermap.forecasted-cloudiness.label = Vorhergesagte Bewölkun
 channel-type.openweathermap.forecasted-cloudiness.description = Zeigt die vorhergesagte Bewölkung an.
 
 channel-type.openweathermap.rain.label = Regen
-channel-type.openweathermap.rain.description = Zeigt den kumulierten Regen der letzten drei Stunden an.
+channel-type.openweathermap.rain.description = Zeigt den kumulierten Regen der letzten Stunde / drei Stunden an.
 
 channel-type.openweathermap.forecasted-rain.label = Vorhergesagter Regen
 channel-type.openweathermap.forecasted-rain.description = Zeigt die vorhergesagte Regenmenge an.
 
 channel-type.openweathermap.snow.label = Schnee
-channel-type.openweathermap.snow.description = Zeigt den kumulierten Schnee der letzten drei Stunden an.
+channel-type.openweathermap.snow.description = Zeigt den kumulierten Schnee der letzten Stunde / drei Stunden an.
 
 channel-type.openweathermap.forecasted-snow.label = Vorhergesagter Schnee
 channel-type.openweathermap.forecasted-snow.description = Zeigt die vorhergesagte Schneemenge an.

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_fr.properties
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_fr.properties
@@ -190,13 +190,13 @@ channel-type.openweathermap.forecasted-cloudiness.label = Nébulosité Prévue
 channel-type.openweathermap.forecasted-cloudiness.description = Nébulosité prévue.
 
 channel-type.openweathermap.rain.label = Pluie
-channel-type.openweathermap.rain.description = Volume de pluie des dernières heure / trois dernières heures.
+channel-type.openweathermap.rain.description = Volume de pluie des dernières heure.
 
 channel-type.openweathermap.forecasted-rain.label = Pluie Prévue
 channel-type.openweathermap.forecasted-rain.description = Volume de pluie prévu.
 
 channel-type.openweathermap.snow.label = Neige
-channel-type.openweathermap.snow.description = Volume de neige des dernières heure / trois dernières heures.
+channel-type.openweathermap.snow.description = Volume de neige des dernières heure.
 
 channel-type.openweathermap.forecasted-snow.label = Neige Prévue
 channel-type.openweathermap.forecasted-snow.description = Volume de neige prévu.

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_fr.properties
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/i18n/openweathermap_fr.properties
@@ -190,13 +190,13 @@ channel-type.openweathermap.forecasted-cloudiness.label = Nébulosité Prévue
 channel-type.openweathermap.forecasted-cloudiness.description = Nébulosité prévue.
 
 channel-type.openweathermap.rain.label = Pluie
-channel-type.openweathermap.rain.description = Volume de pluie des 3 dernières heures.
+channel-type.openweathermap.rain.description = Volume de pluie des dernières heure / trois dernières heures.
 
 channel-type.openweathermap.forecasted-rain.label = Pluie Prévue
 channel-type.openweathermap.forecasted-rain.description = Volume de pluie prévu.
 
 channel-type.openweathermap.snow.label = Neige
-channel-type.openweathermap.snow.description = Volume de neige des 3 dernières heures.
+channel-type.openweathermap.snow.description = Volume de neige des dernières heure / trois dernières heures.
 
 channel-type.openweathermap.forecasted-snow.label = Neige Prévue
 channel-type.openweathermap.forecasted-snow.description = Volume de neige prévu.

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
@@ -268,7 +268,7 @@
 	<channel-type id="rain">
 		<item-type>Number:Length</item-type>
 		<label>Rain</label>
-		<description>Rain volume for the last 3 hours.</description>
+		<description>Rain volume for the last one/three hour(s).</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -284,7 +284,7 @@
 	<channel-type id="snow">
 		<item-type>Number:Length</item-type>
 		<label>Snow</label>
-		<description>Snow volume for the last 3 hours.</description>
+		<description>Snow volume for the last one/three hour(s).</description>
 		<category>Snow</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>

--- a/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
+++ b/addons/binding/org.openhab.binding.openweathermap/ESH-INF/thing/channel-types.xml
@@ -268,7 +268,7 @@
 	<channel-type id="rain">
 		<item-type>Number:Length</item-type>
 		<label>Rain</label>
-		<description>Rain volume for the last one/three hour(s).</description>
+		<description>Rain volume of the last hour.</description>
 		<category>Rain</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>
@@ -284,7 +284,7 @@
 	<channel-type id="snow">
 		<item-type>Number:Length</item-type>
 		<label>Snow</label>
-		<description>Snow volume for the last one/three hour(s).</description>
+		<description>Snow volume of the last hour.</description>
 		<category>Snow</category>
 		<state readOnly="true" pattern="%.2f %unit%" />
 	</channel-type>

--- a/addons/binding/org.openhab.binding.openweathermap/README.md
+++ b/addons/binding/org.openhab.binding.openweathermap/README.md
@@ -93,8 +93,12 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 | current          | wind-direction | Number:Angle         | Current wind direction.                                                 |
 | current          | gust-speed     | Number:Speed         | Current gust speed. **Advanced**                                        |
 | current          | cloudiness     | Number:Dimensionless | Current cloudiness.                                                     |
-| current          | rain           | Number:Length        | Rain volume for the last three hours.                                   |
-| current          | snow           | Number:Length        | Snow volume for the last three hours.                                   |
+| current          | rain           | Number:Length        | Rain volume for the last one/three hour(s).                             |
+| current          | snow           | Number:Length        | Snow volume for the last one/three hour(s).                             |
+
+**Attention**: Rain item is showing "1h" in the case when data are received from weather stations directly.
+The fact is that some METAR stations do not have precipitation indicators or do not measure precipitation conditions due to some other technical reasons.
+In this case, we use model data. So, rain item is showing "3h" when our system returns an API response based on model data.
 
 ### 3 Hour Forecast
 

--- a/addons/binding/org.openhab.binding.openweathermap/README.md
+++ b/addons/binding/org.openhab.binding.openweathermap/README.md
@@ -93,12 +93,14 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 | current          | wind-direction | Number:Angle         | Current wind direction.                                                 |
 | current          | gust-speed     | Number:Speed         | Current gust speed. **Advanced**                                        |
 | current          | cloudiness     | Number:Dimensionless | Current cloudiness.                                                     |
-| current          | rain           | Number:Length        | Rain volume for the last one/three hour(s).                             |
-| current          | snow           | Number:Length        | Snow volume for the last one/three hour(s).                             |
+| current          | rain           | Number:Length        | Rain volume of the last hour.                                           |
+| current          | snow           | Number:Length        | Snow volume of the last hour.                                           |
 
 **Attention**: Rain item is showing "1h" in the case when data are received from weather stations directly.
 The fact is that some METAR stations do not have precipitation indicators or do not measure precipitation conditions due to some other technical reasons.
-In this case, we use model data. So, rain item is showing "3h" when our system returns an API response based on model data.
+In this case, we use model data.
+So, rain item is showing "3h" when the API response based on model data.
+The "3h" value will be divided by three to always have an estimated value for one hour.
 
 ### 3 Hour Forecast
 

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
@@ -88,8 +88,7 @@ public class OpenWeatherMapConnection {
     private final OpenWeatherMapAPIHandler handler;
     private final HttpClient httpClient;
 
-    private static final ByteArrayFileCache IMAGE_CACHE = new ByteArrayFileCache(
-            "org.eclipse.smarthome.binding.openweathermap");
+    private static final ByteArrayFileCache IMAGE_CACHE = new ByteArrayFileCache("org.openhab.binding.openweathermap");
     private final ExpiringCacheMap<String, String> cache;
 
     private final JsonParser parser = new JsonParser();

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -283,15 +283,11 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getQuantityTypeState(weatherData.getClouds().getAll(), PERCENT);
                     break;
                 case CHANNEL_RAIN:
-                    state = getQuantityTypeState(
-                            weatherData.getRain() == null || weatherData.getRain().getVolume() == null ? 0
-                                    : weatherData.getRain().getVolume(),
+                    state = getQuantityTypeState(weatherData.getRain() == null ? 0 : weatherData.getRain().getVolume(),
                             MILLI(METRE));
                     break;
                 case CHANNEL_SNOW:
-                    state = getQuantityTypeState(
-                            weatherData.getSnow() == null || weatherData.getSnow().getVolume() == null ? 0
-                                    : weatherData.getSnow().getVolume(),
+                    state = getQuantityTypeState(weatherData.getSnow() == null ? 0 : weatherData.getSnow().getVolume(),
                             MILLI(METRE));
                     break;
             }
@@ -361,15 +357,11 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     break;
                 case CHANNEL_RAIN:
                     state = getQuantityTypeState(
-                            forecastData.getRain() == null || forecastData.getRain().getVolume() == null ? 0
-                                    : forecastData.getRain().getVolume(),
-                            MILLI(METRE));
+                            forecastData.getRain() == null ? 0 : forecastData.getRain().getVolume(), MILLI(METRE));
                     break;
                 case CHANNEL_SNOW:
                     state = getQuantityTypeState(
-                            forecastData.getSnow() == null || forecastData.getSnow().getVolume() == null ? 0
-                                    : forecastData.getSnow().getVolume(),
-                            MILLI(METRE));
+                            forecastData.getSnow() == null ? 0 : forecastData.getSnow().getVolume(), MILLI(METRE));
                     break;
             }
             logger.debug("Update channel '{}' of group '{}' with new state '{}'.", channelId, channelGroupId, state);

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -14,6 +14,7 @@ package org.openhab.binding.openweathermap.internal.handler;
 
 import static org.eclipse.smarthome.core.library.unit.MetricPrefix.*;
 import static org.eclipse.smarthome.core.library.unit.SIUnits.*;
+import static org.eclipse.smarthome.core.library.unit.SmartHomeUnits.*;
 import static org.openhab.binding.openweathermap.internal.OpenWeatherMapBindingConstants.*;
 
 import java.util.ArrayList;
@@ -26,7 +27,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -268,30 +268,30 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getQuantityTypeState(weatherData.getMain().getPressure(), HECTO(PASCAL));
                     break;
                 case CHANNEL_HUMIDITY:
-                    state = getQuantityTypeState(weatherData.getMain().getHumidity(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(weatherData.getMain().getHumidity(), PERCENT);
                     break;
                 case CHANNEL_WIND_SPEED:
-                    state = getQuantityTypeState(weatherData.getWind().getSpeed(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(weatherData.getWind().getSpeed(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_WIND_DIRECTION:
-                    state = getQuantityTypeState(weatherData.getWind().getDeg(), SmartHomeUnits.DEGREE_ANGLE);
+                    state = getQuantityTypeState(weatherData.getWind().getDeg(), DEGREE_ANGLE);
                     break;
                 case CHANNEL_GUST_SPEED:
-                    state = getQuantityTypeState(weatherData.getWind().getGust(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(weatherData.getWind().getGust(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_CLOUDINESS:
-                    state = getQuantityTypeState(weatherData.getClouds().getAll(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(weatherData.getClouds().getAll(), PERCENT);
                     break;
                 case CHANNEL_RAIN:
                     state = getQuantityTypeState(
-                            weatherData.getRain() == null || weatherData.getRain().get3h() == null ? 0
-                                    : weatherData.getRain().get3h(),
+                            weatherData.getRain() == null || weatherData.getRain().getVolume() == null ? 0
+                                    : weatherData.getRain().getVolume(),
                             MILLI(METRE));
                     break;
                 case CHANNEL_SNOW:
                     state = getQuantityTypeState(
-                            weatherData.getSnow() == null || weatherData.getSnow().get3h() == null ? 0
-                                    : weatherData.getSnow().get3h(),
+                            weatherData.getSnow() == null || weatherData.getSnow().getVolume() == null ? 0
+                                    : weatherData.getSnow().getVolume(),
                             MILLI(METRE));
                     break;
             }
@@ -345,30 +345,30 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getQuantityTypeState(forecastData.getMain().getPressure(), HECTO(PASCAL));
                     break;
                 case CHANNEL_HUMIDITY:
-                    state = getQuantityTypeState(forecastData.getMain().getHumidity(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(forecastData.getMain().getHumidity(), PERCENT);
                     break;
                 case CHANNEL_WIND_SPEED:
-                    state = getQuantityTypeState(forecastData.getWind().getSpeed(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(forecastData.getWind().getSpeed(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_WIND_DIRECTION:
-                    state = getQuantityTypeState(forecastData.getWind().getDeg(), SmartHomeUnits.DEGREE_ANGLE);
+                    state = getQuantityTypeState(forecastData.getWind().getDeg(), DEGREE_ANGLE);
                     break;
                 case CHANNEL_GUST_SPEED:
-                    state = getQuantityTypeState(forecastData.getWind().getGust(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(forecastData.getWind().getGust(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_CLOUDINESS:
-                    state = getQuantityTypeState(forecastData.getClouds().getAll(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(forecastData.getClouds().getAll(), PERCENT);
                     break;
                 case CHANNEL_RAIN:
                     state = getQuantityTypeState(
-                            forecastData.getRain() == null || forecastData.getRain().get3h() == null ? 0
-                                    : forecastData.getRain().get3h(),
+                            forecastData.getRain() == null || forecastData.getRain().getVolume() == null ? 0
+                                    : forecastData.getRain().getVolume(),
                             MILLI(METRE));
                     break;
                 case CHANNEL_SNOW:
                     state = getQuantityTypeState(
-                            forecastData.getSnow() == null || forecastData.getSnow().get3h() == null ? 0
-                                    : forecastData.getSnow().get3h(),
+                            forecastData.getSnow() == null || forecastData.getSnow().getVolume() == null ? 0
+                                    : forecastData.getSnow().getVolume(),
                             MILLI(METRE));
                     break;
             }
@@ -419,19 +419,19 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getQuantityTypeState(forecastData.getPressure(), HECTO(PASCAL));
                     break;
                 case CHANNEL_HUMIDITY:
-                    state = getQuantityTypeState(forecastData.getHumidity(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(forecastData.getHumidity(), PERCENT);
                     break;
                 case CHANNEL_WIND_SPEED:
-                    state = getQuantityTypeState(forecastData.getSpeed(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(forecastData.getSpeed(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_WIND_DIRECTION:
-                    state = getQuantityTypeState(forecastData.getDeg(), SmartHomeUnits.DEGREE_ANGLE);
+                    state = getQuantityTypeState(forecastData.getDeg(), DEGREE_ANGLE);
                     break;
                 case CHANNEL_GUST_SPEED:
-                    state = getQuantityTypeState(forecastData.getGust(), SmartHomeUnits.METRE_PER_SECOND);
+                    state = getQuantityTypeState(forecastData.getGust(), METRE_PER_SECOND);
                     break;
                 case CHANNEL_CLOUDINESS:
-                    state = getQuantityTypeState(forecastData.getClouds(), SmartHomeUnits.PERCENT);
+                    state = getQuantityTypeState(forecastData.getClouds(), PERCENT);
                     break;
                 case CHANNEL_RAIN:
                     state = getQuantityTypeState(forecastData.getRain() == null ? 0 : forecastData.getRain(),

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Rain.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Rain.java
@@ -22,8 +22,18 @@ import com.google.gson.annotations.SerializedName;
  * @author Christoph Weitkamp - Initial contribution
  */
 public class Rain {
+    @SerializedName("1h")
+    private @Nullable Double oneHour;
     @SerializedName("3h")
     private @Nullable Double threeHours;
+
+    public @Nullable Double get1h() {
+        return oneHour;
+    }
+
+    public void set1h(Double oneHour) {
+        this.oneHour = oneHour;
+    }
 
     public @Nullable Double get3h() {
         return threeHours;
@@ -31,5 +41,9 @@ public class Rain {
 
     public void set3h(Double threeHours) {
         this.threeHours = threeHours;
+    }
+
+    public @Nullable Double getVolume() {
+        return threeHours == null ? oneHour : threeHours;
     }
 }

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Rain.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Rain.java
@@ -43,7 +43,7 @@ public class Rain {
         this.threeHours = threeHours;
     }
 
-    public @Nullable Double getVolume() {
-        return threeHours == null ? oneHour : threeHours;
+    public Double getVolume() {
+        return oneHour != null ? oneHour : threeHours != null ? threeHours / 3 : 0;
     }
 }

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Snow.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Snow.java
@@ -22,8 +22,18 @@ import com.google.gson.annotations.SerializedName;
  * @author Christoph Weitkamp - Initial contribution
  */
 public class Snow {
+    @SerializedName("1h")
+    private @Nullable Double oneHour;
     @SerializedName("3h")
     private @Nullable Double threeHours;
+
+    public @Nullable Double get1h() {
+        return oneHour;
+    }
+
+    public void set1h(Double oneHour) {
+        this.oneHour = oneHour;
+    }
 
     public @Nullable Double get3h() {
         return threeHours;
@@ -31,5 +41,9 @@ public class Snow {
 
     public void set3h(Double threeHours) {
         this.threeHours = threeHours;
+    }
+
+    public @Nullable Double getVolume() {
+        return threeHours == null ? oneHour : threeHours;
     }
 }

--- a/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Snow.java
+++ b/addons/binding/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/model/base/Snow.java
@@ -43,7 +43,7 @@ public class Snow {
         this.threeHours = threeHours;
     }
 
-    public @Nullable Double getVolume() {
-        return threeHours == null ? oneHour : threeHours;
+    public Double getVolume() {
+        return oneHour != null ? oneHour : threeHours != null ? threeHours / 3 : 0;
     }
 }


### PR DESCRIPTION
- Renamed cache folder
- Prioritize '1h' and divide '3h' by three to always have an estimated value for one hour

Closes #5058

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>