### PR TITLE
[avmfritz] Reenable itests

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/pom.xml
+++ b/bundles/org.openhab.binding.avmfritz/pom.xml
@@ -13,31 +13,4 @@
 
   <name>openHAB Add-ons :: Bundles :: AVM FRITZ! Binding</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.2.12</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.2.11</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>2.2.11</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
@@ -5,10 +5,9 @@
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>
-        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
-        <bundle dependency="true">mvn:javax.xml.bind/jaxb-api/2.2.12</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/2.2.11</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/2.2.11</bundle>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.9.0</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.avmfritz/${project.version}</bundle>
     </feature>
 </features>

--- a/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
@@ -5,9 +5,9 @@
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>
-        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
-        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.9.0</bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.9.0</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.avmfritz/${project.version}</bundle>
     </feature>
 </features>

--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -24,5 +24,5 @@ Export-Package:
 
 -runrequires.ee: \
     bnd.identity;id='org.apache.servicemix.specs.activation-api-1.1',\
-    bnd.identity;id='org.apache.servicemix.specs.annotation-api-1.3',\
-    bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.2'
+    bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.2',\
+    bnd.identity;id='org.apache.servicemix.bundles.jaxb-impl'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -5,6 +5,11 @@ Fragment-Host: org.openhab.binding.avmfritz
 
 -runrequires: bnd.identity;id='org.openhab.binding.avmfritz.tests'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #
@@ -57,10 +62,9 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.objectweb.asm.commons;version='[7.0.0,7.0.1)',\
 	org.objectweb.asm.tree;version='[7.0.0,7.0.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.avmfritz.tests/pom.xml
+++ b/itests/org.openhab.binding.avmfritz.tests/pom.xml
@@ -19,26 +19,6 @@
       <artifactId>org.openhab.binding.avmfritz</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.2.12</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.2.11</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>2.2.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openhab.binding.avmfritz.internal.ahamodel.AVMFritzBaseModel;
 import org.openhab.binding.avmfritz.internal.ahamodel.DeviceListModel;
@@ -43,8 +42,7 @@ import org.openhab.binding.avmfritz.internal.util.JAXBUtils;
  *
  * @author Christoph Weitkamp - Initial contribution
  */
-@Ignore
-public class AVMFritzDiscoveryServiceTest extends AVMFritzThingHandlerOSGiTest {
+public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTest {
 
     private static final ThingUID BRIGE_THING_ID = new ThingUID("avmfritz:fritzbox:1");
 

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -10,6 +10,7 @@ Fragment-Host: org.openhab.binding.nest
 
 # We would like to use the "volatile" storage only
 -runblacklist: \
+    bnd.identity;id='org.apache.aries.javax.jax.rs-api',\
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'
 
@@ -61,11 +62,10 @@ Fragment-Host: org.openhab.binding.nest
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
 	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'

--- a/itests/org.openhab.binding.nest.tests/pom.xml
+++ b/itests/org.openhab.binding.nest.tests/pom.xml
@@ -19,11 +19,6 @@
       <artifactId>org.openhab.binding.nest</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
-    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
- Changed dependencies based on Java EE modules (openhab/openhab-core#920)
- Reactivated avmfritz tests
- Fixed Nest tests

Adresses #5775
Fixes #5413

I disabled non working itests and told Travis to run with performing itests. Another issue popped up related to Astro issues (seems to be related to #5720).

```
[ERROR] Tests run: 22, Failures: 9, Errors: 0, Skipped: 1, Time elapsed: 0.338 s <<< FAILURE! - in org.openhab.binding.astro.internal.calc.SunCalcTest
[ERROR] testGetSunInfoForNauticDawnAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.059 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55124826E12> but was:<1.55124485E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForNauticDawnAccuracy(SunCalcTest.java:109)
[ERROR] testGetSunInfoForNauticDuskAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55129335E12> but was:<1.55128981E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForNauticDuskAccuracy(SunCalcTest.java:169)
[ERROR] testGetSunInfoForAstronomicalDawnAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.5512459E12> but was:<1.55124236E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForAstronomicalDawnAccuracy(SunCalcTest.java:98)
[ERROR] testGetSunInfoForAstronomicalDuskAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55129571E12> but was:<1.55129217E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForAstronomicalDuskAccuracy(SunCalcTest.java:180)
[ERROR] testGetSunInfoForRiseAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.006 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55125272E12> but was:<1.55124918E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForRiseAccuracy(SunCalcTest.java:131)
[ERROR] testGetSunInfoForCivilDawnAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.006 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55125062E12> but was:<1.55124708E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForCivilDawnAccuracy(SunCalcTest.java:120)
[ERROR] testGetSunInfoForCivilDuskAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55129125E12> but was:<1.55128771E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForCivilDuskAccuracy(SunCalcTest.java:158)
[ERROR] testGetSunInfoForSetAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55129125E12> but was:<1.55128758E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForSetAccuracy(SunCalcTest.java:149)
[ERROR] testGetSunInfoForSunNoonAccuracy(org.openhab.binding.astro.internal.calc.SunCalcTest)  Time elapsed: 0.004 s  <<< FAILURE!
java.lang.AssertionError: expected:<1.55127199E12> but was:<1.55126845E12>
	at org.openhab.binding.astro.internal.calc.SunCalcTest.testGetSunInfoForSunNoonAccuracy(SunCalcTest.java:140)
[INFO] Running org.openhab.binding.astro.internal.model.SunTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.openhab.binding.astro.internal.model.SunTest
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SunCalcTest.testGetSunInfoForAstronomicalDawnAccuracy:98 expected:<1.5512459E12> but was:<1.55124236E12>
[ERROR]   SunCalcTest.testGetSunInfoForAstronomicalDuskAccuracy:180 expected:<1.55129571E12> but was:<1.55129217E12>
[ERROR]   SunCalcTest.testGetSunInfoForCivilDawnAccuracy:120 expected:<1.55125062E12> but was:<1.55124708E12>
[ERROR]   SunCalcTest.testGetSunInfoForCivilDuskAccuracy:158 expected:<1.55129125E12> but was:<1.55128771E12>
[ERROR]   SunCalcTest.testGetSunInfoForNauticDawnAccuracy:109 expected:<1.55124826E12> but was:<1.55124485E12>
[ERROR]   SunCalcTest.testGetSunInfoForNauticDuskAccuracy:169 expected:<1.55129335E12> but was:<1.55128981E12>
[ERROR]   SunCalcTest.testGetSunInfoForRiseAccuracy:131 expected:<1.55125272E12> but was:<1.55124918E12>
[ERROR]   SunCalcTest.testGetSunInfoForSetAccuracy:149 expected:<1.55129125E12> but was:<1.55128758E12>
[ERROR]   SunCalcTest.testGetSunInfoForSunNoonAccuracy:140 expected:<1.55127199E12> but was:<1.55126845E12>
[INFO] 
[ERROR] Tests run: 39, Failures: 9, Errors: 0, Skipped: 1
```

I am not sure if the Hue tests are really working because they are complaining about unsatisfied references too.
```
Components implementing org.eclipse.smarthome.config.discovery.DiscoveryService:
5 [ACTIVE] org.openhab.binding.hue.internal.discovery.HueBridgeNupnpDiscovery in org.openhab.binding.hue
46 [UNSATISFIED_REFERENCE] org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService in org.openhab.core.config.discovery.upnp
	UpnpService (org.jupnp.UpnpService)
		1 [UNSATISFIED_REFERENCE] org.jupnp.UpnpServiceImpl in org.jupnp
			OSGiUpnpServiceConfiguration (org.jupnp.OSGiUpnpServiceConfiguration)
			HttpService (org.osgi.service.http.HttpService)
				No component implementing org.osgi.service.http.HttpService is currently registered.
Make sure to add the appropriate bundle and set 'Default Auto-Start=true' in the launch config.
Components implementing org.eclipse.smarthome.config.discovery.DiscoveryService:
5 [ACTIVE] org.openhab.binding.hue.internal.discovery.HueBridgeNupnpDiscovery in org.openhab.binding.hue
46 [UNSATISFIED_REFERENCE] org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService in org.openhab.core.config.discovery.upnp
	UpnpService (org.jupnp.UpnpService)
		1 [UNSATISFIED_REFERENCE] org.jupnp.UpnpServiceImpl in org.jupnp
			OSGiUpnpServiceConfiguration (org.jupnp.OSGiUpnpServiceConfiguration)
			HttpService (org.osgi.service.http.HttpService)
				No component implementing org.osgi.service.http.HttpService is currently registered.
Make sure to add the appropriate bundle and set 'Default Auto-Start=true' in the launch config.
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
