### PR TITLE
[mqtt] change the 1st rule for synchronizing instances

### DIFF
--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -327,7 +327,7 @@ rule "Receive all"
 when 
       Channel "mqtt:broker:myUnsecureBroker:myTriggerChannel" triggered
 then 
-    //The receivedEvent String contains elements we dont need, we only need everything after the "/" as this is were Item name and state are, this part is written to val parts2
+    //The receivedEvent String contains unneeded elements like the mqtt topic, we only need everything after the "/" as this is were Item name and state are
     val parts1 = receivedEvent.toString.split("/").get(1)
     val parts2 = parts1.split("#")
     sendCommand(parts2.get(0), parts2.get(1))

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -325,7 +325,7 @@ Now push those changes to your items in a `rules` file:
 ```xtend
 rule "Receive all"
 when 
-      Channel "mqtt:broker:MQTTBroker:myTriggerChannel" triggered
+      Channel "mqtt:broker:myUnsecureBroker:myTriggerChannel" triggered
 then 
     val parts1 = receivedEvent.toString.split("/").get(1)
     val parts2 = parts1.split("#")

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -323,12 +323,13 @@ The trigger channel will trigger for each received message on the MQTT topic "al
 Now push those changes to your items in a `rules` file:
 
 ```xtend
-rule "Publish all"
+rule "Receive all"
 when 
-      Channel "mqtt:broker:myUnsecureBroker:myTriggerChannel" triggered
-then
-    val parts = receivedEvent.split("#")
-    sendCommand(parts.get(0), parts.get(1))
+      Channel "mqtt:broker:MQTTBroker:myTriggerChannel" triggered
+then 
+    val parts1 = receivedEvent.toString.split("/").get(1)
+    val parts2 = parts1.split("#")
+    sendCommand(parts2.get(0), parts2.get(1))
 end
 ```
 

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -327,7 +327,7 @@ rule "Receive all"
 when 
       Channel "mqtt:broker:myUnsecureBroker:myTriggerChannel" triggered
 then 
-    //The receivedEvent String contains unneeded elements like the mqtt topic, we only need everything after the "/" as this is were Item name and state are
+    //The receivedEvent String contains unneeded elements like the mqtt topic, we only need everything after the "/" as this is were item name and state are
     val parts1 = receivedEvent.toString.split("/").get(1)
     val parts2 = parts1.split("#")
     sendCommand(parts2.get(0), parts2.get(1))

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -327,6 +327,7 @@ rule "Receive all"
 when 
       Channel "mqtt:broker:myUnsecureBroker:myTriggerChannel" triggered
 then 
+    //The receivedEvent String contains elements we dont need, we only need everything after the "/" as this is were Item name and state are, this part is written to val parts2
     val parts1 = receivedEvent.toString.split("/").get(1)
     val parts2 = parts1.split("#")
     sendCommand(parts2.get(0), parts2.get(1))


### PR DESCRIPTION
The original rule doesn't work as it includes part in the string that don't belong to the item name giving this error
```
2019-03-17 19:22:13.017 [vent.ChannelTriggeredEvent] - mqtt:broker:MQTTBroker:myTriggerChannel triggered allItems/LichterketteFenster#ON

==> /var/log/openhab2/openhab.log <==

2019-03-17 19:22:13.068 [WARN ] [rthome.model.script.actions.BusEvent] - Item 'mqtt:broker:MQTTBroker:myTriggerChannel triggered allItems/LichterketteFenster' does not exist.
```
So I propose too split the string twice and change rule name to "Receive all".

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
