### PR TITLE
[kodi] Changed 'DynamicStateDescriptionProvider' implementation to use new 'BaseDynamicStateDescriptionProvider'

### DIFF
--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiDynamicStateDescriptionProvider.java
@@ -12,53 +12,30 @@
  */
 package org.openhab.binding.kodi.internal;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.thing.Channel;
-import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
-import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.StateOption;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * Dynamic provider of state options while leaving other state description fields as original.
  *
- * @author Gregory Moyer - Initial contribution
- * @author Christoph Weitkamp - Adapted to Kodi binding
+ * @author Christoph Weitkamp - Initial contribution
  */
 @Component(service = { DynamicStateDescriptionProvider.class, KodiDynamicStateDescriptionProvider.class })
 @NonNullByDefault
-public class KodiDynamicStateDescriptionProvider implements DynamicStateDescriptionProvider {
-    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+public class KodiDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
 
-    public void setStateOptions(ChannelUID channelUID, List<StateOption> options) {
-        channelOptionsMap.put(channelUID, options);
+    @Reference
+    protected void setChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
     }
 
-    @Override
-    public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
-            @Nullable Locale locale) {
-        List<StateOption> options = channelOptionsMap.get(channel.getUID());
-        if (options == null) {
-            return null;
-        }
-
-        if (original != null) {
-            return new StateDescription(original.getMinimum(), original.getMaximum(), original.getStep(),
-                    original.getPattern(), original.isReadOnly(), options);
-        }
-        return new StateDescription(null, null, null, null, false, options);
-    }
-
-    @Deactivate
-    public void deactivate() {
-        channelOptionsMap.clear();
+    protected void unsetChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = null;
     }
 }


### PR DESCRIPTION
- Changed `DynamicStateDescriptionProvider` implementation to use new `BaseDynamicStateDescriptionProvider`. It now supports translated state options.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>