### PR TITLE
[network] fix iputils-arping option for setting maximal packet count

### DIFF
--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -317,7 +317,7 @@ public class NetworkUtils {
             proc = new ProcessBuilder(arpUtilPath, "-w", String.valueOf(timeoutInMS), 
                                       "-x", ipV4address).start();
         } else {
-            proc = new ProcessBuilder(arpUtilPath, "-w", String.valueOf(timeoutInMS / 1000), "-C", "1", "-I",
+            proc = new ProcessBuilder(arpUtilPath, "-w", String.valueOf(timeoutInMS / 1000), "-c", "1", "-I",
                     interfaceName, ipV4address).start();
         }
 


### PR DESCRIPTION
The network binding documentation mentioned the "iputils-arping" version as a possible option:
https://www.openhab.org/addons/bindings/network/#network-binding

The current version of this tool does not support the option "-C" (uppercase).
But it actually supports the "-c" (lowercase) option, in order to set the maximum packet count.

Verification on openhabian release v1.4.1:
- install iputils-arping: "apt-get install iputils-arping"
- check arping: "man arping"
8<--
    -c count
        Stop after sending count ARP REQUEST packets. With deadline option, instead wait for count ARP REPLY packets, or until the timeout expires.
-->8    
-> there is no parameter "-C" (uppercase) as an option.
-> but the option "-c" (lowercase) exists
