### PR TITLE
[dwdunwetter] Fix build.plugins.plugin.version is missing warning

### DIFF
--- a/addons/binding/org.openhab.binding.dwdunwetter.test/pom.xml
+++ b/addons/binding/org.openhab.binding.dwdunwetter.test/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>pom</artifactId>
     <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
           <dependency-resolution>
@@ -53,7 +53,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
           <dependencies>


### PR DESCRIPTION
Fixes the following warning when building with Maven:

```
[WARNING] Some problems were encountered while building the effective model for org.openhab.binding:org.openhab.binding.dwdunwetter.test:eclipse-test-plugin:2.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:target-platform-configuration is missing. @ org.openhab.binding:org.openhab.binding.dwdunwetter.test:[unknown-version], /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.dwdunwetter.test/pom.xml, line 20, column 15
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:tycho-surefire-plugin is missing. @ org.openhab.binding:org.openhab.binding.dwdunwetter.test:[unknown-version], /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.dwdunwetter.test/pom.xml, line 55, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```