### PR TITLE
Update MQTT Things and Channels Binding page

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -173,6 +173,21 @@ The channel expects values on the corresponding MQTT topic to be in this format 
 
 You can connect this channel to a Rollershutter or Dimmer item.
 
+## Item Actions
+In order for OH to publish to an MQTT broker (either embedded, local or remote) the MQTT version 1.x binding supported actions defined within an items file:
+
+```Switch MySwitch {mqtt=">[mqtt:broker:/mytopic:command:ON:1],>[mqtt:broker:/mytopic:command:OFF:0]"}```
+
+In the MQTT version 2.x binding, the publish action is performed via Rules instead.
+
+Items file:
+```Switch MySwitch "MySwitch"```
+
+Sitemap file:
+```Switch item=MySwitch```
+
+Configure a rule which is triggered by the switch (or some other input) and include the rule action below.
+
 ## Rule Actions
 
 This binding includes a rule action, which allows to publish MQTT messages from within rules.


### PR DESCRIPTION
I'm suggesting a slight change to the MQTT Things and Channels Binding documentation because I spent a lot of time trying to make MQTT publish work from an items file when (far as I can tell from my request and replies in the Community) this is a v1 approach, and the v2 method is via Rules.

Could be wrong though. Discard if so!

Thanks

Signed-off-by: Simon Tims <si@simontims.com>