### PR TITLE
[openhabcloud] Reduced logging levels

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -216,7 +216,7 @@ public class CloudClient {
         }).on(Socket.EVENT_ERROR, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                logger.error("Socket.IO error: {}", args[0]);
+                logger.debug("Socket.IO error: {}", args[0]);
             }
         }).on("request", new Emitter.Listener() {
             @Override
@@ -282,7 +282,7 @@ public class CloudClient {
      */
 
     public void onError(IOException error) {
-        logger.error("{}", error.getMessage());
+        logger.debug("{}", error.getMessage());
     }
 
     /**
@@ -361,7 +361,7 @@ public class CloudClient {
                 request.content(new BytesContentProvider(requestBody.getBytes()));
             } else {
                 // TODO: Reject unsupported methods
-                logger.error("Unsupported request method {}", requestMethod);
+                logger.warn("Unsupported request method {}", requestMethod);
                 return;
             }
             ResponseListener listener = new ResponseListener(requestId);
@@ -369,12 +369,8 @@ public class CloudClient {
             // If successfully submitted request to http client, add it to the list of currently
             // running requests to be able to cancel it if needed
             runningRequests.put(requestId, request);
-        } catch (JSONException e) {
-            logger.error("{}", e.getMessage());
-        } catch (IOException e) {
-            logger.error("{}", e.getMessage());
-        } catch (URISyntaxException e) {
-            logger.error("{}", e.getMessage());
+        } catch (JSONException | IOException | URISyntaxException e) {
+            logger.debug("{}", e.getMessage());
         }
     }
 
@@ -392,7 +388,7 @@ public class CloudClient {
                     request.header(headerName, headerValue);
                 }
             } catch (JSONException e) {
-                logger.error("Error processing request headers: {}", e.getMessage());
+                logger.warn("Error processing request headers: {}", e.getMessage());
             }
         }
     }
@@ -408,7 +404,7 @@ public class CloudClient {
                 runningRequests.remove(requestId);
             }
         } catch (JSONException e) {
-            logger.error("{}", e.getMessage());
+            logger.debug("{}", e.getMessage());
         }
     }
 
@@ -421,7 +417,7 @@ public class CloudClient {
                     this.listener.sendCommand(itemName, data.getString("command"));
                 }
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         } else {
             logger.warn("Received command from openHAB Cloud for item '{}', which is not exposed.", itemName);
@@ -447,7 +443,7 @@ public class CloudClient {
                 notificationMessage.put("severity", severity);
                 socket.emit("notification", notificationMessage);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         } else {
             logger.debug("No connection, notification is not sent");
@@ -471,7 +467,7 @@ public class CloudClient {
                 notificationMessage.put("severity", severity);
                 socket.emit("lognotification", notificationMessage);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         } else {
             logger.debug("No connection, notification is not sent");
@@ -495,7 +491,7 @@ public class CloudClient {
                 notificationMessage.put("severity", severity);
                 socket.emit("broadcastnotification", notificationMessage);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         } else {
             logger.debug("No connection, notification is not sent");
@@ -518,7 +514,7 @@ public class CloudClient {
                 itemUpdateMessage.put("itemStatus", itemState);
                 socket.emit("itemupdate", itemUpdateMessage);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         } else {
             logger.debug("No connection, Item update is not sent");
@@ -540,7 +536,7 @@ public class CloudClient {
         try {
             jettyClient.stop();
         } catch (Exception e) {
-            logger.error("{}", e.getMessage());
+            logger.error("Could not stop Jetty client: {}", e.getMessage());
         }
         socket.disconnect();
     }
@@ -578,7 +574,7 @@ public class CloudClient {
                     headersJSON.put(field.getName(), field.getValue());
                 }
             } catch (JSONException e) {
-                logger.error("Error forming response headers: {}", e.getMessage());
+                logger.warn("Error forming response headers: {}", e.getMessage());
             }
             return headersJSON;
         }
@@ -612,21 +608,20 @@ public class CloudClient {
                     socket.emit("responseFinished", responseJson);
                     logger.debug("Finished responding to request {}", mRequestId);
                 } catch (JSONException e) {
-                    logger.error("{}", e.getMessage());
+                    logger.debug("{}", e.getMessage());
                 }
             }, 1, TimeUnit.MILLISECONDS);
         }
 
         @Override
         public synchronized void onFailure(Request request, Throwable failure) {
-            logger.error("{}", failure.getMessage());
             JSONObject responseJson = new JSONObject();
             try {
                 responseJson.put("id", mRequestId);
                 responseJson.put("responseStatusText", "openHAB connection error: " + failure.getMessage());
                 socket.emit("responseError", responseJson);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         }
 
@@ -640,7 +635,7 @@ public class CloudClient {
                 socket.emit("responseContentBinary", responseJson);
                 logger.debug("Sent content to request {}", mRequestId);
             } catch (JSONException e) {
-                logger.error("{}", e.getMessage());
+                logger.debug("{}", e.getMessage());
             }
         }
 
@@ -659,7 +654,7 @@ public class CloudClient {
                     logger.debug("Sent headers to request {}", mRequestId);
                     logger.debug("{}", responseJson.toString());
                 } catch (JSONException e) {
-                    logger.error("{}", e.getMessage());
+                    logger.debug("{}", e.getMessage());
                 }
             } else {
                 // We should not send headers for the second time...


### PR DESCRIPTION
- Reduced logging levels

To prevent outputs like this which occurred when openHAB Cloud is down. But the binding is capable of handling it and continues its work without any problem.

```
2019-05-05 19:19:39.224 [ERROR] [io.openhabcloud.internal.CloudClient] - Socket.IO error: {}
io.socket.engineio.client.EngineIOException: xhr poll error
        at io.socket.engineio.client.Transport.onError(Transport.java:71) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.engineio.client.transports.PollingXHR.access$100(PollingXHR.java:19) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.engineio.client.transports.PollingXHR$6$1.run(PollingXHR.java:124) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.thread.EventThread$2.run(EventThread.java:80) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: java.io.IOException: 400
        at io.socket.engineio.client.transports.PollingXHR$Request$1.run(PollingXHR.java:218) ~[?:?]
        ... 1 more
```
```
2019-05-14 13:02:40.221 [ERROR] [io.openhabcloud.internal.CloudClient] - Socket.IO error: {}
io.socket.engineio.client.EngineIOException: xhr poll error
        at io.socket.engineio.client.Transport.onError(Transport.java:71) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.engineio.client.transports.PollingXHR.access$100(PollingXHR.java:19) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.engineio.client.transports.PollingXHR$6$1.run(PollingXHR.java:124) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at io.socket.thread.EventThread$2.run(EventThread.java:80) [230:org.openhab.io.openhabcloud:2.5.0.M1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: java.io.IOException: 502
        at io.socket.engineio.client.transports.PollingXHR$Request$1.run(PollingXHR.java:218) ~[?:?]
        ... 1 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
