### PR TITLE
[lutron] Fix for keypad/VCRX CCI channels

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -212,7 +212,7 @@ Supplying a model is not required, as there is only one model.
 
 To support the contact closure inputs, CCI channels named *cci[n]* are created with item type Contact and category Switch.
 They are marked as Advanced, so they will not be automatically linked to items in the Paper UI's Simple Mode.
-They accept both OPEN/CLOSED and ON/OFF commands and present OPEN/CLOSED states.
+They present OPEN/CLOSED states but do not accept commands as Contact items are read-only in OpenHAB.
 Note that the `autorelease` option **does not** apply to CCI channels.
 
 Example:
@@ -359,7 +359,7 @@ Appropriate channels will be created automatically by the keypad, ttkeypad, and 
 |cco        |switchstatus   |OnOffType     |OnOffType, RefreshType                                 |
 |keypads    |button*        |OnOffType     |OnOffType                                              |
 |           |led*           |OnOffType     |OnOffType, RefreshType                                 |
-|           |cci*           |OpenClosedType|OpenClosedType, OnOffType                              |
+|           |cci*           |OpenClosedType|(*readonly*)                                           |
 |shade      |shadelevel     |PercentType   |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
 |greenmode  |step           |DecimalType   |DecimalType, OnOffType (ON=2,OFF=1), RefreshType       |
 |timeclock  |clockmode      |DecimalType   |DecimalType, RefreshType                               |

--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -212,8 +212,8 @@ Supplying a model is not required, as there is only one model.
 
 To support the contact closure inputs, CCI channels named *cci[n]* are created with item type Contact and category Switch.
 They are marked as Advanced, so they will not be automatically linked to items in the Paper UI's Simple Mode.
-They accept ON/OFF commands and present ON/OFF states the same as a keypad button.
-Note that the `autorelease` option also applies to CCI channels.
+They accept both OPEN/CLOSED and ON/OFF commands and present OPEN/CLOSED states.
+Note that the `autorelease` option **does not** apply to CCI channels.
 
 Example:
 
@@ -351,23 +351,23 @@ Appropriate channels will be created automatically by the keypad, ttkeypad, and 
 
 ### Commands supported by channels
 
-| Thing     | Channel       |Native Type | Accepts                                               |
-|-----------|---------------|------------|-------------------------------------------------------|
-|dimmer     |lightlevel     |PercentType |OnOffType, PercentType                                 |
-|switch     |switchstatus   |OnOffType   |OnOffType                                              |
-|occ. sensor|occupancystatus|OnOffType   |(*readonly*)                                           |
-|cco        |switchstatus   |OnOffType   |OnOffType, RefreshType                                 |
-|keypads    |button*        |OnOffType   |OnOffType                                              |
-|           |led*           |OnOffType   |OnOffType, RefreshType                                 |
-|           |cci*           |OnOffType   |OnOffType                                              |
-|shade      |shadelevel     |PercentType |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
-|greenmode  |step           |DecimalType |DecimalType, OnOffType (ON=2,OFF=1), RefreshType       |
-|timeclock  |clockmode      |DecimalType |DecimalType, RefreshType                               |
-|           |sunrise        |DateTimeType|RefreshType (*readonly*)                               |
-|           |sunset         |DateTimeType|RefreshType (*readonly*)                               |
-|           |execevent      |DecimalType |DecimalType                                            |
-|           |enableevent    |DecimalType |DecimalType                                            |
-|           |disableevent   |DecimalType |DecimalType                                            |
+| Thing     | Channel       | Native Type  | Accepts                                               |
+|-----------|---------------|--------------|-------------------------------------------------------|
+|dimmer     |lightlevel     |PercentType   |OnOffType, PercentType                                 |
+|switch     |switchstatus   |OnOffType     |OnOffType                                              |
+|occ. sensor|occupancystatus|OnOffType     |(*readonly*)                                           |
+|cco        |switchstatus   |OnOffType     |OnOffType, RefreshType                                 |
+|keypads    |button*        |OnOffType     |OnOffType                                              |
+|           |led*           |OnOffType     |OnOffType, RefreshType                                 |
+|           |cci*           |OpenClosedType|OpenClosedType, OnOffType                              |
+|shade      |shadelevel     |PercentType   |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
+|greenmode  |step           |DecimalType   |DecimalType, OnOffType (ON=2,OFF=1), RefreshType       |
+|timeclock  |clockmode      |DecimalType   |DecimalType, RefreshType                               |
+|           |sunrise        |DateTimeType  |RefreshType (*readonly*)                               |
+|           |sunset         |DateTimeType  |RefreshType (*readonly*)                               |
+|           |execevent      |DecimalType   |DecimalType                                            |
+|           |enableevent    |DecimalType   |DecimalType                                            |
+|           |disableevent   |DecimalType   |DecimalType                                            |
 
 Most channels receive immediate notifications of device state changes from the Lutron control system.
 The only exceptions are **greenmode** *step*, which is periodically polled and accepts REFRESH commands to initiate immediate polling, and **timeclock** *sunrise* and *sunset*, which must be polled daily using REFRESH commands to retrieve current values.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -268,14 +269,35 @@ public abstract class BaseKeypadHandler extends LutronHandler {
             return;
         }
 
-        // For buttons and CCIs, handle OnOffType commands
-        if (isButton(componentID) || isCCI(componentID)) {
+        // For buttons, handle OnOffType commands
+        if (isButton(componentID)) {
             if (command instanceof OnOffType) {
                 if (command == OnOffType.ON) {
                     device(componentID, ACTION_PRESS);
                     if (autoRelease) {
                         device(componentID, ACTION_RELEASE);
                     }
+                } else if (command == OnOffType.OFF) {
+                    device(componentID, ACTION_RELEASE);
+                }
+            } else {
+                logger.warn("Invalid command type {} received for channel {} device {}", command, channelUID,
+                        getThing().getUID());
+            }
+            return;
+        }
+        
+        // For CCIs, handle OpenClosedType and OnOffType commands
+        if (isCCI(componentID)) {
+            if (command instanceof OpenClosedType) {
+                if (command == OpenClosedType.CLOSED) {
+                    device(componentID, ACTION_PRESS);
+                } else if (command == OpenClosedType.OPEN) {
+                    device(componentID, ACTION_RELEASE);
+                }
+            } else if (command instanceof OnOffType) {
+                if (command == OnOffType.ON) {
+                    device(componentID, ACTION_PRESS);
                 } else if (command == OnOffType.OFF) {
                     device(componentID, ACTION_RELEASE);
                 }
@@ -335,12 +357,20 @@ public abstract class BaseKeypadHandler extends LutronHandler {
                         updateState(channelUID, OnOffType.OFF);
                     }
                 } else if (ACTION_PRESS.toString().equals(parameters[1])) {
-                    updateState(channelUID, OnOffType.ON);
-                    if (autoRelease) {
-                        updateState(channelUID, OnOffType.OFF);
+                    if (isButton(component)) {
+                        updateState(channelUID, OnOffType.ON);
+                        if (autoRelease) {
+                            updateState(channelUID, OnOffType.OFF);
+                        }
+                    } else { // component is CCI
+                        updateState(channelUID, OpenClosedType.CLOSED);
                     }
                 } else if (ACTION_RELEASE.toString().equals(parameters[1])) {
-                    updateState(channelUID, OnOffType.OFF);
+                    if (isButton(component)) {
+                        updateState(channelUID, OnOffType.OFF);
+                    } else { // component is CCI
+                        updateState(channelUID, OpenClosedType.OPEN);
+                    }
                 } else if (ACTION_HOLD.toString().equals(parameters[1])) {
                     updateState(channelUID, OnOffType.OFF); // Signal a release if we receive a hold code as we will not
                                                             // get a subsequent release.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
@@ -287,24 +287,10 @@ public abstract class BaseKeypadHandler extends LutronHandler {
             return;
         }
         
-        // For CCIs, handle OpenClosedType and OnOffType commands
+        // Contact channels for CCIs are read-only, so ignore commands
         if (isCCI(componentID)) {
-            if (command instanceof OpenClosedType) {
-                if (command == OpenClosedType.CLOSED) {
-                    device(componentID, ACTION_PRESS);
-                } else if (command == OpenClosedType.OPEN) {
-                    device(componentID, ACTION_RELEASE);
-                }
-            } else if (command instanceof OnOffType) {
-                if (command == OnOffType.ON) {
-                    device(componentID, ACTION_PRESS);
-                } else if (command == OnOffType.OFF) {
-                    device(componentID, ACTION_RELEASE);
-                }
-            } else {
-                logger.warn("Invalid command type {} received for channel {} device {}", command, channelUID,
-                        getThing().getUID());
-            }
+            logger.debug("Invalid command type {} received for channel {} device {}", command, channelUID,
+                    getThing().getUID());
             return;
         }
     }


### PR DESCRIPTION
Hi. This PR contains a small fix for CCI channels in the Lutron keypad handler.  They were not using the proper command types.  Mea culpa.

Regards,
Bob