### PR TITLE
update POMs with changed dependencies

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/pom.xml
+++ b/bundles/org.openhab.binding.avmfritz/pom.xml
@@ -33,9 +33,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.denonmarantz/pom.xml
+++ b/bundles/org.openhab.binding.denonmarantz/pom.xml
@@ -34,9 +34,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.dlinksmarthome/pom.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/pom.xml
@@ -34,9 +34,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- JAX-WS -->

--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -38,9 +38,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- JNA -->

--- a/bundles/org.openhab.binding.xmltv/pom.xml
+++ b/bundles/org.openhab.binding.xmltv/pom.xml
@@ -33,10 +33,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
-      <scope>provided</scope>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
+     <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
With #5701 some depencencies have changed to OSGi bundles. This updates the dependencies.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
