### PR TITLE
Fix including libraries with bnd includeresource on Windows

### DIFF
--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -561,7 +561,7 @@ Import-Package: \\
         </file>
       </activation>
       <properties>
-        <bnd.includeresource>${project.basedir}/lib/; lib:=true</bnd.includeresource>
+        <bnd.includeresource>${.}/../../lib/; lib:=true</bnd.includeresource>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
This way adding libraries with includeresource should work on both Linux and Windows.

See https://github.com/openhab/openhab2-addons/pull/5190#issuecomment-475602640.