### PR TITLE
don't drop the itests projects from reactor on skipTests

### DIFF
--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -35,9 +35,9 @@ Fragment-Host: org.openhab.binding.astro
 	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -64,7 +64,7 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)'

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -23,7 +23,6 @@ Fragment-Host: org.openhab.binding.feed
 #
 -runbundles: \
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.bundles.jdom;version='[2.0.6,2.0.7)',\
@@ -72,4 +71,5 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	slf4j.api;version='[1.7.16,1.7.17)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -65,9 +65,9 @@ Fragment-Host: org.openhab.binding.hue
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -52,8 +52,8 @@ Fragment-Host: org.openhab.binding.max
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -31,7 +31,6 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -63,7 +62,6 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	com.h2database.mvstore;version='[1.4.199,1.4.200)',\
 	io.netty.buffer;version='[4.1.34,4.1.35)',\
 	io.netty.codec;version='[4.1.34,4.1.35)',\
@@ -76,4 +74,6 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.openhab.io.mqttembeddedbroker;version='[2.5.0,2.5.1)',\
 	io.moquette.moquette-broker;version='[0.12.1,0.12.2)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -63,7 +62,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	com.h2database.mvstore;version='[1.4.199,1.4.200)',\
 	io.netty.buffer;version='[4.1.34,4.1.35)',\
 	io.netty.codec;version='[4.1.34,4.1.35)',\
@@ -76,4 +74,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.openhab.io.mqttembeddedbroker;version='[2.5.0,2.5.1)',\
 	io.moquette.moquette-broker;version='[0.12.1,0.12.2)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -65,7 +65,7 @@ Fragment-Host: org.openhab.binding.nest
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -56,8 +56,8 @@ Fragment-Host: org.openhab.binding.ntp
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -50,7 +50,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
@@ -61,6 +60,7 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.jmdns;version='[3.5.5,3.5.6)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.californium.core;version='[1.0.7,1.0.8)',\
@@ -63,6 +62,7 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -70,9 +70,9 @@ Fragment-Host: org.openhab.binding.wemo
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.io.hueemulation.tests/itest.bndrun
+++ b/itests/org.openhab.io.hueemulation.tests/itest.bndrun
@@ -48,7 +48,6 @@ Fragment-Host: org.openhab.io.hueemulation
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
@@ -78,6 +77,7 @@ Fragment-Host: org.openhab.io.hueemulation
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -36,9 +36,9 @@ Fragment-Host: org.openhab.persistence.mapdb
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>bom</module>
     <module>bundles</module>
     <module>features</module>
+    <module>itests</module>
   </modules>
 
   <scm>
@@ -666,17 +667,6 @@ Import-Package: \\
       </properties>
     </profile>
 
-    <profile>
-      <id>skip-itest</id>
-      <activation>
-        <property>
-          <name>!skipTests</name>
-        </property>
-      </activation>
-      <modules>
-        <module>itests</module>
-      </modules>
-    </profile>
     <profile>
       <id>with-bnd-resolver-resolve</id>
       <activation>


### PR DESCRIPTION
The bnd-testing-maven-plugin that is used to run the tests already
checks for the skipTests property and do not execute any tests if
defined.
We should keep the integration tests part of the reactor also if the
tests are not executed.

Related to: https://github.com/openhab/openhab-core/pull/873