### PR TITLE
Upgrade to Karaf 4.2.4

### DIFF
--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -304,6 +304,7 @@
         <feature>openhab-runtime-base</feature>
         <bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/2.2.4</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/2.9.0</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.9.0</bundle>
         <bundle dependency="true">mvn:org.apache.cxf/cxf-core/3.1.9</bundle>
         <bundle dependency="true">mvn:org.apache.cxf.services.wsn/cxf-services-wsn-api/3.1.9</bundle>
         <bundle dependency="true">mvn:org.apache.felix/org.apache.felix.framework/6.0.2</bundle>

--- a/poms/bnd/pom.xml
+++ b/poms/bnd/pom.xml
@@ -56,7 +56,7 @@
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
     <bnd.version>4.2.0</bnd.version>
-    <karaf.version>4.2.2</karaf.version>
+    <karaf.version>4.2.4</karaf.version>
     <sat.version>0.6.1</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
 


### PR DESCRIPTION
The org.apache.servicemix.specs.saaj-api-1.3 bundle dependency is added to the Helios Binding feature because javax.xml.soap is no longer provided by bundle 0, see [KARAF-6093](https://issues.apache.org/jira/browse/KARAF-6093).

For Karaf 4.2.3 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12344587

For Karaf 4.2.4 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12344856&projectId=12311140

---

Shoud be merged together with:

* https://github.com/openhab/openhab-core/pull/723
* https://github.com/openhab/openhab-webui/pull/56
* https://github.com/openhab/openhab-distro/pull/900