### PR TITLE
Rework add-libraries profile for CLI and Eclipse

### DIFF
--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -470,19 +470,6 @@ Import-Package: \\
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>com.googlecode.addjars-maven-plugin</groupId>
-                    <artifactId>addjars-maven-plugin</artifactId>
-                    <versionRange>[1.0.5,)</versionRange>
-                    <goals>
-                      <goal>add-jars</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
                     <versionRange>[4.2.1,)</versionRange>
@@ -554,7 +541,7 @@ Import-Package: \\
 
   <profiles>
     <profile>
-      <id>add-libraries</id>
+      <id>add-libraries-cli</id>
       <activation>
         <file>
           <exists>lib/</exists>
@@ -592,6 +579,21 @@ Import-Package: \\
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>add-libraries-eclipse</id>
+      <activation>
+        <file>
+          <exists>lib/</exists>
+        </file>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <properties>
+        <bnd.includeresource>${.}/lib/; filter:=*.jar; lib:=true</bnd.includeresource>
+      </properties>
     </profile>
 
     <profile>

--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -559,6 +559,9 @@ Import-Package: \\
         <file>
           <exists>lib/</exists>
         </file>
+        <property>
+          <name>!m2e.version</name>
+        </property>
       </activation>
       <properties>
         <bnd.includeresource>${.}/../../lib/; filter:=*.jar; lib:=true</bnd.includeresource>


### PR DESCRIPTION
There is an issue in the addjars-maven-plugin that it modifies the basepath:

https://code.google.com/archive/p/addjars-maven-plugin/issues/8

Because the lib dir is used with `${.}` it is relative to the base path
(required for Windows, see #5196). The addjars-maven-plugin doesn't run in Eclipse
because it has no m2e lifecycle mapping. bnd tools now has issues including the
resources in Eclipse. This generates error messages for such projects in Eclipse.

For now the best solution seems to disable this profile in Eclipse. :disappointed: