### PR TITLE
[avmfritz] Downgrade JAXB to 2.2

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/pom.xml
+++ b/bundles/org.openhab.binding.avmfritz/pom.xml
@@ -17,19 +17,25 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <version>2.2.12</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.3.2</version>
+      <version>2.2.11</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.11</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -68,7 +68,7 @@
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>
-        <bundle dependency="true">mvn:javax.activation/activation/1.1.1</bundle>
+        <bundle dependency="true">wrap:mvn:javax.activation/activation/1.1.1$Bundle-Name=Javax%20Activation&amp;Bundle-SymbolicName=javax.activation.activation&amp;Bundle-Version=1.1.1</bundle>
         <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.2.12</bundle>
         <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.2.11</bundle>
         <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.2.11</bundle>

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -68,9 +68,10 @@
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>
-        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.3.1</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.3.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.3.0</bundle>
+        <bundle dependency="true">mvn:javax.activation/activation/1.1.1</bundle>
+        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.2.12</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.2.11</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.2.11</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.avmfritz/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
Fixes #5341 

This downgrades JAXB to 2.2 since 2.3 seems to have problems on Java 8. Contains only AVMFritz. Needs to be extended to the other bundles.
