### PR TITLE
[samsungtv] Fix for #5794 thing not going to offline 

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryListener;
@@ -199,8 +200,9 @@ public class SamsungTvHandler extends BaseThingHandler implements DiscoveryListe
     }
 
     @Override
-    public void reportError(@Nullable ThingStatusDetail statusDetail, @Nullable String message, @Nullable Throwable e) {
-        logger.info("Error was reported: {}", message, e);
+    public void reportError(@NonNull ThingStatusDetail statusDetail, @Nullable String message, @Nullable Throwable e) {
+        logger.debug("Error was reported: {}", message, e);
+        updateStatus(ThingStatus.OFFLINE, statusDetail, message);
     }
 
     /**


### PR DESCRIPTION
Fix for #5794 thing not going to offline 

Bugfix to make the thing go offline when a connection error occurs. This addresses #5794.
A compiled version is available at: https://drive.google.com/open?id=1BAg5Xs1UtuZi61p5FpXjVJGWV31-HLK8

