### PR TITLE
[keba] start command implementation, authentication feature.

### DIFF
--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -43,6 +43,7 @@ All devices support the following channels:
 | sessionrfidclass   | String    | yes       | RFID tag class used for the last charging session                      |
 | sessionid          | Number    | yes       | session ID of the last charging session                                |
 | setenergylimit     | Number    | no        | set an energy limit for an already running or the next charging session|
+| authenticate       | String    | no        | authenticate and start a session using RFID tag+RFID class             |
 
 
 ## Example

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -70,6 +70,7 @@ public class KebaBindingConstants {
     public static final String CHANNEL_SESSION_RFID_CLASS = "sessionrfidclass";
     public static final String CHANNEL_SESSION_SESSION_ID = "sessionid";
     public static final String CHANNEL_SETENERGY = "setenergylimit";
+    public static final String CHANNEL_AUTHENTICATE = "authenticate";
 
     public enum KebaType {
         P20,

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -562,6 +562,14 @@ public class KeContactHandler extends BaseThingHandler {
                     }
                     break;
                 }
+                case CHANNEL_AUTHENTICATE: {
+                    if (command instanceof StringType) {
+                        String cmd = command.toString();
+                        // cmd must contain ID + CLASS (works only if the RFID TAG is in the whitelist of the Keba station) 
+                        transceiver.send("start " + cmd , this);
+                    }
+                    break;
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/ESH-INF/thing/kecontact.xml
@@ -54,6 +54,7 @@
 			<channel id="sessionrfidclass" typeId="sessionrfidclass" />
 			<channel id="sessionid" typeId="sessionid" />
 			<channel id="setenergylimit" typeId="setenergylimit" />
+			<channel id="authenticate" typeId="authenticate" />
 		</channels>
 
 		<config-description>
@@ -252,4 +253,10 @@
 		<description>An energy limit for an already running or the next charging session.</description>
 		<state pattern="%d Wh" readOnly="false"></state>
 	</channel-type>
+	<channel-type id="authenticate">
+		<item-type>String</item-type>
+		<label>Authenticate</label>
+		<description>Authenticate and start a charging session</description>
+		<state readOnly="false"></state>
+	</channel-type>	
 </thing:thing-descriptions>


### PR DESCRIPTION
In order to start a charging session on Keba with RFID enabled, this command can be used. The syntax is a String "RFIDTAG RFIDCLASS" seperator is a whitespace, so e.g "123abdef00000000 00000000000000000000" is a valid string. Be remembered the RFID TAG must be whitlisted to the Keba, so if the keba has never seen this tag it will not work.

tested on a P30c

Signed-off-by: Juergen Benz <juergen.benz@gmail.com>
