### PR TITLE
[deconz] Added support for ZHAVibration sensors

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -26,6 +26,7 @@ These things are supported:
 | Open/Close Sensor                 | ZHAOpenClose                      | `openclosesensor`    |
 | Water Leakage Sensor              | ZHAWater                          | `waterleakagesensor` |
 | Alarm Sensor                      | ZHAAlarm                          | `alarmsensor`        |
+| Vibration Sensor                  | ZHAVibration                      | `vibrationsensor`    |
 | deCONZ Artificial Daylight Sensor | deCONZ specific: simulated sensor | `daylightsensor`     |
 
 ## Discovery
@@ -91,6 +92,7 @@ The devices support some of the following channels:
 | waterleakage    | Switch                   |      R      | Status of water leakage: `ON` = water leakage detected; `OFF` = no water leakage detected | waterleakagesensor                           |
 | alarm           | Switch                   |      R      | Status of an alarm: `ON` = alarm was triggered; `OFF` = no alarm                          | alarmsensor                                  |
 | tampered        | Switch                   |      R      | Status of a zone: `ON` = zone is being tampered; `OFF` = zone is not tampered             | any IAS sensor                               |
+| vibration       | Switch                   |      R      | Status of vibration: `ON` = vibration was detected; `OFF` = no vibration                  | alarmsensor                                  |
 | light           | String                   |      R      | Light level: `Daylight`,`Sunset`,`Dark`                                                   | daylightsensor                               |
 | value           | Number                   |      R      | Sun position: `130` = dawn; `140` = sunrise; `190` = sunset; `210` = dusk                 | daylightsensor                               |
 | battery_level   | Number                   |      R      | Battery level (in %)                                                                      | any battery-powered sensor                   |

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.deconz.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
@@ -21,6 +22,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class BindingConstants {
 
     public static final String BINDING_ID = "deconz";
@@ -40,6 +42,7 @@ public class BindingConstants {
     public static final ThingTypeUID THING_TYPE_WATERLEAKAGE_SENSOR = new ThingTypeUID(BINDING_ID,
             "waterleakagesensor");
     public static final ThingTypeUID THING_TYPE_ALARM_SENSOR = new ThingTypeUID(BINDING_ID, "alarmsensor");
+    public static final ThingTypeUID THING_TYPE_VIBRATION_SENSOR = new ThingTypeUID(BINDING_ID, "vibrationsensor");
 
     // List of all Channel ids
     public static final String CHANNEL_PRESENCE = "presence";
@@ -63,6 +66,7 @@ public class BindingConstants {
     public static final String CHANNEL_WATERLEAKAGE = "waterleakage";
     public static final String CHANNEL_ALARM = "alarm";
     public static final String CHANNEL_TAMPERED = "tampered";
+    public static final String CHANNEL_VIBRATION = "vibration";
     public static final String CHANNEL_BATTERY_LEVEL = "battery_level";
     public static final String CHANNEL_BATTERY_LOW = "battery_low";
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/HandlerFactory.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/HandlerFactory.java
@@ -44,12 +44,12 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.deconz")
 @NonNullByDefault
 public class HandlerFactory extends BaseThingHandlerFactory {
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
-            .of(BRIDGE_TYPE, THING_TYPE_PRESENCE_SENSOR, THING_TYPE_DAYLIGHT_SENSOR, THING_TYPE_POWER_SENSOR,
-                    THING_TYPE_CONSUMPTION_SENSOR, THING_TYPE_LIGHT_SENSOR, THING_TYPE_TEMPERATURE_SENSOR,
-                    THING_TYPE_HUMIDITY_SENSOR, THING_TYPE_PRESSURE_SENSOR, THING_TYPE_SWITCH,
-                    THING_TYPE_OPENCLOSE_SENSOR, THING_TYPE_WATERLEAKAGE_SENSOR, THING_TYPE_ALARM_SENSOR)
-            .collect(Collectors.toSet()));
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(BRIDGE_TYPE, THING_TYPE_PRESENCE_SENSOR, THING_TYPE_DAYLIGHT_SENSOR,
+                    THING_TYPE_POWER_SENSOR, THING_TYPE_CONSUMPTION_SENSOR, THING_TYPE_LIGHT_SENSOR,
+                    THING_TYPE_TEMPERATURE_SENSOR, THING_TYPE_HUMIDITY_SENSOR, THING_TYPE_PRESSURE_SENSOR,
+                    THING_TYPE_SWITCH, THING_TYPE_OPENCLOSE_SENSOR, THING_TYPE_WATERLEAKAGE_SENSOR,
+                    THING_TYPE_ALARM_SENSOR, THING_TYPE_VIBRATION_SENSOR).collect(Collectors.toSet()));
 
     private @NonNullByDefault({}) WebSocketFactory webSocketFactory;
     private @NonNullByDefault({}) HttpClientFactory httpClientFactory;

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -42,12 +42,12 @@ import org.openhab.binding.deconz.internal.handler.DeconzBridgeHandler;
  */
 @NonNullByDefault
 public class ThingDiscoveryService extends AbstractDiscoveryService implements ThingHandlerService {
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
-            .of(THING_TYPE_PRESENCE_SENSOR, THING_TYPE_DAYLIGHT_SENSOR, THING_TYPE_POWER_SENSOR,
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_PRESENCE_SENSOR, THING_TYPE_DAYLIGHT_SENSOR, THING_TYPE_POWER_SENSOR,
                     THING_TYPE_CONSUMPTION_SENSOR, THING_TYPE_LIGHT_SENSOR, THING_TYPE_TEMPERATURE_SENSOR,
                     THING_TYPE_HUMIDITY_SENSOR, THING_TYPE_PRESSURE_SENSOR, THING_TYPE_SWITCH,
-                    THING_TYPE_OPENCLOSE_SENSOR, THING_TYPE_WATERLEAKAGE_SENSOR, THING_TYPE_ALARM_SENSOR)
-            .collect(Collectors.toSet()));
+                    THING_TYPE_OPENCLOSE_SENSOR, THING_TYPE_WATERLEAKAGE_SENSOR, THING_TYPE_ALARM_SENSOR,
+                    THING_TYPE_VIBRATION_SENSOR).collect(Collectors.toSet()));
 
     private @Nullable DeconzBridgeHandler handler;
     private @Nullable ScheduledFuture<?> scanningJob;
@@ -108,6 +108,8 @@ public class ThingDiscoveryService extends AbstractDiscoveryService implements T
             thingTypeUID = THING_TYPE_WATERLEAKAGE_SENSOR;
         } else if (sensor.type.contains("ZHAAlarm")) {
             thingTypeUID = THING_TYPE_ALARM_SENSOR; // ZHAAlarm
+        } else if (sensor.type.contains("ZHAVibration")) {
+            thingTypeUID = THING_TYPE_VIBRATION_SENSOR; // ZHAVibration
         } else {
             return;
         }

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
@@ -402,6 +402,9 @@ public class SensorThingHandler extends BaseThingHandler implements ValueUpdateL
             case CHANNEL_TAMPERED:
                 updateState(channelUID, Boolean.TRUE.equals(state.tampered) ? OnOffType.ON : OnOffType.OFF);
                 break;
+            case CHANNEL_VIBRATION:
+                updateState(channelUID, Boolean.TRUE.equals(state.vibration) ? OnOffType.ON : OnOffType.OFF);
+                break;
             case CHANNEL_BUTTON:
                 if (buttonevent != null) {
                     updateState(channelUID, new DecimalType(buttonevent));

--- a/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/config/config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:deconz:bridge">
+		<parameter name="host" type="text" required="true">
+			<label>Host Address</label>
+			<context>network-address</context>
+			<description>IP address or host name and port</description>
+		</parameter>
+		<parameter name="apikey" type="text" required="false">
+			<label>API Key</label>
+			<description>If no API Key is provided, a new one will be requested. You need to authorize the access on the deCONZ
+				web interface.</description>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:deconz:sensor">
+		<parameter name="id" type="text" required="true">
+			<label>Sensor ID</label>
+			<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -7,17 +7,8 @@
 	<bridge-type id="deconz">
 		<label>deCONZ</label>
 		<description>A running deCONZ software instance</description>
-		<config-description>
-			<parameter name="host" type="text" required="true">
-				<label>Host Address</label>
-				<context>network-address</context>
-				<description>IP address or host name and port</description>
-			</parameter>
-			<parameter name="apikey" type="text" required="false">
-				<label>API Key</label>
-				<description>If no API Key is provided, a new one will be requested. You need to authorize the access on the deCONZ web interface.</description>
-			</parameter>
-		</config-description>
+
+		<config-description-ref uri="thing-type:deconz:bridge" />
 	</bridge-type>
 
 	<thing-type id="presencesensor">
@@ -30,12 +21,10 @@
 			<channel typeId="presence" id="presence" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="presence">
@@ -63,12 +52,10 @@
 			<channel typeId="power" id="power" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="power">
@@ -105,12 +92,10 @@
 			<channel typeId="consumption" id="consumption"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="consumption">
@@ -131,18 +116,17 @@
 			<channel typeId="button" id="button" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="buttonevent">
 		<kind>Trigger</kind>
 		<label>Button Trigger</label>
-		<description>This channel is triggered on a button event. The trigger payload consists of the button event number.</description>
+		<description>This channel is triggered on a button event. The trigger payload consists of the button event number.
+		</description>
 		<event></event>
 	</channel-type>
 
@@ -166,12 +150,10 @@
 			<channel typeId="daylight" id="daylight" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="lightlux">
@@ -212,12 +194,10 @@
 			<channel typeId="temperature" id="temperature" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="temperature">
@@ -237,12 +217,10 @@
 			<channel typeId="humidity" id="humidity" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="humidity">
@@ -262,12 +240,10 @@
 			<channel typeId="pressure" id="pressure"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="pressure">
@@ -287,12 +263,10 @@
 			<channel typeId="value" id="value"></channel>
 			<channel typeId="light" id="light"></channel>
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="value">
@@ -325,12 +299,10 @@
 			<channel typeId="open" id="open" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="open">
@@ -350,12 +322,10 @@
 			<channel typeId="waterleakage" id="waterleakage" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="waterleakage">
@@ -375,18 +345,46 @@
 			<channel typeId="alarm" id="alarm" />
 			<channel typeId="last_updated" id="last_updated" />
 		</channels>
-		<config-description>
-			<parameter name="id" type="text" required="true">
-				<label>Sensor ID</label>
-				<description>The deCONZ bridge assigns an integer number ID to each sensor.</description>
-			</parameter>
-		</config-description>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
 	</thing-type>
 
 	<channel-type id="alarm">
 		<item-type>Switch</item-type>
 		<label>Alarm</label>
 		<description>Alarm was triggered.</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="tampered">
+		<item-type>Switch</item-type>
+		<label>Tampered</label>
+		<description>A zone is being tampered.</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<thing-type id="vibrationsensor">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="deconz" />
+		</supported-bridge-type-refs>
+		<label>Vibration Sensor</label>
+		<description>A vibration sensor</description>
+		<channels>
+			<channel typeId="vibration" id="vibration" />
+			<channel typeId="last_updated" id="last_updated" />
+		</channels>
+
+		<representation-property>uid</representation-property>
+
+		<config-description-ref uri="thing-type:deconz:sensor" />
+	</thing-type>
+
+	<channel-type id="vibration">
+		<item-type>Switch</item-type>
+		<label>Vibration</label>
+		<description>Vibration was detected.</description>
 		<state readOnly="true" />
 	</channel-type>
 


### PR DESCRIPTION
- Added support for ZHAVibration sensors
- Moved `config-description` to separate file and add reference to thing type definitions
- Added `representation-property` to sensor thing types
- Added missing channel type definition for `tampered` (see #5071)

Depends on #5223

Closes #5191

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>