### PR TITLE
[spotify] Fixed deadlock causing status to stop.

### DIFF
--- a/bundles/org.openhab.binding.spotify/README.md
+++ b/bundles/org.openhab.binding.spotify/README.md
@@ -210,7 +210,7 @@ sitemap spotify label="Spotify Sitemap" {
 
   Frame label="Spotify Player Info" {
     Selection item=spotifyDevices       label="Active device [%]"
-    Player    item=spotifyTrackPlayer   label="Player"
+    Default   item=spotifyTrackPlayer   label="Player"
     Switch    item=spotifyDeviceShuffle label="Shuffle mode:"
     Text      item=spotifyTrackRepeat   label="Repeat mode: [%s]"
     Text      item=spotifyTrackProgress label="Track progress: [%s]"
@@ -223,17 +223,17 @@ sitemap spotify label="Spotify Sitemap" {
   }
 
   Frame label="My Spotify Device 1" {
-    Text item=device1DeviceName label="Device Name [%s]"
-    Player item=device1Player
-    Slider item=device1DeviceVolume
-    Switch item=device1DeviceShuffle
+    Text    item=device1DeviceName label="Device Name [%s]"
+    Default item=device1Player
+    Slider  item=device1DeviceVolume
+    Switch  item=device1DeviceShuffle
   }
 
    Frame label="My Spotify Device 2" {
-    Text item=device2DeviceName label="Device Name [%s]"
-    Player item=device2Player
-    Slider item=device2DeviceVolume
-    Switch item=device2DeviceShuffle
+    Text    item=device2DeviceName label="Device Name [%s]"
+    Default item=device2Player
+    Slider  item=device2DeviceVolume
+    Switch  item=device2DeviceShuffle
   }
 }
 ```

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/api/SpotifyConnector.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/api/SpotifyConnector.java
@@ -48,9 +48,8 @@ class SpotifyConnector {
     private static final String RETRY_AFTER_HEADER = "Retry-After";
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
-    private static final int HTTP_CLIENT_TIMEOUT_SECONDS = 3;
+    private static final int HTTP_CLIENT_TIMEOUT_SECONDS = 10;
     private static final int HTTP_CLIENT_RETRY_COUNT = 5;
-    private static final int DEFAULT_RETRY_DELAY_SECONDS = 5;
 
     private final Logger logger = LoggerFactory.getLogger(SpotifyConnector.class);
 
@@ -61,7 +60,7 @@ class SpotifyConnector {
     /**
      * Constructor.
      *
-     * @param scheduler  Scheduler to reschedule calls when rate limit exceeded or call not ready
+     * @param scheduler Scheduler to reschedule calls when rate limit exceeded or call not ready
      * @param httpClient http client to use to make http calls
      */
     public SpotifyConnector(ScheduledExecutorService scheduler, HttpClient httpClient) {
@@ -73,8 +72,8 @@ class SpotifyConnector {
      * Performs a call to the Spotify Web Api and returns the raw response. In there are problems this method can throw
      * a Spotify exception.
      *
-     * @param requester     The function to construct the request with http client that is passed as argument to the
-     *                          function
+     * @param requester The function to construct the request with http client that is passed as argument to the
+     *            function
      * @param authorization The authorization string to use in the Authorization header
      * @return the raw reponse given
      */
@@ -114,8 +113,8 @@ class SpotifyConnector {
         /**
          * Constructor.
          *
-         * @param requester     The function to construct the request with http client that is passed as argument to the
-         *                          function
+         * @param requester The function to construct the request with http client that is passed as argument to the
+         *            function
          * @param authorization The authorization string to use in the Authorization header
          */
         public Caller(Function<HttpClient, Request> requester, String authorization) {
@@ -185,8 +184,9 @@ class SpotifyConnector {
                     break;
                 case ACCEPTED_202:
                     logger.debug(
-                            "Spotify Web API returned code 202 - The request has been accepted for processing, but the processing has not been completed. Retrying...");
-                    delaySeconds = DEFAULT_RETRY_DELAY_SECONDS;
+                            "Spotify Web API returned code 202 - The request has been accepted for processing, but the processing has not been completed.");
+                    future.complete(response);
+                    success = true;
                     break;
                 case BAD_REQUEST_400:
                     throw new SpotifyException(processErrorState(response));

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
@@ -107,7 +107,7 @@ public class SpotifyDeviceDiscoveryService extends AbstractDiscoveryService {
             try {
                 bridgeHandler.listDevices().forEach(this::thingDiscovered);
             } catch (RuntimeException e) {
-                logger.debug("Finding devices failed with message: ", e.getMessage());
+                logger.debug("Finding devices failed with message: {}", e.getMessage(), e);
             }
         }
     }

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
@@ -43,7 +43,7 @@ class SpotifyHandleCommands {
 
     private final Logger logger = LoggerFactory.getLogger(SpotifyDeviceHandler.class);
 
-    private SpotifyApi spotifyApi;
+    private final SpotifyApi spotifyApi;
 
     private List<Device> devices = Collections.emptyList();
     private List<Playlist> playlists = Collections.emptyList();

--- a/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -137,7 +137,7 @@ bridge you have configured.</description>
 	</channel-type>
 	<channel-type id="activeDevices">
 		<item-type>String</item-type>
-		<label>Active Device Name</label>
+		<label>Active Devices</label>
 		<description>List of active devices.</description>
 	</channel-type>
 	<channel-type id="activeDeviceType" advanced="true">


### PR DESCRIPTION
Under certain conditions when a command is given, for example play next and a refresh happened a almost the same time a deadlock could happen causing the binding to hang. This fix limits synchronization on time formatter to only what matters and not wraps it also around state update (that is also synchronized).
Removed retry on 202. This is given when a command is given, so it's not necessary to retry that command.
Also made some documentation and other small code fixes.