### PR TITLE
Remove version and groupId duplication from POMs

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/pom.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>org.openhab.binding.amazonechocontrol</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Amazon Echo Control Binding</name>
 

--- a/bundles/org.openhab.binding.digitalstrom/pom.xml
+++ b/bundles/org.openhab.binding.digitalstrom/pom.xml
@@ -9,7 +9,6 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.digitalstrom</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: DigitalSTROM Binding</name>

--- a/bundles/org.openhab.binding.fsinternetradio/pom.xml
+++ b/bundles/org.openhab.binding.fsinternetradio/pom.xml
@@ -9,7 +9,6 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.fsinternetradio</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: FSInternetRadio Binding</name>

--- a/bundles/org.openhab.binding.ftpupload/pom.xml
+++ b/bundles/org.openhab.binding.ftpupload/pom.xml
@@ -9,9 +9,7 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.ftpupload</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: FTP Upload Binding</name>
 

--- a/bundles/org.openhab.binding.km200/pom.xml
+++ b/bundles/org.openhab.binding.km200/pom.xml
@@ -9,9 +9,7 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.km200</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: KM200 Binding</name>
 

--- a/bundles/org.openhab.binding.logreader/pom.xml
+++ b/bundles/org.openhab.binding.logreader/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>org.openhab.binding.logreader</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Log Reader Binding</name>
 

--- a/bundles/org.openhab.binding.neato/pom.xml
+++ b/bundles/org.openhab.binding.neato/pom.xml
@@ -9,9 +9,7 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.neato</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Neato Binding</name>
 

--- a/bundles/org.openhab.binding.neeo/pom.xml
+++ b/bundles/org.openhab.binding.neeo/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>org.openhab.binding.neeo</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Neeo Binding</name>
 

--- a/bundles/org.openhab.binding.solarlog/pom.xml
+++ b/bundles/org.openhab.binding.solarlog/pom.xml
@@ -9,9 +9,7 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.solarlog</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Solar-Log Binding</name>
 

--- a/bundles/org.openhab.binding.sonyaudio/pom.xml
+++ b/bundles/org.openhab.binding.sonyaudio/pom.xml
@@ -9,7 +9,6 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.sonyaudio</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: SonyAudio Binding</name>

--- a/bundles/org.openhab.binding.tado/pom.xml
+++ b/bundles/org.openhab.binding.tado/pom.xml
@@ -9,9 +9,7 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.binding.tado</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Tado Binding</name>
 </project>

--- a/bundles/org.openhab.binding.valloxmv/pom.xml
+++ b/bundles/org.openhab.binding.valloxmv/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>org.openhab.binding.valloxmv</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: ValloxMV Binding</name>
 

--- a/bundles/org.openhab.binding.velbus/pom.xml
+++ b/bundles/org.openhab.binding.velbus/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>org.openhab.binding.velbus</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: Velbus Binding</name>
 

--- a/bundles/org.openhab.binding.volvooncall/pom.xml
+++ b/bundles/org.openhab.binding.volvooncall/pom.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.openhab.addons.bundles</groupId>
-		<artifactId>org.openhab.addons.reactor.bundles</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
-	</parent>
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.0-SNAPSHOT</version>
+  </parent>
 
-	<artifactId>org.openhab.binding.volvooncall</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+  <artifactId>org.openhab.binding.volvooncall</artifactId>
 
-	<name>openHAB Add-ons :: Bundles :: Volvo On Call Binding</name>
+  <name>openHAB Add-ons :: Bundles :: Volvo On Call Binding</name>
 
 </project>


### PR DESCRIPTION
These properties duplicate the parent values so they are unnecessary.