### PR TITLE
Fix missing feature bundles

### DIFF
--- a/features/openhab-addons/pom.xml
+++ b/features/openhab-addons/pom.xml
@@ -50,7 +50,7 @@
                   </fileset>
                   <filterchain>
                     <linecontainsRegExp>
-                      <regexp pattern="(feature>)|(feature\s)|(bundle\s)"/>
+                      <regexp pattern="(feature>)|(feature\s)|(bundle>)|(bundle\s)"/>
                     </linecontainsRegExp>
                   </filterchain>
                   <footer file="src/main/resources/footer.xml" filtering="no"/>


### PR DESCRIPTION
Adapt regular expression so it also matches the bundles of the openhab-io-webaudio and openhab-misc-market features.

See also: https://github.com/openhab/openhab-core/issues/821