### PR TITLE
Fixed .classpath files.

### DIFF
--- a/bundles/org.openhab.binding.darksky/.classpath
+++ b/bundles/org.openhab.binding.darksky/.classpath
@@ -28,5 +28,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.fsinternetradio/.classpath
+++ b/bundles/org.openhab.binding.fsinternetradio/.classpath
@@ -28,5 +28,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.logreader/.classpath
+++ b/bundles/org.openhab.binding.logreader/.classpath
@@ -13,9 +13,9 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -23,6 +23,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="lib/commons-io-2.7-20180506.jar"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/bundles/org.openhab.binding.robonect/.classpath
+++ b/bundles/org.openhab.binding.robonect/.classpath
@@ -13,9 +13,9 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -28,6 +28,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="lib/jd2xx.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.tado/.classpath
+++ b/bundles/org.openhab.binding.tado/.classpath
@@ -13,9 +13,9 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -28,5 +28,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="lib/tado-api-client-1.2.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.transform.bin2json/.classpath
+++ b/bundles/org.openhab.transform.bin2json/.classpath
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <classpathentry kind="src" output="target/classes" path="src/main/java">
-                <attributes>
-                        <attribute name="optional" value="true"/>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="src" output="target/test-classes" path="src/test/java">
-                <attributes>
-                        <attribute name="optional" value="true"/>
-                        <attribute name="maven.pomderived" value="true"/>
-                        <attribute name="test" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.voice.marytts/.classpath
+++ b/bundles/org.openhab.voice.marytts/.classpath
@@ -29,5 +29,17 @@
 	<classpathentry kind="lib" path="lib/marytts-runtime-5.1-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="lib/marytts-server-5.1-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="lib/marytts-signalproc-5.1-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="lib/emotionml-checker-java-1.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="lib/freetts-1.0.jar"/>
+	<classpathentry kind="lib" path="lib/freetts-de-1.0.jar"/>
+	<classpathentry kind="lib" path="lib/freetts-en_us-1.0.jar"/>
+	<classpathentry kind="lib" path="lib/jtok-core-1.9.1.jar"/>
+	<classpathentry kind="lib" path="lib/mwdumper-1.16.jar"/>
+	<classpathentry kind="lib" path="lib/opennlp-maxent-3.0.1-incubating.jar"/>
+	<classpathentry kind="lib" path="lib/opennlp-tools-1.5.1-incubating.jar"/>
+	<classpathentry kind="lib" path="lib/sgt-3.0.jar"/>
+	<classpathentry kind="lib" path="lib/voice-bits1-hsmm-5.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="lib/voice-bits3-hsmm-5.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="lib/voice-cmu-slt-hsmm-5.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
With the migration to bnd not all .classpath files were updated accordingly. This would result in eclipse updating these files when loaded and showing up to git as modified. This change corrects those files.

Note: I've added all other libraries downloaded by marytts to the .classpath. Eclipse doesn't complain because they are missing. But I would expect they should be added.