### PR TITLE
[openhabcloud] partly revert unwrapping

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
@@ -6,8 +6,8 @@
         <feature>openhab-runtime-base</feature>
         <feature prerequisite="true">wrap</feature>
         <bundle dependency="true">mvn:org.json/json/20180813</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.12.1_1</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.15.0_1</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp3/okhttp/3.12.1$Bundle-Name=OkHttp&amp;Bundle-SymbolicName=com.squareup.okhttp&amp;Bundle-Version=3.12.1</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okio/okio/1.15.0$Bundle-Name=Okio&amp;Bundle-SymbolicName=com.squareup.okio&amp;Bundle-Version=1.15.0</bundle>   
         <bundle dependency="true">wrap:mvn:io.socket/socket.io-client/1.0.0$Bundle-Name=Socket.IO%20Client&amp;Bundle-SymbolicName=io.socket.socket.io-client&amp;Bundle-Version=1.0.0</bundle>
         <bundle dependency="true">wrap:mvn:io.socket/engine.io-client/1.0.0$Bundle-Name=Engine.IO%20Client&amp;Bundle-SymbolicName=io.socket.engine.io-client&amp;Bundle-Version=1.0.0</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.io.openhabcloud/${project.version}</bundle>


### PR DESCRIPTION
optional imports from automatic wrapping of other bundles prevent needed bundles from being installed

Report: https://community.openhab.org/t/openhab-cloud-connector-not-working-anymore-after-snapshot-1607/76308

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
