### PR TITLE
provide Java EE dependencies via POMs

### DIFF
--- a/bundles/org.openhab.binding.dlinksmarthome/pom.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/pom.xml
@@ -15,44 +15,20 @@
   <name>openHAB Add-ons :: Bundles :: D-Link Smart Home Binding</name>
 
   <dependencies>
-    <!-- JAXB -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>org.openhab</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>${jaxb.version}</version>
+      <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.3.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>2.3.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <!-- JAX-WS -->
-    <dependency>
-      <groupId>javax.xml.soap</groupId>
-      <artifactId>javax.xml.soap-api</artifactId>
-      <version>1.4.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.ws</groupId>
-      <artifactId>jaxws-rt</artifactId>
-      <version>2.3.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.messaging.saaj</groupId>
-      <artifactId>saaj-impl</artifactId>
-      <version>1.5.1</version>
+      <groupId>org.openhab</groupId>
+      <artifactId>jax-ws</artifactId>
+      <version>${jaxws.version}</version>
+      <type>pom</type>
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  
+
 </project>

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -17,6 +17,19 @@
 
     <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
+    <!-- Features for Java EE bundles -->
+
+    <feature name="openhab-jaxb" description="JAXB bundles" version="1.0.0">
+        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.3.1</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.3.2</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.3.0</bundle>
+    </feature>
+    <feature name="openhab-jaxws" description="JAX-WS (SOAP) bundles" version="1.0.0">
+        <bundle dependency="true">mvn:javax.xml.soap/javax.xml.soap-api/1.4.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.sun.xml.ws/jaxws-rt/2.3.2$Bundle-Name=JAX%20WS%20RI%20Runtime%20Bundle&amp;Bundle-SymbolicName=com.sun.xml.ws.jaxws-rt&amp;Bundle-Version=2.3.2</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.messaging.saaj/saaj-impl/1.5.1</bundle>
+    </feature>
+
     <!-- binding -->
 
     <feature name="openhab-binding-airquality" description="Air Quality Binding" version="${project.version}">
@@ -148,14 +161,8 @@
     <feature name="openhab-binding-dlinksmarthome" description="D-Link Smart Home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-mdns</feature>
-        <!-- JAXB bundles -->
-        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.3.1</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.3.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.3.0</bundle>
-        <!-- JAX-WS (SOAP) bundles -->
-        <bundle dependency="true">mvn:javax.xml.soap/javax.xml.soap-api/1.4.0</bundle>
-        <bundle dependency="true">wrap:mvn:com.sun.xml.ws/jaxws-rt/2.3.2$Bundle-Name=JAX%20WS%20RI%20Runtime%20Bundle&amp;Bundle-SymbolicName=com.sun.xml.ws.jaxws-rt&amp;Bundle-Version=2.3.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.messaging.saaj/saaj-impl/1.5.1</bundle>
+        <feature>openhab-jaxb</feature>
+        <feature>openhab-jaxws</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.dlinksmarthome/${project.version}</bundle>
     </feature>
 

--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -59,6 +59,8 @@
     <karaf.version>4.2.2</karaf.version>
     <sat.version>0.6.1</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
+    <jaxb.version>1.0.0</jaxb.version>
+    <jaxws.version>1.0.0</jaxws.version>
 
     <bnd.importpackage></bnd.importpackage>
     <bnd.includeresource></bnd.includeresource>

--- a/poms/deps/jaxb/pom.xml
+++ b/poms/deps/jaxb/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.openhab</groupId>
+  <artifactId>jaxb</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <name>openHAB 2 JAXB dependencies</name>
+
+  <description>openHAB Dependencies for JAXB</description>
+
+  <organization>
+    <name>openHAB.org</name>
+    <url>http://www.openhab.org</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License 2.0</name>
+      <url>https://www.eclipse.org/legal/epl-2.0/</url>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/poms/deps/jaxws/pom.xml
+++ b/poms/deps/jaxws/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.openhab</groupId>
+  <artifactId>jaxb</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <name>openHAB 2 JAX-WS (SOAP) dependencies</name>
+
+  <description>openHAB Dependencies for JAX-WS (SOAP)</description>
+
+  <organization>
+    <name>openHAB.org</name>
+    <url>http://www.openhab.org</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License 2.0</name>
+      <url>https://www.eclipse.org/legal/epl-2.0/</url>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.xml.soap</groupId>
+      <artifactId>javax.xml.soap-api</artifactId>
+      <version>1.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-rt</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.messaging.saaj</groupId>
+      <artifactId>saaj-impl</artifactId>
+      <version>1.5.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
This is a proposal to define the packages removed in Java 11 which are used by several bindings in an easy way. It consists of two POMs which define the required dependencies and two karaf features. The POMs need to be moved to a repository which is accessible during build time.

For testing purposes I defined a local repo, added the POMs there and added the repo to the base pom. The dlinksmarthome binding is converted as an example to shows the benefits.