### PR TITLE
[modbus] Change bridge to offline during reinitialization

### DIFF
--- a/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
+++ b/addons/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
@@ -65,6 +65,11 @@ public abstract class AbstractModbusEndpointThingHandler<E extends ModbusSlaveEn
     public void initialize() {
         synchronized (this) {
             logger.trace("Initializing {} from status {}", this.getThing().getUID(), this.getThing().getStatus());
+            if (this.getThing().getStatus().equals(ThingStatus.ONLINE)) {
+                // If the bridge was online then first change it to offline.
+                // this ensures that children will be notified about the change
+                updateStatus(ThingStatus.OFFLINE);
+            }
             try {
                 configure();
                 @Nullable


### PR DESCRIPTION
I noticed that things connected to a modbus bridge won't be reinitialized when the bridge changes. Digging down to openhab core I found out that connected things are only notified when the bridge changes status.

This small PR changes the bridge to OFFLINE if it was ONLINE when a change happened.

This is a split of the original PR #4220 as requested by @davidgraeff .