### PR TITLE
[homekit] Fix NoClassDefFoundError by adding missing javax.jmdns package import

### DIFF
--- a/addons/io/org.openhab.io.homekit/META-INF/MANIFEST.MF
+++ b/addons/io/org.openhab.io.homekit/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Bundle-Version: 2.5.0.qualifier
 Export-Package: org.openhab.io.homekit
 Import-Package: 
  com.google.common.collect,
+ javax.jmdns,
  org.apache.commons.io,
  org.apache.commons.lang.builder,
  org.eclipse.jdt.annotation;resolution:=optional,


### PR DESCRIPTION
Caused by #4920
Fixes #5432

There's quite a flood of exceptions due to this bug when installing the Demo package.