### PR TITLE
Use bnd for including resources to workaround infinite Eclipse builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
     <bnd.importpackage></bnd.importpackage>
     <bnd.exportpackage></bnd.exportpackage>
-    <bnd.includeresource></bnd.includeresource>
+    <bnd.includeresource>-${.}/NOTICE, -${.}/*.xsd</bnd.includeresource>
 
     <feature.directory>src/main/feature/feature.xml</feature.directory>
   </properties>
@@ -119,20 +119,6 @@
   </dependencyManagement>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>.</directory>
-        <includes>
-          <!-- general -->
-          <include>NOTICE</include>
-          <!-- only a very rare -->
-          <include>*.xsd</include>
-        </includes>
-      </resource>
-    </resources>
     <pluginManagement>
       <plugins>
 
@@ -621,7 +607,7 @@ Import-Package: \\
         </file>
       </activation>
       <properties>
-        <bnd.includeresource>${.}/../../lib/; filter:=*.jar; lib:=true</bnd.includeresource>
+        <bnd.includeresource>-${.}/../../NOTICE, -${.}/../../*.xsd, ${.}/../../lib/; filter:=*.jar; lib:=true</bnd.includeresource>
         <feature.directory>../../src/main/feature/feature.xml</feature.directory>
       </properties>
       <build>
@@ -664,7 +650,7 @@ Import-Package: \\
         </file>
       </activation>
       <properties>
-        <bnd.includeresource>${.}/lib/; filter:=*.jar; lib:=true</bnd.includeresource>
+        <bnd.includeresource>-${.}/NOTICE, -${.}/*.xsd, ${.}/lib/; filter:=*.jar; lib:=true</bnd.includeresource>
       </properties>
     </profile>
 


### PR DESCRIPTION
When "Build Automatically" is enabled in Eclipse, the build never ends.
It seems there is a bnd issue with the way resources are defined in the reactor POM.
The workaround seems to be to include all resources using bnd.

See also:

* https://github.com/bndtools/bnd/issues/3220
* https://github.com/openhab/openhab2-addons/issues/5554

---

Together with:

* https://github.com/openhab/openhab-core/pull/842
* https://github.com/openhab/openhab-webui/pull/75

This PR fixes #5554