### PR TITLE
[pioneeravr] Add Listening Mode Channels

### DIFF
--- a/bundles/org.openhab.binding.pioneeravr/README.md
+++ b/bundles/org.openhab.binding.pioneeravr/README.md
@@ -86,6 +86,66 @@ Here after are the ID values of the input sources (depending on you AVR input so
 * 57: Spotify
 * 31: HDMI (cyclic)
 
+## Listening Modes
+
+The *Listening Mode* is set by user to instruct the AVR how to treat the audio signal and do upscaling, downscaling and amplification. This settings corresponds to the settings made with the remote control or front panel. What the AVR actually does with each setting/input-signal-combination can be read out using the *Playing Listening Mode* channel.
+
+* 0001: STEREO (cyclic)
+* 0010: STANDARD (cyclic)
+* 0009: STEREO (direct set)
+* 0011: (2ch source)
+* 0013: PRO LOGIC2 MOVIE
+* 0018: PRO LOGIC2x MOVIE
+* 0014: PRO LOGIC2 MUSIC
+* 0019: PRO LOGIC2x MUSIC
+* 0015: PRO LOGIC2 GAME
+* 0020: PRO LOGIC2x GAME
+* 0031: PRO LOGIC2z HEIGHT
+* 0032: WIDE SURROUND MOVIE
+* 0033: WIDE SURROUND MUSIC
+* 0012: PRO LOGIC
+* 0016: Neo:6 CINEMA
+* 0017: Neo:6 MUSIC
+* 0037: Neo:X CINEMA
+* 0038: Neo:X MUSIC
+* 0039: Neo:X GAME
+* 0040: Dolby Surround
+* 0041: EXTENDED STEREO
+* 0021: (Multi ch source) Channel base straight decode
+* 0022: (Multi ch source)+DOLBY EX
+* 0023: (Multi ch source)+PRO LOGIC2x MOVIE
+* 0024: (Multi ch source)+PRO LOGIC2x MUSIC
+* 0034: (Multi-ch Source)+PRO LOGIC2z HEIGHT
+* 0035: (Multi-ch Source)+WIDE SURROUND MOVIE
+* 0036: (Multi-ch Source)+WIDE SURROUND MUSIC
+* 0025: (Multi ch source)DTS-ES Neo:6
+* 0026: (Multi ch source)DTS-ES matrix
+* 0027: (Multi ch source)DTS-ES discrete
+* 0030: (Multi ch source)DTS-ES 8ch discrete
+* 0043: (Multi ch source)+Neo:X CINEMA
+* 0044: (Multi ch source)+Neo:X MUSIC
+* 0045: (Multi ch source)+Neo:X GAME
+* 0050: (Multi ch source)+Dolby Surround
+* 0100: ADVANCED SURROUND (cyclic)
+* 0101: ACTION
+* 0103: DRAMA
+* 0118: ADVANCED GAME
+* 0117: SPORTS
+* 0107: CLASSICAL
+* 0110: ROCK/POP
+* 0003: Front Stage Surround Advance
+* 0200: ECO MODE (cyclic)
+* 0212: ECO MODE 1
+* 0213: ECO MODE 2
+* 0153: RETRIEVER AIR
+* 0113: PHONES SURROUND
+* 0005: AUTO SURR/STREAM DIRECT (cyclic)
+* 0006: AUTO SURROUND
+* 0151: Auto Level Control (A.L.C.)
+* 0007: DIRECT
+* 0008: PURE DIRECT
+* 0152: OPTIMUM SURROUND
+
 ## Playing Listening Modes
 
 The *Playing Listening Mode* is the Listening Mode that is actually playing as opposed to the *Listening Mode* set by the user. The *Playing Listening Mode* is what the display on the device shows.
@@ -208,6 +268,7 @@ Dimmer vsx921VolumeDimmer        "Volume [%.1f] %"        <none>        (All)   
 Number vsx921VolumeNumber        "Volume [%.1f] dB"        <none>        (All)    { channel="pioneeravr:ipAvr:vsx921:volumeDb" }
 String vsx921InputSourceSet        "Input"                    <none>        (All)    { channel="pioneeravr:ipAvr:vsx921:setInputSource" }
 String vsx921InformationDisplay "Information [%s]"        <none>         (All)    { channel="pioneeravr:ipAvr:vsx921:displayInformation" }
+String vsx921ListeningMode "Listening Mode [%s]"        <none>         (All)    { channel="pioneeravr:ipAvr:vsx921:listeningMode" }
 String vsx921PlayingListeningMode "Playing Listening Mode [%s]"        <none>         (All)    { channel="pioneeravr:ipAvr:vsx921:playingListeningMode" }
 ```
 
@@ -223,6 +284,7 @@ sitemap demo label="Main Menu"
 		Setpoint item=vsx921VolumeNumber minValue="-80" maxValue="12" step="0.5"
 		Switch item=vsx921InputSourceSet mappings=[04="DVD", 15="DVR/BDR", 25="BD"]
 		Text item=vsx921InformationDisplay
+		Switch item=vsx921ListeningMode mappings=["0009"="Stereo", "0040"="Dolby Surround", "0010"="next"]
 		Text item=vsx921PlayingListeningMode
 	}
 }

--- a/bundles/org.openhab.binding.pioneeravr/README.md
+++ b/bundles/org.openhab.binding.pioneeravr/README.md
@@ -86,6 +86,110 @@ Here after are the ID values of the input sources (depending on you AVR input so
 * 57: Spotify
 * 31: HDMI (cyclic)
 
+## Playing Listening Modes
+
+The *Playing Listening Mode* is the Listening Mode that is actually playing as opposed to the *Listening Mode* set by the user. The *Playing Listening Mode* is what the display on the device shows.
+
+* 0101: [)(]PLIIx MOVIE
+* 0102: [)(]PLII MOVIE
+* 0103: [)(]PLIIx MUSIC
+* 0104: [)(]PLII MUSIC
+* 0105: [)(]PLIIx GAME
+* 0106: [)(]PLII GAME
+* 0107: [)(]PROLOGIC
+* 0108: Neo:6 CINEMA
+* 0109: Neo:6 MUSIC
+* 010c: 2ch Straight Decode
+* 010d: [)(]PLIIz HEIGHT
+* 010e: WIDE SURR MOVIE
+* 010f: WIDE SURR MUSIC
+* 0110: STEREO
+* 0111: Neo:X CINEMA
+* 0112: Neo:X MUSIC
+* 0113: Neo:X GAME
+* 0117: Dolby Surround
+* 0118: EXTENDED STEREO
+* 1101: [)(]PLIIx MOVIE
+* 1102: [)(]PLIIx MUSIC
+* 1103: [)(]DIGITAL EX
+* 1104: DTS Neo:6
+* 1105: ES MATRIX
+* 1106: ES DISCRETE
+* 1107: DTS-ES 8ch
+* 1108: multi ch Channel base Straight Decode
+* 1109: [)(]PLIIz HEIGHT
+* 110a: WIDE SURR MOVIE
+* 110b: WIDE SURR MUSIC
+* 110c: Neo:X CINEMA
+* 110d: Neo:X MUSIC
+* 110e: Neo:X GAME
+* 110f: Dolby Surround
+* 0201: ACTION
+* 0202: DRAMA
+* 0208: ADVANCEDGAME
+* 0209: SPORTS
+* 020a: CLASSICAL
+* 020b: ROCK/POP
+* 020e: PHONES SURR.
+* 020f: FRONT STAGE SURROUND ADVANCE
+* 0211: SOUND RETRIEVER AIR
+* 0212: ECO MODE 1
+* 0213: ECO MODE 2
+* 0401: STEREO
+* 0402: [)(]PLII MOVIE
+* 0403: [)(]PLIIx MOVIE
+* 0405: AUTO SURROUND Straight Decode
+* 0406: [)(]DIGITAL EX
+* 0407: [)(]PLIIx MOVIE
+* 0408: DTS +Neo:6
+* 0409: ES MATRIX
+* 040a: ES DISCRETE
+* 040b: DTS-ES 8ch
+* 040e: RETRIEVER AIR
+* 040f: Neo:X CINEMA
+* 0411: Dolby Surround
+* 0501: STEREO
+* 0502: [)(]PLII MOVIE
+* 0503: [)(]PLIIx MOVIE
+* 0504: DTS/DTS-HD
+* 0505: ALC Straight Decode
+* 0506: [)(]DIGITAL EX
+* 0507: [)(]PLIIx MOVIE
+* 0508: DTS +Neo:6
+* 0509: ES MATRIX
+* 050a: ES DISCRETE
+* 050b: DTS-ES 8ch
+* 050e: RETRIEVER AIR
+* 050f: Neo:X CINEMA
+* 0601: STEREO
+* 0602: [)(]PLII MOVIE
+* 0603: [)(]PLIIx MOVIE
+* 0604: Neo:6 CINEMA
+* 0605: STREAM DIRECT NORMAL Straight Decode
+* 0606: [)(]DIGITAL EX
+* 0607: [)(]PLIIx MOVIE
+* 0609: ES MATRIX
+* 060a: ES DISCRETE
+* 060b: DTS-ES 8ch
+* 060c: Neo:X CINEMA
+* 060e: NORMAL DIRECT Dolby Surround
+* 0701: STREAM DIRECT PURE 2ch
+* 0702: [)(]PLII MOVIE
+* 0703: [)(]PLIIx MOVIE
+* 0704: Neo:6 CINEMA
+* 0705: STREAM DIRECT PURE Straight Decode
+* 0706: [)(]DIGITAL EX
+* 0707: [)(]PLIIx MOVIE
+* 0708: (nothing)
+* 0709: ES MATRIX
+* 070a: ES DISCRETE
+* 070b: DTS-ES 8ch
+* 070c: Neo:X CINEMA
+* 070e: PURE DIRECT Dolby Surround
+* 0881: OPTIMUM
+* 0e01: HDMI THROUGH
+* 0f01: MULTI CH IN
+
 ## Example
 
 *demo.Things:
@@ -104,6 +208,7 @@ Dimmer vsx921VolumeDimmer        "Volume [%.1f] %"        <none>        (All)   
 Number vsx921VolumeNumber        "Volume [%.1f] dB"        <none>        (All)    { channel="pioneeravr:ipAvr:vsx921:volumeDb" }
 String vsx921InputSourceSet        "Input"                    <none>        (All)    { channel="pioneeravr:ipAvr:vsx921:setInputSource" }
 String vsx921InformationDisplay "Information [%s]"        <none>         (All)    { channel="pioneeravr:ipAvr:vsx921:displayInformation" }
+String vsx921PlayingListeningMode "Playing Listening Mode [%s]"        <none>         (All)    { channel="pioneeravr:ipAvr:vsx921:playingListeningMode" }
 ```
 
 *demo.sitemap:
@@ -118,6 +223,7 @@ sitemap demo label="Main Menu"
 		Setpoint item=vsx921VolumeNumber minValue="-80" maxValue="12" step="0.5"
 		Switch item=vsx921InputSourceSet mappings=[04="DVD", 15="DVR/BDR", 25="BD"]
 		Text item=vsx921InformationDisplay
+		Text item=vsx921PlayingListeningMode
 	}
 }
 ```

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * The {@link PioneerAvrBinding} class defines common constants, which are used across the whole binding.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 @NonNullByDefault
 public class PioneerAvrBindingConstants {
@@ -45,7 +46,7 @@ public class PioneerAvrBindingConstants {
                     .collect(Collectors.toSet()));
 
     public static final Set<String> SUPPORTED_DEVICE_MODELS2016 = Collections.unmodifiableSet(
-            Stream.of("SC-99", "SC-LX89", "SC-97", "SC-LX79", "SC-95", "SC-LX59", "SC-92", "SC-91", "VSX-90", "VSX-45")
+            Stream.of("SC-99", "SC-LX89", "SC-97", "SC-LX79", "SC-95", "SC-LX59", "SC-92", "SC-91", "VSX-90", "VSX-45", "VSX-830")
                     .collect(Collectors.toSet()));
 
     // List of all Thing Type UIDs
@@ -71,6 +72,7 @@ public class PioneerAvrBindingConstants {
     public static final String VOLUME_DB_CHANNEL = "volumeDb";
     public static final String MUTE_CHANNEL = "mute";
     public static final String SET_INPUT_SOURCE_CHANNEL = "setInputSource";
+    public static final String LISTENING_MODE_CHANNEL = "listeningMode";
     public static final String PLAYING_LISTENING_MODE_CHANNEL = "playingListeningMode";
     public static final String DISPLAY_INFORMATION_CHANNEL = "displayInformation#displayInformation";
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
@@ -71,6 +71,7 @@ public class PioneerAvrBindingConstants {
     public static final String VOLUME_DB_CHANNEL = "volumeDb";
     public static final String MUTE_CHANNEL = "mute";
     public static final String SET_INPUT_SOURCE_CHANNEL = "setInputSource";
+    public static final String PLAYING_LISTENING_MODE_CHANNEL = "playingListeningMode";
     public static final String DISPLAY_INFORMATION_CHANNEL = "displayInformation#displayInformation";
 
     public static final String GROUP_CHANNEL_PATTERN = "zone%s#%s";

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
@@ -131,6 +131,7 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
         updateState(getChannelUID(PioneerAvrBindingConstants.VOLUME_DB_CHANNEL, zone), UnDefType.UNDEF);
         updateState(getChannelUID(PioneerAvrBindingConstants.VOLUME_DIMMER_CHANNEL, zone), UnDefType.UNDEF);
         updateState(getChannelUID(PioneerAvrBindingConstants.SET_INPUT_SOURCE_CHANNEL, zone), UnDefType.UNDEF);
+        updateState(getChannelUID(PioneerAvrBindingConstants.PLAYING_LISTENING_MODE_CHANNEL, zone), UnDefType.UNDEF);
     }
 
     /**
@@ -206,6 +207,10 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
 
                 case INPUT_SOURCE_CHANNEL:
                     manageInputSourceChannelUpdate(response);
+                    break;
+
+                case PLAYING_LISTENING_MODE:
+                    managePlayingListeningModeUpdate(response);
                     break;
 
                 case DISPLAY_INFORMATION:
@@ -285,6 +290,16 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
      */
     private void manageInputSourceChannelUpdate(AvrResponse response) {
         updateState(getChannelUID(PioneerAvrBindingConstants.SET_INPUT_SOURCE_CHANNEL, response.getZone()),
+                new StringType(response.getParameterValue()));
+    }
+
+    /**
+     * Notify an AVR now-playing, in-effect listening mode (audio output format) update to openHAB
+     *
+     * @param response
+     */
+    private void managePlayingListeningModeUpdate(AvrResponse response) {
+        updateState(getChannelUID(PioneerAvrBindingConstants.PLAYING_LISTENING_MODE_CHANNEL, response.getZone()),
                 new StringType(response.getParameterValue()));
     }
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * AVR connection.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public abstract class AbstractAvrHandler extends BaseThingHandler
         implements AvrUpdateListener, AvrDisconnectionListener {
@@ -120,6 +121,7 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
         connection.sendVolumeQuery(zone);
         connection.sendMuteQuery(zone);
         connection.sendSourceInputQuery(zone);
+        connection.sendListeningModeQuery(zone);
     }
 
     /**
@@ -131,6 +133,7 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
         updateState(getChannelUID(PioneerAvrBindingConstants.VOLUME_DB_CHANNEL, zone), UnDefType.UNDEF);
         updateState(getChannelUID(PioneerAvrBindingConstants.VOLUME_DIMMER_CHANNEL, zone), UnDefType.UNDEF);
         updateState(getChannelUID(PioneerAvrBindingConstants.SET_INPUT_SOURCE_CHANNEL, zone), UnDefType.UNDEF);
+        updateState(getChannelUID(PioneerAvrBindingConstants.LISTENING_MODE_CHANNEL, zone), UnDefType.UNDEF);
         updateState(getChannelUID(PioneerAvrBindingConstants.PLAYING_LISTENING_MODE_CHANNEL, zone), UnDefType.UNDEF);
     }
 
@@ -169,6 +172,8 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
                 commandSent = connection.sendVolumeCommand(command, getZoneFromChannelUID(channelUID.getId()));
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.SET_INPUT_SOURCE_CHANNEL)) {
                 commandSent = connection.sendInputSourceCommand(command, getZoneFromChannelUID(channelUID.getId()));
+            } else if (channelUID.getId().contains(PioneerAvrBindingConstants.LISTENING_MODE_CHANNEL)) {
+                commandSent = connection.sendListeningModeCommand(command, getZoneFromChannelUID(channelUID.getId()));
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.MUTE_CHANNEL)) {
                 commandSent = connection.sendMuteCommand(command, getZoneFromChannelUID(channelUID.getId()));
             } else {
@@ -207,6 +212,10 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
 
                 case INPUT_SOURCE_CHANNEL:
                     manageInputSourceChannelUpdate(response);
+                    break;
+
+                case LISTENING_MODE:
+                    manageListeningModeUpdate(response);
                     break;
 
                 case PLAYING_LISTENING_MODE:
@@ -300,6 +309,16 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
      */
     private void managePlayingListeningModeUpdate(AvrResponse response) {
         updateState(getChannelUID(PioneerAvrBindingConstants.PLAYING_LISTENING_MODE_CHANNEL, response.getZone()),
+                new StringType(response.getParameterValue()));
+    }
+
+    /**
+     * Notify an AVR set listening mode (user-selected audio mode) update to openHAB
+     *
+     * @param response
+     */
+    private void manageListeningModeUpdate(AvrResponse response) {
+        updateState(getChannelUID(PioneerAvrBindingConstants.LISTENING_MODE_CHANNEL, response.getZone()),
                 new StringType(response.getParameterValue()));
     }
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ParameterizedCommand.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ParameterizedCommand.java
@@ -20,6 +20,7 @@ import org.openhab.binding.pioneeravr.internal.protocol.avr.AvrConnectionExcepti
  * A command which accept a parameter.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public class ParameterizedCommand extends SimpleCommand {
 
@@ -29,7 +30,8 @@ public class ParameterizedCommand extends SimpleCommand {
     public enum ParameterizedCommandType implements AvrCommand.CommandType {
 
         VOLUME_SET("[0-9]{2,3}", "VL", "ZV", "YV", "HZV"),
-        INPUT_CHANNEL_SET("[0-9]{2}", "FN", "ZS", "ZT", "ZEA");
+        INPUT_CHANNEL_SET("[0-9]{2}", "FN", "ZS", "ZT", "ZEA"),
+        LISTENING_MODE_SET("[0-9]{4}", "SR");
 
         private String[] zoneCommands;
         private String parameterPattern;

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
@@ -34,6 +34,7 @@ public class Response implements AvrResponse {
         VOLUME_LEVEL("[0-9]{2,3}", "VOL", "ZV", "YV", "HZV"),
         MUTE_STATE("[0-1]", "MUT", "Z2MUT", "Z3MUT", "HZM"),
         INPUT_SOURCE_CHANNEL("[0-9]{2}", "FN", "Z2F", "Z3F", "ZEA"),
+        PLAYING_LISTENING_MODE("[0-9a-f]{4}", "LM"),
         DISPLAY_INFORMATION("[0-9a-fA-F]{30}", "FL");
 
         private String[] responsePrefixZone;

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
@@ -23,6 +23,7 @@ import org.openhab.binding.pioneeravr.internal.protocol.avr.AvrResponse;
  * Represent an AVR response.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public class Response implements AvrResponse {
 
@@ -34,6 +35,7 @@ public class Response implements AvrResponse {
         VOLUME_LEVEL("[0-9]{2,3}", "VOL", "ZV", "YV", "HZV"),
         MUTE_STATE("[0-1]", "MUT", "Z2MUT", "Z3MUT", "HZM"),
         INPUT_SOURCE_CHANNEL("[0-9]{2}", "FN", "Z2F", "Z3F", "ZEA"),
+        LISTENING_MODE("[0-9]{4}", "SR"),
         PLAYING_LISTENING_MODE("[0-9a-f]{4}", "LM"),
         DISPLAY_INFORMATION("[0-9a-fA-F]{30}", "FL");
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/SimpleCommand.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/SimpleCommand.java
@@ -18,6 +18,7 @@ import org.openhab.binding.pioneeravr.internal.protocol.avr.AvrCommand;
  * A simple command without parameters.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public class SimpleCommand implements AvrCommand {
 
@@ -37,6 +38,8 @@ public class SimpleCommand implements AvrCommand {
         MUTE_QUERY("?M", "?Z2M", "?Z3M", "?HZM"),
         INPUT_CHANGE_CYCLIC("FU"),
         INPUT_CHANGE_REVERSE("FD"),
+        LISTENING_MODE_CHANGE_CYCLIC("0010SR"),
+        LISTENING_MODE_QUERY("?S"),
         INPUT_QUERY("?F", "?ZS", "?ZT", "?ZEA");
 
         private String zoneCommands[];

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Antoine Besnard - Initial contribution
  * @author Rainer Ostendorf - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public abstract class StreamAvrConnection implements AvrConnection {
 
@@ -190,6 +191,11 @@ public abstract class StreamAvrConnection implements AvrConnection {
     }
 
     @Override
+    public boolean sendListeningModeQuery(int zone) {
+        return sendCommand(RequestResponseFactory.getIpControlCommand(SimpleCommandType.LISTENING_MODE_QUERY, zone));
+    }
+
+    @Override
     public boolean sendPowerCommand(Command command, int zone) throws CommandTypeNotSupportedException {
         AvrCommand commandToSend = null;
 
@@ -260,6 +266,23 @@ public abstract class StreamAvrConnection implements AvrConnection {
             String inputSourceValue = ((StringType) command).toString();
             commandToSend = RequestResponseFactory.getIpControlCommand(ParameterizedCommandType.INPUT_CHANNEL_SET, zone)
                     .setParameter(inputSourceValue);
+        } else {
+            throw new CommandTypeNotSupportedException("Command type not supported.");
+        }
+
+        return sendCommand(commandToSend);
+    }
+
+    @Override
+    public boolean sendListeningModeCommand(Command command, int zone) throws CommandTypeNotSupportedException {
+        AvrCommand commandToSend = null;
+
+        if (command == IncreaseDecreaseType.INCREASE) {
+            commandToSend = RequestResponseFactory.getIpControlCommand(SimpleCommandType.LISTENING_MODE_CHANGE_CYCLIC, zone);
+        } else if (command instanceof StringType) {
+            String listeningModeValue = ((StringType) command).toString();
+            commandToSend = RequestResponseFactory.getIpControlCommand(ParameterizedCommandType.LISTENING_MODE_SET, zone)
+                    .setParameter(listeningModeValue);
         } else {
             throw new CommandTypeNotSupportedException("Command type not supported.");
         }

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
@@ -20,6 +20,7 @@ import org.openhab.binding.pioneeravr.internal.protocol.event.AvrUpdateListener;
  * Represent a connection to a remote Pioneer AVR.
  *
  * @author Antoine Besnard - Initial contribution
+ * @author Leroy Foerster - Listening Mode, Playing Listening Mode
  */
 public interface AvrConnection {
 
@@ -88,6 +89,14 @@ public interface AvrConnection {
     public boolean sendSourceInputQuery(int zone);
 
     /**
+     * Send a listening mode state query to the AVR
+     *
+     * @param zone
+     * @return
+     */
+    public boolean sendListeningModeQuery(int zone);
+
+    /**
      * Send a power command ot the AVR based on the openHAB command
      *
      * @param command
@@ -113,6 +122,15 @@ public interface AvrConnection {
      * @return
      */
     public boolean sendInputSourceCommand(Command command, int zone) throws CommandTypeNotSupportedException;
+
+    /**
+     * Send a listening mode selection command to the AVR based on the openHAB command
+     *
+     * @param command
+     * @param zone
+     * @return
+     */
+    public boolean sendListeningModeCommand(Command command, int zone) throws CommandTypeNotSupportedException;
 
     /**
      * Send a mute command to the AVR based on the openHAB command

--- a/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -70,7 +70,7 @@
 
 	<thing-type id="ipAvr2015">
 		<label>Pioneer AVR over IP 2015</label>
-		<description>Control a 2015 Pioneer AVR (SC-89, SC-LX88, SC-87, SC-LX78, SC-85, SC-LX58, SC-82, SC-2024, SC-81, VSX-80) over IP </description>
+		<description>Control a 2015 Pioneer AVR (SC-89, SC-LX88, SC-87, SC-LX78, SC-85, SC-LX58, SC-82, SC-2024, SC-81, VSX-80, VSX-830) over IP </description>
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation" />
@@ -198,6 +198,7 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceChannel" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
 			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
@@ -210,6 +211,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceChannel2014" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -221,6 +224,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceZoneChannel2014" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -232,6 +237,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceHDZoneChannel2014" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -243,6 +250,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceChannel2015" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -254,6 +263,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceZoneChannel2014" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -265,6 +276,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceHDZoneChannel2015" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -276,6 +289,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceChannel2016" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -287,6 +302,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceZoneChannel2016" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -298,6 +315,8 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceHDZoneChannel2016" />
+			<channel id="listeningMode" typeId="listeningModeChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -625,6 +644,71 @@
 		<label>Display</label>
 		<description>Display the information displayed on the AVR front screen</description>
 		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="listeningModeChannel">
+		<item-type>String</item-type>
+		<label>Listening Mode</label>
+		<description>Set the listening mode</description>
+		<state>
+			<options>
+				<option value="0001">STEREO (cyclic)</option>
+				<option value="0010">STANDARD (cyclic)</option>
+				<option value="0009">STEREO (direct set)</option>
+				<option value="0011">(2ch source)</option>
+				<option value="0013">PRO LOGIC2 MOVIE</option>
+				<option value="0018">PRO LOGIC2x MOVIE</option>
+				<option value="0014">PRO LOGIC2 MUSIC</option>
+				<option value="0019">PRO LOGIC2x MUSIC</option>
+				<option value="0015">PRO LOGIC2 GAME</option>
+				<option value="0020">PRO LOGIC2x GAME</option>
+				<option value="0031">PRO LOGIC2z HEIGHT</option>
+				<option value="0032">WIDE SURROUND MOVIE</option>
+				<option value="0033">WIDE SURROUND MUSIC</option>
+				<option value="0012">PRO LOGIC</option>
+				<option value="0016">Neo:6 CINEMA</option>
+				<option value="0017">Neo:6 MUSIC</option>
+				<option value="0037">Neo:X CINEMA</option>
+				<option value="0038">Neo:X MUSIC</option>
+				<option value="0039">Neo:X GAME</option>
+				<option value="0040">Dolby Surround</option>
+				<option value="0041">EXTENDED STEREO</option>
+				<option value="0021">(Multi ch source) Channel base straight decode</option>
+				<option value="0022">(Multi ch source)+DOLBY EX</option>
+				<option value="0023">(Multi ch source)+PRO LOGIC2x MOVIE</option>
+				<option value="0024">(Multi ch source)+PRO LOGIC2x MUSIC</option>
+				<option value="0034">(Multi-ch Source)+PRO LOGIC2z HEIGHT</option>
+				<option value="0035">(Multi-ch Source)+WIDE SURROUND MOVIE</option>
+				<option value="0036">(Multi-ch Source)+WIDE SURROUND MUSIC</option>
+				<option value="0025">(Multi ch source)DTS-ES Neo:6</option>
+				<option value="0026">(Multi ch source)DTS-ES matrix</option>
+				<option value="0027">(Multi ch source)DTS-ES discrete</option>
+				<option value="0030">(Multi ch source)DTS-ES 8ch discrete</option>
+				<option value="0043">(Multi ch source)+Neo:X CINEMA </option>
+				<option value="0044">(Multi ch source)+Neo:X MUSIC</option>
+				<option value="0045">(Multi ch source)+Neo:X GAME</option>
+				<option value="0050">(Multi ch source)+Dolby Surround</option>
+				<option value="0100">ADVANCED SURROUND (cyclic)</option>
+				<option value="0101">ACTION</option>
+				<option value="0103">DRAMA</option>
+				<option value="0118">ADVANCED GAME</option>
+				<option value="0117">SPORTS</option>
+				<option value="0107">CLASSICAL</option>
+				<option value="0110">ROCK/POP</option>
+				<option value="0003">Front Stage Surround Advance</option>
+				<option value="0200">ECO MODE (cyclic)</option>
+				<option value="0212">ECO MODE 1</option>
+				<option value="0213">ECO MODE 2</option>
+				<option value="0153">RETRIEVER AIR</option>
+				<option value="0113">PHONES SURROUND</option>
+				<option value="0005">AUTO SURR/STREAM DIRECT (cyclic)</option>
+				<option value="0006">AUTO SURROUND</option>
+				<option value="0151">Auto Level Control (A.L.C.)</option>
+				<option value="0007">DIRECT</option>
+				<option value="0008">PURE DIRECT</option>
+				<option value="0152">OPTIMUM SURROUND</option>
+			</options>
+		</state>
 	</channel-type>
 
 	<channel-type id="playingListeningModeChannel">

--- a/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -198,6 +198,7 @@
 			<channel id="volumeDb" typeId="volumeChannelDb" />
 			<channel id="mute" typeId="muteChannel" />
 			<channel id="setInputSource" typeId="setInputSourceChannel" />
+			<channel id="playingListeningMode" typeId="playingListeningModeChannel" />
 		</channels>
 	</channel-group-type>
 
@@ -623,6 +624,13 @@
 		<item-type>String</item-type>
 		<label>Display</label>
 		<description>Display the information displayed on the AVR front screen</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="playingListeningModeChannel">
+		<item-type>String</item-type>
+		<label>Playing Listening Mode</label>
+		<description>Display the effective listening mode</description>
 		<state readOnly="true" />
 	</channel-type>
 


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->
# [pioneeravr] Add Listening Mode Channels

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->
This improves the *pioneeravr* binding by adding two channels for setting and reading the *Listening Mode* and reading the *Playing Listening Mode*.

## Listening Modes

The *Listening Mode* is set by user to instruct the AVR how to treat the audio signal and do upscaling, downscaling and amplification. This settings corresponds to the settings made with the remote control or front panel. What the AVR actually does with each setting/input-signal-combination can be read out using the *Playing Listening Mode* channel.

## Playing Listening Modes

The *Playing Listening Mode* is the Listening Mode that is actually playing as opposed to the *Listening Mode* set by the user. The *Playing Listening Mode* is what the display on the device shows.

## Forum Discussions

- [PioneerAVR 2 - Listen Mode](https://community.openhab.org/t/pioneeravr-2-listen-mode/18595)

## Related Issues

Closes #1653 

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

## JARs For Testing

https://github.com/gersilex/openhab2-addons/releases

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
