### PR TITLE
[homekit] NPE protection

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
@@ -72,7 +72,11 @@ class HomekitAccessoryRegistry {
     }
 
     public synchronized void unsetBridge() {
-        this.bridge = null;
+        final HomekitRoot oldBridge = bridge;
+        if (oldBridge != null) {
+            createdAccessories.values().forEach(accessory -> oldBridge.removeAccessory(accessory));
+        }
+        bridge = null;
     }
 
     public synchronized void addRootAccessory(String itemName, HomekitAccessory accessory) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
@@ -45,6 +45,10 @@ public class HomekitAccessoryUpdater {
         if (item == null) {
             return;
         }
+        if (callback == null) {
+            logger.trace("The received subscription contains a null callback, skipping");
+            return;
+        }
         ItemKey itemKey = new ItemKey(item, key);
         subscriptionsByName.compute(itemKey, (k, v) -> {
             if (v != null) {


### PR DESCRIPTION
Fixes #5645 

- prevent null-callbacks from being added
- properly remove subscriptions if bridge is removed

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>

