### PR TITLE
Travis configuration improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,54 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 language: java
-jdk: oraclejdk8
-before_install: echo "MAVEN_OPTS='-Xms1g -Xmx2g -XX:PermSize=512m -XX:MaxPermSize=1g'" > ~/.mavenrc
 
+jdk:
+  - openjdk8
+  - openjdk11
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.p2
+
+before_install:
+  - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc
 install:
-  - echo 'mvn clean install -B -DskipChecks=true -DskipTests=true -V 1> .build.stdout 2> .build.stderr' > .build.sh
-  - chmod 0755 .build.sh
-script:
-  - travis_wait 60 ./.build.sh
+  - |
+    function extra_maven_opts() {
+        if [ "$TRAVIS_JDK_VERSION" != "openjdk8" ]; then echo "-Denforcer.skip=true"; fi;
+    }
+    function prevent_timeout() {
+        local i=0
+        while [ -e /proc/$1 ]; do
+            # print zero width char every 3 minutes while building
+            if [ "$i" -eq "180" ]; then printf %b '\u200b'; i=0; else i=$((i+1)); fi
+            sleep 1
+        done
+    }
+    function print_reactor_summary() {
+        sed -ne '/\[INFO\] Reactor Summary:/,$ p' "$1" | sed 's/\[INFO\] //'
+    }
+    function mvnp() {
+        set -o pipefail # exit build with error when pipes fail
+        local command=(mvn $@)
+        exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
+            tee .build.log | # write output to log
+            stdbuf -oL grep -E '^\[INFO\] Building .+ \[.+\]$' | # filter progress
+            sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
+            sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
+        local pid=$!
+        prevent_timeout $pid &
+        wait $pid
+    }
 after_success:
-  - tail -n  200 .build.stdout
+  - print_reactor_summary .build.log
 after_failure:
-  - tail -n  300 .build.stderr
-  - tail -n 2000 .build.stdout
+  - tail -n 2000 .build.log
+env: # required for allowing failures
+matrix:
+  allow_failures:
+    - jdk: openjdk11
+script:
+  - mvnp clean install -B -DskipChecks=true -DskipTests=true $(extra_maven_opts)


### PR DESCRIPTION
Similar to https://github.com/openhab/openhab-core/pull/643, I've also improved the openhab2-addons Travis configuration.

---

This PR makes it possible again to follow progress of a Travis build while it's running. While building it shows the reactor progress information while making sure the build doesn't timeout by appending zero width characters every 3 minutes.

While I was at it I've made some other configuration improvements as well:

* Uses the new Xenial Travis images which easily allows for running Java 11 builds
* Builds using OpenJDK 8 instead of Oracle JDK 8. Oracle JDK 8 is no longer available in the Xenial images. I've done a lot of builds already with it and it works equally well.
* Adds a new OpenJDK 11 build which is allowed to fail. This makes it easy to see what needs to be done for successfully compiling the code with Java 11. It disables the enforcer for the Java 11 build.
* On successful builds only the reactor summary is printed (instead of the most recent 200 lines)
* Removes JVM options that are no longer supported in Java 8 and which result in warnings:
  `-XX:PermSize=512m -XX:MaxPermSize=1g`

The build times remain the same with this configuration.