### PR TITLE
Travis: Build new binding pull requests with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 *.iml
 npm-debug.log
+.build.log
 
 .metadata/
 bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,58 +15,15 @@ cache:
 before_cache:
   # remove resolver-status.properties, they change with each run and invalidate the cache
   - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;
-  
-install:
-  - |
-    function prevent_timeout() {
-        local i=0
-        while [ -e /proc/$1 ]; do
-            # print zero width char every 3 minutes while building
-            if [ "$i" -eq "180" ]; then printf %b '\u200b'; i=0; else i=$((i+1)); fi
-            sleep 1
-        done
-    }
-    function print_reactor_summary() {
-        sed -ne '/\[INFO\] Reactor Summary:/,$ p' "$1" | sed 's/\[INFO\] //'
-    }
-    function mvnp() {
-        echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
-        set -o pipefail # exit build with error when pipes fail
-        local command=(mvn $@)
-        exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
-            tee .build.log | # write output to log
-            stdbuf -oL grep -E '^\[INFO\] Building .+ \[.+\]$' | # filter progress
-            sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
-            sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
-        local pid=$!
-        prevent_timeout $pid &
-        wait $pid
-    }
-after_success:
-  - print_reactor_summary .build.log
-after_failure:
-  - tail -n 1000 .build.log
-  
+
 notifications:
     webhooks: https://www.travisbuddy.com/
     on_success: never
+    on_change: never
 
 travisBuddy:
     insertMode: update
     successBuildLog: false
 
 script:
-  - |
-    CHANGED_DIR=`git diff --diff-filter=A --dirstat=files,0 HEAD~1 bundles/ | sed 's/^[ 0-9.]\+% bundles\///g' | grep -o -P "^([^/]*)" | uniq`
-    if [ -e "bundles/$CHANGED_DIR" ]; then
-       echo "Build only bundles/$CHANGED_DIR"
-       echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
-       cd "bundles/$CHANGED_DIR"
-       mvn clean install 2>&1 | tee ../.build.log
-       if [ -e "../itests/$CHANGED_DIR" ]; then
-         cd "../itests/$CHANGED_DIR"
-         mvn clean install 2>&1 | tee -a ../.build.log
-       fi
-    else
-       mvnp clean install -B -DskipChecks=true -DskipTests=true
-    fi
+  - buildci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ before_cache:
   # remove resolver-status.properties, they change with each run and invalidate the cache
   - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;
   
-before_install:
-  - echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
 install:
   - |
     function prevent_timeout() {
@@ -32,6 +30,7 @@ install:
         sed -ne '/\[INFO\] Reactor Summary:/,$ p' "$1" | sed 's/\[INFO\] //'
     }
     function mvnp() {
+        echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
         set -o pipefail # exit build with error when pipes fail
         local command=(mvn $@)
         exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
@@ -46,6 +45,28 @@ install:
 after_success:
   - print_reactor_summary .build.log
 after_failure:
-  - tail -n 2000 .build.log
+  - tail -n 1000 .build.log
+  
+notifications:
+    webhooks: https://www.travisbuddy.com/
+    on_success: never
+
+travisBuddy:
+    insertMode: update
+    successBuildLog: false
+
 script:
-  - mvnp clean install -B -DskipChecks=true -DskipTests=true
+  - |
+    CHANGED_DIR=`git diff --diff-filter=A --dirstat=files,0 HEAD~1 bundles/ | sed 's/^[ 0-9.]\+% bundles\///g' | grep -o -P "^([^/]*)" | uniq`
+    if [ -e "bundles/$CHANGED_DIR" ]; then
+       echo "Build only bundles/$CHANGED_DIR"
+       echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
+       cd "bundles/$CHANGED_DIR"
+       mvn clean install 2>&1 | tee ../.build.log
+       if [ -e "../itests/$CHANGED_DIR" ]; then
+         cd "../itests/$CHANGED_DIR"
+         mvn clean install 2>&1 | tee -a ../.build.log
+       fi
+    else
+       mvnp clean install -B -DskipChecks=true -DskipTests=true
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ before_cache:
 
 notifications:
     webhooks: https://www.travisbuddy.com/
-    on_success: never
-    on_change: never
 
 travisBuddy:
     insertMode: update
-    successBuildLog: false
+    successBuildLog: true
 
-script:
-  - buildci.sh
+before_install: true
+before_script: true
+install: true
+script: ./buildci.sh

--- a/buildci.sh
+++ b/buildci.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+function prevent_timeout() {
+    local i=0
+    while [ -e /proc/$1 ]; do
+        # print zero width char every 3 minutes while building
+        if [ "$i" -eq "180" ]; then printf %b '\u200b'; i=0; else i=$((i+1)); fi
+        sleep 1
+    done
+}
+
+function print_reactor_summary() {
+    sed -ne '/\[INFO\] Reactor Summary:/,$ p' "$1" | sed 's/\[INFO\] //'
+}
+
+function mvnp() {
+    set -o pipefail # exit build with error when pipes fail
+    local command=(mvn $@)
+    exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
+        tee .build.log | # write output to log
+        stdbuf -oL grep -E '^\[INFO\] Building .+ \[.+\]$' | # filter progress
+        sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
+        sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
+    local pid=$!
+    prevent_timeout $pid &
+    wait $pid
+}
+
+# Determine if this is a new addon -> Perform tests + integration tests and all SAT checks with increased warning level
+CHANGED_DIR=`git diff --diff-filter=A --dirstat=files,0 master...HEAD bundles/ | sed 's/^[ 0-9.]\+% bundles\///g' | grep -o -P "^([^/]*)" | uniq`
+CDIR=`pwd`
+
+if [ ! -z "$CHANGED_DIR" ] && [ -e "bundles/$CHANGED_DIR" ]; then
+    echo "New addon pull request: Building $CHANGED_DIR"
+    echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
+    cd "bundles/$CHANGED_DIR"
+    mvn clean install 2>&1 | tee $CDIR/.build.log
+    if [ -e "../itests/$CHANGED_DIR" ]; then
+      echo "New addon pull request: Building itest $CHANGED_DIR"
+      cd "../itests/$CHANGED_DIR"
+      mvn clean install 2>&1 | tee -a $CDIR/.build.log
+    fi
+else
+    echo "Build all"
+    echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
+    mvnp clean install -B -DskipChecks=true -DskipTests=true
+    if [ $? -eq 0 ]; then
+      print_reactor_summary .build.log
+    else
+      tail -n 1000 .build.log
+    fi
+fi

--- a/buildci.sh
+++ b/buildci.sh
@@ -17,10 +17,11 @@ function mvnp() {
     set -o pipefail # exit build with error when pipes fail
     local command=(mvn $@)
     exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
+	stdbuf -o0 grep -vE "Download(ed|ing) from [a-z.]+: https:" | # filter out downloads
         tee .build.log | # write output to log
         stdbuf -oL grep -E '^\[INFO\] Building .+ \[.+\]$' | # filter progress
-        sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
-        sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
+        stdbuf -o0 sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
+        stdbuf -o0 sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
     local pid=$!
     prevent_timeout $pid &
     wait $pid
@@ -32,13 +33,19 @@ CDIR=`pwd`
 
 if [ ! -z "$CHANGED_DIR" ] && [ -e "bundles/$CHANGED_DIR" ]; then
     echo "New addon pull request: Building $CHANGED_DIR"
-    echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
+    echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.openhab.tools.analysis.report.ReportUtility=DEBUG -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
     cd "bundles/$CHANGED_DIR"
-    mvn clean install 2>&1 | tee $CDIR/.build.log
+    mvn clean install -B 2>&1 | 
+	    stdbuf -o0 grep -vE "Download(ed|ing) from [a-z.]+: https:" | # Filter out Download(s)
+	    stdbuf -o0 grep -v "target/code-analysis" | # filter out some debug code from reporting utility
+	    tee $CDIR/.build.log
     if [ -e "../itests/$CHANGED_DIR" ]; then
       echo "New addon pull request: Building itest $CHANGED_DIR"
       cd "../itests/$CHANGED_DIR"
-      mvn clean install 2>&1 | tee -a $CDIR/.build.log
+      mvn clean install -B 2>&1 | 
+	      stdbuf -o0 grep -vE "Download(ed|ing) from [a-z.]+: https:" | # Filter out Download(s)
+	      stdbuf -o0 grep -v "target/code-analysis" | # filter out some debug code from reporting utility
+	      tee -a $CDIR/.build.log
     fi
 else
     echo "Build all"

--- a/travis-buddy-failure-template.md
+++ b/travis-buddy-failure-template.md
@@ -1,0 +1,22 @@
+## Travis tests have failed
+Hey @{{pullRequestAuthor}},
+please read the following log in order to understand the failure reason. There might also be some helpful tips along the way.
+It'll be awesome if you fix what's wrong and commit the changes.
+
+{{#jobs}}
+### {{displayName}}
+{{#scripts}}
+<details>
+  <summary>
+    <strong>
+     Expand here
+    </strong>
+  </summary>
+
+```
+{{&contents}}
+```
+</details>
+<br />
+{{/scripts}}
+{{/jobs}}

--- a/travis-buddy-success-template.md
+++ b/travis-buddy-success-template.md
@@ -1,0 +1,21 @@
+## Travis tests were successful
+Hey @{{pullRequestAuthor}},
+we found no major flaws with your code. Still you might want to look at this logfile, as we usually suggest some optional improvements.
+
+{{#jobs}}
+### {{displayName}}
+{{#scripts}}
+<details>
+  <summary>
+    <strong>
+     {{command}}
+    </strong>
+  </summary>
+
+```
+{{&contents}}
+```
+</details>
+<br />
+{{/scripts}}
+{{/jobs}}


### PR DESCRIPTION
### travisbuddy
This PR adds travisbuddy to .travis.yml. That service add (update) a comment to a PR on a build failure with the log attached. This is an intermediate step until we have full github checks api support and a curl command figured out to report SAT findings and Test results to the "Checks" tab. See also #4935

### Partial build
The PR commits are analysed and if exactly one new directory is added to bundles/ then a build with tests and checks is performed for that new bundle otherwise the full repo build without tests and checks is executed as before.

### WIP
* This PR includes an absolute irrelevant commit for testing the bundles/ changed detection
* Karaf feature test is not yet performed in the partial build
* SAT should fail if a new binding is not added to the bom or the parent pom.xml or the karaf feature file
* Maven is still showing downloads although I have `-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn` set. That clutters the build log which would otherwise only show SAT and test reports

### Advantage for a new binding pull request

* Build time of under 5 minutes
* Clean log with only relevant SAT and test findings for that new PR. We can even increase the SAT report level and make more warnings fail the build.
* Review time can be spend on more important questions like architecture and technology patterns

Signed-off-by: David Graeff <david.graeff@web.de>
