### PR TITLE
fix feature verification

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -294,6 +294,9 @@
                 <goal>features-generate-descriptor</goal>
               </goals>
               <phase>generate-resources</phase>
+              <configuration>
+                <inputFile>${feature.directory}</inputFile>
+              </configuration>
             </execution>
             <execution>
               <id>karaf-feature-verification</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <bnd.exportpackage></bnd.exportpackage>
     <bnd.includeresource></bnd.includeresource>
 
+    <feature.directory>src/main/feature/feature.xml</feature.directory>
   </properties>
 
   <dependencyManagement>
@@ -660,6 +661,7 @@ Import-Package: \\
       </activation>
       <properties>
         <bnd.includeresource>${.}/../../lib/; filter:=*.jar; lib:=true</bnd.includeresource>
+        <feature.directory>../../src/main/feature/feature.xml</feature.directory>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Feature verification was notproperly performed for bundles with embedded libraries because the addjars-maven-plugin changes ${project.basedir} and a non existing input-file was used for generating the features descriptor. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
