### PR TITLE
[modbus] Fix modbus io groupId dependency in modbus binding pom.

### DIFF
--- a/bundles/org.openhab.binding.modbus/pom.xml
+++ b/bundles/org.openhab.binding.modbus/pom.xml
@@ -14,7 +14,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.openhab.io</groupId>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.io.transport.modbus</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
Closes #5474