### PR TITLE
[keba] add RFID tag id and sessionID

### DIFF
--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -66,7 +66,10 @@ public class KebaBindingConstants {
     public static final String CHANNEL_DISPLAY = "display";
     public static final String CHANNEL_AUTHON = "authon";
     public static final String CHANNEL_AUTHREQ = "authreq";
-
+    public static final String CHANNEL_SESSION_RFID_TAG = "sessionRFIDtag";
+    public static final String CHANNEL_SESSION_RFID_CLASS = "sessionRFIDclass";
+    public static final String CHANNEL_SESSION_SESSION_ID = "sessionID";
+    
     public enum KebaType {
         P20,
         P30

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -83,6 +83,7 @@ public class KeContactHandler extends BaseThingHandler {
     private int maxSystemCurrent = 63000;
     private KebaType type;
     private KebaSeries series;
+    private int lastState = 0;
 
     public KeContactHandler(Thing thing) {
         super(thing);
@@ -258,8 +259,14 @@ public class KeContactHandler extends BaseThingHandler {
                         break;
                     }
                     case "State": {
-                        State newState = new DecimalType(entry.getValue().getAsInt());
+                        int state = entry.getValue().getAsInt();
+                        State newState = new DecimalType(state);
                         updateState(new ChannelUID(getThing().getUID(), CHANNEL_STATE), newState);
+                        if (lastState != state){
+                            // the state is different from the last one, so we will trigger a report100
+                            transceiver.send("report 100", this);
+                            lastState = state;
+                        }
                         break;
                     }
                     case "Enable sys": {
@@ -429,6 +436,24 @@ public class KeContactHandler extends BaseThingHandler {
                         int state = entry.getValue().getAsInt();
                         State newState = new DecimalType(state);
                         updateState(new ChannelUID(getThing().getUID(), CHANNEL_AUTHREQ), newState);
+                        break;
+                    }
+                    case "RFID tag": {
+                        String state = entry.getValue().getAsString().trim();
+                        State newState = new StringType(state);
+                        updateState(new ChannelUID(getThing().getUID(), CHANNEL_SESSION_RFID_TAG), newState);
+                        break;
+                    }
+                    case "RFID class": {
+                        String state = entry.getValue().getAsString().trim();
+                        State newState = new StringType(state);
+                        updateState(new ChannelUID(getThing().getUID(), CHANNEL_SESSION_RFID_CLASS), newState);
+                        break;
+                    }
+                    case "Session ID": {
+                        int state = entry.getValue().getAsInt();
+                        State newState = new DecimalType(state);
+                        updateState(new ChannelUID(getThing().getUID(), CHANNEL_SESSION_SESSION_ID), newState);
                         break;
                     }
                 }

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -37,9 +37,9 @@
 			<channel id="display" typeId="display" />
 			<channel id="authreq" typeId="switch" />
 			<channel id="authon" typeId="switch" />
-            <channel id="sessionRFIDtag" typeId="sessionRFIDtag" />
-            <channel id="sessionRFIDclass" typeId="sessionRFIDclass" />
-            <channel id="sessionID" typeId="sessionID" />
+			<channel id="sessionRFIDtag" typeId="sessionRFIDtag" />
+			<channel id="sessionRFIDclass" typeId="sessionRFIDclass" />
+			<channel id="sessionID" typeId="sessionID" />
 		</channels>
 
 		<config-description>

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -37,6 +37,9 @@
 			<channel id="display" typeId="display" />
 			<channel id="authreq" typeId="switch" />
 			<channel id="authon" typeId="switch" />
+            <channel id="sessionRFIDtag" typeId="RFID" />
+            <channel id="sessionRFIDclass" typeId="RFID" />
+            <channel id="sessionID" typeId="ID" />
 		</channels>
 
 		<config-description>
@@ -169,5 +172,22 @@
 		<description>Authentication enabled</description>
 		<state readOnly="true"></state>
 	</channel-type>
-
+    <channel-type id="sessionRFIDtag">
+		<item-type>String</item-type>
+		<label>RFID Tag</label>
+		<description>RFID Tag used for the last charging session</description>
+		<state readOnly="true"></state>
+	</channel-type>
+    <channel-type id="sessionRFIDclass">
+		<item-type>String</item-type>
+		<label>RFID Tag class</label>
+		<description>RFID Tag class used for the last charging session</description>
+		<state readOnly="true"></state>
+	</channel-type>
+    <channel-type id="sessionID">
+		<item-type>String</item-type>
+		<label>Session ID</label>
+		<description>Session ID of the last charging session</description>
+		<state readOnly="true"></state>
+	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -37,9 +37,9 @@
 			<channel id="display" typeId="display" />
 			<channel id="authreq" typeId="switch" />
 			<channel id="authon" typeId="switch" />
-            <channel id="sessionRFIDtag" typeId="RFID" />
-            <channel id="sessionRFIDclass" typeId="RFID" />
-            <channel id="sessionID" typeId="ID" />
+            <channel id="sessionRFIDtag" typeId="sessionRFIDtag" />
+            <channel id="sessionRFIDclass" typeId="sessionRFIDclass" />
+            <channel id="sessionID" typeId="sessionID" />
 		</channels>
 
 		<config-description>
@@ -185,7 +185,7 @@
 		<state readOnly="true"></state>
 	</channel-type>
     <channel-type id="sessionID">
-		<item-type>String</item-type>
+		<item-type>Number</item-type>
 		<label>Session ID</label>
 		<description>Session ID of the last charging session</description>
 		<state readOnly="true"></state>


### PR DESCRIPTION
In order to retrieve the RFID Tag used on a Keba i interoduced the "Report100" which is getting the RFID and SessionID of the last charging session done. The Report100 is only done if the session state changes, not to overload the connection with too many reports. Tested on a keba p30c. 
