### PR TITLE
[daikin] Fix rounding for set point temperature

### DIFF
--- a/addons/binding/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/addons/binding/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -203,6 +203,9 @@ public class DaikinAcUnitHandler extends BaseThingHandler {
             return false;
         }
 
+        // Only half degree increments are allowed, all others are silently rejected by the A/C units
+        newTemperature = Math.round(newTemperature * 2) / 2.0;
+
         ControlInfo info = webTargets.getControlInfo();
         info.temp = Optional.of(newTemperature);
         webTargets.setControlInfo(info);


### PR DESCRIPTION
[daikin] Fix rounding for set point temperature

The Daikin systems reject any temperatures which are not whole or half degrees in Celcius. When the code was switched to UoM the rounding logic that ensured the numbers were valid was lost. The Daikin system simply silently ignores any unexpected values so no errors are shown, the temperature just won't be changed. This is exceptionally pronounced on Fahrenheit since degrees Fahrenheit pretty much never result in a whole or half degree when converted to Celsius.

Signed-off-by: Tim Waterhouse <tim@timwaterhouse.com>
