### PR TITLE
[Deconz] restart websocket connection

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
@@ -269,6 +269,10 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Unknown reason");
         }
+        stopTimer();
+        // Wait for POLL_FREQUENCY_SEC after a connection error before trying again
+        scheduledFuture = scheduler.scheduleWithFixedDelay(this::startWebsocket, POLL_FREQUENCY_SEC, POLL_FREQUENCY_SEC,
+                TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
Try to restart websocket connection not only on `connectionLost` but also on `connectionError`.

Signed-off-by: David Gräff <david.graeff@web.de>