### PR TITLE
[embeddedbroker] Karaf fix: Add h2 store for persistence

### DIFF
--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -950,6 +950,7 @@
         <bundle dependency="true">wrap:mvn:io.netty/netty-codec/4.1.34.Final$Bundle-Name=Netty%20Codec&amp;Bundle-SymbolicName=io.netty.netty-codec&amp;Bundle-Version=4.1.34</bundle>
         <bundle dependency="true">wrap:mvn:io.netty/netty-resolver/4.1.34.Final$Bundle-Name=Netty%20Resolver&amp;Bundle-SymbolicName=io.netty.netty-resolver&amp;Bundle-Version=4.1.34</bundle>
         <bundle dependency="true">wrap:mvn:io.netty/netty-handler/4.1.34.Final$Bundle-Name=Netty%20Handler&amp;Bundle-SymbolicName=io.netty.netty-handler&amp;Bundle-Version=4.1.34</bundle>
+	<bundle dependency="true">mvn:com.h2database/h2-mvstore/1.4.199</bundle>
         <bundle dependency="true">wrap:mvn:io.moquette/moquette-broker/0.12.1$Bundle-Name=Moquette%20MQTT%20Broker&amp;Bundle-SymbolicName=io.moquette.moquette-broker&amp;Bundle-Version=0.12.1</bundle>
         <bundle>mvn:org.openhab.addons.bundles/org.openhab.io.mqttembeddedbroker/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
If persistence is enabled, the h2 mvstore dependency must be available.
Fortunately an osgi bundle.

Signed-off-by: David Gräff <david.graeff@web.de>