### PR TITLE
[mqtt] Remove mandatory condition for name and datatype property attributes (fixes #5186)

### DIFF
--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/Property.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/Property.java
@@ -160,6 +160,11 @@ public class Property implements AttributeChanged {
 
         Value value;
         Boolean isDecimal = null;
+
+        if (attributes.name == "") {
+            attributes.name = propertyID;
+        }
+
         switch (attributes.datatype) {
             case boolean_:
                 value = new OnOffValue("true", "false");

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/PropertyAttributes.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/PropertyAttributes.java
@@ -18,7 +18,6 @@ import java.util.TreeMap;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.internal.mapping.AbstractMqttAttributeClass;
 import org.openhab.binding.mqtt.generic.internal.mapping.MQTTvalueTransform;
-import org.openhab.binding.mqtt.generic.internal.mapping.MandatoryField;
 import org.openhab.binding.mqtt.generic.internal.mapping.TopicPrefix;
 
 /**
@@ -40,7 +39,7 @@ public class PropertyAttributes extends AbstractMqttAttributeClass {
         color_
     }
 
-    public @MandatoryField String name = "";
+    public String name = "";
 
     /**
      * stateful + non-settable: The node publishes a property state (temperature sensor)
@@ -53,7 +52,7 @@ public class PropertyAttributes extends AbstractMqttAttributeClass {
     public boolean settable = false;
     public boolean retained = true;
     public String unit = "";
-    public @MandatoryField @MQTTvalueTransform(suffix = "_") DataTypeEnum datatype = DataTypeEnum.unknown;
+    public @MQTTvalueTransform(suffix = "_") DataTypeEnum datatype = DataTypeEnum.unknown;
     public String format = "";
 
     @Override


### PR DESCRIPTION
Hi @davidgraeff!

Here you have a PR to fix the issue reported yesterday (#5186): Homie 3 convention doesn't force properties to have a name and datatype attributes.

Best regards,

Aitor 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>