### PR TITLE
Update enforcer and Travis CI for allowing Java 11 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
 install:
   - |
-    function extra_maven_opts() {
-        if [ "$TRAVIS_JDK_VERSION" != "openjdk8" ]; then echo "-Denforcer.skip=true"; fi;
-    }
     function prevent_timeout() {
         local i=0
         while [ -e /proc/$1 ]; do
@@ -51,4 +48,4 @@ after_success:
 after_failure:
   - tail -n 2000 .build.log
 script:
-  - mvnp clean install -B -DskipChecks=true -DskipTests=true $(extra_maven_opts)
+  - mvnp clean install -B -DskipChecks=true -DskipTests=true

--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -589,7 +589,7 @@ Import-Package: \\
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8.0-40,1.9)</version>
+                  <version>[1.8.0-40,1.9),[9.0,12.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
The code can be successfully compiled with Java 11 so it's no longer necessary to enforce Java 8.
This also allows for removing the enforcer override for the Travis CI Java 11 build.

Similar to https://github.com/openhab/openhab-core/pull/688.