### PR TITLE
[lutron] Add support for HomeWorks QS International seeTouch keypads

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -29,6 +29,7 @@ This binding currently supports the following thing types:
 * **occupancysensor** - Occupancy/vacancy sensor
 * **keypad** - Lutron seeTouch or Hybrid seeTouch Keypad
 * **ttkeypad** - Tabletop seeTouch Keypad
+* **intlkeypad** - International seeTouch Keypad (HomeWorks QS only)
 * **pico** - Pico Keypad
 * **virtualkeypad** - Repeater virtual keypad
 * **vcrx** - Visor control receiver module (VCRX)
@@ -166,6 +167,27 @@ Example:
 
 ```
 Thing lutron:ttkeypad:bedroomkeypad (lutron:ipbridge:radiora2) [ integrationId=11, model="T10RL" autorelease="true" ]
+```
+
+### International SeeTouch Keypads (Homeworks QS)
+
+International SeeTouch keypads used in the Homeworks QS system use the **intlkeypad** thing.
+It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same button and led channel types as the **keypad** thing.
+See the **keypad** section above for a full discussion of configuration and use.
+
+If using auto-discovery, remember to select the correct value for the `model` parameter after accepting the **intlkeypad** thing from the inbox.
+The correct channels will then be automatically configured.
+
+To support this keypad's contact closure inputs, CCI channels named *cci1* and *cci2* are created with item type Contact and category Switch.
+They are marked as Advanced, so they will not be automatically linked to items in the Paper UI's Simple Mode.
+They accept ON/OFF commands and present ON/OFF states the same as a keypad button.
+
+Supported settings for `model` parameter: 2B, 3B, 4B, 5BRL, 6BRL, 7BRL, 8BRL, 10BRL / Generic (default)
+
+Example:
+
+```
+Thing lutron:intlkeypad:kitchenkeypad (lutron:ipbridge:radiora2) [ integrationId=15, model="10BRL" autorelease="true" ]
 ```
 
 ### Pico Keypads
@@ -346,8 +368,8 @@ The following is a summary of channels for all RadioRA2 binding things:
 | timeclock           | enableevent       | Number        | Enable event or monitor events enabled       |
 | timeclock           | disableevent      | Number        | Disable event or monitor events disabled     |
 
-The channels available on each keypad device (i.e. keypad, ttkeypad, pico, vcrx, and virtualkeypad) will vary with keypad type and model.
-Appropriate channels will be created automatically by the keypad, ttkeypad, and pico handlers based on the setting of the `model` parameter for those thing types.
+The channels available on each keypad device (i.e. keypad, ttkeypad, intlkeypad, pico, vcrx, and virtualkeypad) will vary with keypad type and model.
+Appropriate channels will be created automatically by the keypad, ttkeypad, intlkeypad, and pico handlers based on the setting of the `model` parameter for those thing types.
 
 ### Commands supported by channels
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -36,6 +36,7 @@ public class LutronBindingConstants {
     public static final ThingTypeUID THING_TYPE_OCCUPANCYSENSOR = new ThingTypeUID(BINDING_ID, "occupancysensor");
     public static final ThingTypeUID THING_TYPE_KEYPAD = new ThingTypeUID(BINDING_ID, "keypad");
     public static final ThingTypeUID THING_TYPE_TTKEYPAD = new ThingTypeUID(BINDING_ID, "ttkeypad");
+    public static final ThingTypeUID THING_TYPE_INTLKEYPAD = new ThingTypeUID(BINDING_ID, "intlkeypad");
     public static final ThingTypeUID THING_TYPE_PICO = new ThingTypeUID(BINDING_ID, "pico");
     public static final ThingTypeUID THING_TYPE_VIRTUALKEYPAD = new ThingTypeUID(BINDING_ID, "virtualkeypad");
     public static final ThingTypeUID THING_TYPE_VCRX = new ThingTypeUID(BINDING_ID, "vcrx");

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -39,6 +39,7 @@ import org.openhab.binding.lutron.internal.handler.MaintainedCcoHandler;
 import org.openhab.binding.lutron.internal.handler.OccupancySensorHandler;
 import org.openhab.binding.lutron.internal.handler.PicoKeypadHandler;
 import org.openhab.binding.lutron.internal.handler.PulsedCcoHandler;
+import org.openhab.binding.lutron.internal.handler.IntlKeypadHandler;
 import org.openhab.binding.lutron.internal.handler.ShadeHandler;
 import org.openhab.binding.lutron.internal.handler.SwitchHandler;
 import org.openhab.binding.lutron.internal.handler.TabletopKeypadHandler;
@@ -66,7 +67,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
     // Used by LutronDeviceDiscoveryService to discover these types
     public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(THING_TYPE_DIMMER, THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR,
-                    THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_PICO, THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX,
+                    THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_INTLKEYPAD, THING_TYPE_PICO, THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX,
                     THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED, THING_TYPE_SHADE, THING_TYPE_TIMECLOCK,
                     THING_TYPE_GREENMODE).collect(Collectors.toSet()));
 
@@ -112,6 +113,8 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
             return new KeypadHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_TTKEYPAD)) {
             return new TabletopKeypadHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_INTLKEYPAD)) {
+            return new IntlKeypadHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_PICO)) {
             return new PicoKeypadHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_VIRTUALKEYPAD)) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -156,16 +156,20 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                     notifyDiscovery(THING_TYPE_KEYPAD, device.getIntegrationId(), label);
                     break;
 
-                case VISOR_CONTROL_RECEIVER:
-                    notifyDiscovery(THING_TYPE_VCRX, device.getIntegrationId(), label);
+                case INTERNATIONAL_SEETOUCH_KEYPAD:
+                    notifyDiscovery(THING_TYPE_INTLKEYPAD, device.getIntegrationId(), label);
                     break;
-
+                
                 case SEETOUCH_TABLETOP_KEYPAD:
                     notifyDiscovery(THING_TYPE_TTKEYPAD, device.getIntegrationId(), label);
                     break;
 
                 case PICO_KEYPAD:
                     notifyDiscovery(THING_TYPE_PICO, device.getIntegrationId(), label);
+                    break;
+                    
+                case VISOR_CONTROL_RECEIVER:
+                    notifyDiscovery(THING_TYPE_VCRX, device.getIntegrationId(), label);
                     break;
 
                 case MAIN_REPEATER:

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/DeviceType.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/DeviceType.java
@@ -19,6 +19,7 @@ package org.openhab.binding.lutron.internal.discovery.project;
  */
 public enum DeviceType {
     HYBRID_SEETOUCH_KEYPAD,
+    INTERNATIONAL_SEETOUCH_KEYPAD,
     MAIN_REPEATER,
     MOTION_SENSOR,
     PICO_KEYPAD,

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IntlKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IntlKeypadHandler.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.handler;
+
+import java.util.Arrays;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler responsible for communicating with Lutron International seeTouch keypads used in
+ * Homeworks QS systems
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class IntlKeypadHandler extends BaseKeypadHandler {
+
+    private static enum Component implements KeypadComponent {
+        BUTTON1(1, "button1", "Button 1"),
+        BUTTON2(2, "button2", "Button 2"),
+        BUTTON3(3, "button3", "Button 3"),
+        BUTTON4(4, "button4", "Button 4"),
+        BUTTON5(5, "button5", "Button 5"),
+        BUTTON6(6, "button6", "Button 6"),
+        BUTTON7(7, "button7", "Button 7"),
+        BUTTON8(8, "button8", "Button 8"),
+        BUTTON9(9, "button9", "Button 9"),
+        BUTTON10(10, "button10", "Button 10"),
+
+        LOWER1(18, "buttonlower", "Lower button"),
+        RAISE1(19, "buttonraise", "Raise button"),
+
+        CCI1(25, "cci1", ""),
+        CCI2(26, "cci2", ""),
+
+        LED1(81, "led1", "LED 1"),
+        LED2(82, "led2", "LED 2"),
+        LED3(83, "led3", "LED 3"),
+        LED4(84, "led4", "LED 4"),
+        LED5(85, "led5", "LED 5"),
+        LED6(86, "led6", "LED 6"),
+        LED7(87, "led7", "LED 7"),
+        LED8(88, "led8", "LED 8"),
+        LED9(89, "led9", "LED 9"),
+        LED10(90, "led10", "LED 10");
+
+        private final int id;
+        private final String channel;
+        private final String description;
+
+        Component(int id, String channel, String description) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+    }
+
+    private final Logger logger = LoggerFactory.getLogger(IntlKeypadHandler.class);
+
+    @Override
+    protected boolean isLed(int id) {
+        return (id >= 81 && id <= 90);
+    }
+
+    @Override
+    protected boolean isButton(int id) {
+        return ((id >= 1 && id <= 10) || (id >= 18 && id <= 19));
+    }
+
+    @Override
+    protected boolean isCCI(int id) {
+        return (id >= 25 && id <= 26);
+    }
+
+    @Override
+    protected void configureComponents(String model) {
+        String mod = model == null ? "Generic" : model;
+        logger.debug("Configuring components for keypad model {}", model);
+
+        cciList.addAll(Arrays.asList(Component.CCI1, Component.CCI2));
+        
+        switch (mod) {
+            case "2B":
+                buttonList.addAll(Arrays.asList(Component.BUTTON7, Component.BUTTON9));
+                ledList.addAll(Arrays.asList(Component.LED7, Component.LED9));
+                break;
+            case "3B":
+                buttonList.addAll(Arrays.asList(Component.BUTTON6, Component.BUTTON8, Component.BUTTON10));
+                ledList.addAll(Arrays.asList(Component.LED6, Component.LED8, Component.LED10));
+                break;
+            case "4B":
+                buttonList.addAll(Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON7, Component.BUTTON9));
+                ledList.addAll(Arrays.asList(Component.LED2, Component.LED4, Component.LED7, Component.LED9));
+                break;
+            case "5BRL":
+                buttonList.addAll(Arrays.asList(Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
+                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
+                ledList.addAll(Arrays.asList(Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                break;
+            case "6BRL":
+                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6, Component.BUTTON8, Component.BUTTON10));
+                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
+                ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5, Component.LED6, Component.LED8, Component.LED10));
+                break;
+            case "7BRL":
+                buttonList.addAll(Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
+                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
+                ledList.addAll(Arrays.asList(Component.LED2, Component.LED4, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                break;
+            case "8BRL":
+                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
+                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
+                ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                break;
+            default:
+                logger.warn("No valid keypad model defined ({}). Assuming 10BRL model.", mod);
+                // fall through
+            case "Generic":
+            case "10BRL":
+                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
+                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
+                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4, Component.LED5, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                break;
+        }
+    }
+
+    public IntlKeypadHandler(Thing thing) {
+        super(thing);
+    }
+
+}

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -297,6 +297,44 @@
 		</config-description>
 	</thing-type>
 
+	<thing-type id="intlkeypad">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>International seeTouch Keypad</label>
+		<description>Lutron International seeTouch keypad (HomeWorks QS Only)</description>
+
+		<config-description>
+			<parameter name="integrationId" type="integer" required="true">
+				<label>Integration ID</label>
+				<description>Address of keypad in the Lutron lighting system</description>
+			</parameter>
+			<parameter name="model" type="text">
+				<label>Keypad Model</label>
+				<description>Keypad/faceplate model number without the system prefix</description>
+				<options>
+					<option value="2B">2B</option>
+					<option value="3B">3B</option>
+					<option value="4B">4B</option>
+					<option value="5BRL">5BRL</option>
+					<option value="6BRL">6BRL</option>
+					<option value="7BRL">7BRL</option>
+					<option value="8BRL">8BRL</option>
+					<option value="10BRL">10BRL</option>
+					<option value="Generic">Generic</option>
+				</options>
+				<default>Generic</default>
+			</parameter>
+			<parameter name="autorelease" type="boolean">
+				<label>Auto-release</label>
+				<description>Automatically release pressed buttons</description>
+				<default>true</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+
 	<thing-type id="pico">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>


### PR DESCRIPTION
Hi. This PR adds support for International seeTouch keypads used in Lutron HomeWorks QS systems. This is part of the on-going work to fully support HomeWorks QS with the Lutron binding.

Regards,
Bob