### PR TITLE
[satel] Added channels for troubles in wireless devices

### DIFF
--- a/bundles/org.openhab.binding.satel/README.md
+++ b/bundles/org.openhab.binding.satel/README.md
@@ -86,10 +86,11 @@ Thing partition partition1 [ id=1, forceArming=true ]
 
 You can configure the following settings for a zone:
 
-| Name        | Required | Description                    |
-|-------------|----------|--------------------------------|
-| id          | yes      | Zone number                    |
-| invertState | no       | Changes active (ON) state to 0 |
+| Name        | Required | Description                                                              |
+|-------------|----------|--------------------------------------------------------------------------|
+| id          | yes      | Zone number                                                              |
+| invertState | no       | Changes active (ON) state to 0                                           |
+| wireless    | no       | This zone is monitored by a wireless detector like APD-100, AFD-100, etc |
 
 Example:
 
@@ -101,16 +102,17 @@ Thing zone zone1 [ id=1 ]
 
 You can configure the following settings for an output:
 
-| Name        | Required | Description                                               |
-|-------------|----------|-----------------------------------------------------------|
-| id          | yes      | Output number                                             |
-| invertState | no       | Changes active (ON) state to 0                            |
-| commandOnly | no       | Accepts commands only, does not update state of the thing |
+| Name        | Required | Description                                                           |
+|-------------|----------|-----------------------------------------------------------------------|
+| id          | yes      | Output number                                                         |
+| invertState | no       | Changes active (ON) state to 0                                        |
+| commandOnly | no       | Accepts commands only, does not update state of the thing             |
+| wireless    | no       | This output controls a wireless device like ASP-100 R, ASW-100 E, etc |
 
 Example:
 
 ```
-Thing output output1 [ id=1, invertState=true ]
+Thing output output1 [ id=1, invertState=true, wireless=false ]
 ```
 
 ### shutter
@@ -176,26 +178,30 @@ Thing event-log EventLog [ ]
 
 ### zone
 
-| Name                   | Type   | Description            |
-|------------------------|--------|------------------------|
-| violation              | Switch | Violation              |
-| tamper                 | Switch | Tamper                 |
-| alarm                  | Switch | Alarm                  |
-| tamper_alarm           | Switch | Tamper alarm           |
-| alarm_memory           | Switch | Alarm memory           |
-| tamper_alarm_memory    | Switch | Tamper alarm memory    |
-| bypass                 | Switch | Bypass                 |
-| no_violation_trouble   | Switch | No violation trouble   |
-| long_violation_trouble | Switch | Long violation trouble |
-| isolate                | Switch | Isolate                |
-| masked                 | Switch | Masked                 |
-| masked_memory          | Switch | Masked memory          |
+| Name                   | Type   | Description                                               |
+|------------------------|--------|-----------------------------------------------------------|
+| violation              | Switch | Violation                                                 |
+| tamper                 | Switch | Tamper                                                    |
+| alarm                  | Switch | Alarm                                                     |
+| tamper_alarm           | Switch | Tamper alarm                                              |
+| alarm_memory           | Switch | Alarm memory                                              |
+| tamper_alarm_memory    | Switch | Tamper alarm memory                                       |
+| bypass                 | Switch | Bypass                                                    |
+| no_violation_trouble   | Switch | No violation trouble                                      |
+| long_violation_trouble | Switch | Long violation trouble                                    |
+| isolate                | Switch | Isolate                                                   |
+| masked                 | Switch | Masked                                                    |
+| masked_memory          | Switch | Masked memory                                             |
+| device_lobatt          | Switch | Indicates low battery level in the wireless device        |
+| device_nocomm          | Switch | Indicates communication troubles with the wireless device |
 
 ### output
 
-| Name  | Type   | Description         |
-|-------|--------|---------------------|
-| state | Switch | State of the output |
+| Name          | Type   | Description                                               |
+|---------------|--------|-----------------------------------------------------------|
+| state         | Switch | State of the output                                       |
+| device_lobatt | Switch | Indicates low battery level in the wireless device        |
+| device_nocomm | Switch | Indicates communication troubles with the wireless device |
 
 ### shutter
 
@@ -239,6 +245,7 @@ Bridge satel:ethm-1:home [ host="192.168.0.2", refresh=1000, userCode="1234", en
     Thing shutter KitchenWindow [ upId=2, downId=3 ]
     Thing system System [ ]
     Thing event-log EventLog [ ]
+    Thing output Siren [ id=17, wireless=true ]
 }
 ```
 
@@ -263,6 +270,8 @@ Number EVENT_LOG_PREV "Event log - previous index [%d]" (Satel) { channel="satel
 DateTime EVENT_LOG_TIME "Event log - time [%1$tF %1$tR]" (Satel) { channel="satel:event-log:home:EventLog:timestamp" }
 String EVENT_LOG_DESCR "Event log - description [%s]" (Satel) { channel="satel:event-log:home:EventLog:description" }
 String EVENT_LOG_DET "Event log - details [%s]" (Satel) { channel="satel:event-log:home:EventLog:details" }
+Switch SIREN_LOBATT "Siren: low battery level" (Satel) { channel="satel:output:home:Siren:device_lobatt" }
+Switch SIREN_NOCOMM "Siren: no communication" (Satel) { channel="satel:output:home:Siren:device_nocomm" }
 ```
 
 ### satel.sitemap
@@ -277,6 +286,8 @@ Frame label="Alarm system" {
         Switch item=LIVING_ALARM
         Switch item=BEDROOM_TAMPER
         Switch item=BEDROOM_TAMPER_M
+        Switch item=SIREN_LOBATT
+        Switch item=SIREN_NOCOMM
     }
     Frame label="Kitchen" {
         Switch item=KITCHEN_LAMP

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBindingConstants.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBindingConstants.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link SatelBindingConstants} class defines common constants, which are
@@ -51,6 +52,10 @@ public class SatelBindingConstants {
     // Virtual devices
     public static final Set<ThingTypeUID> VIRTUAL_THING_TYPES_UIDS = Stream.of(THING_TYPE_SYSTEM, THING_TYPE_EVENTLOG)
             .collect(Collectors.toSet());
+
+    // Channel types
+    public static final ChannelTypeUID CHANNEL_TYPE_LOBATT = new ChannelTypeUID("system", "low-battery");
+    public static final ChannelTypeUID CHANNEL_TYPE_NOCOMM = new ChannelTypeUID(BINDING_ID, "device_nocomm");
 
     // List of all Channel ids except those covered by state enums
     public static final String CHANNEL_SHUTTER_STATE = "shutter_state";

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/config/SatelThingConfig.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/config/SatelThingConfig.java
@@ -29,6 +29,7 @@ public class SatelThingConfig {
     private boolean invertState;
     private boolean forceArming;
     private boolean commandOnly;
+    private boolean wireless;
 
     /**
      * @return device identifier
@@ -70,6 +71,13 @@ public class SatelThingConfig {
      */
     public boolean isCommandOnly() {
         return commandOnly;
+    }
+
+    /**
+     * @return if <code>true</code> the thing is a wireless device
+     */
+    public boolean isWireless() {
+        return wireless;
     }
 
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/discovery/SatelDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/discovery/SatelDeviceDiscoveryService.java
@@ -74,6 +74,12 @@ public class SatelDeviceDiscoveryService extends AbstractDiscoveryService {
             }
         }
         if (!scanStopped) {
+            scanForDevices(DeviceType.KEYPAD, 8);
+        }
+        if (!scanStopped) {
+            scanForDevices(DeviceType.EXPANDER, 64);
+        }
+        if (!scanStopped) {
             scanForDevices(DeviceType.PARTITION_WITH_OBJECT, bridgeHandler.getIntegraType().getPartitions());
         }
         if (!scanStopped) {
@@ -98,8 +104,9 @@ public class SatelDeviceDiscoveryService extends AbstractDiscoveryService {
             if (bridgeHandler.sendCommand(cmd, false)) {
                 String name = cmd.getName(bridgeHandler.getEncoding());
                 int deviceKind = cmd.getDeviceKind();
-                logger.debug("Found device: type={}, id={}, name={}, kind/function={}", deviceType.name(), i, name,
-                        deviceKind);
+                int info = cmd.getAdditionalInfo();
+                logger.debug("Found device: type={}, id={}, name={}, kind/function={}, info={}", deviceType.name(), i,
+                        name, deviceKind, info);
                 if (isDeviceAvailable(deviceType, deviceKind)) {
                     addDevice(deviceType, deviceKind, i, name);
                 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelOutputHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelOutputHandler.java
@@ -34,17 +34,12 @@ import org.openhab.binding.satel.internal.types.StateType;
  *
  * @author Krzysztof Goworek - Initial contribution
  */
-public class SatelOutputHandler extends SatelStateThingHandler {
+public class SatelOutputHandler extends WirelessChannelsHandler {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_OUTPUT);
 
     public SatelOutputHandler(Thing thing) {
         super(thing);
-    }
-
-    @Override
-    protected StateType getStateType(String channelId) {
-        return OutputState.valueOf(channelId.toUpperCase());
     }
 
     @Override
@@ -59,6 +54,15 @@ public class SatelOutputHandler extends SatelStateThingHandler {
         }
 
         return null;
+    }
+
+    @Override
+    protected StateType getStateType(String channelId) {
+        StateType result = super.getStateType(channelId);
+        if (result == null) {
+            result = OutputState.valueOf(channelId.toUpperCase());
+        }
+        return result;
     }
 
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelStateThingHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelStateThingHandler.java
@@ -98,14 +98,43 @@ public abstract class SatelStateThingHandler extends SatelThingHandler {
         }
     }
 
+    /**
+     * Returns bit number of given state type for this thing.
+     * This number addresses the bit in bit set sent to or received from alarm system.
+     * Usually this number is the device identifier.
+     *
+     * @param stateType state type
+     * @return bit number in state bit set
+     */
     protected int getStateBitNbr(StateType stateType) {
         return thingConfig.getId() - 1;
     }
 
+    /**
+     * Converts openHAB command sent to a channel into Satel message.
+     *
+     * @param channel channel the command was sent to
+     * @param command sent command
+     * @return Satel message that reflects sent command
+     */
     protected abstract SatelCommand convertCommand(ChannelUID channel, Command command);
 
+    /**
+     * Derived handlers must return appropriate state type for channels they support.
+     *
+     * @param channelId channel identifier to get state type for
+     * @return object that represents state type
+     * @see #getChannel(StateType)
+     */
     protected abstract StateType getStateType(String channelId);
 
+    /**
+     * Returns channel for given state type. Usually channels have the same ID as state type name they represent.
+     *
+     * @param stateType state type to get channel for
+     * @return channel object
+     * @see #getStateType(String)
+     */
     protected Channel getChannel(StateType stateType) {
         String channelId = stateType.toString().toLowerCase();
         Channel channel = getThing().getChannel(channelId);
@@ -115,6 +144,12 @@ public abstract class SatelStateThingHandler extends SatelThingHandler {
         return channel;
     }
 
+    /**
+     * Returns list of commands required to update thing state basing on event describing changes since last refresh.
+     *
+     * @param event list of state changes since last refresh
+     * @return collection of {@link IntegraStateCommand}
+     */
     protected Collection<SatelCommand> getRefreshCommands(NewStatesEvent event) {
         Collection<SatelCommand> result = new LinkedList<>();
         boolean forceRefresh = requiresRefresh();
@@ -129,6 +164,12 @@ public abstract class SatelStateThingHandler extends SatelThingHandler {
         return result;
     }
 
+    /**
+     * Checks if this thing requires unconditional refresh of all its channels.
+     * Clears the flag afterwards.
+     *
+     * @return if <code>true</code> this thing requires full refresh
+     */
     protected boolean requiresRefresh() {
         return requiresRefresh.getAndSet(false);
     }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelThingHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelThingHandler.java
@@ -61,16 +61,35 @@ public abstract class SatelThingHandler extends BaseThingHandler implements Sate
         }
     }
 
+    /**
+     * Updates switch channel with given state.
+     *
+     * @param channelID channel ID
+     * @param switchOn  if <code>true</code> the channel is updated with ON state, with OFF state otherwise
+     */
     protected void updateSwitch(String channelID, boolean switchOn) {
         ChannelUID channelUID = new ChannelUID(this.getThing().getUID(), channelID);
         updateSwitch(channelUID, switchOn);
     }
 
+    /**
+     * Updates switch channel with given state.
+     *
+     * @param channelUID channel UID
+     * @param switchOn   if <code>true</code> the channel is updated with ON state, with OFF state otherwise
+     */
     protected void updateSwitch(ChannelUID channelUID, boolean switchOn) {
         State state = switchOn ? OnOffType.ON : OnOffType.OFF;
         updateState(channelUID, state);
     }
 
+    /**
+     * Creates bitset of given size with particular bits set to 1.
+     *
+     * @param size bitset size in bytes
+     * @param ids  bits to set, first bit is 1
+     * @return bitset as array of bytes
+     */
     protected byte[] getObjectBitset(int size, int... ids) {
         byte[] bitset = new byte[size];
         for (int id : ids) {

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelZoneHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelZoneHandler.java
@@ -34,17 +34,12 @@ import org.openhab.binding.satel.internal.types.ZoneState;
  *
  * @author Krzysztof Goworek - Initial contribution
  */
-public class SatelZoneHandler extends SatelStateThingHandler {
+public class SatelZoneHandler extends WirelessChannelsHandler {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_ZONE);
 
     public SatelZoneHandler(Thing thing) {
         super(thing);
-    }
-
-    @Override
-    protected StateType getStateType(String channelId) {
-        return ZoneState.valueOf(channelId.toUpperCase());
     }
 
     @Override
@@ -73,6 +68,15 @@ public class SatelZoneHandler extends SatelStateThingHandler {
         }
 
         return null;
+    }
+
+    @Override
+    protected StateType getStateType(String channelId) {
+        StateType result = super.getStateType(channelId);
+        if (result == null) {
+            result = ZoneState.valueOf(channelId.toUpperCase());
+        }
+        return result;
     }
 
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/WirelessChannelsHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/WirelessChannelsHandler.java
@@ -63,6 +63,11 @@ public abstract class WirelessChannelsHandler extends SatelStateThingHandler {
         updateThing(thingBuilder.build());
     }
 
+    /**
+     * Defines the thing as a wireless or wired device.
+     *
+     * @return <code>true</code> if the thing is, or is configured as a wireless device
+     */
     protected boolean isWirelessDevice() {
         return thingConfig.isWireless();
     }
@@ -106,6 +111,12 @@ public abstract class WirelessChannelsHandler extends SatelStateThingHandler {
         }
     }
 
+    /**
+     * Returns channel UID for given state type.
+     *
+     * @param stateType state type to get channel UID for
+     * @return channel UID object
+     */
     private ChannelUID getChannelUID(StateType stateType) {
         String channelId = stateType.toString().toLowerCase();
         return new ChannelUID(getThing().getUID(), channelId);

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/WirelessChannelsHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/WirelessChannelsHandler.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.satel.internal.handler;
+
+import static org.openhab.binding.satel.internal.SatelBindingConstants.*;
+
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.openhab.binding.satel.internal.types.StateType;
+import org.openhab.binding.satel.internal.types.TroubleState;
+
+/**
+ * The {@link WirelessChannelsHandler} is base thing handler class for things that can be wireless devices.
+ * It adds support for two additional channels:
+ * <ul>
+ * <li><i>device_lobatt</i> - low battery indication</li>
+ * <li><i>device_nocomm</i> - communication problems indication</li>
+ * </ul>
+ * adding them if the device is configured as a wireless device.
+ *
+ * @author Krzysztof Goworek - Initial contribution
+ */
+public abstract class WirelessChannelsHandler extends SatelStateThingHandler {
+
+    public WirelessChannelsHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        // add/remove channels depending on whether or not the device is wireless
+        final int wirelessDeviceId = thingConfig.getId() - bridgeHandler.getIntegraType().getOnMainboard();
+        ThingBuilder thingBuilder = editThing();
+        if (isWirelessDevice() && wirelessDeviceId > 0) {
+            // if a wireless device, remove channels for wireless devices
+            if (getChannel(TroubleState.DEVICE_LOBATT) == null) {
+                thingBuilder.withChannel(ChannelBuilder.create(getChannelUID(TroubleState.DEVICE_LOBATT), "Switch")
+                        .withType(CHANNEL_TYPE_LOBATT).build());
+            }
+            if (getChannel(TroubleState.DEVICE_NOCOMM) == null) {
+                thingBuilder.withChannel(ChannelBuilder.create(getChannelUID(TroubleState.DEVICE_NOCOMM), "Switch")
+                        .withType(CHANNEL_TYPE_NOCOMM).build());
+            }
+        } else {
+            // if not a wireless device, remove channels for wireless devices
+            thingBuilder.withoutChannel(getChannelUID(TroubleState.DEVICE_LOBATT))
+                    .withoutChannel(getChannelUID(TroubleState.DEVICE_NOCOMM));
+        }
+        updateThing(thingBuilder.build());
+    }
+
+    protected boolean isWirelessDevice() {
+        return thingConfig.isWireless();
+    }
+
+    @Override
+    protected int getStateBitNbr(StateType stateType) {
+        int bitNbr = thingConfig.getId() - 1;
+        if (stateType instanceof TroubleState) {
+            // for wireless devices we need to correct bit number
+            switch ((TroubleState) stateType) {
+                case DEVICE_LOBATT1:
+                case DEVICE_NOCOMM1:
+                case OUTPUT_NOCOMM1:
+                    bitNbr -= 120;
+                    // pass through
+                case DEVICE_LOBATT:
+                case DEVICE_NOCOMM:
+                case OUTPUT_NOCOMM:
+                    bitNbr -= bridgeHandler.getIntegraType().getOnMainboard();
+                    break;
+                default:
+                    // other states are either not supported or don't need correction
+                    break;
+            }
+        }
+        return bitNbr;
+    }
+
+    @Override
+    protected StateType getStateType(String channelId) {
+        String stateName = channelId.toUpperCase();
+        if (TroubleState.DEVICE_LOBATT.name().equals(stateName)
+                || TroubleState.DEVICE_NOCOMM.name().equals(stateName)) {
+            if (thingConfig.getId() - bridgeHandler.getIntegraType().getOnMainboard() > 120) {
+                // last 120 ACU-100 devices in INTEGRA 256 PLUS
+                stateName += "1";
+            }
+            return TroubleState.valueOf(stateName);
+        } else {
+            return null;
+        }
+    }
+
+    private ChannelUID getChannelUID(StateType stateType) {
+        String channelId = stateType.toString().toLowerCase();
+        return new ChannelUID(getThing().getUID(), channelId);
+    }
+
+}

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
@@ -18,32 +18,34 @@ package org.openhab.binding.satel.internal.types;
  * @author Krzysztof Goworek - Initial contribution
  */
 public enum IntegraType {
-    UNKNOWN(-1, "Unknown", 0, 0),
-    I24(0, "Integra 24", 4, 24),
-    I32(1, "Integra 32", 16, 32),
-    I64(2, "Integra 64", 32, 64),
-    I128(3, "Integra 128", 32, 128),
-    I128_SIM300(4, "Integra 128-WRL SIM300", 32, 128),
-    I128_LEON(132, "Integra 128-WRL LEON", 32, 128),
-    I64_PLUS(66, "Integra 64 Plus", 32, 64),
-    I128_PLUS(67, "Integra 128 Plus", 32, 128),
-    I256_PLUS(72, "Integra 256 Plus", 32, 256, true);
+    UNKNOWN(-1, "Unknown", 0, 0, 0),
+    I24(0, "Integra 24", 4, 24, 4),
+    I32(1, "Integra 32", 16, 32, 8),
+    I64(2, "Integra 64", 32, 64, 16),
+    I128(3, "Integra 128", 32, 128, 16),
+    I128_SIM300(4, "Integra 128-WRL SIM300", 32, 128, 8),
+    I128_LEON(132, "Integra 128-WRL LEON", 32, 128, 8),
+    I64_PLUS(66, "Integra 64 Plus", 32, 64, 16),
+    I128_PLUS(67, "Integra 128 Plus", 32, 128, 16),
+    I256_PLUS(72, "Integra 256 Plus", 32, 256, 16, true);
 
     private int code;
     private String name;
     private int partitions;
     private int zones;
+    private int onMainboard;
     private boolean extPayload;
 
-    IntegraType(int code, String name, int partitions, int zones) {
-        this(code, name, partitions, zones, false);
+    IntegraType(int code, String name, int partitions, int zones, int onMainboard) {
+        this(code, name, partitions, zones, onMainboard, false);
     }
 
-    IntegraType(int code, String name, int partitions, int zones, boolean extPayload) {
+    IntegraType(int code, String name, int partitions, int zones, int onMainboard, boolean extPayload) {
         this.code = code;
         this.name = name;
         this.partitions = partitions;
         this.zones = zones;
+        this.onMainboard = onMainboard;
         this.extPayload = extPayload;
     }
 
@@ -69,6 +71,13 @@ public enum IntegraType {
     }
 
     /**
+     * @return wired zones/outputs available on mainboard
+     */
+    public int getOnMainboard() {
+        return onMainboard;
+    }
+
+    /**
      * @return <code>true</code> if this Integra requires extended message payload
      */
     public boolean hasExtPayload() {
@@ -79,7 +88,7 @@ public enum IntegraType {
      * Returns Integra type for given code.
      *
      * @param code
-     *            code to get type for
+     *                 code to get type for
      * @return Integra type object
      */
     public static IntegraType valueOf(int code) {

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/IntegraType.java
@@ -87,8 +87,7 @@ public enum IntegraType {
     /**
      * Returns Integra type for given code.
      *
-     * @param code
-     *                 code to get type for
+     * @param code code to get type for
      * @return Integra type object
      */
     public static IntegraType valueOf(int code) {

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/StateType.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/types/StateType.java
@@ -58,6 +58,12 @@ public interface StateType {
      */
     int getBytesCount(boolean extendedCmd);
 
+    /**
+     * Builds bit set based on list of state types. Each bit is addressed by refresh command.
+     *
+     * @param states list of states
+     * @return built bit set
+     */
     public static BitSet getStatesBitSet(StateType... states) {
         BitSet stateBits = new BitSet();
         for (StateType state : states) {

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/common.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/common.xml
@@ -6,7 +6,7 @@
 
 	<channel-type id="device_nocomm">
 		<item-type>Switch</item-type>
-		<label>No communication</label>
+		<label>No Communication</label>
 		<description>Indicates communication troubles with the wireless device</description>
 		<state readOnly="true" />
 	</channel-type>

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/common.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/common.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="satel"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="device_nocomm">
+		<item-type>Switch</item-type>
+		<label>No communication</label>
+		<description>Indicates communication troubles with the wireless device</description>
+		<state readOnly="true" />
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/output.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/output.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="satel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="satel"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
@@ -33,6 +34,10 @@
 			<parameter name="commandOnly" type="boolean" required="false">
 				<label>Command only</label>
 				<description>Accepts commands only, does not update state of the thing</description>
+			</parameter>
+			<parameter name="wireless" type="boolean" required="false">
+				<label>Wireless output</label>
+				<description>This output controls a wireless device like ASP-100 R, ASW-100 E, etc.</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/zone.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/zone.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="satel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="satel"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
@@ -39,6 +40,10 @@
 			<parameter name="invertState" type="boolean" required="false">
 				<label>Invert state</label>
 				<description>Changes active (ON) state to 0</description>
+			</parameter>
+			<parameter name="wireless" type="boolean" required="false">
+				<label>Wireless zone</label>
+				<description>This zone is monitored by a wireless detector like APD-100, AFD-100, etc</description>
 			</parameter>
 		</config-description>
 


### PR DESCRIPTION
This PR adds additional channels for wireless devices, like AXD-200, APD-200, etc. 

These devices do not differ much from corresponding wired devices and actually they can be used with existing version of the binding. However most of them are battery devices and they provide additional "low battery" signal to the system. Also when communication is broken, for example when battery is completely exhausted in the device, the system indicates this situation with "no communication" signal. 

Both of the signals are supported in this new version of the binding by adding two additional channels to "Zone" and "Output" things. To make them available the device must be configured as "wireless" device in the thing configuration.

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>
