### PR TITLE
[amazonechocontrol] Fix problem with new json parser in new build environment

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -1051,7 +1051,7 @@ public class Connection {
         JsonAnnouncementTarget target = new JsonAnnouncementTarget();
         target.customerId = device.deviceOwnerCustomerId;
         TargetDevice[] devices = new TargetDevice[1];
-        TargetDevice deviceTarget = target.new TargetDevice();
+        TargetDevice deviceTarget = new TargetDevice();
         deviceTarget.deviceSerialNumber = device.serialNumber;
         deviceTarget.deviceTypeId = device.deviceType;
         devices[0] = deviceTarget;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -809,7 +809,7 @@ public class Connection {
     private <T> T parseJson(String json, Class<T> type) throws JsonSyntaxException {
         try {
             return gson.fromJson(json, type);
-        } catch (JsonSyntaxException e) {
+        } catch (JsonSyntaxException | JsonParseException | IllegalStateException e) {
             logger.warn("Parsing json failed {}", e);
             logger.warn("Illegal json: {}", json);
             throw e;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -99,6 +99,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 
 /**
@@ -809,7 +810,7 @@ public class Connection {
     private <T> T parseJson(String json, Class<T> type) throws JsonSyntaxException {
         try {
             return gson.fromJson(json, type);
-        } catch (JsonSyntaxException | JsonParseException | IllegalStateException e) {
+        } catch (JsonParseException | IllegalStateException e) {
             logger.warn("Parsing json failed {}", e);
             logger.warn("Illegal json: {}", json);
             throw e;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -185,7 +185,7 @@ public class AccountHandler extends BaseBridgeHandler implements IWebSocketComma
             flashBriefingProfileHandlers.add(flashBriefingProfileHandler);
         }
         Connection connection = this.connection;
-        if (connection != null) {
+        if (connection != null && connection.getIsLoggedIn()) {
             if (currentFlashBriefingJson.isEmpty()) {
                 updateFlashBriefingProfiles(connection);
             }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonActivities.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonActivities.java
@@ -29,7 +29,7 @@ public class JsonActivities {
 
     public @Nullable Activity @Nullable [] activities;
 
-    public class Activity {
+    public static class Activity {
         public @Nullable String activityStatus;
         public @Nullable Long creationTimestamp;
         public @Nullable String description;
@@ -45,14 +45,14 @@ public class JsonActivities {
         public @Nullable String utteranceId;
         public @Nullable Long version;
 
-        public class SourceDeviceId {
+        public static class SourceDeviceId {
             public @Nullable String deviceAccountId;
             public @Nullable String deviceType;
             public @Nullable String serialNumber;
 
         }
 
-        public class Description {
+        public static class Description {
 
             public @Nullable String summary;
             public @Nullable String firstUtteranceId;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAnnouncementContent.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAnnouncementContent.java
@@ -28,13 +28,13 @@ public class JsonAnnouncementContent {
     public final Display display = new Display();
     public final Speak speak = new Speak();
 
-    public class Display {
+    public static class Display {
         public @Nullable String title;
         public @Nullable String body;
 
     }
 
-    public class Speak {
+    public static class Speak {
         public String type = "text";
         public @Nullable String value;
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAnnouncementTarget.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAnnouncementTarget.java
@@ -26,7 +26,7 @@ public class JsonAnnouncementTarget {
     public @Nullable String customerId;
     public @Nullable TargetDevice @Nullable [] devices;
 
-    public class TargetDevice {
+    public static class TargetDevice {
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceTypeId;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAscendingAlarm.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAscendingAlarm.java
@@ -25,7 +25,7 @@ public class JsonAscendingAlarm {
 
     public @Nullable AscendingAlarmModel @Nullable [] ascendingAlarmModelList;
 
-    public class AscendingAlarmModel {
+    public static class AscendingAlarmModel {
         public @Nullable Boolean ascendingAlarmEnabled;
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceType;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAutomation.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAutomation.java
@@ -32,13 +32,13 @@ public class JsonAutomation {
     public long creationTimeEpochMillis;
     public long lastUpdatedTimeEpochMillis;
 
-    public class Trigger {
+    public static class Trigger {
         public @Nullable Payload payload;
         public @Nullable String id;
         public @Nullable String type;
     }
 
-    public class Payload {
+    public static class Payload {
         public @Nullable String customerId;
         public @Nullable String utterance;
         public @Nullable String locale;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonBluetoothStates.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonBluetoothStates.java
@@ -44,7 +44,7 @@ public class JsonBluetoothStates {
 
     public @Nullable BluetoothState @Nullable [] bluetoothStates;
 
-    public class PairedDevice {
+    public static class PairedDevice {
         public @Nullable String address;
         public boolean connected;
         public @Nullable String deviceClass;
@@ -53,7 +53,7 @@ public class JsonBluetoothStates {
 
     }
 
-    public class BluetoothState {
+    public static class BluetoothState {
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceType;
         public @Nullable String friendlyName;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonCommandPayloadPushActivity.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonCommandPayloadPushActivity.java
@@ -28,7 +28,7 @@ public class JsonCommandPayloadPushActivity {
 
     public @Nullable Key key;
 
-    public class Key {
+    public static class Key {
         public @Nullable String entryId;
         public @Nullable String registeredUserId;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonCommandPayloadPushDevice.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonCommandPayloadPushDevice.java
@@ -25,7 +25,7 @@ public class JsonCommandPayloadPushDevice {
 
     public @Nullable DopplerId dopplerId;
 
-    public class DopplerId {
+    public static class DopplerId {
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceType;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDeviceNotificationState.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDeviceNotificationState.java
@@ -25,7 +25,7 @@ public class JsonDeviceNotificationState {
 
     public @Nullable DeviceNotificationState @Nullable [] deviceNotificationStates;
 
-    public class DeviceNotificationState {
+    public static class DeviceNotificationState {
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceType;
         public @Nullable String softwareVersion;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDevices.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDevices.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class JsonDevices {
 
-    public class Device {
+    public static class Device {
         public @Nullable String accountName;
         public @Nullable String serialNumber;
         public @Nullable String deviceOwnerCustomerId;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonExchangeTokenResponse.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonExchangeTokenResponse.java
@@ -26,15 +26,15 @@ import org.eclipse.jdt.annotation.Nullable;
 public class JsonExchangeTokenResponse {
     public @Nullable Response response;
 
-    public class Response {
+    public static class Response {
         public @Nullable Tokens tokens;
     }
 
-    public class Tokens {
+    public static class Tokens {
         public @Nullable Map<String, Cookie[]> cookies;
     }
 
-    public class Cookie {
+    public static class Cookie {
         public @Nullable String Path;
         public @Nullable Boolean Secure;
         public @Nullable String Value;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonMediaState.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonMediaState.java
@@ -47,7 +47,7 @@ public class JsonMediaState {
     // public long timeLastShuffled; parsing fails with some values, so do not use it
     public int volume;
 
-    public class QueueEntry {
+    public static class QueueEntry {
 
         public @Nullable String album;
         public @Nullable String albumAsin;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlayerState.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlayerState.java
@@ -24,7 +24,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class JsonPlayerState {
     public @Nullable PlayerInfo playerInfo;
 
-    public class PlayerInfo {
+    public static class PlayerInfo {
         public @Nullable String state;
         public @Nullable InfoText infoText;
         public @Nullable InfoText miniInfoText;
@@ -37,7 +37,7 @@ public class JsonPlayerState {
 
         public @Nullable Progress progress;
 
-        public class InfoText {
+        public static class InfoText {
             public boolean multiLineMode;
             public @Nullable String subText1;
             public @Nullable String subText2;
@@ -45,24 +45,24 @@ public class JsonPlayerState {
 
         }
 
-        public class Provider {
+        public static class Provider {
             public @Nullable String providerDisplayName;
             public @Nullable String providerName;
         }
 
-        public class Volume {
+        public static class Volume {
             public boolean muted;
             public int volume;
         }
 
-        public class MainArt {
+        public static class MainArt {
             public @Nullable String altText;
             public @Nullable String artType;
             public @Nullable String contentType;
             public @Nullable String url;
         }
 
-        public class Progress {
+        public static class Progress {
             public @Nullable Boolean allowScrubbing;
             public @Nullable Object locationInfo;
             public @Nullable Long mediaLength;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
@@ -27,7 +27,7 @@ public class JsonPlaylists {
 
     public @Nullable Map<String, @Nullable PlayList @Nullable []> playlists;
 
-    public class PlayList {
+    public static class PlayList {
         public @Nullable String playlistId;
         public @Nullable String title;
         public int trackCount;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonRegisterAppRequest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonRegisterAppRequest.java
@@ -38,7 +38,7 @@ public class JsonRegisterAppRequest {
     public UserContextMap user_context_map = new UserContextMap();
     public String[] requested_token_type = { "bearer", "mac_dms", "website_cookies" };
 
-    public class Cookies {
+    public static class Cookies {
         @Nullable
         public JsonWebSiteCookie @Nullable [] website_cookies;
         @Nullable
@@ -46,7 +46,7 @@ public class JsonRegisterAppRequest {
 
     }
 
-    public class RegistrationData {
+    public static class RegistrationData {
         public String domain = "Device";
         public String app_version = "2.2.223830.0";
         public String device_type = "A2IVLV5VM2W81";
@@ -59,12 +59,12 @@ public class JsonRegisterAppRequest {
         public String software_version = "1";
     }
 
-    public class AuthData {
+    public static class AuthData {
         @Nullable
         public String access_token;
     }
 
-    public class UserContextMap {
+    public static class UserContextMap {
         public String frc = "";
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonRegisterAppResponse.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonRegisterAppResponse.java
@@ -29,19 +29,21 @@ public class JsonRegisterAppResponse {
     @Nullable
     public String request_id;
 
-    public class Response {
+    public static class Response {
         @Nullable
         public Success success;
     }
 
-    public class Success {
+    public static class Success {
         @Nullable
         public Extensions extensions;
         @Nullable
         public Tokens tokens;
+        @Nullable
+        public String customer_id;
     }
 
-    public class Extensions {
+    public static class Extensions {
         @Nullable
         public DeviceInfo device_info;
         @Nullable
@@ -50,7 +52,7 @@ public class JsonRegisterAppResponse {
         public String customer_id;
     }
 
-    public class DeviceInfo {
+    public static class DeviceInfo {
         @Nullable
         public String device_name;
         @Nullable
@@ -60,7 +62,7 @@ public class JsonRegisterAppResponse {
 
     }
 
-    public class CustomerInfo {
+    public static class CustomerInfo {
         @Nullable
         public String account_pool;
         @Nullable
@@ -73,7 +75,7 @@ public class JsonRegisterAppResponse {
         public String given_name;
     }
 
-    public class Tokens {
+    public static class Tokens {
         @Nullable
         public Object website_cookies;
         @Nullable
@@ -82,14 +84,14 @@ public class JsonRegisterAppResponse {
         public Bearer bearer;
     }
 
-    public class MacDms {
+    public static class MacDms {
         @Nullable
         public String device_private_key;
         @Nullable
         public String adp_token;
     }
 
-    public class Bearer {
+    public static class Bearer {
         @Nullable
         public String access_token;
         @Nullable

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonWakeWords.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonWakeWords.java
@@ -24,7 +24,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class JsonWakeWords {
     public @Nullable WakeWord @Nullable [] wakeWords;
 
-    public class WakeWord {
+    public static class WakeWord {
         public @Nullable Boolean active;
         public @Nullable String deviceSerialNumber;
         public @Nullable String deviceType;


### PR DESCRIPTION
I have updated my development environment to the new bndtools
Unfortunately the binding does not work anymore. I figured out that the json parsing is the problem. Now inner classes can only be created if the a marked as static. 
I have no idea whats going on here, because this works in the past. Maybe a wrong gson version is now used?
Anyway, the PR fixes this issue, but it would be nice for me to understand what was changed.