### PR TITLE
[avmfritz] Fixed flapping ONLINE/OFFLINE status of FRITZ!Powerline 546E device in standalone mode

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/README.md
+++ b/bundles/org.openhab.binding.avmfritz/README.md
@@ -77,28 +77,31 @@ If correct credentials are set in the bridge configuration, connected AHA device
 
 ### FRITZ!Box
 
-- ipAddress (mandatory), default "fritz.box"
-- protocol (optional, http or https), default "http"
-- port (optional, 0 to 65335), no default (derived from protocol: 80 or 443)
-- password (optional), no default (depends on FRITZ!Box security configuration)
-- user (optional), no default (depends on FRITZ!Box security configuration)
-- pollingInterval (optional, 5 to 60), default 15 (in seconds)
-- asyncTimeout (optional, 1000 to 60000), default 10000 (in millis)
-- syncTimeout (optional, 500 to 15000), default 2000 (in millis)
+- `ipAddress` (mandatory), default "fritz.box"
+- `protocol` (optional, "http" or "https"), default "http"
+- `port` (optional, 0 to 65335), no default (derived from protocol: 80 or 443)
+- `password` (optional), no default (depends on FRITZ!Box security configuration)
+- `user` (optional), no default (depends on FRITZ!Box security configuration)
+- `pollingInterval` (optional, 5 to 60), default 15 (in seconds)
+- `asyncTimeout` (optional, 1000 to 60000), default 10000 (in milliseconds)
+- `syncTimeout` (optional, 500 to 15000), default 2000 (in milliseconds)
 
 ### FRITZ!Powerline 546E
 
-- ipAddress (mandatory), default "fritz.powerline"
-- protocol (optional, http or https), default "http"
-- port (optional, 0 to 65335), no default (derived from protocol: 80 or 443)
-- password (optional), no default (depends on FRITZ!Powerline security configuration)
-- pollingInterval (optional, 5 to 60), default 15 (in seconds)
-- asyncTimeout (optional, 1000 to 60000), default 10000 (in millis)
-- syncTimeout (optional, 500 to 15000), default 2000 (in millis)
+- `ain` (optional, advanced), no default (AIN number of the device)
+- `ipAddress` (mandatory), default "fritz.powerline"
+- `protocol` (optional, "http" or "https"), default "http"
+- `port` (optional, 0 to 65335), no default (derived from protocol: 80 or 443)
+- `password` (optional), no default (depends on FRITZ!Powerline security configuration)
+- `pollingInterval` (optional, 5 to 60), default 15 (in seconds)
+- `asyncTimeout` (optional, 1000 to 60000), default 10000 (in milliseconds)
+- `syncTimeout` (optional, 500 to 15000), default 2000 (in milliseconds)
 
-### AHA things connected to FRITZ!Box bridge
+If the FRITZ!Powerline 546E is added via auto-discovery it determines its own `ain`, otherwise you have to configure it manually.
 
-- AIN (mandatory), no default (AIN number of device)
+### Things Connected To FRITZ!Box Or FRITZ!Powerline 546E
+
+- `ain` (mandatory), no default (AIN number of the device)
 
 ## Supported Channels
 

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -51,6 +51,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -371,9 +372,13 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
             updateState(channel.getUID(), state);
         } else {
             logger.debug("Channel '{}' in thing '{}' does not exist, recreating thing.", channelId, thing.getUID());
-            AVMFritzBaseThingHandler handler = (AVMFritzBaseThingHandler) thing.getHandler();
+            ThingHandler handler = thing.getHandler();
             if (handler != null) {
-                handler.createChannel(channelId);
+                if (handler instanceof AVMFritzBaseThingHandler) {
+                    ((AVMFritzBaseThingHandler) handler).createChannel(channelId);
+                } else if (handler instanceof Powerline546EHandler) {
+                    ((Powerline546EHandler) handler).createChannel(channelId);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.avmfritz.internal.BindingConstants.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -74,8 +75,10 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler {
 
     @Override
     public void addDeviceList(List<AVMFritzBaseModel> devicelist) {
-        Optional<AVMFritzBaseModel> optionalDevice = devicelist.stream()
-                .filter(it -> it.getIdentifier().equals(getIdentifier())).findFirst();
+        String identifier = getIdentifier();
+        Predicate<AVMFritzBaseModel> predicate = identifier == null ? it -> getThing().getUID().equals(getThingUID(it))
+                : it -> it.getIdentifier().equals(identifier);
+        Optional<AVMFritzBaseModel> optionalDevice = devicelist.stream().filter(predicate).findFirst();
         if (optionalDevice.isPresent()) {
             AVMFritzBaseModel device = optionalDevice.get();
             devicelist.remove(device);

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/ESH-INF/config/config.xml
@@ -78,6 +78,11 @@
 			<label>Connection</label>
 			<description>Connection settings.</description>
 		</parameter-group>
+		<parameter name="ain" type="text">
+			<label>AIN</label>
+			<description>The AHA id (AIN) that identifies one specific FRITZ! device.</description>
+			<advanced>true</advanced>
+		</parameter>
 		<parameter name="ipAddress" type="text" required="true" groupName="network">
 			<context>network-address</context>
 			<label>IP address</label>

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/ESH-INF/i18n/avmfritz_de.properties
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/ESH-INF/i18n/avmfritz_de.properties
@@ -57,6 +57,8 @@ bridge-type.config.avmfritz.fritzbox.asyncTimeout.description = Timeout für asyn
 bridge-type.config.avmfritz.fritzbox.syncTimeout.label = Synchroner Timeout
 bridge-type.config.avmfritz.fritzbox.syncTimeout.description = Timeout für synchrone Abfragen der FRITZ!Box (in Millisekunden).
 
+bridge-type.config.avmfritz.fritzpowerline.ain.description = Die AHA ID (AIN) zur Identifikation des FRITZ!Powerline Gerätes.
+
 bridge-type.config.avmfritz.fritzpowerline.ipAddress.label = IP-Adresse
 bridge-type.config.avmfritz.fritzpowerline.ipAddress.description = Lokale IP-Adresse oder Hostname des FRITZ!Powerline Gerätes.
 


### PR DESCRIPTION
- Fixed flapping ONLINE/OFFLINE status of FRITZ!Powerline 546E device in standalone mode
- Fixed creation of `voltage` channel for FRITZ!Powerline 546E device in standalone mode

See https://community.openhab.org/t/repeating-hingstatusinfochangedevent-with-fritz-powerline-546e-going-from-online-to-offline/73648/

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
