### PR TITLE
Use one reactor for bnd and tycho builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,12 @@ jdk: oraclejdk8
 before_install: echo "MAVEN_OPTS='-Xms1g -Xmx2g -XX:PermSize=512m -XX:MaxPermSize=1g'" > ~/.mavenrc
 
 install:
-  - echo 'set -e' > .build.sh
-  - echo 'cd poms/tycho; mvn clean install -B -DskipChecks=true -DskipTests=true -V 1> .build.stdout 2> .build.stderr; cd ../..' >> .build.sh
-  - echo 'cd poms/bnd; mvn clean install -B -DskipChecks=true -DskipTests=true -V 1> .build.stdout 2> .build.stderr; cd ../..' >> .build.sh
+  - echo 'mvn clean install -B -DskipChecks=true -DskipTests=true -V 1> .build.stdout 2> .build.stderr' > .build.sh
   - chmod 0755 .build.sh
 script:
   - travis_wait 60 ./.build.sh
 after_success:
-  - tail -n  200 poms/tycho/.build.stdout
-  - tail -n  200 poms/bnd/.build.stdout
+  - tail -n  200 .build.stdout
 after_failure:
-  - tail -n  300 poms/tycho/.build.stderr
-  - tail -n 2000 poms/tycho/.build.stdout
-  - tail -n  300 poms/bnd/.build.stderr
-  - tail -n 2000 poms/bnd/.build.stdout
+  - tail -n  300 .build.stderr
+  - tail -n 2000 .build.stdout

--- a/pom.xml
+++ b/pom.xml
@@ -7,36 +7,18 @@
   <packaging>pom</packaging>
   <name>openHAB 2 Add-ons</name>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.3</version>
-        <executions>
-          <execution>
-            <id>entering-module</id>
-            <phase>validate</phase>
-            <configuration>
-              <tasks>
-                <echo>Hello!</echo>
-                <echo>We are in the process to change the headless build system.</echo>
-                <echo>In the transition phase (while not all bundles has been migrated)</echo>
-                <echo>you need to trigger the separate builds yourself.</echo>
-                <echo>The non migrated stuff is part of "poms/tycho".</echo>
-                <echo>the non migrated stuff is part of "poms/bnd".</echo>
-                <echo>Execute something similar to:</echo>
-                <echo>cd poms/tycho; mvn clean install; cd ../..</echo>
-                <echo>cd poms/bnd; mvn clean install; cd ../..</echo>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+  <!--
+    Hello!
+    We are in the process to change the headless build system.
+
+    In the transition phase (while not all bundles have been migrated):
+     * the non-migrated bundles are part of "poms/tycho"
+     * the migrated bundles are part of "poms/bnd"
+  -->
+
+  <modules>
+    <module>poms/tycho</module>
+    <module>poms/bnd</module>
+  </modules>
 
 </project>

--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -146,8 +146,8 @@
           <artifactId>sat-plugin</artifactId>
           <version>{sat.version}</version>
           <configuration>
-            <checkstyleProperties>${basedirRoot}/../tools/checkstyle.properties</checkstyleProperties>
-            <checkstyleFilter>${basedirRoot}/../tools/checkstyle_suppressions.xml</checkstyleFilter>
+            <checkstyleProperties>${basedirRoot}/tools/checkstyle.properties</checkstyleProperties>
+            <checkstyleFilter>${basedirRoot}/tools/checkstyle_suppressions.xml</checkstyleFilter>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
It currently doesn't seem to be an issue to use both bnd and tycho in the same reactor. So if this also works with Jenkins this would be a good simplification.

See https://github.com/openhab/openhab2-addons/pull/5018#issuecomment-471173379