### PR TITLE
Remove non-existing fsinternetradio.tests from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,6 @@
 /addons/binding/org.openhab.binding.exec/ @kgoderis
 /addons/binding/org.openhab.binding.feed/ @svilenvul
 /addons/binding/org.openhab.binding.feed.test/ @svilenvul
-/bundles/org.openhab.binding.fsinternetradio.test/ @paphko
 /addons/binding/org.openhab.binding.ftpupload/ @paulianttila
 /addons/binding/org.openhab.binding.groheondus/ @FlorianSW
 /addons/binding/org.openhab.binding.hdpowerview/ @beowulfe


### PR DESCRIPTION
These tests were moved into the bundle itself in #5334.