### PR TITLE
[astro] Fixed handling of division by 0 for new moon

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
@@ -129,7 +129,7 @@ public class MoonCalc {
         long parentNewMoonMillis = DateTimeUtils.toCalendar(parentNewMoon).getTimeInMillis();
         long ageRangeTimeMillis = phase.getNew().getTimeInMillis() - parentNewMoonMillis;
         long ageCurrentMillis = System.currentTimeMillis() - parentNewMoonMillis;
-        double agePercent = ageCurrentMillis * 100.0 / ageRangeTimeMillis;
+        double agePercent = ageRangeTimeMillis != 0 ? ageCurrentMillis * 100.0 / ageRangeTimeMillis : 0;
         phase.setAgePercent(agePercent);
         phase.setAgeDegree(3.6 * agePercent);
         double illumination = getIllumination(DateTimeUtils.dateToJulianDate(calendar));


### PR DESCRIPTION
- Fixed handling of division by 0 for new moon

The division by 0 results in `Double.POSITIVE_INFINITY` ("Infinity" after converting to String) which cannot be parsed correctly by the `QuantityType` / `BigDecimal` constructor and leads to an error:

```
2019-06-03 09:10:29.391 [ERROR] [o.internal.handler.AstroThingHandler] - Can't update state for channel astro:moon:local:phase#ageDegree : null
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:?]
        at org.openhab.binding.astro.internal.util.PropertyUtils.getPropertyValue(PropertyUtils.java:98) ~[235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.util.PropertyUtils.getPropertyValue(PropertyUtils.java:100) ~[235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.util.PropertyUtils.getPropertyValue(PropertyUtils.java:88) ~[235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.util.PropertyUtils.getState(PropertyUtils.java:53) ~[235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.handler.AstroThingHandler.publishChannelIfLinked(AstroThingHandler.java:155) [235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.handler.AstroThingHandler.publishPlanet(AstroThingHandler.java:138) [235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.handler.MoonHandler.publishPositionalInfo(MoonHandler.java:63) [235:org.openhab.binding.astro:2.5.0.201906041542]
        at org.openhab.binding.astro.internal.job.PositionalJob.run(PositionalJob.java:45) [235:org.openhab.binding.astro:2.5.0.201906041542]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: java.lang.NumberFormatException
        at java.math.BigDecimal.<init>(BigDecimal.java:497) ~[?:?]
        at java.math.BigDecimal.<init>(BigDecimal.java:383) ~[?:?]
        at java.math.BigDecimal.<init>(BigDecimal.java:809) ~[?:?]
        at org.eclipse.smarthome.core.library.types.QuantityType.<init>(QuantityType.java:109) ~[?:?]
        at org.openhab.binding.astro.internal.model.MoonPhase.getAgeDegree(MoonPhase.java:147) ~[?:?]
        ... 19 more
```

Closes https://github.com/eclipse/smarthome/issues/6808

See also https://community.openhab.org/t/astro-binding-throwing-exceptions-for-moon-since-00-00-this-morning/47775

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
