### PR TITLE
[mqtt] Fix channelType creation when channels are restored

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
@@ -208,7 +208,7 @@ public class Device implements AbstractMqttAttributeClass.AttributeChanged {
             // Restores the properties attribute object via the channels configuration.
             Property property = node.createProperty(propertyID,
                     channel.getConfiguration().as(PropertyAttributes.class));
-            property.createChannelFromAttribute();
+            property.attributesReceived();
 
             node.properties.put(propertyID, property);
         }


### PR DESCRIPTION
As discussed in #5469, the first proposal is applied to fix the bug, replacing the 'createChannelFromAttribute()' function with 'attributesReceived()' method.

Closes #5469 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>