### PR TITLE
[keba] Add setenergy command

### DIFF
--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -42,7 +42,7 @@ All devices support the following channels:
 | sessionrfidtag     | String    | yes       | RFID tag used for the last charging session                            |
 | sessionrfidclass   | String    | yes       | RFID tag class used for the last charging session                      |
 | sessionid          | Number    | yes       | session ID of the last charging session                                |
-
+| setenergy          | Number    | no        | set an energy limit for an already running or the next charging session|
 
 ## Example
 
@@ -76,6 +76,7 @@ Number KebaSessionEnergy  {channel="keba:kecontact:1:sessionconsumption"}
 Number KebaTotalEnergy  {channel="keba:kecontact:1:totalconsumption"}
 Switch KebaInputSwitch  {channel="keba:kecontact:1:input"}
 Switch KebaOutputSwitch  {channel="keba:kecontact:1:output"}
+Number KebaSetEnergy {channel="keba:kecontact:1:setenergy"}
 ```
 
 demo.sitemap:
@@ -96,6 +97,7 @@ sitemap demo label="Main Menu"
 				Text item=KebaFailSafeCurrent label="Failsafe supply current [%.0f mA]"
 				Text item=KebaSessionEnergy label="Energy during current session [%.0f Wh]"
 				Text item=KebaTotalEnergy label="Energy during all sessions [%.0f Wh]"
+                Switch item=KebaSetEnergy label="Set charge energy" mappings=[0="off", 20000="20kWh"]
 			}
 }
 ```

--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -77,7 +77,7 @@ Number KebaSessionEnergy  {channel="keba:kecontact:1:sessionconsumption"}
 Number KebaTotalEnergy  {channel="keba:kecontact:1:totalconsumption"}
 Switch KebaInputSwitch  {channel="keba:kecontact:1:input"}
 Switch KebaOutputSwitch  {channel="keba:kecontact:1:output"}
-Number KebaSetEnergy {channel="keba:kecontact:1:setenergy"}
+Number KebaSetEnergyLimit {channel="keba:kecontact:1:setenergylimit"}
 ```
 
 demo.sitemap:
@@ -98,7 +98,7 @@ sitemap demo label="Main Menu"
 				Text item=KebaFailSafeCurrent label="Failsafe supply current [%.0f mA]"
 				Text item=KebaSessionEnergy label="Energy during current session [%.0f Wh]"
 				Text item=KebaTotalEnergy label="Energy during all sessions [%.0f Wh]"
-                Switch item=KebaSetEnergy label="Set charge energy" mappings=[0="off", 20000="20kWh"]
+				Switch item=KebaSetEnergyLimit label="Set charge energy limit" mappings=[0="off", 20000="20kWh"]
 			}
 }
 ```

--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -42,7 +42,8 @@ All devices support the following channels:
 | sessionrfidtag     | String    | yes       | RFID tag used for the last charging session                            |
 | sessionrfidclass   | String    | yes       | RFID tag class used for the last charging session                      |
 | sessionid          | Number    | yes       | session ID of the last charging session                                |
-| setenergy          | Number    | no        | set an energy limit for an already running or the next charging session|
+| setenergylimit     | Number    | no        | set an energy limit for an already running or the next charging session|
+
 
 ## Example
 

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -69,7 +69,7 @@ public class KebaBindingConstants {
     public static final String CHANNEL_SESSION_RFID_TAG = "sessionrfidtag";
     public static final String CHANNEL_SESSION_RFID_CLASS = "sessionrfidclass";
     public static final String CHANNEL_SESSION_SESSION_ID = "sessionid";
-    public static final String CHANNEL_SETENERGY = "setenergy";
+    public static final String CHANNEL_SETENERGY = "setenergylimit";
 
     public enum KebaType {
         P20,

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -69,6 +69,7 @@ public class KebaBindingConstants {
     public static final String CHANNEL_SESSION_RFID_TAG = "sessionrfidtag";
     public static final String CHANNEL_SESSION_RFID_CLASS = "sessionrfidclass";
     public static final String CHANNEL_SESSION_SESSION_ID = "sessionid";
+    public static final String CHANNEL_SETENERGY = "setenergy";
 
     public enum KebaType {
         P20,

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -467,6 +467,12 @@ public class KeContactHandler extends BaseThingHandler {
                         updateState(CHANNEL_SESSION_SESSION_ID, newState);
                         break;
                     }
+                    case "Setenergy": {
+                        int state = entry.getValue().getAsInt() / 10;
+                        State newState = new DecimalType(state);
+                        updateState(CHANNEL_SETENERGY, newState);
+                        break;
+                    }
                 }
             }
         } catch (JsonParseException e) {
@@ -545,6 +551,14 @@ public class KeContactHandler extends BaseThingHandler {
                         } else {
                             logger.warn("'Display' is not supported on a KEBA KeContact {}:{}", type, series);
                         }
+                    }
+                    break;
+                }
+                case CHANNEL_SETENERGY: {
+                    if (command instanceof DecimalType) {
+                        transceiver.send(
+                                "setenergy " + String.valueOf(
+                                        Math.min(Math.max(0, ((DecimalType) command).intValue()*10), 999999999)), this);
                     }
                     break;
                 }

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -53,6 +53,7 @@
 			<channel id="sessionrfidtag" typeId="sessionrfidtag" />
 			<channel id="sessionrfidclass" typeId="sessionrfidclass" />
 			<channel id="sessionid" typeId="sessionid" />
+			<channel id="setenergy" typeId="setenergy" />
 		</channels>
 
 		<config-description>
@@ -244,5 +245,11 @@
 		<label>Session ID</label>
 		<description>Session ID of the last charging session</description>
 		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="setenergy">
+		<item-type>Number</item-type>
+		<label>Setenergy</label>
+		<description>set an energy limit for an already running or the next charging session.</description>
+		<state pattern="%d Wh" readOnly="false"></state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -53,7 +53,7 @@
 			<channel id="sessionrfidtag" typeId="sessionrfidtag" />
 			<channel id="sessionrfidclass" typeId="sessionrfidclass" />
 			<channel id="sessionid" typeId="sessionid" />
-			<channel id="setenergy" typeId="setenergy" />
+			<channel id="setenergylimit" typeId="setenergylimit" />
 		</channels>
 
 		<config-description>
@@ -246,9 +246,9 @@
 		<description>Session ID of the last charging session</description>
 		<state readOnly="true"></state>
 	</channel-type>
-	<channel-type id="setenergy">
+	<channel-type id="setenergylimit">
 		<item-type>Number</item-type>
-		<label>Setenergy</label>
+		<label>Setenergylimit</label>
 		<description>set an energy limit for an already running or the next charging session.</description>
 		<state pattern="%d Wh" readOnly="false"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -248,8 +248,8 @@
 	</channel-type>
 	<channel-type id="setenergylimit">
 		<item-type>Number</item-type>
-		<label>Setenergylimit</label>
-		<description>set an energy limit for an already running or the next charging session.</description>
+		<label>Energy limit</label>
+		<description>An energy limit for an already running or the next charging session.</description>
 		<state pattern="%d Wh" readOnly="false"></state>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
introduce setenergy command (for openhab#4417) this is adding read and write item setenergy to set a charging limit in Wh. Quite handy command to limit the overall carge the car gets. if you only want to charge 20kWh set it to 20000. also added documentation.

Fixes #4417