### PR TITLE
[keba] Ignore values if the curr hw commands sends 0

### DIFF
--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -281,7 +281,7 @@ public class KeContactHandler extends BaseThingHandler {
                         maxSystemCurrent = state;
                         State newState = new DecimalType(state);
                         updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_SYSTEM_CURRENT), newState);
-                        if (maxSystemCurrent != 0){
+                        if (maxSystemCurrent != 0) {
                             if (maxSystemCurrent < maxPresetCurrent) {
                                 transceiver.send("curr " + String.valueOf(maxSystemCurrent), this);
                                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT),
@@ -291,7 +291,7 @@ public class KeContactHandler extends BaseThingHandler {
                             }
                         }
                         else {
-                            logger.warn("maxSystemCurrent is 0. Ignoring.");
+                            logger.debug("maxSystemCurrent is 0. Ignoring.");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -281,12 +281,17 @@ public class KeContactHandler extends BaseThingHandler {
                         maxSystemCurrent = state;
                         State newState = new DecimalType(state);
                         updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_SYSTEM_CURRENT), newState);
-                        if (maxSystemCurrent < maxPresetCurrent) {
-                            transceiver.send("curr " + String.valueOf(maxSystemCurrent), this);
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT),
-                                    new DecimalType(maxSystemCurrent));
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT_RANGE),
-                                    new PercentType((maxSystemCurrent - 6000) * 100 / (maxSystemCurrent - 6000)));
+                        if (maxSystemCurrent != 0){
+                            if (maxSystemCurrent < maxPresetCurrent) {
+                                transceiver.send("curr " + String.valueOf(maxSystemCurrent), this);
+                                updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT),
+                                        new DecimalType(maxSystemCurrent));
+                                updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT_RANGE),
+                                        new PercentType((maxSystemCurrent - 6000) * 100 / (maxSystemCurrent - 6000)));
+                            }
+                        }
+                        else {
+                            logger.warn("maxSystemCurrent is 0. Ignoring.");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -289,8 +289,7 @@ public class KeContactHandler extends BaseThingHandler {
                                 updateState(new ChannelUID(getThing().getUID(), CHANNEL_MAX_PRESET_CURRENT_RANGE),
                                         new PercentType((maxSystemCurrent - 6000) * 100 / (maxSystemCurrent - 6000)));
                             }
-                        }
-                        else {
+                        } else {
                             logger.debug("maxSystemCurrent is 0. Ignoring.");
                         }
                         break;


### PR DESCRIPTION
[KEBA] ignore 0 mA if keba booting up. 

on my p30c after bootup the "curr hw" is sometimes reporting 0 mA.
0 is a invalid value, only values from 6000 are valid. then it would set 6000 as min value,
but on first charging it will then not jump to 32000 but stay on 6000. as the documentation
tells "curr" is affecting the changes power output until keba is reset, or "currtime" is used.

tested on a P30c.
also the Documentation is stating values only from 6000 are valid. 
