### PR TITLE
[enocean] Fix A5-38-08 Dimmer reset to 0

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
@@ -102,7 +102,7 @@ public class A5_38_08_Dimming extends _4BSMessage {
     public State convertToStateImpl(String channelId, String channelTypeId, State currentState, Configuration config) {
         switch (channelId) {
             case CHANNEL_DIMMER:
-                if (!getBit(0, 0)) {
+                if (!getBit(getDB_0(), 0)) {
                     return new PercentType(0);
                 } else {
                     int dimmValue = getDB_2Value();

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
@@ -110,7 +110,7 @@ public class A5_38_08_Dimming extends _4BSMessage {
                     EnOceanChannelDimmerConfig c = config.as(EnOceanChannelDimmerConfig.class);
 
                     if (!c.eltakoDimmer) {
-                        if (getBit(0, 2)) {
+                        if (getBit(getDB_0(), 2)) {
                             // relative value
                         } else {
                             // absolute value

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_38/A5_38_08_Dimming.java
@@ -103,19 +103,18 @@ public class A5_38_08_Dimming extends _4BSMessage {
         switch (channelId) {
             case CHANNEL_DIMMER:
                 if (!getBit(getDB_0(), 0)) {
+                    // Switching Command is OFF (DB0.0==0), return 0%
                     return new PercentType(0);
                 } else {
+                    // DB2 contains the Dimming value (absolute[0...255] or relative/Eltako [0...100])
                     int dimmValue = getDB_2Value();
 
                     EnOceanChannelDimmerConfig c = config.as(EnOceanChannelDimmerConfig.class);
-
-                    if (!c.eltakoDimmer) {
-                        if (getBit(getDB_0(), 2)) {
-                            // relative value
-                        } else {
-                            // absolute value
-                            dimmValue /= 2.55;
-                        }
+                    
+                    // if Standard dimmer and Dimming Range is absolute (DB0.2==0), 
+                    if (!c.eltakoDimmer && !getBit(getDB_0(),2)) {
+                        //  map range [0...255] to [0%...100%]
+                        dimmValue /= 2.55;
                     }
 
                     return new PercentType(dimmValue);


### PR DESCRIPTION
Fix the getbit parameter 0, so that internal dimmer state resembles the external state.

As described in issue #5608, the getbit function will always return false.

Fixes #5608