### PR TITLE
[robonect] Fix Eclipse project file

### DIFF
--- a/bundles/org.openhab.binding.robonect/.project
+++ b/bundles/org.openhab.binding.robonect/.project
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
 	<name>org.openhab.binding.robonect</name>


### PR DESCRIPTION
Eclipse can no longer import the project because a newline got added in #5325.