### PR TITLE
@davidgraeff is the MQTT integration tests code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -215,8 +215,8 @@
 /itests/org.openhab.binding.dmx.tests/ @J-N-K
 /itests/org.openhab.binding.hue.tests/ @cweitkamp
 /itests/org.openhab.binding.max.tests/ @marcelrv
-/itests/org.openhab.binding.mqtt.homeassistant.tests/ @wborn
-/itests/org.openhab.binding.mqtt.homie.tests/ @wborn
+/itests/org.openhab.binding.mqtt.homeassistant.tests/ @davidgraeff
+/itests/org.openhab.binding.mqtt.homie.tests/ @davidgraeff
 /itests/org.openhab.binding.nest.tests/ @wborn
 /itests/org.openhab.binding.ntp.tests/ @marcelrv
 /itests/org.openhab.binding.onewire.tests/ @J-N-K


### PR DESCRIPTION
It probably got copy/pasted from the code owners line below (nest) in #5240.
Hopefully with this change #5414 will also be fixed soon. :wink:
