### PR TITLE
Travis Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.p2
+  - $HOME/.bnd/cache/
 
 before_cache:
   # remove resolver-status.properties, they change with each run and invalidate the cache


### PR DESCRIPTION
We do not use p2 anymore in this repo. Remove the cache directory. Add the bnd cache directory instead.
It should speed up itests.

PS: Small patch exception, no sign off