### PR TITLE
Inherit from openHAB Super POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </repository>
     <snapshotRepository>
       <id>jfrog</id>
-      <url>${oh.repo.distBaseUrl}/libs-snapshot-local</url>
+      <url>${oh.repo.snapshotBaseUrl}/libs-snapshot-local</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
   <distributionManagement>
     <repository>
       <id>bintray</id>
-      <url>${repo.distBaseUrl}/openhab2-addons/;publish=1</url>
+      <url>${oh.repo.distBaseUrl}/openhab2-addons/;publish=1</url>
     </repository>
     <snapshotRepository>
       <id>jfrog</id>
-      <url>${repo.snapshotBaseUrl}/libs-snapshot-local</url>
+      <url>${oh.repo.distBaseUrl}/libs-snapshot-local</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </repository>
     <snapshotRepository>
       <id>jfrog</id>
-      <url>https://openhab.jfrog.io/openhab/libs-snapshot-local</url>
+      <url>${repo.snapshotBaseUrl}/libs-snapshot-local</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -116,45 +116,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>openhab-dist</id>
-      <name>openHAB Distribution Repository</name>
-      <url>${repo.distBaseUrl}</url>
-    </repository>
-
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>openhab-release</id>
-      <name>JFrog Artifactory Repository</name>
-      <url>https://openhab.jfrog.io/openhab/libs-release</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>openhab-artifactory-release</id>
-      <url>https://openhab.jfrog.io/openhab/libs-release</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <build>
     <resources>
@@ -354,12 +315,6 @@ Import-Package: \\
               <version>3.16.0</version>
             </dependency>
           </dependencies>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
         </plugin>
 
         <plugin>
@@ -748,28 +703,6 @@ Import-Package: \\
           </plugins>
         </pluginManagement>
       </build>
-    </profile>
-    <profile>
-      <id>openhab-snapshot-repository</id>
-      <activation>
-        <property>
-          <name>!noOhSnapRepo</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
-          </snapshots>
-          <id>openhab-artifactory-snapshot</id>
-          <name>JFrog Artifactory Repository</name>
-          <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
-        </repository>
-      </repositories>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.openhab</groupId>
+    <artifactId>openhab-super-pom</artifactId>
+    <version>[1.0, 2.0)</version>
+  </parent>
+
   <groupId>org.openhab.addons</groupId>
   <artifactId>org.openhab.addons.reactor</artifactId>
   <version>2.5.0-SNAPSHOT</version>
@@ -44,7 +50,7 @@
   <distributionManagement>
     <repository>
       <id>bintray</id>
-      <url>https://api.bintray.com/maven/openhab/mvn/openhab2-addons/;publish=1</url>
+      <url>${repo.distBaseUrl}/openhab2-addons/;publish=1</url>
     </repository>
     <snapshotRepository>
       <id>jfrog</id>
@@ -120,9 +126,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>jcenter</id>
-      <name>JCenter Repository</name>
-      <url>https://jcenter.bintray.com</url>
+      <id>openhab-dist</id>
+      <name>openHAB Distribution Repository</name>
+      <url>${repo.distBaseUrl}</url>
     </repository>
 
     <repository>
@@ -133,7 +139,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>openhab-artifactory-release</id>
+      <id>openhab-release</id>
       <name>JFrog Artifactory Repository</name>
       <url>https://openhab.jfrog.io/openhab/libs-release</url>
     </repository>


### PR DESCRIPTION
This PR carves out repositories and the deploy plugin to the newly introduced openHAB Super POM. It cannot be merged before https://github.com/openhab/infrastructure/pull/4 is merged and the first release of the Super POM is done.