### PR TITLE
[lgwebos] Binding fails to install due to invalid bundle version

### DIFF
--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -456,7 +456,7 @@
         <feature>openhab-runtime-base</feature>
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.2.3</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.2.3</bundle>
-        <bundle dependency="true">wrap:mvn:xpp3/xpp3/1.1.4c$Bundle-Name=MXP1%20XmlPull%20Engine&amp;Bundle-SymbolicName=xpp3.xpp3&amp;Bundle-Version=1.1.4c</bundle>
+        <bundle dependency="true">wrap:mvn:xpp3/xpp3/1.1.4c$Bundle-Name=MXP1%20XmlPull%20Engine&amp;Bundle-SymbolicName=xpp3.xpp3&amp;Bundle-Version=1.1.4.c</bundle>
         <bundle dependency="true">wrap:mvn:org.json/json/20140107$Bundle-Name=JSON%20in%20Java&amp;Bundle-SymbolicName=org.json.json&amp;Bundle-Version=20140107</bundle>
         <bundle dependency="true">wrap:mvn:org.java-websocket/java-websocket/1.3.2$Bundle-Name=Java%20Websocket%20Client&amp;Bundle-SymbolicName=org.java-websocket.java-websocket&amp;Bundle-Version=1.3.2</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.lgwebos/${project.version}</bundle>


### PR DESCRIPTION
The wrapped xpp3 bundle version added in #5451 does not follow the OSGi [semantic versioning](https://www.osgi.org/wp-content/uploads/SemanticVersioning.pdf) scheme causing the following exception:

```
20:41:02.879 [ERROR] [.core.karaf.internal.FeatureInstaller] - Failed installing 'openhab-binding-lgwebos': Invalid Manifest header "Bundle-Version": 1.1.4c
org.osgi.framework.BundleException: Invalid Manifest header "Bundle-Version": 1.1.4c
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.getSymbolicNameAndVersion(OSGiManifestBuilderFactory.java:248)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder(OSGiManifestBuilderFactory.java:79)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder(OSGiManifestBuilderFactory.java:54)
	at org.eclipse.osgi.storage.Storage.getBuilder(Storage.java:615)
	at org.eclipse.osgi.storage.Storage.install(Storage.java:541)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.installBundle(BundleContextImpl.java:146)
	at org.eclipse.equinox.internal.region.BundleIdBasedRegion.installBundle0(BundleIdBasedRegion.java:117)
	at org.eclipse.equinox.internal.region.BundleIdBasedRegion.installBundleAtLocation(BundleIdBasedRegion.java:97)
	at org.apache.karaf.features.internal.service.BundleInstallSupportImpl.installBundle(BundleInstallSupportImpl.java:135)
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.installBundle(FeaturesServiceImpl.java:1134)
	at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:871)
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1058)
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:994)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalArgumentException: invalid version "1.1.4c": non-numeric "4c"
	at org.osgi.framework.Version.parseInt(Version.java:170)
	at org.osgi.framework.Version.<init>(Version.java:134)
	at org.osgi.framework.Version.valueOf(Version.java:257)
	at org.osgi.framework.Version.parseVersion(Version.java:228)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.getSymbolicNameAndVersion(OSGiManifestBuilderFactory.java:244)
	... 16 more
Caused by: java.lang.NumberFormatException: For input string: "4c"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.osgi.framework.Version.parseInt(Version.java:168)
	... 20 more
```

As a result add-on installation fails. See also this [community topic](https://community.openhab.org/t/snapshots-starting-with-2-5-0-s1568-1-broke-jsondb-parsing/72401/31?u=wborn).

