### PR TITLE
[rfxcom] Worked on repairing support for RFXThermostat3 messages

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -154,7 +154,7 @@ This binding currently supports following channel types:
 |-----------------|---------------|------------------------------------------------------------------------------------|
 | chimesound      | Number        | Id of the chime sound                                                              |
 | command         | Switch        | Command channel.                                                                   |
-| commandId       | String        | Id of the command.                                                                 |
+ | commandId       | Number        | Id of the command (between 0 and 255).                                             |
 | commandString   | String        | Id of the command.                                                                 |
 | contact         | Contact       | Contact channel.                                                                   |
 | datetime        | DateTime      | DateTime channel.                                                                  |

--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -155,10 +155,12 @@ This binding currently supports following channel types:
 | chimesound      | Number        | Id of the chime sound                                                              |
 | command         | Switch        | Command channel.                                                                   |
 | commandId       | String        | Id of the command.                                                                 |
+| commandString   | String        | Id of the command.                                                                 |
 | contact         | Contact       | Contact channel.                                                                   |
 | datetime        | DateTime      | DateTime channel.                                                                  |
 | dimminglevel    | Dimmer        | Dimming level channel.                                                             |
 | forecast        | String        | Weather forecast from device: NO\_INFO\_AVAILABLE/SUNNY/PARTLY\_CLOUDY/CLOUDY/RAIN |
+| tempcontrol     | Dimmer        | Global control for temperature also setting ON, OFF, UP, DOWN                      |
 | humidity        | Number        | Relative humidity level in percentages.                                            |
 | humiditystatus  | String        | Current humidity status: NORMAL/COMFORT/DRY/WET                                    |
 | instantamp      | Number        | Instant current in Amperes.                                                        |
@@ -964,10 +966,31 @@ A Thermostat3 device.
 
 #### Channels
 
-| Name        | Channel Type                        | Item Type | Remarks  |
-|-------------|-------------------------------------|-----------|----------|
-| command     | [command](#channels)                | Switch    |          |
-| signalLevel | [system.signal-strength](#channels) | Number    |          |
+| Name              | Channel Type                        | Item Type     | Remarks  |
+|-------------------|-------------------------------------|---------------|----------|
+| command           | [command](#channels)                | Switch        |          |
+| command2nd        | [command](#channels)                | Switch        |          |
+| control\*         | [tempcontrol](#channels)            | Rollershutter |          |
+| commandString\*\* | [commandString](#channels)          | String        |          |
+| signalLevel       | [system.signal-strength](#channels) | Number        |          |
+
+\* `control` supports:
+
+* UP
+* DOWN
+* STOP
+
+\*\* `commandString` supports:
+
+* OFF
+* ON
+* UP
+* DOWN
+* RUN_UP
+* RUN_DOWN
+* SECOND_ON
+* SECOND_OFF
+* STOP
 
 #### Configuration Options
 
@@ -981,6 +1004,8 @@ A Thermostat3 device.
         *   MERTIK\_\_G6R\_H4TB\_\_G6_H4T\_\_G6R\_H4T21\_Z22 - Mertik (G6R H4TB, G6R H4T, or G6R H4T21\-Z22)
         *   MERTIK\_\_G6R\_H4TD\_\_G6R\_H4T16 - Mertik (G6R H4TD or G6R H4T16)
         *   MERTIK\_\_G6R\_H4S\_TRANSMIT\_ONLY - Mertik (G6R H4S \- transmit only)
+
+#### Examples
 
 
 ### undecoded - RFXCOM Undecoded RF Messages

--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -160,7 +160,7 @@ This binding currently supports following channel types:
 | datetime        | DateTime      | DateTime channel.                                                                  |
 | dimminglevel    | Dimmer        | Dimming level channel.                                                             |
 | forecast        | String        | Weather forecast from device: NO\_INFO\_AVAILABLE/SUNNY/PARTLY\_CLOUDY/CLOUDY/RAIN |
-| tempcontrol     | Dimmer        | Global control for temperature also setting ON, OFF, UP, DOWN                      |
+| tempcontrol     | Rollershutter | Global control for temperature also setting ON, OFF, UP, DOWN                      |
 | humidity        | Number        | Relative humidity level in percentages.                                            |
 | humiditystatus  | String        | Current humidity status: NORMAL/COMFORT/DRY/WET                                    |
 | instantamp      | Number        | Instant current in Amperes.                                                        |

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/DeviceMessageListener.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/DeviceMessageListener.java
@@ -28,9 +28,9 @@ public interface DeviceMessageListener {
      * This method is called whenever the message is received from the bridge.
      *
      * @param bridge
-     *            The RFXCom bridge where message is received.
+     *                    The RFXCom bridge where message is received.
      * @param message
-     *            The message which received.
+     *                    The message which received.
      */
     void onDeviceMessageReceived(ThingUID bridge, RFXComDeviceMessage message) throws RFXComException;
 }

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/RFXComBindingConstants.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/RFXComBindingConstants.java
@@ -67,8 +67,11 @@ public class RFXComBindingConstants {
     public static final String CHANNEL_VENETIAN_BLIND = "venetianBlind";
     public static final String CHANNEL_SUN_WIND_DETECTOR = "sunWindDetector";
     public static final String CHANNEL_COMMAND = "command";
+    public static final String CHANNEL_COMMAND_SECOND = "command2nd";
+    public static final String CHANNEL_CONTROL = "control";
     public static final String CHANNEL_PROGRAM = "program";
     public static final String CHANNEL_COMMAND_ID = "commandId";
+    public static final String CHANNEL_COMMAND_STRING = "commandString";
     public static final String CHANNEL_MOOD = "mood";
     public static final String CHANNEL_SIGNAL_LEVEL = "signalLevel";
     public static final String CHANNEL_DIMMING_LEVEL = "dimmingLevel";

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComConnectorInterface.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComConnectorInterface.java
@@ -27,8 +27,8 @@ public interface RFXComConnectorInterface {
      * Procedure for connecting to RFXCOM controller.
      *
      * @param device
-     *            Controller connection parameters (e.g. serial port name or IP
-     *            address).
+     *                   Controller connection parameters (e.g. serial port name or IP
+     *                   address).
      */
     public void connect(RFXComBridgeConfiguration device) throws Exception;
 
@@ -42,7 +42,7 @@ public interface RFXComConnectorInterface {
      * Procedure for send raw data to RFXCOM controller.
      *
      * @param data
-     *            raw bytes.
+     *                 raw bytes.
      */
     public void sendMessage(byte[] data) throws IOException;
 
@@ -50,7 +50,7 @@ public interface RFXComConnectorInterface {
      * Procedure for register event listener.
      *
      * @param listener
-     *            Event listener instance to handle events.
+     *                     Event listener instance to handle events.
      */
     public void addEventListener(RFXComEventListener listener);
 
@@ -58,7 +58,7 @@ public interface RFXComConnectorInterface {
      * Procedure for remove event listener.
      *
      * @param listener
-     *            Event listener instance to remove.
+     *                     Event listener instance to remove.
      */
     public void removeEventListener(RFXComEventListener listener);
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComEventListener.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComEventListener.java
@@ -23,7 +23,7 @@ public interface RFXComEventListener {
      * Procedure for receive raw data from RFXCOM controller.
      *
      * @param data
-     *            Received raw data.
+     *                 Received raw data.
      */
     void packetReceived(byte[] data);
 
@@ -31,7 +31,7 @@ public interface RFXComEventListener {
      * Procedure for receiving information fatal error.
      *
      * @param error
-     *            Error occurred.
+     *                  Error occurred.
      */
     void errorOccurred(String error);
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -141,13 +141,17 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
                     updateStatus(ThingStatus.ONLINE);
 
                     for (Channel channel : getThing().getChannels()) {
-                        String channelId = channel.getUID().getId();
+                        ChannelUID uid = channel.getUID();
+                        String channelId = uid.getId();
 
                         try {
                             if (channelId.equals(CHANNEL_LOW_BATTERY)) {
-                                updateState(channelId, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
+                                updateState(uid, isLowBattery(message.convertToState(CHANNEL_BATTERY_LEVEL)));
                             } else {
-                                updateState(channelId, message.convertToState(channelId));
+                                State state = message.convertToState(channelId);
+                                if (state != null) {
+                                    updateState(uid, state);
+                                }
                             }
                         } catch (RFXComException e) {
                             logger.trace("{} does not handle {}", channelId, message);

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
@@ -152,7 +152,7 @@ public class RFXComLighting2Message extends RFXComDeviceMessageImpl<RFXComLighti
      * Convert a 0-15 scale value to a percent type.
      *
      * @param pt
-     *            percent type to convert
+     *               percent type to convert
      * @return converted value 0-15
      */
     public static int getDimLevelFromPercentType(PercentType pt) {
@@ -164,7 +164,7 @@ public class RFXComLighting2Message extends RFXComDeviceMessageImpl<RFXComLighti
      * Convert a 0-15 scale value to a percent type.
      *
      * @param value
-     *            percent type to convert
+     *                  percent type to convert
      * @return converted value 0-15
      */
     public static PercentType getPercentTypeFromDimLevel(int value) {

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -73,10 +73,10 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
     /**
      * Note: for the lighting5 commands, some command are only supported for certain sub types and
      * command-bytes might even have a different meaning for another sub type.
-     * <p>
+    *
      * If no sub types are specified for a command, its supported by all sub types.
      * An example is the command OFF which is represented by the byte 0x00 for all subtypes.
-     * <p>
+    *
      * Otherwise the list of sub types after the command-bytes indicates the sub types
      * which support this command with this byte.
      * Example byte value 0x03 means GROUP_ON for IT and some others while it means MOOD1 for LIGHTWAVERF

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -73,10 +73,10 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
     /**
      * Note: for the lighting5 commands, some command are only supported for certain sub types and
      * command-bytes might even have a different meaning for another sub type.
-    *
+     *
      * If no sub types are specified for a command, its supported by all sub types.
      * An example is the command OFF which is represented by the byte 0x00 for all subtypes.
-    *
+     *
      * Otherwise the list of sub types after the command-bytes indicates the sub types
      * which support this command with this byte.
      * Example byte value 0x03 means GROUP_ON for IT and some others while it means MOOD1 for LIGHTWAVERF
@@ -206,7 +206,7 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
      * Convert a 0-31 scale value to a percent type.
      *
      * @param pt
-     *            percent type to convert
+     *               percent type to convert
      * @return converted value 0-31
      */
     public static int getDimLevelFromPercentType(PercentType pt) {
@@ -218,7 +218,7 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
      * Convert a 0-31 scale value to a percent type.
      *
      * @param value
-     *            percent type to convert
+     *                  percent type to convert
      * @return converted value 0-31
      */
     public static PercentType getPercentTypeFromDimLevel(int value) {

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessage.java
@@ -28,7 +28,7 @@ public interface RFXComMessage {
      * Procedure for encode raw data.
      *
      * @param data
-     *            Raw data.
+     *                 Raw data.
      */
     void encodeMessage(byte[] data) throws RFXComException;
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -12,21 +12,24 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import org.eclipse.smarthome.core.library.types.*;
+import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
+import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
-import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4T1;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22;
 
 /**
  * RFXCOM data class for thermostat3message.

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -12,21 +12,21 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.CHANNEL_COMMAND;
-import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.*;
+import org.eclipse.smarthome.core.library.types.*;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.UpDownType;
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.Type;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
+import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
+import static org.openhab.binding.rfxcom.internal.messages.ByteEnumUtil.fromByte;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4T1;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22;
 
 /**
  * RFXCOM data class for thermostat3message.
@@ -98,7 +98,6 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
     public SubType subType;
     private int unitId;
     public Commands command;
-    private byte commandId;
 
     public RFXComThermostat3Message() {
         super(PacketType.THERMOSTAT3);
@@ -115,7 +114,7 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         str += super.toString();
         str += ", Sub type = " + subType;
         str += ", Device Id = " + getDeviceId();
-        str += ", Command = " + command + "(" + commandId + ")";
+        str += ", Command = " + command;
         str += ", Signal level = " + signalLevel;
 
         return str;
@@ -132,8 +131,7 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
 
         subType = fromByte(SubType.class, super.subType);
         unitId = (data[4] & 0xFF) << 16 | (data[5] & 0xFF) << 8 | (data[6] & 0xFF);
-        commandId = data[7];
-        command = Commands.fromByte(commandId, subType);
+        command = Commands.fromByte(data[7], subType);
         signalLevel = (byte) ((data[8] & 0xF0) >> 4);
     }
 
@@ -159,19 +157,51 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
         switch (channelId) {
             case CHANNEL_COMMAND:
                 switch (command) {
+                    case RUN_DOWN:
                     case OFF:
-                    case SECOND_OFF:
                         return OnOffType.OFF;
                     case ON:
+                    case RUN_UP:
+                    case UP:
+                        return OnOffType.ON;
                     case SECOND_ON:
+                    case SECOND_OFF:
+                        return null;
+                    default:
+                        return UnDefType.UNDEF;
+
+                }
+            case CHANNEL_CONTROL:
+                switch (command) {
+                    case ON:
                         return OnOffType.ON;
                     case UP:
+                    case RUN_UP:
                         return UpDownType.UP;
+                    case OFF:
+                        return OnOffType.OFF;
                     case DOWN:
+                    case RUN_DOWN:
                         return UpDownType.DOWN;
+                    case SECOND_ON:
+                    case SECOND_OFF:
+                    case STOP:
+                        return null;
                     default:
                         throw new RFXComUnsupportedChannelException("Can't convert " + command + " for " + channelId);
                 }
+            case CHANNEL_COMMAND_SECOND:
+                switch (command) {
+                    case SECOND_OFF:
+                        return OnOffType.OFF;
+                    case SECOND_ON:
+                        return OnOffType.ON;
+                    default:
+                        return null;
+                }
+            case CHANNEL_COMMAND_STRING:
+                return command == null ? UnDefType.UNDEF : StringType.valueOf(command.toString());
+
             default:
                 return super.convertToState(channelId);
         }
@@ -183,13 +213,33 @@ public class RFXComThermostat3Message extends RFXComDeviceMessageImpl<RFXComTher
             case CHANNEL_COMMAND:
                 if (type instanceof OnOffType) {
                     command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
-                } else if (type instanceof UpDownType) {
-                    command = (type == UpDownType.UP ? Commands.UP : Commands.DOWN);
-                } else if (type instanceof OpenClosedType) {
-                    command = (type == OpenClosedType.CLOSED ? Commands.ON : Commands.OFF);
                 } else {
                     throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
                 }
+                break;
+
+            case CHANNEL_COMMAND_SECOND:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.SECOND_ON : Commands.SECOND_OFF);
+                } else {
+                    throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
+                }
+                break;
+
+            case CHANNEL_CONTROL:
+                if (type instanceof UpDownType) {
+                    command = (type == UpDownType.UP ? Commands.UP : Commands.DOWN);
+                } else if (type == StopMoveType.STOP) {
+                    command = Commands.STOP;
+                } else if (type instanceof PercentType) {
+                    command = ((PercentType) type).as(UpDownType.class) == UpDownType.UP ? Commands.UP : Commands.DOWN;
+                } else {
+                    throw new RFXComUnsupportedChannelException("Channel " + channelId + " does not accept " + type);
+                }
+                break;
+
+            case CHANNEL_COMMAND_STRING:
+                command = Commands.valueOf(type.toString().toUpperCase());
                 break;
 
             default:

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/channels.xml
@@ -30,6 +30,13 @@
 		<state min="0" max="255" step="1" pattern="%d" readOnly="false"></state>
 	</channel-type>
 
+	<channel-type id="commandString">
+		<item-type>String</item-type>
+		<label>Command String</label>
+		<description>Command channel, Name of the channel</description>
+		<state min="0" max="255" step="1" pattern="%d" readOnly="false"></state>
+	</channel-type>
+
 	<channel-type id="contact">
 		<item-type>Contact</item-type>
 		<label>Contact</label>
@@ -68,6 +75,12 @@
 		<label>Set-point</label>
 		<description>Requested temperature</description>
 		<state min="0" max="255" step="1" pattern="%d °C" readOnly="false"></state>
+	</channel-type>
+
+	<channel-type id="tempcontrol">
+		<item-type>Rollershutter</item-type>
+		<label>Global Temperature Control</label>
+		<description>Requested temperature setting, UP, DOWN, STOP</description>
 	</channel-type>
 
 	<channel-type id="motion">

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/channels.xml
@@ -26,15 +26,14 @@
 	<channel-type id="commandId">
 		<item-type>Number</item-type>
 		<label>Command ID</label>
-		<description>Command channel, ID of the channel</description>
+		<description>Command channel, ID of the command</description>
 		<state min="0" max="255" step="1" pattern="%d" readOnly="false"></state>
 	</channel-type>
 
 	<channel-type id="commandString">
 		<item-type>String</item-type>
 		<label>Command String</label>
-		<description>Command channel, Name of the channel</description>
-		<state min="0" max="255" step="1" pattern="%d" readOnly="false"></state>
+		<description>Command channel, Name of the command</description>
 	</channel-type>
 
 	<channel-type id="contact">

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/thermostat3.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/thermostat3.xml
@@ -16,6 +16,9 @@
 
 		<channels>
 			<channel id="command" typeId="command" />
+			<channel id="command2nd" typeId="command" />
+			<channel id="control" typeId="tempcontrol" />
+			<channel id="commandString" typeId="commandString" />
 			<channel id="signalLevel" typeId="system.signal-strength" />
 		</channels>
 

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComChimeMessage.SubType;
 
-
 /**
  * Test for RFXCom-binding
  *

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
@@ -37,7 +37,8 @@ public class RFXComDateTimeMessageTest {
         assertEquals("Date time", "2003-04-29T13:21:10", msg.dateTime);
         assertEquals("Signal Level", 2, RFXComTestHelper.getActualIntValue(msg, CHANNEL_SIGNAL_LEVEL));
 
-        assertEquals("Converted value", DateTimeType.valueOf("2003-04-29T13:21:10"), msg.convertToState(CHANNEL_DATE_TIME));
+        assertEquals("Converted value", DateTimeType.valueOf("2003-04-29T13:21:10"),
+                msg.convertToState(CHANNEL_DATE_TIME));
 
         byte[] decoded = msg.decodeMessage();
 

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
@@ -21,7 +21,6 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.Commands;
 import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.SubType;
 
-
 /**
  * Test for RFXCom-binding
  *
@@ -29,12 +28,11 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.Sub
  * @author Mike Jagdis - added message handling and real test
  */
 public class RFXComHomeConfortTest {
-    private void testMessage(SubType subType, Commands command, String deviceId, String data)
-            throws RFXComException {
+    private void testMessage(SubType subType, Commands command, String deviceId, String data) throws RFXComException {
 
         RFXComHomeConfortMessage message = (RFXComHomeConfortMessage) RFXComMessageFactory.createMessage(HOME_CONFORT);
         message.setSubType(subType);
-	message.command = command;
+        message.command = command;
         message.setDeviceId(deviceId);
 
         assertArrayEquals(HexUtils.hexToBytes(data), message.decodeMessage());

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
@@ -44,7 +44,7 @@ public class RFXComInterfaceControlMessageTest {
         configuration.enableBlindsT1T2T3T4 = false;
         configuration.enableBlindsT0 = false;
         configuration.enableProGuard = false;
-//      configuration.enableFS20Packets = false;
+        // configuration.enableFS20Packets = false;
         configuration.enableLaCrosse = false;
         configuration.enableHidekiUPM = false;
         configuration.enableADLightwaveRF = false;
@@ -60,11 +60,11 @@ public class RFXComInterfaceControlMessageTest {
         configuration.enableX10 = false;
     }
 
-    private void testMessage(RFXComInterfaceMessage.TransceiverType transceiverType, RFXComBridgeConfiguration configuration, String data)
-            throws RFXComException {
+    private void testMessage(RFXComInterfaceMessage.TransceiverType transceiverType,
+            RFXComBridgeConfiguration configuration, String data) throws RFXComException {
 
         assertArrayEquals(HexUtils.hexToBytes(data),
-            new RFXComInterfaceControlMessage(transceiverType, configuration).decodeMessage());
+                new RFXComInterfaceControlMessage(transceiverType, configuration).decodeMessage());
     }
 
     @Test
@@ -133,11 +133,11 @@ public class RFXComInterfaceControlMessageTest {
         testMessage(_433_92MHZ_TRANSCEIVER, configuration, "0D00000203530000200000000000");
     }
 
-//  @Test
-//  public void testFS20PacketsMessage() throws RFXComException {
-//      configuration.enableFS20Packets = true;
-//      testMessage(_433_92MHZ_TRANSCEIVER, configuration, "0D00000203530000100000000000");
-//  }
+    // @Test
+    // public void testFS20PacketsMessage() throws RFXComException {
+    // configuration.enableFS20Packets = true;
+    // testMessage(_433_92MHZ_TRANSCEIVER, configuration, "0D00000203530000100000000000");
+    // }
 
     @Test
     public void testLaCrosseMessage() throws RFXComException {

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
@@ -57,8 +57,7 @@ public class RFXComLighting4MessageTest {
     }
 
     private void testMessage(String hexMsg, RFXComLighting4Message.SubType subType, String deviceId, Integer pulse,
-            byte commandByte, Integer seqNbr, int signalLevel, int offCommand, int onCommand)
-            throws RFXComException {
+            byte commandByte, Integer seqNbr, int signalLevel, int offCommand, int onCommand) throws RFXComException {
         RFXComLighting4Message msg = (RFXComLighting4Message) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
         assertEquals("Sensor Id", deviceId, msg.getDeviceId());

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
@@ -38,12 +38,11 @@ public class RFXComRfyMessageTest {
         RFXComTestHelper.basicBoundaryCheck(RFY, message);
     }
 
-    private void testMessage(SubType subType, Commands command, String deviceId, String data)
-            throws RFXComException {
+    private void testMessage(SubType subType, Commands command, String deviceId, String data) throws RFXComException {
 
         RFXComRfyMessage message = (RFXComRfyMessage) RFXComMessageFactory.createMessage(RFY);
         message.setSubType(subType);
-	message.command = command;
+        message.command = command;
         message.setDeviceId(deviceId);
 
         assertArrayEquals(HexUtils.hexToBytes(data), message.decodeMessage());

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
@@ -12,6 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.Assert.*;
+import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.*;
+
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -22,13 +27,6 @@ import org.eclipse.smarthome.core.util.HexUtils;
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4T1;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22;
 
 /**
  * Test for RFXCom-binding
@@ -53,20 +51,16 @@ public class RFXComThermostat3MessageTest {
 
     @Test
     public void testSomeMessages() throws RFXComException {
-        testMessage("08420101019FAB0280", MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22, 1, "106411", RFXComThermostat3Message.Commands.UP, (byte) 8, OnOffType.ON, null, UpDownType.UP, StringType.valueOf("UP"));
-        testMessage("084200000000410500", MERTIK__G6R_H4T1, 0, "65", RFXComThermostat3Message.Commands.RUN_DOWN, (byte) 0, OnOffType.OFF, null, UpDownType.DOWN, StringType.valueOf("RUN_DOWN"));
+        testMessage("08420101019FAB0280", MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22, 1, "106411",
+                RFXComThermostat3Message.Commands.UP, (byte) 8, OnOffType.ON, null, UpDownType.UP,
+                StringType.valueOf("UP"));
+        testMessage("084200000000410500", MERTIK__G6R_H4T1, 0, "65", RFXComThermostat3Message.Commands.RUN_DOWN,
+                (byte) 0, OnOffType.OFF, null, UpDownType.DOWN, StringType.valueOf("RUN_DOWN"));
     }
 
-    private void testMessage(String hexMessage,
-                             RFXComThermostat3Message.SubType subtype,
-                             int sequenceNumber, String sensorId,
-                             RFXComThermostat3Message.Commands command,
-                             byte signalLevel,
-                             State commandChannel,
-                             State secondCommandChannel,
-                             State controlChannel,
-                             State commandStringChannel
-    ) throws RFXComException {
+    private void testMessage(String hexMessage, RFXComThermostat3Message.SubType subtype, int sequenceNumber,
+            String sensorId, RFXComThermostat3Message.Commands command, byte signalLevel, State commandChannel,
+            State secondCommandChannel, State controlChannel, State commandStringChannel) throws RFXComException {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComThermostat3Message msg = (RFXComThermostat3Message) RFXComMessageFactory.createMessage(message);
         assertEquals("SubType", subtype, msg.subType);
@@ -86,7 +80,6 @@ public class RFXComThermostat3MessageTest {
     }
     // TODO please add tests for real messages
 
-
     @Test
     public void testCommandChannelOn() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
@@ -100,7 +93,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_command_channel_off() throws RFXComUnsupportedChannelException {
+    public void testCommandChannelOff() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND, OnOffType.OFF);
@@ -112,7 +105,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_second_command_channel_on() throws RFXComUnsupportedChannelException {
+    public void testSecondCommandChannelOn() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_SECOND, OnOffType.ON);
@@ -124,7 +117,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_second_command_channel_off() throws RFXComUnsupportedChannelException {
+    public void testSecondCommandChannelOff() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_SECOND, OnOffType.OFF);
@@ -136,7 +129,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_control_up() throws RFXComUnsupportedChannelException {
+    public void testControlUp() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_CONTROL, UpDownType.UP);
@@ -149,7 +142,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_control_down() throws RFXComUnsupportedChannelException {
+    public void testControlDown() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_CONTROL, UpDownType.DOWN);
@@ -162,7 +155,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_control_stop() throws RFXComUnsupportedChannelException {
+    public void testControlStop() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_CONTROL, StopMoveType.STOP);
@@ -170,13 +163,12 @@ public class RFXComThermostat3MessageTest {
         assertEquals(UnDefType.UNDEF, msg.convertToState(CHANNEL_COMMAND));
         assertEquals(StringType.valueOf("STOP"), msg.convertToState(CHANNEL_COMMAND_STRING));
 
-
         assertNull(msg.convertToState(CHANNEL_CONTROL));
         assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
     }
 
     @Test
-    public void test_status_off() throws RFXComUnsupportedChannelException {
+    public void testStatusOff() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("OFF"));
@@ -188,7 +180,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_on() throws RFXComUnsupportedChannelException {
+    public void testStatusOn() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("On"));
@@ -200,7 +192,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_up() throws RFXComUnsupportedChannelException {
+    public void testStatusUp() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("UP"));
@@ -213,7 +205,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_down() throws RFXComUnsupportedChannelException {
+    public void testStatusDown() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("down"));
@@ -225,7 +217,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_run_up() throws RFXComUnsupportedChannelException {
+    public void testStatusRunUp() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("RUN_UP"));
@@ -237,7 +229,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_run_down() throws RFXComUnsupportedChannelException {
+    public void testStatusRunDown() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("RUN_DOWN"));
@@ -249,7 +241,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_stop() throws RFXComUnsupportedChannelException {
+    public void testStatusStop() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("STOP"));
@@ -262,7 +254,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_second_on() throws RFXComUnsupportedChannelException {
+    public void testStatusSecondOn() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("SECOND_ON"));
@@ -275,7 +267,7 @@ public class RFXComThermostat3MessageTest {
     }
 
     @Test
-    public void test_status_second_off() throws RFXComUnsupportedChannelException {
+    public void testStatusSecondOff() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("SECOND_OFF"));

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
@@ -88,7 +88,7 @@ public class RFXComThermostat3MessageTest {
 
 
     @Test
-    public void test_command_channel_on() throws RFXComUnsupportedChannelException {
+    public void testCommandChannelOn() throws RFXComUnsupportedChannelException {
         RFXComThermostat3Message msg = new RFXComThermostat3Message();
 
         msg.convertFromState(CHANNEL_COMMAND, OnOffType.ON);

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
@@ -12,13 +12,23 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
-import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22;
-
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.util.HexUtils;
 import org.junit.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4T1;
+import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22;
 
 /**
  * Test for RFXCom-binding
@@ -43,18 +53,237 @@ public class RFXComThermostat3MessageTest {
 
     @Test
     public void testSomeMessages() throws RFXComException {
-        String hexMessage = "08420101019FAB0280";
+        testMessage("08420101019FAB0280", MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22, 1, "106411", RFXComThermostat3Message.Commands.UP, (byte) 8, OnOffType.ON, null, UpDownType.UP, StringType.valueOf("UP"));
+        testMessage("084200000000410500", MERTIK__G6R_H4T1, 0, "65", RFXComThermostat3Message.Commands.RUN_DOWN, (byte) 0, OnOffType.OFF, null, UpDownType.DOWN, StringType.valueOf("RUN_DOWN"));
+    }
+
+    private void testMessage(String hexMessage,
+                             RFXComThermostat3Message.SubType subtype,
+                             int sequenceNumber, String sensorId,
+                             RFXComThermostat3Message.Commands command,
+                             byte signalLevel,
+                             State commandChannel,
+                             State secondCommandChannel,
+                             State controlChannel,
+                             State commandStringChannel
+    ) throws RFXComException {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComThermostat3Message msg = (RFXComThermostat3Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", MERTIK__G6R_H4TB__G6R_H4T__G6R_H4T21_Z22, msg.subType);
-        assertEquals("Seq Number", 1, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "106411", msg.getDeviceId());
-        assertEquals("Command", RFXComThermostat3Message.Commands.UP, msg.command);
-        assertEquals("Signal Level", (byte) 8, msg.signalLevel);
+        assertEquals("SubType", subtype, msg.subType);
+        assertEquals("Seq Number", sequenceNumber, (short) (msg.seqNbr & 0xFF));
+        assertEquals("Sensor Id", sensorId, msg.getDeviceId());
+        assertEquals(CHANNEL_COMMAND, command, msg.command);
+        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+
+        assertEquals(commandChannel, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(secondCommandChannel, msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertEquals(controlChannel, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(commandStringChannel, msg.convertToState(CHANNEL_COMMAND_STRING));
 
         byte[] decoded = msg.decodeMessage();
 
         assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
     }
     // TODO please add tests for real messages
+
+
+    @Test
+    public void test_command_channel_on() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND, OnOffType.ON);
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("ON"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_command_channel_off() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND, OnOffType.OFF);
+
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_CONTROL));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertEquals(StringType.valueOf("OFF"), msg.convertToState(CHANNEL_COMMAND_STRING));
+    }
+
+    @Test
+    public void test_second_command_channel_on() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_SECOND, OnOffType.ON);
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("SECOND_ON"), msg.convertToState(CHANNEL_COMMAND_STRING));
+    }
+
+    @Test
+    public void test_second_command_channel_off() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_SECOND, OnOffType.OFF);
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("SECOND_OFF"), msg.convertToState(CHANNEL_COMMAND_STRING));
+    }
+
+    @Test
+    public void test_control_up() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_CONTROL, UpDownType.UP);
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.UP, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("UP"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_control_down() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_CONTROL, UpDownType.DOWN);
+
+        assertEquals(UnDefType.UNDEF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.DOWN, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("DOWN"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_control_stop() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_CONTROL, StopMoveType.STOP);
+
+        assertEquals(UnDefType.UNDEF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(StringType.valueOf("STOP"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_off() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("OFF"));
+
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("OFF"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_on() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("On"));
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("ON"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_up() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("UP"));
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.UP, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("UP"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_down() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("down"));
+
+        assertEquals(UnDefType.UNDEF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.DOWN, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("DOWN"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_run_up() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("RUN_UP"));
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.UP, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("RUN_UP"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_run_down() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("RUN_DOWN"));
+
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(UpDownType.DOWN, msg.convertToState(CHANNEL_CONTROL));
+        assertEquals(StringType.valueOf("RUN_DOWN"), msg.convertToState(CHANNEL_COMMAND_STRING));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_stop() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("STOP"));
+
+        assertEquals(UnDefType.UNDEF, msg.convertToState(CHANNEL_COMMAND));
+        assertEquals(StringType.valueOf("STOP"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+        assertNull(msg.convertToState(CHANNEL_COMMAND_SECOND));
+    }
+
+    @Test
+    public void test_status_second_on() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("SECOND_ON"));
+
+        assertEquals(OnOffType.ON, msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertEquals(StringType.valueOf("SECOND_ON"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND));
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+    }
+
+    @Test
+    public void test_status_second_off() throws RFXComUnsupportedChannelException {
+        RFXComThermostat3Message msg = new RFXComThermostat3Message();
+
+        msg.convertFromState(CHANNEL_COMMAND_STRING, StringType.valueOf("SECOND_OFF"));
+
+        assertEquals(OnOffType.OFF, msg.convertToState(CHANNEL_COMMAND_SECOND));
+        assertEquals(StringType.valueOf("SECOND_OFF"), msg.convertToState(CHANNEL_COMMAND_STRING));
+
+        assertNull(msg.convertToState(CHANNEL_COMMAND));
+        assertNull(msg.convertToState(CHANNEL_CONTROL));
+    }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
@@ -53,8 +53,7 @@ public class RFXComUndecodedRFMessageTest {
                 .createMessage(PacketType.UNDECODED_RF_MESSAGE);
         msg.subType = RFXComUndecodedRFMessage.SubType.ARC;
         msg.seqNbr = 1;
-        msg.rawPayload = HexUtils
-                .hexToBytes("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021");
+        msg.rawPayload = HexUtils.hexToBytes("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021");
         msg.decodeMessage();
     }
 }


### PR DESCRIPTION
Fixes #4633 

Test jar: 
~~org.openhab.binding.rfxcom-2.5.0-SNAPSHOT.jar.zip~~

New test jar:
[org.openhab.binding.rfxcom-2.5.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab2-addons/files/3336194/org.openhab.binding.rfxcom-2.5.0-SNAPSHOT.jar.zip)


To use the Themostat3 now you should be able to either use the string-item to control all the commands: 

```
GashaardCommandString.sendCommand("RUN_DOWN")
```

Or use either the command or control items:

```
GashaardCommand.sendCommand(OFF)
GasHaardControl.sendCommand(UP)
```

If you proper compact ideas / examples for the README they are welcome so I can include them in the PR.