### PR TITLE
[openhabcloud] Create dedicated HttpClient from the factory to connect to the local OpenHAB (Issue #5770)

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -71,17 +71,6 @@ public class CloudClient {
      * Logger for this class
      */
     private Logger logger = LoggerFactory.getLogger(CloudClient.class);
-    /*
-     * This constant defines maximum number of HTTP connections per peer
-     * address for HTTP client which performs local connections to openHAB
-     */
-    private static final int HTTP_CLIENT_MAX_CONNECTIONS_PER_DEST = 200;
-
-    /*
-     * This constant defines HTTP request timeout. It should be kept at about
-     * 30 seconds minimum to make it work for long polling requests
-     */
-    private static final long HTTP_CLIENT_TIMEOUT = 30;
 
     /*
      * This variable holds base URL for the openHAB Cloud connections
@@ -330,7 +319,7 @@ public class CloudClient {
             if (data.has("protocol")) {
                 proto = data.getString("protocol");
             }
-            request.timeout(HTTP_CLIENT_TIMEOUT, TimeUnit.SECONDS).header("X-Forwarded-Proto", proto);
+            request.header("X-Forwarded-Proto", proto);
 
             if (requestMethod.equals("GET")) {
                 request.method(HttpMethod.GET);


### PR DESCRIPTION
[openhabcloud] Create dedicated HttpClient from the factory to connect to the local OpenHAB (Issue #5770)

Create a custom instance of HttpClient to connect to the local OpenHAB so that it can have a dedicated configurable amount of allowed connections to the rest api backend

I have moved the config of the HttpClient from CloudClient.java to CloudService.java so that its configuration (esp amount of councurrent connections) can be updated (not done this configurable yet, by now left the previously existing 200)

