### PR TITLE
[enocean] Add two new channel config parameters "eltakoDimmer" and "storeValue".

### DIFF
--- a/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
+++ b/addons/binding/org.openhab.binding.enocean/ESH-INF/thing/channels.xml
@@ -73,6 +73,16 @@
 				<label>Ramping time</label>
 				<description>A5-38-08: Ramping Time (in seconds), 0 = no ramping, 1..255 = seconds to 100%; D2-01-01: 0 = switch, 1-3 = timer 1-3, 4 = stop</description>
 			</parameter>
+			<parameter name="eltakoDimmer" type="boolean">
+				<label>Eltako Dimmer</label>
+				<description>True for Eltako dimmer, false otherwise. Defaults to true for compatibility purpose.</description>
+				<default>true</default>
+			</parameter>
+			<parameter name="storeValue" type="boolean">
+				<label>Store value</label>
+				<description>Store final value</description>
+				<default>false</default>
+			</parameter>
 		</config-description>
 	</channel-type>
 
@@ -195,14 +205,14 @@
 		<description>Received Signal Strength Indication</description>
 		<state readOnly="true" />
 	</channel-type>
-	
+
 	<channel-type id="repeatCount" advanced="true">
 		<item-type>Number</item-type>
 		<label>RepeatCount</label>
 		<description>Number of repeaters involved in the transmission of the telegram</description>
 		<state readOnly="true" />
 	</channel-type>
-	
+
 	<channel-type id="lastReceived" advanced="true">
 		<item-type>DateTime</item-type>
 		<label>LastReceived</label>

--- a/addons/binding/org.openhab.binding.enocean/README.md
+++ b/addons/binding/org.openhab.binding.enocean/README.md
@@ -244,6 +244,8 @@ Some channels can be configured with parameters.
 |---------------|----------------|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | rollershutter | shutTime       | Time (in seconds) to completely close the rollershutter              |                                                                                                                                     |
 | dimmer        | rampingTime    | Duration of dimming                                                  | A5-38-08: Ramping Time (in seconds), 0 = default ramping, 1..255 = seconds to 100%; D2-01-01: 0 = switch, 1-3 = timer 1-3, 4 = stop |
+|               | eltakoDimmer   | Flag for Eltako dimmers, because Eltako does interpret this EEP differently | True for Eltako dimmer, false otherwise. Defaults to true for compatibility purpose.                                         |
+|               | storeValue     | Store final value. For Eltako devices, block dimming value.          | True or false. Defaults to false.                                         |
 | teachInCMD    | manufacturerId | Id is used for 4BS teach in with EEP                                 | HEX                                                                                                                                 |
 |               | teachInMSG     | Use this message if teach in type and/or manufacturer id are unknown | HEX                                                                                                                                 |
 

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelDimmerConfig.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelDimmerConfig.java
@@ -20,8 +20,12 @@ package org.openhab.binding.enocean.internal.config;
 public class EnOceanChannelDimmerConfig {
 
     public Integer rampingTime;
+    public Boolean eltakoDimmer;
+    public Boolean storeValue;
 
     public EnOceanChannelDimmerConfig() {
         rampingTime = 0;
+        eltakoDimmer = true;
+        storeValue = false;
     }
 }

--- a/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelDimmerConfig.java
+++ b/addons/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelDimmerConfig.java
@@ -19,13 +19,8 @@ package org.openhab.binding.enocean.internal.config;
  */
 public class EnOceanChannelDimmerConfig {
 
-    public Integer rampingTime;
-    public Boolean eltakoDimmer;
-    public Boolean storeValue;
+    public Integer rampingTime = 0;
+    public Boolean eltakoDimmer = true;
+    public Boolean storeValue = false;
 
-    public EnOceanChannelDimmerConfig() {
-        rampingTime = 0;
-        eltakoDimmer = true;
-        storeValue = false;
-    }
 }


### PR DESCRIPTION
Signed-off-by: Dominik Vorreiter <dominikkv@gmx.de>

Fixes the bug for EEP profile A5-38-08 CMD 0x02 (dimming) for non-Eltako dimmers, where the dimming value was sent incorrectly to the actuator. With this PR, there is a new channel parameter "eltakoDimmer", which determines how the dimming value is sent. It defaults to "true" so it does not break current installations. 

Furthermore, there is a new parameter "storeValue" to give the user the possibility to set this value. It is sent to the actuator. I'm not sure what it really does. For Eltako devices, this parameters sets the "block dimm value" field.

closes #4865

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
