### PR TITLE
[onewire] remove error logging

### DIFF
--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwHandlerFactory.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwHandlerFactory.java
@@ -64,7 +64,6 @@ public class OwHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
-        logger.error("factory {} creating thing {}", this, thing);
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (OwserverBridgeHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {


### PR DESCRIPTION
This logging statement was added for debugging purposes and unintentionally entered the codebase.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
