### PR TITLE
Attach source JARs without forking to fix Jenkins warnings

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -258,7 +258,7 @@
           <execution>
             <id>attach-sources</id>
             <goals>
-              <goal>jar</goal>
+              <goal>jar-no-fork</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This fixes the following warnings on Jenkins builds:

`[WARNING] Failed to getClass for org.apache.maven.plugins.source.SourceJarMojo`

See also:
* [JENKINS-27372](https://issues.jenkins-ci.org/browse/JENKINS-27372)
* https://github.com/openhab/openhab-core/pull/741