### PR TITLE
[globalcache] trigger serial receive channel

### DIFF
--- a/bundles/org.openhab.binding.globalcache/README.md
+++ b/bundles/org.openhab.binding.globalcache/README.md
@@ -331,6 +331,18 @@ then
 end
 ```
 
+This is an example of how to react to feedback from the serial port from within a rule.
+
+```
+rule "Process feedback from serial port"
+when
+    Channel "globalcache:gc100_06:000C1EFFF039:sl-m1#c1-receive" triggered
+then
+    var serialResponse = triggerEvent.getEvent().toString
+    // parse serialResponse
+end
+```
+
 ### Manual Thing Creation
 
 Place a file named *globalcache.things* in the *conf/things* directory.

--- a/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/handler/GlobalCacheHandler.java
+++ b/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/handler/GlobalCacheHandler.java
@@ -1072,6 +1072,7 @@ public class GlobalCacheHandler extends BaseThingHandler {
                     String encodedReply = URLEncoder.encode(new String(buffer, CHARSET), CHARSET);
                     logger.debug("encodedReply='{}'", encodedReply);
                     updateState(channel.getUID(), new StringType(encodedReply));
+                    triggerChannel(channel.getUID(), encodedReply);
                 } catch (UnsupportedEncodingException e) {
                     logger.warn("Exception while encoding data read from serial device: {}", e.getMessage());
                 }


### PR DESCRIPTION
Signed-off-by: Nick Hill <knikhilwiz@gmail.com>

[ third try is the charm - there is exactly one commit in this PR and it is properly signed off to meet the DCO checks. I hope that this goes through. Phew! ]

Updates on items work well for the UI, since you are largely interested in the final state of a sequence of updates. However, for a serial channel, all bits of data need to be processed in rules. For a rule that is watching for received updates, the actual update is not available in the rule and the only way to access the event is by looking at Item.state. For cases where a device is sending a quick sequence of feedback, when this is coupled with the line termination character, there is a race between the rule being called and referencing Item.state within the rule. This often results in Item.state within the rule just returning the line termination characters and not the actual messages. So, trigger the channel so that the content is available as a receivedEvent in rules.

I also have a stashed change that defines a new channel, but it seems unnecessarily complex. Triggering it on the existing receive channel seems simpler and will just work for any existing configurations. Includes changes to the docs.