### PR TITLE
[mqtt] Delete binding.xml

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="mqtt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
-
-	<name>MQTT Homie Binding</name>
-	<description>Allows to auto-discover Homie devices on your MQTT broker</description>
-	<author>David Graeff</author>
-</binding:binding>


### PR DESCRIPTION
Multiple binding.xml files with the same binding-id are not possible.

In my opinion the core should allow to reference bridges defined in other bundles which would allow me to give each bundle its own binding id, but that is not the case.

This is the first of three files to be deleted to fix the reported issue of PaperUI showing the wrong binding label. See #5373

Signed-off-by: David Gräff <david.graeff@web.de>
