### PR TITLE
Fix ignore Eclipse specific settings pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ bundles/io/org.openhab.io.multimedia.tts.marytts/lib/
 .metadata/
 */plugin.xml_gen
 targetplatform/*.launch
-.settings/org.eclipse.*
+**/.settings/org.eclipse.*
 
 distribution/openhabhome/logs/*.log
 distribution/openhabhome/*.zip


### PR DESCRIPTION
Fixes the pattern that was added in #5216 which does not seem to work.