### PR TITLE
[xmppclient] remove wrapping and force dependency install

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -4,8 +4,7 @@
 
     <feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature prerequisite="true">wrap</feature>
-        <bundle dependency="true">mvn:org.igniterealtime.smack/smack-java7/4.3.3</bundle>
+        
         <bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.3.3</bundle>
         <bundle dependency="true">mvn:org.igniterealtime.smack/smack-im/4.3.3</bundle>
         <bundle dependency="true">mvn:org.igniterealtime.smack/smack-tcp/4.3.3</bundle>
@@ -14,9 +13,11 @@
         <bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/0.6.3</bundle>
         <bundle dependency="true">mvn:org.minidns/minidns-core/0.3.3</bundle>
         <bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.3.3</bundle>
-        <bundle dependency="true">mvn:org.igniterealtime.smack/smack-resolver-javax/4.3.3</bundle>
         <bundle dependency="true">mvn:org.igniterealtime.smack/smack-sasl-javax/4.3.3</bundle>
-        <bundle dependency="true">wrap:mvn:xpp3/xpp3/1.1.4c$Bundle-Name=XPP3%20Library&amp;Bundle-SymbolicName=xpp3-xpp3&amp;Bundle-Version=1.1.4</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_7</bundle>
+        <!-- FIXME: implicit dependencies required at runtime but not automatically installed, this is a workaround -->
+        <bundle start-level="80">mvn:org.igniterealtime.smack/smack-resolver-javax/4.3.3</bundle>
+        <bundle start-level="80">mvn:org.igniterealtime.smack/smack-java7/4.3.3</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.xmppclient/${project.version}</bundle>
     </feature>
 </features>


### PR DESCRIPTION
Fixes #5473 

- Replaced wrapped xpp3 with servicemix
- The missing dependencies are not properly referenced by the bundles that need them at runtime. Therefore we have to force their installation.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
