### PR TITLE
[hueemulation] Use a 2nd readyMarker as the smarthome one doesn't seem to come

### DIFF
--- a/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -286,9 +286,12 @@ public class HueEmulationService implements ReadyTracker {
 
     @Override
     public synchronized void onReadyMarkerAdded(ReadyMarker readyMarker) {
-        if (started || !"org.eclipse.smarthome.model.core".equals(readyMarker.getIdentifier())) {
+        if (started || !("org.openhab.core.model.core".equals(readyMarker.getIdentifier()) || 
+			"org.eclipse.smarthome.model.core".equals(readyMarker.getIdentifier()))) {
+	    // logger.debug("onReadyMarkerAdded readyMarker: {}", readyMarker.getIdentifier());
             return;
         }
+	logger.debug("onReadyMarkerAdded started=true readyMarker: {}", readyMarker.getIdentifier());
 
         started = true;
         HttpContext httpContext = httpService.createDefaultHttpContext();


### PR DESCRIPTION
Use a 2nd readyMarker as the smarthome one doesn't seem to come on 2.5.0-SNAPSHOT systems.

This might be the wrong solution as the real root cause might be
that the org.eclipse.smarthome.core.model readyMarker is missing.
Anyhow this fixes the problem from issue #5419 on my installation and might serve
as an interims solution.

Bugfix/workaround for Issue #5419