### PR TITLE
[chromecast] Update README.md to fix example things to working format

### DIFF
--- a/bundles/org.openhab.binding.chromecast/README.md
+++ b/bundles/org.openhab.binding.chromecast/README.md
@@ -92,7 +92,8 @@ binding.chromecast:callbackUrl=http://192.168.30.58:8080
 demo.things:
 
 ```java
-chromecast:audio:myCC [ ipAddress="192.168.xxx.xxx"]
+Thing chromecast:audio:myCC "Lounge Chromecast Audio" [ ipAddress="192.168.xxx.xxx", port=xxxx]
+Thing chromecast:chromecast:KitchenHomeHub "Kitchen Home Hub" [ipAddress="192.168.xxx.xxx", port=8009]
 ```
 
 demo.items:

--- a/bundles/org.openhab.binding.chromecast/README.md
+++ b/bundles/org.openhab.binding.chromecast/README.md
@@ -92,7 +92,7 @@ binding.chromecast:callbackUrl=http://192.168.30.58:8080
 demo.things:
 
 ```java
-Thing chromecast:audio:myCC "Lounge Chromecast Audio" [ ipAddress="192.168.xxx.xxx", port=xxxx]
+Thing chromecast:audio:myCC "Lounge Chromecast Audio" [ipAddress="192.168.xxx.xxx", port=xxxx]
 Thing chromecast:chromecast:KitchenHomeHub "Kitchen Home Hub" [ipAddress="192.168.xxx.xxx", port=8009]
 ```
 


### PR DESCRIPTION
[Chromecast ] Update README.md to fix example things to working format.

Wrong format for the thing file example and it refused to work until these changes were made. Earlier on in the readme it gives a correct example for an audiogroup and mentions that the PORT must be specified. 100% certain this is an error in the readme and I have tested the suggested changes for a few weeks now.

Signed-off-by: Matthew Skinner <matt@pcmus.com>