### PR TITLE
[mqtt] Have a working Group Id

### DIFF
--- a/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponentsTests.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponentsTests.java
@@ -74,8 +74,9 @@ public class DiscoverComponentsTests extends JavaOSGiTest {
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing,
                 scheduler, null, gson, transformationServiceProvider));
 
-        discover.startDiscovery(connection, 50, new HaID("homeassistant", "object", "node", "component"), discovered)
-                .get(100, TimeUnit.MILLISECONDS);
+        HandlerConfiguration config = new HandlerConfiguration("homeassistant", "object");
+
+        discover.startDiscovery(connection, 50, HaID.fromConfig(config), discovered).get(100, TimeUnit.MILLISECONDS);
 
     }
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaIDTests.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaIDTests.java
@@ -24,9 +24,9 @@ public class HaIDTests {
     public void testWithoutNode() {
         HaID subject = new HaID("homeassistant/switch/name/config");
 
-        assertThat(subject.getObjectID(), is("name"));
+        assertThat(subject.objectID, is("name"));
 
-        assertThat(subject.getComponent(), is("switch"));
+        assertThat(subject.component, is("switch"));
         assertThat(subject.getTopic("suffix"), is("homeassistant/switch/name/suffix"));
 
         Configuration config = new Configuration();
@@ -46,9 +46,9 @@ public class HaIDTests {
     public void testWithNode() {
         HaID subject = new HaID("homeassistant/switch/node/name/config");
 
-        assertThat(subject.getObjectID(), is("name"));
+        assertThat(subject.objectID, is("name"));
 
-        assertThat(subject.getComponent(), is("switch"));
+        assertThat(subject.component, is("switch"));
         assertThat(subject.getTopic("suffix"), is("homeassistant/switch/node/name/suffix"));
 
         Configuration config = new Configuration();

--- a/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaIDTests.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic.test/src/test/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaIDTests.java
@@ -15,9 +15,8 @@ package org.openhab.binding.mqtt.generic.internal.convention.homeassistant;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.junit.Test;
-import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.HaID;
 
 public class HaIDTests {
 
@@ -25,20 +24,44 @@ public class HaIDTests {
     public void testWithoutNode() {
         HaID subject = new HaID("homeassistant/switch/name/config");
 
-        assertThat(subject.getThingID(), is("name"));
-        assertThat(subject.getChannelGroupTypeID(), is("name_switch"));
-        assertThat(subject.getChannelTypeID("channel"), is(new ChannelTypeUID("mqtt:name_switch_channel")));
-        assertThat(subject.getChannelGroupID(), is("switch_"));
+        assertThat(subject.getObjectID(), is("name"));
+
+        assertThat(subject.getComponent(), is("switch"));
+        assertThat(subject.getTopic("suffix"), is("homeassistant/switch/name/suffix"));
+
+        Configuration config = new Configuration();
+        subject.toConfig(config);
+
+        HaID restore = HaID.fromConfig("homeassistant", config);
+
+        assertThat(restore, is(subject));
+
+        HandlerConfiguration haConfig = subject.toHandlerConfiguration();
+
+        restore = HaID.fromConfig(haConfig);
+        assertThat(restore, is(new HaID("homeassistant/+/name/config")));
     }
 
     @Test
     public void testWithNode() {
         HaID subject = new HaID("homeassistant/switch/node/name/config");
 
-        assertThat(subject.getThingID(), is("name"));
-        assertThat(subject.getChannelGroupTypeID(), is("name_switchnode"));
-        assertThat(subject.getChannelTypeID("channel"), is(new ChannelTypeUID("mqtt:name_switchnode_channel")));
-        assertThat(subject.getChannelGroupID(), is("switch_node"));
+        assertThat(subject.getObjectID(), is("name"));
+
+        assertThat(subject.getComponent(), is("switch"));
+        assertThat(subject.getTopic("suffix"), is("homeassistant/switch/node/name/suffix"));
+
+        Configuration config = new Configuration();
+        subject.toConfig(config);
+
+        HaID restore = HaID.fromConfig("homeassistant", config);
+
+        assertThat(restore, is(subject));
+
+        HandlerConfiguration haConfig = subject.toHandlerConfiguration();
+
+        restore = HaID.fromConfig(haConfig);
+        assertThat(restore, is(new HaID("homeassistant/+/node/name/config")));
     }
 
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic/ESH-INF/config/homeassistant-channel-config.xml
+++ b/addons/binding/org.openhab.binding.mqtt.generic/ESH-INF/config/homeassistant-channel-config.xml
@@ -5,7 +5,22 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="mqtt:ha_channel">
-		<parameter name="config" type="text">
+		<parameter name="component" type="text" readOnly="true" required="true">
+			<label>Component</label>
+			<description>Type of the channel group.</description>
+			<default></default>
+		</parameter>
+		<parameter name="nodeid" type="text" readOnly="true">
+			<label>Node ID</label>
+			<description>Optional node name of the component</description>
+			<default></default>
+		</parameter>
+		<parameter name="objectid" type="text" readOnly="true" required="true">
+			<label>Object ID</label>
+			<description>Object id of the component</description>
+			<default></default>
+		</parameter>
+		<parameter name="config" type="text" readOnly="true" required="true">
 			<label>Json Configuration</label>
 			<description>The json configuration string received by the component via MQTT.</description>
 			<default></default>

--- a/addons/binding/org.openhab.binding.mqtt.generic/README.md
+++ b/addons/binding/org.openhab.binding.mqtt.generic/README.md
@@ -23,6 +23,7 @@ Find the next table to understand the topology mapping from Homie to the Framewo
 | Property | Channel       | homie/super-car/engine/temperature |
 
 System trigger channels are supported using non-retained properties, with *enum* data type and with the following formats:
+
 * Format: "PRESSED,RELEASED" -> system.rawbutton
 * Format: "SHORT\_PRESSED,DOUBLE\_PRESSED,LONG\_PRESSED" -> system.button
 * Format: "DIR1\_PRESSED,DIR1\_RELEASED,DIR2\_PRESSED,DIR2\_RELEASED" -> system.rawrocker
@@ -124,6 +125,7 @@ You can connect this channel to a Contact or Switch item.
 * __on__: An optional string (like "BRIGHT") that is recognized as on state. (ON will always be recognized.)
 * __off__: An optional string (like "DARK") that is recognized as off state. (OFF will always be recognized.)
 * __onBrightness__: If you connect this channel to a Switch item and turn it on,
+
 color and saturation are preserved from the last state, but
 the brightness will be set to this configured initial brightness (default: 10%).
 
@@ -234,9 +236,9 @@ Here are a few examples:
 ## Troubleshooting
 
 * If you get the error "No MQTT client": Please update your installation.
-* If you use the Mosquitto broker: Please be aware that there is a relatively low setting
-  for retained messages. At some point messages will just not being delivered
-  anymore: Change the setting 
+* If you use the Mosquitto broker: Please be aware that there is a relatively low setting 
+for retained messages. At some point messages will just not being delivered anymore: 
+Change the setting 
 
 ## Examples
 

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
@@ -180,12 +180,13 @@ public class CChannel {
             ChannelTypeUID channelTypeUID;
 
             channelUID = new ChannelUID(component.channelGroupUID, channelID);
-            channelTypeUID = component.haID.getChannelTypeID(channelID);
+            channelTypeUID = new ChannelTypeUID(MqttBindingConstants.BINDING_ID,
+                    channelUID.getGroupId() + "_" + channelID);
             channelState = new ChannelState(
                     ChannelConfigBuilder.create().withRetain(retain).withStateTopic(state_topic)
                             .withCommandTopic(command_topic).build(),
                     channelUID, valueState, channelStateUpdateListener);
-
+                    
             if (StringUtils.isBlank(state_topic)) {
                 type = ChannelTypeBuilder.trigger(channelTypeUID, label)
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL)).build();
@@ -197,6 +198,8 @@ public class CChannel {
 
             Configuration configuration = new Configuration();
             configuration.put("config", component.channelConfigurationJson);
+            component.haID.toConfig(configuration);
+
             channel = ChannelBuilder.create(channelUID, channelState.getItemType()).withType(channelTypeUID)
                     .withKind(type.getKind()).withLabel(label).withConfiguration(configuration).build();
 

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
@@ -186,7 +186,7 @@ public class CChannel {
                     ChannelConfigBuilder.create().withRetain(retain).withStateTopic(state_topic)
                             .withCommandTopic(command_topic).build(),
                     channelUID, valueState, channelStateUpdateListener);
-                    
+
             if (StringUtils.isBlank(state_topic)) {
                 type = ChannelTypeBuilder.trigger(channelTypeUID, label)
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL)).build();

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
@@ -50,7 +50,7 @@ public class CFactory {
                 channelConfigurationJSON, gson).listener(updateListener)
                         .transformationProvider(transformationServiceProvider);
         try {
-            switch (haID.getComponent()) {
+            switch (haID.component) {
                 case "alarm_control_panel":
                     return new ComponentAlarmControlPanel(componentConfiguration);
                 case "binary_sensor":

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.mqtt.generic.internal.convention.homeassistant;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.internal.generic.TransformationServiceProvider;
@@ -44,13 +43,14 @@ public class CFactory {
      * @param updateListener A channel state update listener
      * @return A HA MQTT Component
      */
-    public static @Nullable AbstractComponent<?> createComponent(ThingUID thingUID, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener updateListener, Gson gson,
+    public static @Nullable AbstractComponent<?> createComponent(ThingUID thingUID, HaID haID,
+            String channelConfigurationJSON, @Nullable ChannelStateUpdateListener updateListener, Gson gson,
             TransformationServiceProvider transformationServiceProvider) {
-        ComponentConfiguration componentConfiguration = new ComponentConfiguration(thingUID, haID, configJSON, gson)
-                .listener(updateListener).transformationProvider(transformationServiceProvider);
+        ComponentConfiguration componentConfiguration = new ComponentConfiguration(thingUID, haID,
+                channelConfigurationJSON, gson).listener(updateListener)
+                        .transformationProvider(transformationServiceProvider);
         try {
-            switch (haID.component) {
+            switch (haID.getComponent()) {
                 case "alarm_control_panel":
                     return new ComponentAlarmControlPanel(componentConfiguration);
                 case "binary_sensor":
@@ -76,27 +76,6 @@ public class CFactory {
             logger.warn("Not supported", e);
         }
         return null;
-    }
-
-    /**
-     * Create a HA MQTT component by a given channel configuration.
-     *
-     * @param basetopic The MQTT base topic, usually "homeassistant"
-     * @param channel A channel with the JSON configuration embedded as configuration (key: 'config')
-     * @param updateListener A channel state update listener
-     * @return A HA MQTT Component
-     */
-    public static @Nullable AbstractComponent<?> createComponent(String basetopic, Channel channel,
-            @Nullable ChannelStateUpdateListener updateListener, Gson gson,
-            TransformationServiceProvider transformationServiceProvider) {
-        HaID haID = new HaID(basetopic, channel.getUID());
-        ThingUID thingUID = channel.getUID().getThingUID();
-        String configJSON = (String) channel.getConfiguration().get("config");
-        if (configJSON == null) {
-            logger.warn("Provided channel does not have a 'config' configuration key!");
-            return null;
-        }
-        return createComponent(thingUID, haID, configJSON, updateListener, gson, transformationServiceProvider);
     }
 
     protected static class ComponentConfiguration {

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponents.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponents.java
@@ -51,7 +51,6 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     private WeakReference<@Nullable MqttBrokerConnection> connectionRef = new WeakReference<>(null);
     protected @NonNullByDefault({}) ComponentDiscovered discoveredListener;
     private int discoverTime;
-    private String topicWithNode = "";
     private String topic = "";
 
     /**
@@ -88,12 +87,12 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         AbstractComponent<?> component = CFactory.createComponent(thingUID, haID, config, updateListener, gson,
                 transformationServiceProvider);
         if (component != null) {
-            logger.trace("Found HomeAssistant thing {} component {}", haID.objectID, haID.component);
+            logger.trace("Found HomeAssistant thing {} component {}", haID.getObjectID(), haID.getComponent());
             if (discoveredListener != null) {
                 discoveredListener.componentDiscovered(haID, component);
             }
         } else {
-            logger.debug("Configuration of HomeAssistant thing {} invalid: {}", haID.objectID, config);
+            logger.debug("Configuration of HomeAssistant thing {} invalid: {}", haID.getObjectID(), config);
         }
     }
 
@@ -106,8 +105,10 @@ public class DiscoverComponents implements MqttMessageSubscriber {
      * </p>
      *
      * @param connection A MQTT broker connection
-     * @param discoverTime The time in milliseconds for the discovery to run. Can be 0 to disable the timeout.
-     *            You need to call {@link #stopDiscovery(MqttBrokerConnection)} at some point in that case.
+     * @param discoverTime The time in milliseconds for the discovery to run. Can be 0 to disable the
+     *            timeout.
+     *            You need to call {@link #stopDiscovery(MqttBrokerConnection)} at some
+     *            point in that case.
      * @param topicDescription Contains the object-id (=device id) and potentially a node-id as well.
      * @param componentsDiscoveredListener Listener for results
      * @return A future that completes normally after the given time in milliseconds or exceptionally on any error.
@@ -116,15 +117,13 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     public CompletableFuture<@Nullable Void> startDiscovery(MqttBrokerConnection connection, int discoverTime,
             HaID topicDescription, ComponentDiscovered componentsDiscoveredListener) {
 
-        this.topicWithNode = topicDescription.baseTopic + "/+/+/" + topicDescription.objectID + "/config";
-        this.topic = topicDescription.baseTopic + "/+/" + topicDescription.objectID + "/config";
+        this.topic = topicDescription.getTopic("config");
         this.discoverTime = discoverTime;
         this.discoveredListener = componentsDiscoveredListener;
         this.connectionRef = new WeakReference<>(connection);
 
-        // Subscribe to the wildcard topics and start receive MQTT retained topics
-        CompletableFuture.allOf(connection.subscribe(topic, this), connection.subscribe(topicWithNode, this))
-                .thenRun(this::subscribeSuccess).exceptionally(this::subscribeFail);
+        // Subscribe to the wildcard topic and start receive MQTT retained topics
+        connection.subscribe(topic, this).thenRun(this::subscribeSuccess).exceptionally(this::subscribeFail);
 
         return discoverFinishedFuture;
     }
@@ -135,7 +134,6 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         if (connection != null && discoverTime > 0) {
             this.stopDiscoveryFuture = scheduler.schedule(() -> {
                 this.stopDiscoveryFuture = null;
-                connection.unsubscribe(topicWithNode, this);
                 connection.unsubscribe(topic, this);
                 this.discoveredListener = null;
                 discoverFinishedFuture.complete(null);
@@ -155,7 +153,6 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         this.discoveredListener = null;
         final MqttBrokerConnection connection = connectionRef.get();
         if (connection != null) {
-            connection.unsubscribe(topicWithNode, this);
             connection.unsubscribe(topic, this);
             connectionRef.clear();
         }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponents.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponents.java
@@ -87,12 +87,12 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         AbstractComponent<?> component = CFactory.createComponent(thingUID, haID, config, updateListener, gson,
                 transformationServiceProvider);
         if (component != null) {
-            logger.trace("Found HomeAssistant thing {} component {}", haID.getObjectID(), haID.getComponent());
+            logger.trace("Found HomeAssistant thing {} component {}", haID.objectID, haID.component);
             if (discoveredListener != null) {
                 discoveredListener.componentDiscovered(haID, component);
             }
         } else {
-            logger.debug("Configuration of HomeAssistant thing {} invalid: {}", haID.getObjectID(), config);
+            logger.debug("Configuration of HomeAssistant thing {} invalid: {}", haID.objectID, config);
         }
     }
 

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaID.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HaID.java
@@ -35,13 +35,13 @@ public class HaID {
     public final String nodeID;
     public final String objectID;
 
-    private final String _topic;
+    private final String topic;
 
     /**
      * Creates a {@link HaID} object for a given HomeAssistant MQTT topic.
      *
      * @param mqttTopic A topic like "homeassistant/binary_sensor/garden/config" or
-     *            "homeassistant/binary_sensor/0/garden/config"
+     *     "homeassistant/binary_sensor/0/garden/config"
      */
     public HaID(String mqttTopic) {
         String[] strings = mqttTopic.split("/");
@@ -63,7 +63,7 @@ public class HaID {
             objectID = strings[2];
         }
 
-        this._topic = createTopic(this);
+        this.topic = createTopic(this);
     }
 
     public HaID() {
@@ -83,7 +83,7 @@ public class HaID {
         this.objectID = objectID;
         this.nodeID = nodeID;
         this.component = component;
-        this._topic = createTopic(this);
+        this.topic = createTopic(this);
     }
 
     private static final String createTopic(HaID id) {
@@ -202,7 +202,7 @@ public class HaID {
      * @return fallback group id
      */
     public String getTopic(String suffix) {
-        return _topic + suffix;
+        return topic + suffix;
     }
 
     @Override
@@ -245,6 +245,6 @@ public class HaID {
 
     @Override
     public String toString() {
-        return _topic;
+        return topic;
     }
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
@@ -29,13 +29,14 @@ public class HandlerConfiguration {
     /**
      * The MQTT prefix topic
      */
-    private String basetopic = "homeassistant";
+    public final String basetopic;
     /**
      * The object id. This is comparable to a Homie Device.
      */
-    private String objectid = "";
+    public final String objectid;
 
     public HandlerConfiguration() {
+        this("homeassistant", "");
     }
 
     public HandlerConfiguration(String basetopic, String objectid) {
@@ -44,16 +45,15 @@ public class HandlerConfiguration {
         this.objectid = objectid;
     }
 
-    public String getBasetopic() {
-        return basetopic;
-    }
-
-    public String getObjectid() {
-        return objectid;
-    }
-
-    public void toProperties(Map<String, Object> properties) {
+    /**
+     * Add the <code>basetopic</code> and <code>objectid</code> to teh properties.
+     *
+     * @param properties
+     * @return the modified propertiess
+     */
+    public <T extends Map<String, Object>> T appendToProperties(T properties) {
         properties.put("basetopic", basetopic);
         properties.put("objectid", objectid);
+        return properties;
     }
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
@@ -27,13 +27,15 @@ import org.openhab.binding.mqtt.generic.internal.handler.HomeAssistantThingHandl
 @NonNullByDefault
 public class HandlerConfiguration {
     /**
+     * hint: cannot be final, or <code>getConfigAs</code> will not work.
      * The MQTT prefix topic
      */
-    public final String basetopic;
+    public String basetopic;
     /**
+     * hint: cannot be final, or <code>getConfigAs</code> will not work.
      * The object id. This is comparable to a Homie Device.
      */
-    public final String objectid;
+    public String objectid;
 
     public HandlerConfiguration() {
         this("homeassistant", "");

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.mqtt.generic.internal.convention.homeassistant;
 
+import java.util.Map;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.internal.handler.HomeAssistantThingHandler;
 
@@ -27,9 +29,31 @@ public class HandlerConfiguration {
     /**
      * The MQTT prefix topic
      */
-    public String basetopic = "homeassistant";
+    private String basetopic = "homeassistant";
     /**
      * The object id. This is comparable to a Homie Device.
      */
-    public String objectid = "";
+    private String objectid = "";
+
+    public HandlerConfiguration() {
+    }
+
+    public HandlerConfiguration(String basetopic, String objectid) {
+        super();
+        this.basetopic = basetopic;
+        this.objectid = objectid;
+    }
+
+    public String getBasetopic() {
+        return basetopic;
+    }
+
+    public String getObjectid() {
+        return objectid;
+    }
+
+    public void toProperties(Map<String, Object> properties) {
+        properties.put("basetopic", basetopic);
+        properties.put("objectid", objectid);
+    }
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homeassistant/HandlerConfiguration.java
@@ -48,10 +48,10 @@ public class HandlerConfiguration {
     }
 
     /**
-     * Add the <code>basetopic</code> and <code>objectid</code> to teh properties.
+     * Add the <code>basetopic</code> and <code>objectid</code> to the properties.
      *
      * @param properties
-     * @return the modified propertiess
+     * @return the modified properties
      */
     public <T extends Map<String, Object>> T appendToProperties(T properties) {
         properties.put("basetopic", basetopic);

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
@@ -31,9 +31,10 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryService;
 import org.openhab.binding.mqtt.generic.internal.MqttBindingConstants;
-import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.ChannelConfigurationTypeAdapterFactory;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.BaseChannelConfiguration;
+import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.ChannelConfigurationTypeAdapterFactory;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.HaID;
+import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.HandlerConfiguration;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -129,9 +130,9 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         // We will of course find multiple of the same unique Thing IDs, for each different component another one.
         // Therefore the components are assembled into a list and given to the DiscoveryResult label for the user to
-        // easily recognise object capabilities.
+        // easily recognize object capabilities.
         HaID topicParts = determineTopicParts(topic);
-        final String thingID = topicParts.getThingID();
+        final String thingID = topicParts.getObjectID();
         final ThingUID thingUID = new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge,
                 thingID);
 
@@ -145,22 +146,22 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         // We need to keep track of already found component topics for a specific object_id/node_id
         Set<String> components = componentsPerThingID.getOrDefault(thingID, new HashSet<>());
-        if (components.contains(topicParts.component)) {
-            logger.trace("Discovered an already known component {}", topicParts.component);
+        if (components.contains(topicParts.getComponent())) {
+            logger.trace("Discovered an already known component {}", topicParts.getComponent());
             return; // If we already know about this object component, ignore the discovered topic.
         }
-        components.add(topicParts.component);
+        components.add(topicParts.getComponent());
         componentsPerThingID.put(thingID, components);
 
         final String componentNames = components.stream().map(c -> HA_COMP_TO_NAME.getOrDefault(c, c))
                 .collect(Collectors.joining(","));
 
-        BaseChannelConfiguration config = BaseChannelConfiguration.fromString(new String(payload, StandardCharsets.UTF_8), gson);
+        BaseChannelConfiguration config = BaseChannelConfiguration
+                .fromString(new String(payload, StandardCharsets.UTF_8), gson);
 
         Map<String, Object> properties = new HashMap<>();
-        properties.put("objectid", topicParts.objectID);
-        properties.put("nodeid", topicParts.nodeID);
-        properties.put("basetopic", BASE_TOPIC);
+        HandlerConfiguration handlerConfig = topicParts.toHandlerConfiguration();
+        handlerConfig.toProperties(properties);
         config.addDeviceProperties(properties);
         // First remove an already discovered thing with the same ID
         thingRemoved(thingUID);
@@ -175,7 +176,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         if (!topic.endsWith("/config")) {
             return;
         }
-        final String thingID = determineTopicParts(topic).getThingID();
+        final String thingID = determineTopicParts(topic).getObjectID();
         componentsPerThingID.remove(thingID);
         thingRemoved(new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge, thingID));
     }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
@@ -161,7 +161,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         Map<String, Object> properties = new HashMap<>();
         HandlerConfiguration handlerConfig = topicParts.toHandlerConfiguration();
-        handlerConfig.appendToProperties(properties);
+        properties = handlerConfig.appendToProperties(properties);
         config.addDeviceProperties(properties);
         // First remove an already discovered thing with the same ID
         thingRemoved(thingUID);

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
@@ -132,7 +132,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         // Therefore the components are assembled into a list and given to the DiscoveryResult label for the user to
         // easily recognize object capabilities.
         HaID topicParts = determineTopicParts(topic);
-        final String thingID = topicParts.getObjectID();
+        final String thingID = topicParts.objectID;
         final ThingUID thingUID = new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge,
                 thingID);
 
@@ -146,11 +146,11 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         // We need to keep track of already found component topics for a specific object_id/node_id
         Set<String> components = componentsPerThingID.getOrDefault(thingID, new HashSet<>());
-        if (components.contains(topicParts.getComponent())) {
-            logger.trace("Discovered an already known component {}", topicParts.getComponent());
+        if (components.contains(topicParts.component)) {
+            logger.trace("Discovered an already known component {}", topicParts.component);
             return; // If we already know about this object component, ignore the discovered topic.
         }
-        components.add(topicParts.getComponent());
+        components.add(topicParts.component);
         componentsPerThingID.put(thingID, components);
 
         final String componentNames = components.stream().map(c -> HA_COMP_TO_NAME.getOrDefault(c, c))
@@ -161,7 +161,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         Map<String, Object> properties = new HashMap<>();
         HandlerConfiguration handlerConfig = topicParts.toHandlerConfiguration();
-        handlerConfig.toProperties(properties);
+        handlerConfig.appendToProperties(properties);
         config.addDeviceProperties(properties);
         // First remove an already discovered thing with the same ID
         thingRemoved(thingUID);
@@ -176,7 +176,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         if (!topic.endsWith("/config")) {
             return;
         }
-        final String thingID = determineTopicParts(topic).getObjectID();
+        final String thingID = determineTopicParts(topic).objectID;
         componentsPerThingID.remove(thingID);
         thingRemoved(new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge, thingID));
     }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomeAssistantThingHandler.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomeAssistantThingHandler.java
@@ -82,7 +82,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     protected HandlerConfiguration config = new HandlerConfiguration();
     private HaID discoveryHomeAssistantID = new HaID();
 
-     protected final TransformationServiceProvider transformationServiceProvider;
+    protected final TransformationServiceProvider transformationServiceProvider;
 
     /**
      * Create a new thing handler for HomeAssistant MQTT components.
@@ -110,7 +110,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     @Override
     public void initialize() {
         config = getConfigAs(HandlerConfiguration.class);
-        if (StringUtils.isEmpty(config.getObjectid())) {
+        if (StringUtils.isEmpty(config.objectid)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Device ID unknown");
             return;
         }
@@ -129,7 +129,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
                 continue;
             }
 
-            HaID haID = HaID.fromConfig(config.getBasetopic(), channel.getConfiguration());
+            HaID haID = HaID.fromConfig(config.basetopic, channel.getConfiguration());
             ThingUID thingUID = channel.getUID().getThingUID();
             String channelConfigurationJSON = (String) channel.getConfiguration().get("config");
             if (channelConfigurationJSON == null) {

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomeAssistantThingHandler.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomeAssistantThingHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -29,12 +30,13 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.AbstractComponent;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.CChannel;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.CFactory;
-import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.ChannelConfigurationTypeAdapterFactory;
+import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents.ComponentDiscovered;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.HaID;
 import org.openhab.binding.mqtt.generic.internal.convention.homeassistant.HandlerConfiguration;
@@ -78,9 +80,9 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     protected final Map<String, AbstractComponent<?>> haComponents = new HashMap<>();
 
     protected HandlerConfiguration config = new HandlerConfiguration();
-    private HaID discoveryHomeAssistantID = new HaID("", "", "", "");
+    private HaID discoveryHomeAssistantID = new HaID();
 
-    protected final TransformationServiceProvider transformationServiceProvider;
+     protected final TransformationServiceProvider transformationServiceProvider;
 
     /**
      * Create a new thing handler for HomeAssistant MQTT components.
@@ -108,11 +110,11 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     @Override
     public void initialize() {
         config = getConfigAs(HandlerConfiguration.class);
-        if (config.objectid.isEmpty()) {
+        if (StringUtils.isEmpty(config.getObjectid())) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Device ID unknown");
             return;
         }
-        discoveryHomeAssistantID = new HaID(config.basetopic, config.objectid, "", "");
+        discoveryHomeAssistantID = HaID.fromConfig(config);
 
         for (Channel channel : thing.getChannels()) {
             final String groupID = channel.getUID().getGroupId();
@@ -127,7 +129,15 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
                 continue;
             }
 
-            component = CFactory.createComponent(config.basetopic, channel, this, gson, transformationServiceProvider);
+            HaID haID = HaID.fromConfig(config.getBasetopic(), channel.getConfiguration());
+            ThingUID thingUID = channel.getUID().getThingUID();
+            String channelConfigurationJSON = (String) channel.getConfiguration().get("config");
+            if (channelConfigurationJSON == null) {
+                logger.warn("Provided channel does not have a 'config' configuration key!");
+            } else {
+                component = CFactory.createComponent(thingUID, haID, channelConfigurationJSON, this, gson,
+                        transformationServiceProvider);
+            }
 
             if (component != null) {
                 haComponents.put(component.uid().getId(), component);


### PR DESCRIPTION
Use the device.unique_id as a channel group id, if availble. Use nodeId,  ObjectId and component as fallback.
Write the information about nodeId and objectId into the channel config to avoid the need to recover the information from the group id.
Also make the channel configuration read only in the GUI. I changes are needed, then a GenericMQTTThing should be used and not a HomeAssistantThing.

With this PR I am having functional autodisovery for tasmota for the already supported compoenents / features.

 @davidgraeff Sorry, but I forgot this PR in my other list, because it was basically already prepared.

This PR is based on #4990 

