### PR TITLE
[spotify] Changed deviceName and playlists channels

### DIFF
--- a/bundles/org.openhab.binding.spotify/README.md
+++ b/bundles/org.openhab.binding.spotify/README.md
@@ -51,13 +51,13 @@ The following configuration options are available on the Spotify Bridge player:
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | clientId      | This is the Client ID provided by Spotify when you add a new Application for openHAB to your Spotify Account. Go to https://developer.spotify.com/ (Required) |
 | clientSecret  | This is the Client Secret provided by Spotify when you add a new Application for openHAB to your Spotify Account.   (Required)                                |
-| refreshPeriod | This is the frequency of the polling requests to the Spotify Connect Web API in seconds.                                                                       |
+| refreshPeriod | This is the frequency of the polling requests to the Spotify Connect Web API in seconds.                                                                      |
 
 The following configuration option is available on the Spotify device:
 
-| Parameter | Description                                           |
-|-----------|-------------------------------------------------------|
-| id        | This is the device ID provided by Spotify (Required). |
+| Parameter  | Description                                             |
+|------------|---------------------------------------------------------|
+| deviceName | This is the device name provided by Spotify (Required). |
 
 
 ## Supported Things
@@ -65,8 +65,13 @@ The following configuration option is available on the Spotify device:
 All Spotify Connect capable devices should be discoverable through this binding.
 If you can control them from Spotify Player app on your PC/Mac/iPhone/Android/xxx you should be able to add it as a thing.
 Some devices can be restricted and not available for playing. The bridge will make these available in the discovery of devices, but they will never be ONLINE.
-A Spotify web player in a browser is only available as long as the page is open. It will get a unique id for that session. If you close the page it will be gone. Opening a new web player will result in a new id.
-Some devices will not be visible (i.e. Chrome casts) when they are not active. They go into a sleep mode and are not visible through the Spotify Web API. The binding will them show as _GONE_.
+A Spotify web player in a browser is only available as long as the page is open.
+It will get a unique id for that session.
+If you close the page it will be gone.
+Opening a new web player will result in a new id.
+Some devices will not be visible (i.e. Chrome casts) when they are not active.
+Some devices will not be visible (i.e. Chrome casts) when they are not active (they go into a sleep mode and are not visible through the Spotify Web API).
+The binding will show them as _GONE_.
 
 ## Discovery
 
@@ -75,7 +80,8 @@ As long as Spotify Connect devices are available in the context of the user acco
 If no devices are showing up, try to connect to the device(s) from your smartphone or computer to make sure the device(s) are in use by your user account.
 
 The discovery of devices in the Spotify Web API is based on what is known by Spotify.
-There is difference from e.g. smartphones and computers which can discover devices on the local network - the Web API cannot do that. It only knows about a device if your account is currently associated with the device.
+There is difference between e.g. smartphones and computers which can discover devices on the local network and the Web API which is not able to do so.
+It only knows about a device if your account is currently associated with the device.
 
 ## Channels
 
@@ -87,7 +93,8 @@ __Common Channels:__
 
 | Channel Type ID | Item Type | Read/Write | Description                                                                                      |
 |-----------------|-----------|------------|--------------------------------------------------------------------------------------------------|
-| deviceName      | Selection | Read-only  | Name of the currently active Connect Device, set the device ID to transfer play to that device.  |
+| deviceName      | String    | Read-write | Name of the currently active Connect Device,                                                     |
+| devices         | Selection | Read-write | List of currently active Connect Devices, Set the device ID to transfer play to that device.     |
 | deviceVolume    | Dimmer    | Read-write | Get or set the active Connect Device volume.                                                     |
 | deviceShuffle   | Switch    | Read-write | Turn on/off shuffle play on the active device.                                                   |
 | trackPlay       | String    | Read-write | Set which music  to play on the active device. This channel accepts Spotify URIs and URLs.       |
@@ -98,7 +105,8 @@ __Common Channels:__
 | trackDurationMs | Number    | Read-only  | The duration of the currently playing track in milliseconds.                                     |
 | trackProgress   | String    | Read-only  | The progress (m:ss) of the currently playing track. This is updated every second.                |
 | trackProgressMs | Number    | Read-only  | The progress of the currently playing track in milliseconds.                                     |
-| playlist        | Selection | Read-only  | This channel will be populated with the users playlists. Set the playlist ID to start.           |
+| playlists       | Selection | Read-write | This channel will be populated with the users playlists. Set the playlist ID to start.           |
+| playlistName    | String    | Read-write | The currently playing playlist. Or empty if no playing list is playing.                          |
 | albumName       | String    | Read-only  | Album Name of the currently playing track.                                                       |
 | albumImage      | RawType   | Read-only  | Album Image of the currently playing track.                                                      |
 | artistName      | String    | Read-only  | Artist Name of the currently playing track.                                                      |
@@ -108,24 +116,25 @@ They are dynamically populated by the binding with the user specific devices and
 
 __Advanced Channels:__
 
-| Channel Type ID | Item Type | Read/Write | Description                                                                                                                                                                 |
-|-----------------|-----------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| accessToken     | String    | Read-only  | The current accessToken used in communication with Web API. This can be used in client-side scripting towards the Web API if you would like to maintain your playlists etc. |
-| trackId         | String    | Read-only  | Track Id of the currently playing track.                                                                                                                                    |
-| trackHref       | String    | Read-only  | Track URL of the currently playing track.                                                                                                                                   |
-| trackUri        | String    | Read-only  | Track URI of the currently playing track.                                                                                                                                   |
-| trackType       | String    | Read-only  | Type of the currently playing track.                                                                                                                                        |
-| trackNumber     | String    | Read-only  | Number of the track on the album/record.                                                                                                                                    |
-| trackDiscNumber | String    | Read-only  | Disc Number of the track on the album/record.                                                                                                                               |
-| trackPopularity | Number    | Read-only  | Currently playing track popularity.                                                                                                                                         |
-| albumId         | String    | Read-only  | Album Id of the currently playing track.                                                                                                                                    |
-| albumUri        | String    | Read-only  | Album URI of the currently playing track.                                                                                                                                   |
-| albumHref       | String    | Read-only  | Album URL of the currently playing track.                                                                                                                                   |
-| albumType       | String    | Read-only  | Album Type of the currently playing track.                                                                                                                                  |
-| artistId        | String    | Read-only  | Artist Id of the currently playing track.                                                                                                                                   |
-| artistUri       | String    | Read-only  | Artist URI of the currently playing track.                                                                                                                                  |
-| artistHref      | String    | Read-only  | Artist URL of the currently playing track.                                                                                                                                  |
-| artistType      | String    | Read-only  | Artist Type of the currently playing track.                                                                                                                                 |
+| Channel Type ID | Item Type | Read/Write | Description                                                 |
+|-----------------|-----------|------------|-------------------------------------------------------------|
+| accessToken     | String    | Read-only  | The current accessToken used in communication with Web API. |
+| deviceId        | String    | Read-write | The Spotify Connect device Id.                              |
+| trackId         | String    | Read-only  | Track Id of the currently playing track.                    |
+| trackHref       | String    | Read-only  | Track URL of the currently playing track.                   |
+| trackUri        | String    | Read-only  | Track URI of the currently playing track.                   |
+| trackType       | String    | Read-only  | Type of the currently playing track.                        |
+| trackNumber     | String    | Read-only  | Number of the track on the album/record.                    |
+| trackDiscNumber | String    | Read-only  | Disc Number of the track on the album/record.               |
+| trackPopularity | Number    | Read-only  | Currently playing track popularity.                         |
+| albumId         | String    | Read-only  | Album Id of the currently playing track.                    |
+| albumUri        | String    | Read-only  | Album URI of the currently playing track.                   |
+| albumHref       | String    | Read-only  | Album URL of the currently playing track.                   |
+| albumType       | String    | Read-only  | Album Type of the currently playing track.                  |
+| artistId        | String    | Read-only  | Artist Id of the currently playing track.                   |
+| artistUri       | String    | Read-only  | Artist URI of the currently playing track.                  |
+| artistHref      | String    | Read-only  | Artist URL of the currently playing track.                  |
+| artistType      | String    | Read-only  | Artist Type of the currently playing track.                 |
 
 ### Devices
 
@@ -136,19 +145,19 @@ Assigning a playlist to the _trackPlay_ channel of the bridge will start playing
 
 __Common Channels:__
 
-| Channel Type ID | Item Type | Read/Write | Description                                                                                                                             |
-|-----------------|-----------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| trackPlay       | String    | Read-write | Track to play on the device. Assigning a track, playlist, artist etc will activate the device and make it the currently playing device. |
-| deviceName      | String    | Read-only  | Name of the device.                                                                                                                     |
-| deviceVolume    | Dimmer    | Read-write | Volume setting for the device.                                                                                                          |
-| devicePlayer    | Player    | Read-write | Player Control of the device.                                                                                                           |
-| deviceShuffle   | Switch    | Read-write | Turn on/off shuffle play.                                                                                                               |
+| Channel Type ID | Item Type | Read/Write | Description                                                     |
+|-----------------|-----------|------------|-----------------------------------------------------------------|
+| trackPlay       | String    | Write-only | Update to play a track, playlist, artist. Activates the device. |
+| deviceName      | String    | Read-only  | Name of the device.                                             |
+| deviceVolume    | Dimmer    | Read-write | Volume setting for the device.                                  |
+| devicePlayer    | Player    | Read-write | Player Control of the device.                                   |
+| deviceShuffle   | Switch    | Read-write | Turn on/off shuffle play.                                       |
 
 __Advanced Channels:__
 
 | Channel Type ID  | Item Type | Read/Write | Description                                                                                                |
 |------------------|-----------|------------|------------------------------------------------------------------------------------------------------------|
-| deviceId         | String    | Read-only  | The Spotify Connect device Id.                                                                             |
+| deviceId         | String    | Read-write | The Spotify Connect device Id.                                                                             |
 | deviceType       | String    | Read-only  | The type of device e.g. Speaker, Smartphone.                                                               |
 | deviceActive     | Switch    | Read-only  | Indicates if the device is active or not. Should be the same as Thing status ONLINE/OFFLINE.               |
 | deviceRestricted | Switch    | Read-only  | Indicates if this device allows to be controlled by the API or not. If restricted it cannot be controlled. |
@@ -162,16 +171,36 @@ spotify.things:
 ```
 Bridge spotify:player:user1 "Me" [clientId="<your client id>", clientSecret="<your client secret>"] {
   Things:
-    device device1 "Device 1" [id="<spotify device id>"]
-    device device2 "Device 2" [id="<spotify device id>"]
+    device device1 "Device 1" [deviceName="<spotify device name>"]
+    device device2 "Device 2" [deviceName="<spotify device name>"]
 }
 ```
 
 spotify.items:
 
 ```
-Player device1Player  {channel="spotify:device:user1:device1:devicePlayer"}
-Player device2Player  {channel="spotify:device:user1:device2:devicePlayer"}
+Player spotifyTrackPlayer   label="Player"               {channel="spotify:player:user1:trackPlayer"}
+String spotifyDevices       label="Active device [%s]"   {channel="spotify:player:user1:devices"}
+Switch spotifyDeviceShuffle label="Shuffle mode"         {channel="spotify:player:user1:deviceShuffle"}
+String spotifyTrackRepeat   label="Repeat mode: [%s]"    {channel="spotify:player:user1:trackRepeat"}
+String spotifyTrackProgress label="Track progress: [%s]" {channel="spotify:player:user1:trackProgress"}
+String spotifyTrackDuration label="Track duration: [%s]" {channel="spotify:player:user1:tackDuration"}
+String spotifyTrackName     label="Track Name: [%s]"     {channel="spotify:player:user1:trackName"}
+String spotifyAlbumName     label="Album Name: [%s]"     {channel="spotify:player:user1:albumName"}
+String spotifyArtistName    label="Artist Name: [%s]"    {channel="spotify:player:user1:artistName"}
+Image  spotifyAlbumImage    label="Album Art"            {channel="spotify:player:user1:albumImage"}
+String spotifyPlaylists     label="Playlists [%s]"       {channel="spotify:player:user1:playlists"}
+String spotifyPlayName      label="Playlist [%s]"        {channel="spotify:player:user1:playlistName"}
+
+String device1DeviceName    {channel="spotify:device:user1:device1:deviceName"}
+Player device1Player        {channel="spotify:device:user1:device1:devicePlayer"}
+Dimmer device1DeviceVolume  {channel="spotify:device:user1:device1:deviceVolume"}
+Switch device1DeviceShuffle {channel="spotify:device:user1:device1:deviceShuffle"}
+
+String device2DeviceName    {channel="spotify:device:user1:device2:deviceName"}
+Player device2Player        {channel="spotify:device:user1:device2:devicePlayer"}
+Dimmer device2DeviceVolume  {channel="spotify:device:user1:device2:deviceVolume"}
+Switch device2DeviceShuffle {channel="spotify:device:user1:device2:deviceShuffle"}
 ```
 
 spotify.sitemap:
@@ -180,30 +209,31 @@ spotify.sitemap:
 sitemap spotify label="Spotify Sitemap" {
 
   Frame label="Spotify Player Info" {
-    Selection item=spotify_player_user1_deviceName label="Active device [%]"
-    Player item="spotify_player_user1_trackPlayer
-    Text item=spotify_player_user1_deviceShuffle label="Currently Player shuffle mode: [%s]"
-    Text item=spotify_player_user1_trackRepeat label="Currently Player repeat mode: [%s]"
-    Text item=spotify_player_user1_trackProgress label="Currently Played track progress: [%s]"
-    Text item=spotify_player_user1_trackDuration label="Currently Played track duration: [%s]"
-    Text item=spotify_player_user1_trackName label="Currently Played Track Name: [%s]"
-    Text item=spotify_player_user1_albumName label="Currently Played Album Name: [%s]"
-    Text item=spotify_player_user1_artistName label="Currently Played Artist Name: [%s]"
-    Selection item=spotify_player_user1_trackPlay label="Playlist" icon="music"
+    Selection item=spotifyDevices       label="Active device [%]"
+    Player    item=spotifyTrackPlayer   label="Player"
+    Switch    item=spotifyDeviceShuffle label="Shuffle mode:"
+    Text      item=spotifyTrackRepeat   label="Repeat mode: [%s]"
+    Text      item=spotifyTrackProgress label="Track progress: [%s]"
+    Text      item=spotifyTrackDuration label="Track duration: [%s]"
+    Text      item=spotifyTrackName     label="Track Name: [%s]"
+    Image     item=spotifyAlbumImage    label="Album Art"
+    Text      item=spotifyAlbumName     label="Currently Played Album Name: [%s]"
+    Text      item=spotifyTrtistName    label="Currently Played Artist Name: [%s]"
+    Selection item=spotifyTrackPlay     label="Playlist" icon="music"
   }
 
   Frame label="My Spotify Device 1" {
-    Text item=spotify_device_user1_device1_deviceName label="Device Name [%s]"
+    Text item=device1DeviceName label="Device Name [%s]"
     Player item=device1Player
-    Slider item=spotify_device_user1_device1_deviceVolume
-    Switch item=spotify_device_user1_device1_deviceShuffle
+    Slider item=device1DeviceVolume
+    Switch item=device1DeviceShuffle
   }
 
    Frame label="My Spotify Device 2" {
-    Text item=spotify_device_user1_device2_deviceName label="Device Name [%s]"
+    Text item=device2DeviceName label="Device Name [%s]"
     Player item=device2Player
-    Slider item=spotify_device_user1_device2_deviceVolume
-    Switch item=spotify_device_user1_device2_deviceShuffle
+    Slider item=device2DeviceVolume
+    Switch item=device2DeviceShuffle
   }
 }
 ```

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyBindingConstants.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyBindingConstants.java
@@ -53,7 +53,8 @@ public class SpotifyBindingConstants {
     public static final String CHANNEL_TRACKPLAYER = "trackPlayer";
     public static final String CHANNEL_TRACKREPEAT = "trackRepeat";
 
-    public static final String CHANNEL_PLAYLIST = "playlist";
+    public static final String CHANNEL_PLAYLISTS = "playlists";
+    public static final String CHANNEL_PLAYLISTNAME = "playlistName";
 
     public static final String CHANNEL_PLAYED_TRACKID = "trackId";
     public static final String CHANNEL_PLAYED_TRACKURI = "trackUri";
@@ -82,7 +83,7 @@ public class SpotifyBindingConstants {
     public static final String CHANNEL_PLAYED_ARTISTTYPE = "artistType";
 
     public static final String CHANNEL_DEVICEID = "deviceId";
-    public static final String CHANNEL_TYPE_ACTIVE_DEVICENAME = "activeDeviceName";
+    public static final String CHANNEL_DEVICES = "devices";
     public static final String CHANNEL_DEVICENAME = "deviceName";
     public static final String CHANNEL_DEVICETYPE = "deviceType";
     public static final String CHANNEL_DEVICEACTIVE = "deviceActive";
@@ -96,5 +97,5 @@ public class SpotifyBindingConstants {
 
     // List of Bridge/Thing properties
     public static final String PROPERTY_SPOTIFY_USER = "user";
-    public static final String PROPERTY_SPOTIFY_DEVICE_ID = "id";
+    public static final String PROPERTY_SPOTIFY_DEVICE_NAME = "deviceName";
 }

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/api/SpotifyConnector.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/api/SpotifyConnector.java
@@ -48,7 +48,7 @@ class SpotifyConnector {
     private static final String RETRY_AFTER_HEADER = "Retry-After";
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
-    private static final int HTTP_CLIENT_TIMEOUT_SECONDS = 30;
+    private static final int HTTP_CLIENT_TIMEOUT_SECONDS = 3;
     private static final int HTTP_CLIENT_RETRY_COUNT = 5;
     private static final int DEFAULT_RETRY_DELAY_SECONDS = 5;
 
@@ -61,7 +61,7 @@ class SpotifyConnector {
     /**
      * Constructor.
      *
-     * @param scheduler Scheduler to reschedule calls when rate limit exceeded or call not ready
+     * @param scheduler  Scheduler to reschedule calls when rate limit exceeded or call not ready
      * @param httpClient http client to use to make http calls
      */
     public SpotifyConnector(ScheduledExecutorService scheduler, HttpClient httpClient) {
@@ -73,8 +73,8 @@ class SpotifyConnector {
      * Performs a call to the Spotify Web Api and returns the raw response. In there are problems this method can throw
      * a Spotify exception.
      *
-     * @param requester The function to construct the request with http client that is passed as argument to the
-     *            function
+     * @param requester     The function to construct the request with http client that is passed as argument to the
+     *                          function
      * @param authorization The authorization string to use in the Authorization header
      * @return the raw reponse given
      */
@@ -114,8 +114,8 @@ class SpotifyConnector {
         /**
          * Constructor.
          *
-         * @param requester The function to construct the request with http client that is passed as argument to the
-         *            function
+         * @param requester     The function to construct the request with http client that is passed as argument to the
+         *                          function
          * @param authorization The authorization string to use in the Authorization header
          */
         public Caller(Function<HttpClient, Request> requester, String authorization) {

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
@@ -115,12 +115,12 @@ public class SpotifyDeviceDiscoveryService extends AbstractDiscoveryService {
     private void thingDiscovered(Device device) {
         Map<String, Object> properties = new HashMap<String, Object>();
 
-        properties.put(PROPERTY_SPOTIFY_DEVICE_ID, device.getId());
+        properties.put(PROPERTY_SPOTIFY_DEVICE_NAME, device.getName());
         ThingUID thing = new ThingUID(SpotifyBindingConstants.THING_TYPE_DEVICE, bridgeUID,
                 device.getId().substring(0, PLAYER_ID_LENGTH));
 
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thing).withBridge(bridgeUID)
-                .withProperties(properties).withRepresentationProperty(PROPERTY_SPOTIFY_DEVICE_ID)
+                .withProperties(properties).withRepresentationProperty(PROPERTY_SPOTIFY_DEVICE_NAME)
                 .withLabel(device.getName()).build();
 
         thingDiscovered(discoveryResult);

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -58,6 +59,7 @@ import org.openhab.binding.spotify.internal.api.exception.SpotifyAuthorizationEx
 import org.openhab.binding.spotify.internal.api.exception.SpotifyException;
 import org.openhab.binding.spotify.internal.api.model.Album;
 import org.openhab.binding.spotify.internal.api.model.Artist;
+import org.openhab.binding.spotify.internal.api.model.Context;
 import org.openhab.binding.spotify.internal.api.model.CurrentlyPlayingContext;
 import org.openhab.binding.spotify.internal.api.model.Device;
 import org.openhab.binding.spotify.internal.api.model.Image;
@@ -316,19 +318,21 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
             try {
                 // Collect devices and populate selection with available devices.
                 final List<Device> ld = devicesCache.getValue();
-                final List<Device> listDevices = ld == null ? Collections.emptyList() : ld;
-                spotifyDynamicStateDescriptionProvider.setDevices(listDevices);
+                final List<Device> devices = ld == null ? Collections.emptyList() : ld;
+                spotifyDynamicStateDescriptionProvider.setDevices(devices);
                 // Collect currently playing context.
                 final CurrentlyPlayingContext pc = playingContextCache.getValue();
                 final CurrentlyPlayingContext playingContext = pc == null ? EMPTY_CURRENTLYPLAYINGCONTEXT : pc;
+                final List<Playlist> lp = playlistCache.getValue();
+                final List<Playlist> playlists = lp == null ? Collections.emptyList() : lp;
                 updateStatus(ThingStatus.ONLINE);
-                updatePlayerInfo(playingContext);
 
-                final List<Playlist> playlists = playlistCache.getValue();
+                handleCommand.setLists(devices, playlists);
+                updatePlayerInfo(playingContext, playlists);
                 spotifyDynamicStateDescriptionProvider
                         .setPlayList(playlists == null ? Collections.emptyList() : playlists);
 
-                updateDevicesStatus(listDevices, playingContext.isPlaying());
+                updateDevicesStatus(devices, playingContext.isPlaying());
                 return true;
             } catch (SpotifyAuthorizationException e) {
                 logger.debug("Authorization error during polling: ", e);
@@ -383,8 +387,9 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
      * Update the player data.
      *
      * @param playerInfo The object with the current playing context
+     * @param playlists List of available playlists
      */
-    private void updatePlayerInfo(CurrentlyPlayingContext playerInfo) {
+    private void updatePlayerInfo(CurrentlyPlayingContext playerInfo, List<Playlist> playlists) {
         updateChannelState(CHANNEL_TRACKPLAYER, playerInfo.isPlaying() ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
         updateChannelState(CHANNEL_DEVICESHUFFLE, playerInfo.isShuffleState() ? OnOffType.ON : OnOffType.OFF);
         updateChannelState(CHANNEL_TRACKREPEAT, playerInfo.getRepeatState());
@@ -403,10 +408,8 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
                 updateChannelState(CHANNEL_PLAYED_TRACKDURATION_FMT,
                         MUSIC_TIME_FORMAT.format(new Date(item.getDurationMs())));
             }
-            updateChannelState(CHANNEL_PLAYLIST,
-                    valueOrEmpty(playerInfo.getContext() != null && "playlist".equals(playerInfo.getContext().getType())
-                            ? playerInfo.getContext().getUri()
-                            : ""));
+
+            updateChannelsPlayList(playerInfo, playlists);
             updateChannelState(CHANNEL_PLAYED_TRACKID, lastTrackId);
             updateChannelState(CHANNEL_PLAYED_TRACKHREF, valueOrEmpty(item.getHref()));
             updateChannelState(CHANNEL_PLAYED_TRACKURI, valueOrEmpty(item.getUri()));
@@ -440,7 +443,8 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
         if (device.getId() != null) {
             lastKnownDeviceId = device.getId();
             updateChannelState(CHANNEL_DEVICEID, valueOrEmpty(lastKnownDeviceId));
-            updateChannelState(CHANNEL_DEVICENAME, valueOrEmpty(lastKnownDeviceId));
+            updateChannelState(CHANNEL_DEVICES, valueOrEmpty(lastKnownDeviceId));
+            updateChannelState(CHANNEL_DEVICENAME, valueOrEmpty(device.getName()));
         }
         lastKnownDeviceActive = device.isActive();
         updateChannelState(CHANNEL_DEVICEACTIVE, lastKnownDeviceActive ? OnOffType.ON : OnOffType.OFF);
@@ -449,6 +453,27 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
         // experienced situations where volume seemed to be undefined...
         updateChannelState(CHANNEL_DEVICEVOLUME,
                 device.getVolumePercent() == null ? UnDefType.UNDEF : new PercentType(device.getVolumePercent()));
+    }
+
+    private void updateChannelsPlayList(CurrentlyPlayingContext playerInfo, @Nullable List<Playlist> playlists) {
+        final Context context = playerInfo.getContext();
+        final String playlistId;
+        String playlistName = "";
+
+        if (context != null && "playlist".equals(context.getType())) {
+            playlistId = "spotify:playlist" + context.getUri().substring(context.getUri().lastIndexOf(':'));
+
+            if (playlists != null) {
+                final Optional<Playlist> optionalPlaylist = playlists.stream()
+                        .filter(pl -> playlistId.equals(pl.getUri())).findFirst();
+
+                playlistName = optionalPlaylist.isPresent() ? optionalPlaylist.get().getName() : "";
+            }
+        } else {
+            playlistId = "";
+        }
+        updateChannelState(CHANNEL_PLAYLISTS, valueOrEmpty(playlistId));
+        updateChannelState(CHANNEL_PLAYLISTNAME, valueOrEmpty(playlistName));
     }
 
     /**

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyDynamicStateDescriptionProvider.java
@@ -72,11 +72,9 @@ public class SpotifyDynamicStateDescriptionProvider implements DynamicStateDescr
             @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
         final String channelId = channel.getUID().getId();
 
-        if (channel.getChannelTypeUID() != null
-                && CHANNEL_TYPE_ACTIVE_DEVICENAME.equals(channel.getChannelTypeUID().getId())
-                && CHANNEL_DEVICENAME.equals(channelId)) {
+        if (CHANNEL_DEVICES.equals(channelId)) {
             return devicesStateDescription;
-        } else if (CHANNEL_PLAYLIST.equals(channelId)) {
+        } else if (CHANNEL_PLAYLISTS.equals(channelId)) {
             return playlistStateDescription;
         } else {
             return originalStateDescription;

--- a/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -18,11 +18,13 @@ register a bridge for each account. Go to http://your openHAB address::8080/conn
 
 			<channel id="deviceId" typeId="activeDeviceId" />
 			<channel id="deviceName" typeId="activeDeviceName" />
+			<channel id="devices" typeId="activeDevices" />
 			<channel id="deviceType" typeId="activeDeviceType" />
 			<channel id="deviceVolume" typeId="system.volume" />
 			<channel id="deviceShuffle" typeId="activeDeviceShuffle" />
 
-			<channel typeId="playlist" id="playlist"></channel>
+			<channel typeId="playlists" id="playlists"></channel>
+			<channel typeId="playlistName" id="playlistName"></channel>
 
 			<channel id="trackPlay" typeId="trackPlay" />
 			<channel id="trackPlayer" typeId="system.media-control" />
@@ -96,6 +98,7 @@ bridge you have configured.</description>
 
 		<channels>
 			<channel id="trackPlay" typeId="trackPlay" />
+			<channel id="deviceId" typeId="deviceId" />
 			<channel id="deviceName" typeId="deviceName" />
 			<channel id="deviceType" typeId="deviceType" />
 			<channel id="devicePlayer" typeId="system.media-control" />
@@ -105,13 +108,13 @@ bridge you have configured.</description>
 			<channel id="deviceShuffle" typeId="deviceShuffle" />
 		</channels>
 
-		<representation-property>id</representation-property>
+		<representation-property>deviceName</representation-property>
 
 		<config-description>
-			<parameter name="id" type="text">
+			<parameter name="deviceName" type="text">
 				<required>true</required>
-				<label>Spotify Device ID</label>
-				<description>This is the device ID provided by Spotify.</description>
+				<label>Spotify Device Name</label>
+				<description>This is the device name provided by Spotify.</description>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -126,13 +129,16 @@ bridge you have configured.</description>
 		<item-type>String</item-type>
 		<label>Active Device Id</label>
 		<description>The Spotify ID of active device</description>
-		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="activeDeviceName">
 		<item-type>String</item-type>
 		<label>Active Device Name</label>
 		<description>The name of the currently active device</description>
-		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="activeDevices">
+		<item-type>String</item-type>
+		<label>Active Device Name</label>
+		<description>List of active devices.</description>
 	</channel-type>
 	<channel-type id="activeDeviceType" advanced="true">
 		<item-type>String</item-type>
@@ -146,11 +152,17 @@ bridge you have configured.</description>
 		<description>If shuffle is on or off on the active device</description>
 	</channel-type>
 
-	<channel-type id="playlist">
+	<channel-type id="playlists">
 		<item-type>String</item-type>
-		<label>Playlist</label>
+		<label>Playlists</label>
 		<description>List of the users playlists</description>
 		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="playlistName">
+		<item-type>String</item-type>
+		<label>Playlist Name</label>
+		<description>Name of the active playlist</description>
 	</channel-type>
 
 	<channel-type id="trackPlay" advanced="true">
@@ -299,6 +311,11 @@ bridge you have configured.</description>
 		<state readOnly="true" />
 	</channel-type>
 
+	<channel-type id="deviceId" advanced="true">
+		<item-type>String</item-type>
+		<label>Device Id</label>
+		<description>The Spotify ID of the device</description>
+	</channel-type>
 	<channel-type id="deviceName">
 		<item-type>String</item-type>
 		<label>Device Name</label>


### PR DESCRIPTION
This changes some of the channels. So it requires the things to be readded
---- 

The deviceName was a option list with id as key, name as value. However that is not usable in rules. In rules only the id can been seen, so it's impossible to create a rule that checks on a name.
This change adds a new channel devices specific for selecting and changes the deviceName channel back to only displaying the name.
Also changed it's possible to select a player by setting the deviceName or deviceId.

For playlists this was the same problem. Therefor a new channel was added playlists that can be used to select a playlist.
Another new playlistName channel is added that shows the name of the playlist being played.

Changed using the device name as representation property instead of the id. This because some devices get a new id when rebooted.

Fixed the bug were the derived playlist name from the playing status didn't match with the id in the selection list. As a result of that problem when selecting a playlist and the active status was returned the playlist didn't show what playlist was playing.