### PR TITLE
[lifx] Fix discovery possibly blocked after exception

### DIFF
--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.lifx.internal.LifxBindingConstants.*;
 import static org.openhab.binding.lifx.internal.util.LifxMessageUtil.randomSourceId;
 import static org.openhab.binding.lifx.internal.util.LifxSelectorUtil.*;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -197,7 +198,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
             } else {
                 logger.info("A discovery scan for LIFX lights is already underway");
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             logger.debug("{} while discovering LIFX lights : {}", e.getClass().getSimpleName(), e.getMessage());
             isScanning = false;
         }

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
@@ -199,6 +199,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
             }
         } catch (Exception e) {
             logger.debug("{} while discovering LIFX lights : {}", e.getClass().getSimpleName(), e.getMessage());
+            isScanning = false;
         }
     }
 


### PR DESCRIPTION
When an exception occurs during discovery it may result in discovery no longer working because the binding thinks a scan is still in progress.

It will then log every minute: _A discovery scan for LIFX lights is already underway_

See: [A discovery scan for LIFX lights is already underway](https://community.openhab.org/t/a-discovery-scan-for-lifx-lights-is-already-underway/70947?u=wborn)