### PR TITLE
Fixxed a typo in the sitemap

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/README.md
+++ b/bundles/org.openhab.binding.denonmarantz/README.md
@@ -113,7 +113,7 @@ Group item=marantz_input label="Receiver" icon="receiver" {
     Default   item=marantz_power
     Default   item=marantz_mute      visibility=[marantz_power==ON]
     Setpoint  item=marantz_volume    label="Volume [%.1f]" minValue=0 maxValue=40 step=0.5  visibility=[marantz_power==ON]
-    Default   item-marantz_volumeDB  visibility=[marantz_power==ON]
+    Default   item=marantz_volumeDB  visibility=[marantz_power==ON]
     Selection item=marantz_input     mappings=[TV=TV,MPLAY=Kodi]  visibility=[marantz_power==ON]
     Default   item=marantz_surround  visibility=[marantz_power==ON]
 }


### PR DESCRIPTION
The following item had a "-" instead of a "=" : marantz_volumeDB 

It did not cause an error when loading up to OpenHUB but it would cause it once you tried to actually use it in the sitemap.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
