### PR TITLE
[loxone] Added automatic tags generation #5615

### DIFF
--- a/bundles/org.openhab.binding.loxone/README.md
+++ b/bundles/org.openhab.binding.loxone/README.md
@@ -161,6 +161,13 @@ Channel label is defined in the following way:
 *   For controls that belong to a room: `<Room name> / <Control name>`
 *   For controls without a room: `<Control name>`
 
+Channels have the default tags as follows:
+
+*   **Dimmer**: when it belongs to a category of _Lights_ type, the channel will be tagged with _Lighting_ tag. 
+*   **InfoOnlyAnalog**: when it belongs to a category of _Indoor Temperature_ type, it will be tagger with _CurrentTemperature_ tag.
+*   **Jalousie**: main rollershutter channel will be tagged with _Blinds_ tag. Shade and automatic shade switch channels will be tagged with _Switchable_ tag.
+*   **LightController (V1 and V2)**: main channel with selected scene will be tagged with _Scene_ tag.
+*   **Switch**, **TimedSwitch** and **Pushbutton** controls: when it belongs to a category that is of a _Lights_ type, the channel will be tagged with _Lighting_ tag. Otherwise it will be tagged with _Switchable_ tag.
 
 ## Advanced Parameters
 

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxServerHandlerApi.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxServerHandlerApi.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.loxone.internal;
 
 import java.io.IOException;
-import java.nio.channels.Channels;
 import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -29,7 +28,7 @@ import com.google.gson.Gson;
 
 /**
  * Representation of a Loxone Miniserver. It is an openHAB {@link Thing}, which is used to communicate with
- * objects (controls) configured in the Miniserver over {@link Channels}.
+ * objects (controls) configured in the Miniserver over channels.
  *
  * @author Pawel Pieczul - Initial contribution
  */

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlAlarm.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlAlarm.java
@@ -38,7 +38,7 @@ import org.openhab.binding.loxone.internal.types.LxUuid;
  * @author Michael Mattan - Initial contribution
  *
  */
-public class LxControlAlarm extends LxControl {
+class LxControlAlarm extends LxControl {
 
     static class Factory extends LxControlInstance {
         @Override

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlDimmer.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlDimmer.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.loxone.internal.types.LxCategory;
 import org.openhab.binding.loxone.internal.types.LxUuid;
 
 /**
@@ -72,6 +73,10 @@ class LxControlDimmer extends LxControl {
     @Override
     public void initialize(LxControlConfig config) {
         super.initialize(config);
+        LxCategory category = getCategory();
+        if (category != null && category.getType() == LxCategory.CategoryType.LIGHTS) {
+            tags.add("Lighting");
+        }
         addChannel("Dimmer", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_DIMMER), defaultChannelLabel,
                 "Dimmer", tags, this::handleCommands, this::getChannelState);
     }

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalog.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalog.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.loxone.internal.LxBindingConstants.*;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.StateDescription;
+import org.openhab.binding.loxone.internal.types.LxCategory;
 import org.openhab.binding.loxone.internal.types.LxUuid;
 
 /**
@@ -54,6 +55,10 @@ class LxControlInfoOnlyAnalog extends LxControl {
     @Override
     public void initialize(LxControlConfig config) {
         super.initialize(config);
+        LxCategory category = getCategory();
+        if (category != null && category.getType() == LxCategory.CategoryType.TEMPERATURE) {
+            tags.add("CurrentTemperature");
+        }
         ChannelUID cid = addChannel("Number", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_RO_ANALOG),
                 defaultChannelLabel, "Analog virtual state", tags, null, () -> getStateDecimalValue(STATE_VALUE));
         String format;

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlJalousie.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlJalousie.java
@@ -15,6 +15,8 @@ package org.openhab.binding.loxone.internal.controls;
 import static org.openhab.binding.loxone.internal.LxBindingConstants.*;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -114,13 +116,17 @@ class LxControlJalousie extends LxControl {
     @Override
     public void initialize(LxControlConfig config) {
         super.initialize(config);
+        Set<String> blindsTags = new HashSet<>(tags);
+        Set<String> switchTags = new HashSet<>(tags);
+        blindsTags.add("Blinds");
+        switchTags.add("Switchable");
         addChannel("Rollershutter", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_ROLLERSHUTTER),
-                defaultChannelLabel, "Rollershutter", tags, this::handleOperateCommands, this::getOperateState);
+                defaultChannelLabel, "Rollershutter", blindsTags, this::handleOperateCommands, this::getOperateState);
         addChannel("Switch", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_SWITCH),
-                defaultChannelLabel + " / Shade", "Rollershutter shading", null, this::handleShadeCommands,
+                defaultChannelLabel + " / Shade", "Rollershutter shading", switchTags, this::handleShadeCommands,
                 () -> OnOffType.OFF);
         addChannel("Switch", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_SWITCH),
-                defaultChannelLabel + " / Auto Shade", "Rollershutter automatic shading", null,
+                defaultChannelLabel + " / Auto Shade", "Rollershutter automatic shading", switchTags,
                 this::handleAutoShadeCommands, this::getAutoShadeState);
     }
 

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlLightController.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlLightController.java
@@ -97,6 +97,7 @@ class LxControlLightController extends LxControl {
     @Override
     public void initialize(LxControlConfig config) {
         super.initialize(config);
+        tags.add("Scene");
         // add only channel, state description will be added later when a control state update message is received
         channelId = addChannel("Number", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_LIGHT_CTRL),
                 defaultChannelLabel, "Light controller", tags, this::handleCommands, this::getChannelState);

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2.java
@@ -118,6 +118,7 @@ class LxControlLightControllerV2 extends LxControl {
     @Override
     public void initialize(LxControlConfig config) {
         super.initialize(config);
+        tags.add("Scene");
         // add only channel, state description will be added later when a control state update message is received
         channelId = addChannel("Number", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_LIGHT_CTRL),
                 defaultChannelLabel, "Light controller V2", tags, this::handleCommands, this::getChannelState);

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlSwitch.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControlSwitch.java
@@ -74,6 +74,8 @@ class LxControlSwitch extends LxControl {
         LxCategory category = getCategory();
         if (category != null && category.getType() == LxCategory.CategoryType.LIGHTS) {
             tags.add("Lighting");
+        } else {
+            tags.add("Switchable");
         }
         addChannel("Switch", new ChannelTypeUID(BINDING_ID, MINISERVER_CHANNEL_TYPE_SWITCH), defaultChannelLabel,
                 "Switch", tags, this::handleSwitchCommands, this::getSwitchState);

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxCategory.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxCategory.java
@@ -28,18 +28,22 @@ public class LxCategory extends LxContainer {
      * @author Pawel Pieczul - initial contribution
      */
     public enum CategoryType {
-    /**
-     * Category for lights
-     */
-    LIGHTS,
-    /**
-     * Category for shading / rollershutter / blinds
-     */
-    SHADING,
-    /**
-     * Unknown category
-     */
-    UNDEFINED
+        /**
+         * Category for lights
+         */
+        LIGHTS,
+        /**
+         * Category for shading / rollershutter / blinds
+         */
+        SHADING,
+        /**
+         * Category for temperatures
+         */
+        TEMPERATURE,
+        /**
+         * Unknown category
+         */
+        UNDEFINED
     }
 
     private String type; // deserialized from JSON
@@ -57,6 +61,8 @@ public class LxCategory extends LxContainer {
                 catType = CategoryType.LIGHTS;
             } else if (tl.equals("shading")) {
                 catType = CategoryType.SHADING;
+            } else if (tl.equals("indoortemperature")) {
+                catType = CategoryType.TEMPERATURE;
             } else {
                 catType = CategoryType.UNDEFINED;
             }

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxState.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxState.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * List of states is read from LoxApp3.json configuration file.
  * <p>
  * Each state is identified by its own UUID and a name of the state. Names are proprietary to a particular type of the
- * control and as such are defined in {@link LxControl} child classes implementation (e.g. {@link LxControlSwitch}
+ * control and as such are defined in {@link LxControl} child classes implementation.
  * Objects of this class are used to bind state updates received from the Miniserver to a control object.
  *
  * @author Pawel Pieczul - initial contribution

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTempTagTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTempTagTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loxone.internal.controls;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for (@link LxControlInfoOnlyAnalog} - check tags for temperature category
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+public class LxControlInfoOnlyAnalogTempTagTest extends LxControlTest {
+    @Before
+    public void setup() {
+        setupControl("0fec5dc3-003e-8800-ffff555fb0c34b9e", "0fe3a451-0283-2afa-ffff403fb0c34b9e",
+                "0fb99a98-02df-46f1-ffff403fb0c34b9e", "Info Only Analog Temperature");
+    }
+
+    @Test
+    public void testControlCreation() {
+        testControlCreation(LxControlInfoOnlyAnalog.class, 2, 0, 1, 1, 1);
+    }
+
+    @Test
+    public void testChannels() {
+        testChannel("Number", null, null, null, null, "%.1f", true, null, Collections.singleton("CurrentTemperature"));
+    }
+}

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTest.java
@@ -32,7 +32,7 @@ public class LxControlInfoOnlyAnalogTest extends LxControlTest {
 
     @Test
     public void testControlCreation() {
-        testControlCreation(LxControlInfoOnlyAnalog.class, 1, 0, 1, 1, 1);
+        testControlCreation(LxControlInfoOnlyAnalog.class, 2, 0, 1, 1, 1);
     }
 
     @Test

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlJalousieTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlJalousieTest.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -45,9 +48,10 @@ public class LxControlJalousieTest extends LxControlTest {
 
     @Test
     public void testChannels() {
-        testChannel("Rollershutter");
-        testChannel("Switch", SHADE_CHANNEL);
-        testChannel("Switch", AUTO_SHADE_CHANNEL);
+        testChannel("Rollershutter", Collections.singleton("Blinds"));
+        Set<String> tags = Collections.singleton("Switchable");
+        testChannel("Switch", SHADE_CHANNEL, tags);
+        testChannel("Switch", AUTO_SHADE_CHANNEL, tags);
     }
 
     @Test

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,7 +58,7 @@ public class LxControlLightControllerV2Test extends LxControlTest {
 
     @Test
     public void testChannels() {
-        testChannel("Number");
+        testChannel("Number", Collections.singleton("Scene"));
     }
 
     @Test
@@ -231,7 +232,8 @@ public class LxControlLightControllerV2Test extends LxControlTest {
         }
         assertNotNull(min);
         assertNotNull(max);
-        testChannel("Number", null, new BigDecimal(min), new BigDecimal(max), BigDecimal.ONE, null, false, options);
+        testChannel("Number", null, new BigDecimal(min), new BigDecimal(max), BigDecimal.ONE, null, false, options,
+                Collections.singleton("Scene"));
     }
 
     private void testMood(String name, String id, boolean isStatic) {
@@ -244,7 +246,7 @@ public class LxControlLightControllerV2Test extends LxControlTest {
             assertEquals(0, mood.getChannels().size());
         } else {
             assertEquals(1, mood.getChannels().size());
-            testChannel(mood, "Switch");
+            testChannel(mood, "Switch", Collections.singleton("Lighting"));
         }
     }
 

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlPushbuttonTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlPushbuttonTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
+import java.util.Collections;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -41,7 +43,7 @@ public class LxControlPushbuttonTest extends LxControlSwitchTest {
     @Override
     @Test
     public void testChannels() {
-        testChannel("Switch");
+        testChannel("Switch", Collections.singleton("Switchable"));
     }
 
     @Override

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSwitchTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSwitchTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
+import java.util.Collections;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -39,7 +41,7 @@ public class LxControlSwitchTest extends LxControlTest {
 
     @Test
     public void testChannels() {
-        testChannel("Switch");
+        testChannel("Switch", Collections.singleton("Lighting"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTest.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.smarthome.core.thing.Channel;
@@ -78,7 +80,7 @@ class LxControlTest {
     }
 
     void testChannel(LxControl ctrl, String itemType, String namePostFix, BigDecimal min, BigDecimal max,
-            BigDecimal step, String format, Boolean readOnly, List<StateOption> options) {
+            BigDecimal step, String format, Boolean readOnly, List<StateOption> options, Set<String> tags) {
         assertNotNull(ctrl);
         Channel c = getChannel(getExpectedName(ctrl.getLabel(), ctrl.getRoom().getName(), namePostFix), ctrl);
         assertNotNull(c);
@@ -111,24 +113,46 @@ class LxControlTest {
         } else {
             assertNull(d);
         }
+        if (tags != null) {
+            assertThat(c.getDefaultTags(), hasItems(tags.toArray(new String[0])));
+        } else {
+            assertThat(c.getDefaultTags(), empty());
+        }
+    }
+
+    void testChannel(String itemType, String namePostFix, BigDecimal min, BigDecimal max, BigDecimal step,
+            String format, Boolean readOnly, List<StateOption> options, Set<String> tags) {
+        LxControl ctrl = getControl(controlUuid);
+        testChannel(ctrl, itemType, namePostFix, min, max, step, format, readOnly, options, tags);
+    }
+
+    void testChannel(String itemType) {
+        testChannel(itemType, null, null, null, null, null, null, null, null);
+    }
+
+    void testChannel(String itemType, Set<String> tags) {
+        testChannel(itemType, null, null, null, null, null, null, null, tags);
+    }
+
+    void testChannel(LxControl ctrl, String itemType) {
+        testChannel(ctrl, itemType, null, null, null, null, null, null, null, null);
+    }
+
+    void testChannel(LxControl ctrl, String itemType, Set<String> tags) {
+        testChannel(ctrl, itemType, null, null, null, null, null, null, null, tags);
+    }
+
+    void testChannel(String itemType, String namePostFix) {
+        testChannel(itemType, namePostFix, null, null, null, null, null, null, null);
+    }
+
+    void testChannel(String itemType, String namePostFix, Set<String> tags) {
+        testChannel(itemType, namePostFix, null, null, null, null, null, null, tags);
     }
 
     void testChannel(String itemType, String namePostFix, BigDecimal min, BigDecimal max, BigDecimal step,
             String format, Boolean readOnly, List<StateOption> options) {
-        LxControl ctrl = getControl(controlUuid);
-        testChannel(ctrl, itemType, namePostFix, min, max, step, format, readOnly, options);
-    }
-
-    void testChannel(String itemType) {
-        testChannel(itemType, null, null, null, null, null, null, null);
-    }
-
-    void testChannel(LxControl ctrl, String itemType) {
-        testChannel(ctrl, itemType, null, null, null, null, null, null, null);
-    }
-
-    void testChannel(String itemType, String namePostFix) {
-        testChannel(itemType, namePostFix, null, null, null, null, null, null);
+        testChannel(itemType, namePostFix, min, max, step, format, readOnly, options, null);
     }
 
     State getChannelState(LxControl ctrl, String namePostFix) {

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTimedSwitchTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTimedSwitchTest.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.loxone.internal.controls;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -41,7 +42,7 @@ public class LxControlTimedSwitchTest extends LxControlTest {
 
     @Test
     public void testChannels() {
-        testChannel("Switch");
+        testChannel("Switch", Collections.singleton("Switchable"));
         testChannel("Number", DELAY_CHANNEL, new BigDecimal(-1), null, null, null, true, null);
     }
 

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
+import org.openhab.binding.loxone.internal.LxBindingConfiguration;
 import org.openhab.binding.loxone.internal.LxServerHandlerApi;
 import org.openhab.binding.loxone.internal.types.LxConfig;
 import org.openhab.binding.loxone.internal.types.LxUuid;
@@ -45,6 +46,7 @@ public class LxServerHandlerDummy implements LxServerHandlerApi {
 
     Gson gson;
     LxConfig config;
+    LxBindingConfiguration bindingConfig = new LxBindingConfiguration();
 
     Queue<String> actionQueue = new LinkedList<>();
 

--- a/bundles/org.openhab.binding.loxone/src/test/resources/org/openhab/binding/loxone/internal/controls/LoxAPP3.json
+++ b/bundles/org.openhab.binding.loxone/src/test/resources/org/openhab/binding/loxone/internal/controls/LoxAPP3.json
@@ -242,6 +242,23 @@
 				"value": "0fec5dc3-003e-8800-ffff403fb0c34b9e"
 			}
 		},
+		"0fec5dc3-003e-8800-ffff555fb0c34b9e": {
+			"name": "Info Only Analog Temperature",
+			"type": "InfoOnlyAnalog",
+			"uuidAction": "0fec5dc3-003e-8800-ffff555fb0c34b9e",
+			"room": "0fe3a451-0283-2afa-ffff403fb0c34b9e",
+			"cat": "0fb99a98-02df-46f1-ffff403fb0c34b9e",
+			"defaultRating": 0,
+			"isFavorite": false,
+			"isSecured": false,
+			"defaultIcon": null,
+			"details": {
+				"format": "%.1f"
+			},
+			"states": {
+				"value": "0fec5dc3-003e-8800-ffff403fb0c35aae"
+			}
+		},
 		"101b50f7-0306-98fb-ffff403fb0c34b9e": {
 			"name": "Info Only Digital",
 			"type": "InfoOnlyDigital",


### PR DESCRIPTION
This PR adds automatic tags generation to channels, to support Google Home scheme described here:  https://www.openhab.org/docs/ecosystem/google-assistant and as a response to request #5615 from @Tihmann.

Changes:
- added binding configuration parameter to switch auto generation off/on (default: on)
- simplified a bit using the binding configuration parameters in the binding and added ability to access them from the LxControl objects
- added generation of tags to:
   - switch (and child classes for timed switch and pushbutton) - when switch belongs to lights category, the tag will be _Lighting_, otherwise _Switchable_
   - dimmer - if it belongs to category lights, tag will be _Lighting_, otherwise none
   - light controller - main channel with selected scene will be tagged _Scene_
   - jalousie (rollershutter) - main channel will be tagged _Blinds_ and shading switches will be tagged _Switchable_

Testing: added unit tests to test the tags creation and that no tags are created if autoTags configuration parameter is off. Some more testing in live setup is described in #5615.

@mmattan, @jatin-28 - can you please take a look and review.

Thanks
Pawel

Signed-off-by: Pawel Pieczul <pieczul@gmail.com>

