### PR TITLE
[neeo] removed outdated dependency on no longer existing bundle

### DIFF
--- a/addons/io/org.openhab.io.neeo/pom.xml
+++ b/addons/io/org.openhab.io.neeo/pom.xml
@@ -17,12 +17,7 @@
 		<dependency>
 			<groupId>org.openhab.core.bundles</groupId>
 			<artifactId>org.openhab.core</artifactId>
-			<version>${ohc.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openhab.core.bundles</groupId>
-			<artifactId>org.openhab.core.ui.dashboard</artifactId>
-			<version>${ohc.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
This fixes the release build issue that currently occurs at https://ci.openhab.org/view/Sandbox/job/sandbox-openhab2-release/1036/.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
