### PR TITLE
[mqtt] Remove binding.xml of sub-bundle

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="mqtt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
-
-	<name>MQTT Thing and Channels Binding</name>
-	<description>Link MQTT topics to things</description>
-	<author>David Graeff</author>
-</binding:binding>


### PR DESCRIPTION
And the last sub-bundle with a binding.xml that is not allowed / cannot be processed.

Signed-off-by: David Gräff <david.graeff@web.de>