### PR TITLE
[daikin] Fix exceptions due to not checking the type of commands

### DIFF
--- a/addons/binding/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/addons/binding/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -77,21 +77,34 @@ public class DaikinAcUnitHandler extends BaseThingHandler {
     private void handleCommandInternal(ChannelUID channelUID, Command command) throws DaikinCommunicationException {
         switch (channelUID.getId()) {
             case DaikinBindingConstants.CHANNEL_AC_POWER:
-                changePower(((OnOffType) command).equals(OnOffType.ON));
-                return;
+                if (command instanceof OnOffType) {
+                    changePower(((OnOffType) command).equals(OnOffType.ON));
+                    return;
+                }
+                break;
             case DaikinBindingConstants.CHANNEL_AC_TEMP:
                 if (changeSetPoint(command)) {
                     return;
                 }
+                break;
             case DaikinBindingConstants.CHANNEL_AC_FAN_SPEED:
-                changeFanSpeed(FanSpeed.valueOf(((StringType) command).toString()));
-                return;
+                if (command instanceof StringType) {
+                    changeFanSpeed(FanSpeed.valueOf(((StringType) command).toString()));
+                    return;
+                }
+                break;
             case DaikinBindingConstants.CHANNEL_AC_FAN_DIR:
-                changeFanDir(FanMovement.valueOf(((StringType) command).toString()));
-                return;
+                if (command instanceof StringType) {
+                    changeFanDir(FanMovement.valueOf(((StringType) command).toString()));
+                    return;
+                }
+                break;
             case DaikinBindingConstants.CHANNEL_AC_MODE:
-                changeMode(Mode.valueOf(((StringType) command).toString()));
-                return;
+                if (command instanceof StringType) {
+                    changeMode(Mode.valueOf(((StringType) command).toString()));
+                    return;
+                }
+                break;
         }
 
         logger.warn("Received command of wrong type for thing '{}' on channel {}", thing.getUID().getAsString(),


### PR DESCRIPTION
[Daikin] Fix exceptions due to not checking the type of commands

Add type checking on the commands received in the Daikin addon to eliminate exceptions due to bad type conversions. This fixes an issue brought up in the end of https://github.com/openhab/openhab2-addons/pull/3044.

Signed-off-by: Tim Waterhouse <tim@timwaterhouse.com>