### PR TITLE
[homematic] fixed ClassCastException when parsing XMLResponse from Lightify-Devices (#5164)

### DIFF
--- a/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/addons/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -41,6 +41,11 @@ public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
     @Override
     @SuppressWarnings("unchecked")
     public Void parse(Object[] message) throws IOException {
+
+        if (message == null || message.length == 0 || !(message[0] instanceof Map)) {
+            return null;
+        }
+
         Map<String, ?> mapMessage = (Map<String, ?>) message[0];
         for (String dpName : mapMessage.keySet()) {
             HmDatapointInfo dpInfo = new HmDatapointInfo(paramsetType, channel, dpName);


### PR DESCRIPTION
fixed ClassCastException when using Osram Lightify Devices binded to Homematic-Bridge/Base which aborted initializing device to get online. added a simple check of Parameter-Object given to parse-method.

Signed-off-by: Kai Neuhaus <code@kaineuhaus.com>