### PR TITLE
[ambientweather] Implement QuantityType for rainfall rate

### DIFF
--- a/bundles/org.openhab.binding.ambientweather/README.md
+++ b/bundles/org.openhab.binding.ambientweather/README.md
@@ -67,7 +67,7 @@ The following channels are supported by the binding. Note that specific weather 
 | weatherData\<station-type\>  | windSpeedAvg10Minute            | Number:Speed            | Ten-minute wind speed average                                 |
 | weatherData\<station-type\>  | windDirectionDegreesAvg10Min    | Number:Angle            | Ten-minute wind direction average                             |
 | weatherData\<station-type\>  | windDirectionAvg10Min           | String                  | Ten-minute wind direction average                             |
-| weatherData\<station-type\>  | rainHourlyRate                  | Number                  | Hourly rate of rainfall                                       |
+| weatherData\<station-type\>  | rainHourlyRate                  | Number:Speed            | Hourly rate of rainfall                                       |
 | weatherData\<station-type\>  | rainDay                         | Number:Length           | Rainfall amount for the day                                   |
 | weatherData\<station-type\>  | rainWeek                        | Number:Length           | Rainfall amount for the week                                  |
 | weatherData\<station-type\>  | rainMonth                       | Number:Length           | Rainfall amount for the month                                 |
@@ -125,7 +125,11 @@ String WS1400IP_WindDirection "Wind Direction [%s]" { channel="ambientweather:ws
 Number:Speed WS1400IP_WindGust "Wind Gust [%.0f %unit%]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#windGust" }
 Number:Speed WS1400IP_WindGustDailyMax "Wind Gust Max Daily [%.0f %unit%]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#windGustMaxDaily" }
 
-Number WS1400IP_RainHourlyRate "Rain Hourly Rate [%.2f in/hr]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainHourlyRate" }
+// Use this if your units are SI
+Number:Speed WS1400IP_RainHourlyRate "Rain Hourly Rate [%.1f mm/h]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainHourlyRate" }
+// Use this if your units are Imperial
+Number:Speed WS1400IP_RainHourlyRate "Rain Hourly Rate [%.2f in/h]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainHourlyRate" }
+
 Number:Length WS1400IP_RainDaily "Rain Daily [%.2f %unit%]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainDay" }
 Number:Length WS1400IP_RainWeekly "Rain Weekly [%.2f %unit%]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainWeek" }
 Number:Length WS1400IP_RainMonthly "Rain Monthly [%.2f %unit%]" { channel="ambientweather:ws1400ip:ws1400ip:weatherDataWs1400ip#rainMonth" }

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws0900ipProcessor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws0900ipProcessor.java
@@ -67,7 +67,7 @@ public class Ws0900ipProcessor extends AbstractProcessor {
         handler.updateQuantity(channelGroupId, CH_WIND_DIRECTION_DEGREES, data.winddir, SmartHomeUnits.DEGREE_ANGLE);
         handler.updateQuantity(channelGroupId, CH_WIND_GUST, data.windgustmph, ImperialUnits.MILES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_WIND_GUST_MAX_DAILY, data.maxdailygust, ImperialUnits.MILES_PER_HOUR);
-        handler.updateNumber(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin);
+        handler.updateQuantity(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin, SmartHomeUnits.INCHES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_RAIN_DAY, data.dailyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_WEEK, data.weeklyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_MONTH, data.monthlyrainin, ImperialUnits.INCH);

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws1400ipProcessor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws1400ipProcessor.java
@@ -70,7 +70,7 @@ public class Ws1400ipProcessor extends AbstractProcessor {
         handler.updateQuantity(channelGroupId, CH_WIND_GUST_MAX_DAILY, data.maxdailygust, ImperialUnits.MILES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_SOLAR_RADIATION, data.solarradiation, SmartHomeUnits.IRRADIANCE);
         handler.updateNumber(channelGroupId, CH_UV_INDEX, data.uv);
-        handler.updateNumber(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin);
+        handler.updateQuantity(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin, SmartHomeUnits.INCHES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_RAIN_DAY, data.dailyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_WEEK, data.weeklyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_MONTH, data.monthlyrainin, ImperialUnits.INCH);

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws2902aProcessor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws2902aProcessor.java
@@ -70,7 +70,7 @@ public class Ws2902aProcessor extends AbstractProcessor {
         handler.updateQuantity(channelGroupId, CH_WIND_GUST_MAX_DAILY, data.maxdailygust, ImperialUnits.MILES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_SOLAR_RADIATION, data.solarradiation, SmartHomeUnits.IRRADIANCE);
         handler.updateNumber(channelGroupId, CH_UV_INDEX, data.uv);
-        handler.updateNumber(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin);
+        handler.updateQuantity(channelGroupId, CH_RAIN_HOURLY_RATE, data.hourlyrainin, SmartHomeUnits.INCHES_PER_HOUR);
         handler.updateQuantity(channelGroupId, CH_RAIN_DAY, data.dailyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_WEEK, data.weeklyrainin, ImperialUnits.INCH);
         handler.updateQuantity(channelGroupId, CH_RAIN_MONTH, data.monthlyrainin, ImperialUnits.INCH);

--- a/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/channels.xml
@@ -73,11 +73,11 @@
 	</channel-type>
 
 	<channel-type id="rainHourlyRate">
-		<item-type>Number</item-type>
+		<item-type>Number:Speed</item-type>
 		<label>Rain Fall Hourly Rate</label>
 		<description>Rain fall hourly rate</description>
 		<category>Rain</category>
-		<state readOnly="true" pattern="%.2f %unit%" />
+		<state readOnly="true" pattern="%.7f %unit%" />
 	</channel-type>
 
 	<channel-type id="rainDay">


### PR DESCRIPTION
Now that openhab/openhab-core#644 is fixed (thanks @cweitkamp), the rainfall rate channel can be converted to the `Number:Speed` QuantityType.

Since the initial version of the binding was merged just yesterday, I really don't see a need to document that this is a breaking change.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
