### PR TITLE
[avmfritz] fixes to build on java 11

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/pom.xml
+++ b/bundles/org.openhab.binding.avmfritz/pom.xml
@@ -13,4 +13,25 @@
 
   <name>openHAB Add-ons :: Bundles :: AVM FRITZ! Binding</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -64,6 +64,9 @@
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>
+        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.3.1</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.3.2</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.3.0</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.avmfritz/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
This adds the necessary dependencies for building the binding on Java 11.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
