### PR TITLE
Fix running SAT in non-root dir

### DIFF
--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -142,12 +142,33 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.commonjava.maven.plugins</groupId>
+          <artifactId>directory-maven-plugin</artifactId>
+          <version>0.3.1</version>
+          <executions>
+            <execution>
+              <id>tycho-dir</id>
+              <goals>
+                <goal>directory-of</goal>
+              </goals>
+              <phase>initialize</phase>
+              <configuration>
+                <property>tychodirRoot</property>
+                <project>
+                  <groupId>org.openhab</groupId>
+                  <artifactId>pom-addons2</artifactId>
+                </project>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.openhab.tools.sat</groupId>
           <artifactId>sat-plugin</artifactId>
           <version>{sat.version}</version>
           <configuration>
-            <checkstyleProperties>${basedirRoot}/tools/checkstyle.properties</checkstyleProperties>
-            <checkstyleFilter>${basedirRoot}/tools/checkstyle_suppressions.xml</checkstyleFilter>
+            <checkstyleProperties>${tychodirRoot}/../../tools/checkstyle.properties</checkstyleProperties>
+            <checkstyleFilter>${tychodirRoot}/../../tools/checkstyle_suppressions.xml</checkstyleFilter>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
With this configuration change it seems possible to use SAT when building at root level as well as  individual project level. See comments in https://github.com/openhab/openhab2-addons/pull/5072.