### PR TITLE
[hueemulation] seperate ipv4 / ipv6

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/glassfish/jersey/servlet/init/JerseyServletContainerInitializer.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/glassfish/jersey/servlet/init/JerseyServletContainerInitializer.java
@@ -25,7 +25,7 @@ import javax.servlet.ServletException;
  */
 public class JerseyServletContainerInitializer implements ServletContainerInitializer {
     @Override
-    public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
+    public void onStartup(Set<Class<?>> c, ServletContext ctx) {
 
     }
 }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -91,8 +91,7 @@ public class HueEmulationService implements EventHandler {
     public class LogAccessInterceptor implements ContainerResponseFilter {
         @NonNullByDefault({})
         @Override
-        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
-                throws IOException {
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
 
             if (!logger.isDebugEnabled()) {
                 return;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
@@ -113,7 +113,7 @@ public class TimerTriggerHandler extends BaseTriggerModuleHandler implements Cal
     }
 
     @Override
-    public Duration call() throws Exception {
+    public Duration call() {
         ((TriggerHandlerCallback) callback).triggered(module, null);
         config.repeat -= 1;
         if (config.repeat == 0) {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/ConfigurationAccess.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/ConfigurationAccess.java
@@ -78,7 +78,7 @@ public class ConfigurationAccess {
     @ApiOperation(value = "Return the full data store")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response getAllApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }
@@ -91,7 +91,7 @@ public class ConfigurationAccess {
     @ApiOperation(value = "Return the configuration")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response getFullConfigApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }
@@ -104,7 +104,7 @@ public class ConfigurationAccess {
     @ApiOperation(value = "Return the reduced configuration")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response putFullConfigApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username, String body) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username, String body) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Rules.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Rules.java
@@ -239,7 +239,7 @@ public class Rules implements RegistryChangeListener<Rule> {
     @ApiOperation(value = "Return all rules")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response getRulesApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Scenes.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Scenes.java
@@ -169,7 +169,7 @@ public class Scenes implements RegistryChangeListener<Rule> {
     @ApiOperation(value = "Return all scenes")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response getScenesApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Schedules.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Schedules.java
@@ -232,7 +232,7 @@ public class Schedules implements RegistryChangeListener<Rule> {
     @ApiOperation(value = "Return all schedules")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response getSchedulesApi(@Context UriInfo uri,
-            @PathParam("username") @ApiParam(value = "username") String username) throws IOException {
+            @PathParam("username") @ApiParam(value = "username") String username) {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/automation/RuleConditionHandlerTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/automation/RuleConditionHandlerTests.java
@@ -67,7 +67,7 @@ public class RuleConditionHandlerTests {
     }
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         ds = new HueDataStore();
 
         ds.lights.put("1", new HueLightEntry(new SwitchItem("switch"), "switch", DeviceType.SwitchType));

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -89,7 +89,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void addSwitchableByCategory() throws IOException {
+    public void addSwitchableByCategory() {
         SwitchItem item = new SwitchItem("switch1");
         item.setCategory("Light");
         itemRegistry.add(item);
@@ -100,7 +100,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void addSwitchableByTag() throws IOException {
+    public void addSwitchableByTag() {
         SwitchItem item = new SwitchItem("switch1");
         item.addTag("Switchable");
         itemRegistry.add(item);
@@ -110,7 +110,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void ignoreByTag() throws IOException {
+    public void ignoreByTag() {
         SwitchItem item = new SwitchItem("switch1");
         item.addTags("Switchable", "internal"); // The ignore tag will win
         itemRegistry.add(item);
@@ -119,7 +119,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void addGroupSwitchableByTag() throws IOException {
+    public void addGroupSwitchableByTag() {
         GroupItem item = new GroupItem("group1", new SwitchItem("switch1"));
         item.addTag("Switchable");
         itemRegistry.add(item);
@@ -129,7 +129,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void addGroupWithoutTypeByTag() throws IOException {
+    public void addGroupWithoutTypeByTag() {
         GroupItem item = new GroupItem("group1", null);
         item.addTag("Switchable");
 
@@ -142,7 +142,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void removeGroupWithoutTypeAndTag() throws IOException {
+    public void removeGroupWithoutTypeAndTag() {
         String groupName = "group1";
         GroupItem item = new GroupItem(groupName, null);
         item.addTag("Switchable");
@@ -157,7 +157,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void updateSwitchable() throws IOException {
+    public void updateSwitchable() {
         SwitchItem item = new SwitchItem("switch1");
         item.setLabel("labelOld");
         item.addTag("Switchable");
@@ -187,7 +187,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void changeSwitchState() throws IOException {
+    public void changeSwitchState() {
 
         assertThat(((HueStatePlug) cs.ds.lights.get("1").state).on, is(false));
 
@@ -204,7 +204,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void changeGroupItemSwitchState() throws IOException {
+    public void changeGroupItemSwitchState() {
 
         assertThat(((HueStatePlug) cs.ds.groups.get("10").action).on, is(false));
 
@@ -221,7 +221,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void changeOnValue() throws IOException {
+    public void changeOnValue() {
 
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
 
@@ -235,7 +235,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void changeOnAndBriValues() throws IOException {
+    public void changeOnAndBriValues() {
 
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(0));
@@ -250,7 +250,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void changeHueSatValues() throws IOException {
+    public void changeHueSatValues() {
         HueLightEntry hueDevice = cs.ds.lights.get("2");
         hueDevice.item.setState(OnOffType.ON);
         hueDevice.state.as(HueStateColorBulb.class).on = true;
@@ -271,7 +271,7 @@ public class LightsAndGroupsTests {
      * Amazon echos are setting ct only, if commanded to turn a light white.
      */
     @Test
-    public void changeCtValue() throws IOException {
+    public void changeCtValue() {
         HueLightEntry hueDevice = cs.ds.lights.get("2");
         hueDevice.item.setState(OnOffType.ON);
         hueDevice.state.as(HueStateColorBulb.class).on = true;
@@ -292,7 +292,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void switchOnWithXY() throws IOException {
+    public void switchOnWithXY() {
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(0));
 
@@ -313,8 +313,7 @@ public class LightsAndGroupsTests {
     }
 
     @Test
-    public void allLightsAndSingleLight()
-            throws InterruptedException, ExecutionException, TimeoutException, IOException {
+    public void allLightsAndSingleLight() {
         Response response = commonSetup.client.target(commonSetup.basePath + "/testuser/lights").request().get();
         assertEquals(200, response.getStatus());
 

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
@@ -92,7 +92,7 @@ public class SensorTests {
     }
 
     @Test
-    public void renameSensor() throws IOException {
+    public void renameSensor() {
 
         assertThat(cs.ds.sensors.get("switch1").name, is("name1"));
 
@@ -107,7 +107,7 @@ public class SensorTests {
     }
 
     @Test
-    public void allAndSingleSensor() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+    public void allAndSingleSensor() {
         Response response = commonSetup.client.target(commonSetup.basePath + "/testuser/sensors").request().get();
         assertEquals(200, response.getStatus());
 

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/UsersAndConfigTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/UsersAndConfigTests.java
@@ -68,17 +68,17 @@ public class UsersAndConfigTests {
     }
 
     @Test
-    public void invalidUser() throws IOException {
+    public void invalidUser() {
         assertFalse(commonSetup.userManagement.authorizeUser("blub"));
     }
 
     @Test
-    public void validUser() throws IOException {
+    public void validUser() {
         assertTrue(commonSetup.userManagement.authorizeUser("testuser"));
     }
 
     @Test
-    public void configStoreRestartOnNoUUID() throws IOException {
+    public void configStoreRestartOnNoUUID() {
         ConfigStore configStore = new ConfigStoreWithoutMetadata(commonSetup.networkAddressService,
                 commonSetup.configAdmin, commonSetup.scheduler);
 
@@ -95,7 +95,7 @@ public class UsersAndConfigTests {
     }
 
     @Test
-    public void addUser() throws IOException {
+    public void addUser() {
         // GET should fail
         assertEquals(405, commonSetup.client.target(commonSetup.basePath).request().get().getStatus());
 
@@ -123,8 +123,7 @@ public class UsersAndConfigTests {
     }
 
     @Test
-    public void UnauthorizedAccessTest()
-            throws InterruptedException, ExecutionException, TimeoutException, IOException {
+    public void UnauthorizedAccessTest() {
 
         // Unauthorized config
         Response response;

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyItemRegistry.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyItemRegistry.java
@@ -90,12 +90,12 @@ public class DummyItemRegistry implements ItemRegistry {
     }
 
     @Override
-    public Item getItem(@Nullable String name) throws ItemNotFoundException {
+    public Item getItem(@Nullable String name) {
         return items.get(name);
     }
 
     @Override
-    public Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException {
+    public Item getItemByPattern(String name) {
         return items.get(name);
     }
 


### PR DESCRIPTION
Resolves exception of combining ipv4 / ipv6 by getting to separate channels

Exception in thread "HueEmulation UPNP Server" java.lang.IllegalArgumentException: IPv6 socket cannot join IPv4 multicast group
        at sun.nio.ch.DatagramChannelImpl.innerJoin(DatagramChannelImpl.java:808)
        at sun.nio.ch.DatagramChannelImpl.join(DatagramChannelImpl.java:894)
        at org.openhab.io.hueemulation.internal.upnp.UpnpServer.accept(UpnpServer.java:439)
        at org.openhab.io.hueemulation.internal.upnp.UpnpServer.accept(UpnpServer.java:1)
        at org.openhab.io.hueemulation.internal.upnp.HueEmulationConfigWithRuntime.run(HueEmulationConfigWithRuntime.java:105)

@davidgraeff would this be a sensible solution?