### PR TITLE
[hueemulation] Fix warnings/stacktraces at startup

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -117,7 +117,7 @@ public class HueEmulationService implements EventHandler {
     // Don't fail the service if the upnp server does not come up
     // That part is required for discovery only but does not affect already configured hue applications
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
-    protected @NonNullByDefault({}) UpnpServer discovery;
+    protected @Nullable UpnpServer discovery;
     @Reference
     protected @NonNullByDefault({}) ConfigStore cs;
     @Reference
@@ -201,10 +201,11 @@ public class HueEmulationService implements EventHandler {
             initParams.put("com.sun.jersey.api.json.POJOMappingFeature", "false");
             initParams.put(ServletProperties.PROVIDER_WEB_APP, "false");
             httpService.registerServlet(RESTAPI_PATH, new ServletContainer(resourceConfig), initParams, null);
-            if (discovery == null) {
+            UpnpServer localDiscovery = discovery;
+            if (localDiscovery == null) {
                 logger.warn("The UPnP Server service has not been started!");
-            } else if (!discovery.upnpAnnouncementThreadRunning()) {
-                discovery.handleEvent(null);
+            } else if (!localDiscovery.upnpAnnouncementThreadRunning()) {
+                localDiscovery.handleEvent(null);
             }
             statusResource.startUpnpSelfTest();
             logger.info("Hue Emulation service available under {}", RESTAPI_PATH);

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.GenericItem;
@@ -111,7 +112,7 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
     @Reference
     protected @NonNullByDefault({}) ItemRegistry itemRegistry;
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
-    protected volatile @NonNullByDefault({}) EventPublisher eventPublisher;
+    protected volatile @Nullable EventPublisher eventPublisher;
 
     /**
      * Registers to the {@link ItemRegistry} and enumerates currently existing items.
@@ -373,9 +374,10 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
 
         // If a command could be created, post it to the framework now
         if (command != null) {
-            if (eventPublisher != null) {
+            EventPublisher localEventPublisher = eventPublisher;
+            if (localEventPublisher != null) {
                 logger.debug("sending {} to {}", command, itemUID);
-                eventPublisher.post(ItemEventFactory.createCommandEvent(itemUID, command, "hueemulation"));
+                localEventPublisher.post(ItemEventFactory.createCommandEvent(itemUID, command, "hueemulation"));
             } else {
                 logger.warn("No event publisher. Cannot post item '{}' command!", itemUID);
             }
@@ -418,8 +420,10 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
         // If a command could be created, post it to the framework now
         if (command != null) {
             logger.debug("sending {} to {}", command, id);
-            if (eventPublisher != null) {
-                eventPublisher.post(ItemEventFactory.createCommandEvent(groupItem.getUID(), command, "hueemulation"));
+            EventPublisher localEventPublisher = eventPublisher;
+            if (localEventPublisher != null) {
+                localEventPublisher
+                        .post(ItemEventFactory.createCommandEvent(groupItem.getUID(), command, "hueemulation"));
             } else {
                 logger.warn("No event publisher. Cannot post item '{}' command!", groupItem.getUID());
             }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
@@ -23,6 +23,8 @@ import java.util.function.Consumer;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.io.hueemulation.internal.HueEmulationConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The upnp server runtime configuration. Based on a {@link HueEmulationConfig} and determined ip address and port.
@@ -33,6 +35,9 @@ import org.openhab.io.hueemulation.internal.HueEmulationConfig;
  */
 @NonNullByDefault
 class HueEmulationConfigWithRuntime extends Thread implements Runnable {
+
+    private final Logger logger = LoggerFactory.getLogger(HueEmulationConfigWithRuntime.class);
+
     final @NonNullByDefault({}) HueEmulationConfig config;
     final InetAddress address;
     final String addressString;
@@ -93,7 +98,8 @@ class HueEmulationConfigWithRuntime extends Thread implements Runnable {
     public synchronized CompletableFuture<@Nullable HueEmulationConfigWithRuntime> startNow(
             @Nullable HueEmulationConfigWithRuntime ignored) {
         if (hasAlreadyBeenStarted) {
-            throw new IllegalStateException("Cannot restart thread");
+            logger.debug("Cannot restart thread");
+            return future;
         }
         hasAlreadyBeenStarted = true;
         super.start();

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
@@ -339,7 +339,7 @@ public class UpnpServer extends HttpServlet implements Consumer<HueEmulationConf
      * configuration ready event and depending on service start order we are also called by our own activate() method
      * when the configuration is already ready at that time.
      * <p>
-     * Therefore this method is "synchronized" and chains a completeable future for each call to re-evaluate the config
+     * Therefore this method is "synchronized" and chains a completable future for each call to re-evaluate the config
      * after the former future has finished.
      */
     @Override


### PR DESCRIPTION
* Properly annotates optional references with nullable to fix NPEs
* Reworked HueEmulationConfigWithRuntime.startNow to prevent IllegalStateException

Fixes #5622

---

This fixes all warning/stacktrace noise from this add-on when using the Demo.