### PR TITLE
[globalcache] Update the Item type for Contact Closures to "Switch"

### DIFF
--- a/bundles/org.openhab.binding.globalcache/README.md
+++ b/bundles/org.openhab.binding.globalcache/README.md
@@ -135,7 +135,7 @@ A *Contact Closure channel* activates the contact closure (relay) on the iTach o
 For example, the following item links to the module 1, connector 1 channel on an iTach CC device.
 
 ```
-Contact MyRelay    "My Relay [%s]"  (gRelays)   { channel="globalcache:itachCC:000C1E039BCF:cc-m1#c1" }
+Switch MyRelay    "My Relay [%s]"  (gRelays)   { channel="globalcache:itachCC:000C1E039BCF:cc-m1#c1" }
 ```
 
 The item definition for an iTach Flex WiFi device would look like this.

--- a/bundles/org.openhab.binding.globalcache/src/main/resources/ESH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.globalcache/src/main/resources/ESH-INF/thing/channel-types.xml
@@ -12,7 +12,7 @@
 	</channel-type>
 
 	<channel-type id="channel-type-cc">
-		<item-type>Contact</item-type>
+		<item-type>Switch</item-type>
 		<label>Contact Closure</label>
 		<description>Transmits contact closure command on module:connector</description>
 	</channel-type>


### PR DESCRIPTION
The current item type prevents globalcache contact closures from being modified by this module, since it is marked as an item type of "Contact" that can only accept "REFRESH" commands. So, while it can show changes that are done external to this module, all the functionality in the module that makes changes to the contact relays can never be triggered.

The documentation at https://www.openhab.org/addons/bindings/globalcache/ has examples that showcase both Switch and Contact item types. This change will make the Switch use cases actually work.

Today, this is shown in the log:
2019-06-12 22:39:05.386 [DEBUG] [.thing.internal.CommunicationManager] - Received event 'ON' (OnOffType) could not be converted to any type accepted by item 'HomeTheaterCurtainsOpen' (Switch)                     2019-06-12 22:39:05.408 [DEBUG] [.thing.internal.CommunicationManager] - Received not accepted type 'OnOffType' for channel 'globalcache:itachCC:000C1E034EF7:cc-m1#c2'                                             

Signed-off-by: Nick Hill <knikhilwiz@gmail.com>
