### PR TITLE
allow to disable openHAB snapshot repository

### DIFF
--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -87,20 +87,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-
-    <!-- snapshots -->
-    <repository>
-      <id>openhab-artifactory-snapshot</id>
-      <name>JFrog Artifactory Repository</name>
-      <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -586,6 +572,28 @@ Import-Package: \\
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>openhab-snapshot-repository</id>
+      <activation>
+        <property>
+          <name>!noOhSnapRepo</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>openhab-artifactory-snapshot</id>
+          <name>JFrog Artifactory Repository</name>
+          <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
     </profile>
   </profiles>
 

--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -88,20 +88,6 @@
       <url>https://openhab.jfrog.io/openhab/libs-release</url>
     </repository>
 
-    <!-- snapshots -->
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <id>openhab-artifactory-snapshot</id>
-      <name>JFrog Artifactory Repository</name>
-      <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
-    </repository>
-
     <!-- openHAB dependencies p2 repository -->
     <repository>
       <id>p2-openhab-deps-repo</id>
@@ -159,5 +145,30 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>openhab-snapshot-repository</id>
+      <activation>
+        <property>
+          <name>!noOhSnapRepo</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>openhab-artifactory-snapshot</id>
+          <name>JFrog Artifactory Repository</name>
+          <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
The addons injects the openHAB snapshot repository with a update policy set to always. This slows done the build as all the time every snapshot dependency is checked using external repository look up.

Repositories are also transitive, so every other reactor that includes an addon is affected.

This change does not affect the normal behavior but it allows to disable the snapshot repository usage by defining the "noOhSnapRepo" property on build time.