### PR TITLE
Require successful Travis CI Java 8 and 11 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,5 @@ after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
-env: # required for allowing failures
-matrix:
-  allow_failures:
-    - jdk: openjdk11
 script:
   - mvnp clean install -B -DskipChecks=true -DskipTests=true $(extra_maven_opts)


### PR DESCRIPTION
We should from now on also require successful [Java 11 Travis CI builds](https://travis-ci.org/openhab/openhab2-addons/jobs/513549994) since we've worked hard to achieve this.