### PR TITLE
[hue] New Features: CLIP Sensor Support

### DIFF
--- a/bundles/org.openhab.binding.hue/README.md
+++ b/bundles/org.openhab.binding.hue/README.md
@@ -47,8 +47,9 @@ The following matrix lists the capabilities (channels) for each type:
 |  0220       |    X   |     X      |       |          X        |
 
 Beside bulbs and luminaires the Hue binding supports some ZigBee sensors.
-Currently only Hue specific sensors are tested successfully (e.g. Hue Motion Sensor, Hue Dimmer Switch, Hue Tap).
+Currently only Hue specific sensors are tested successfully (e.g. Hue Motion Sensor, Hue Dimmer Switch, Hue Tap, CLIP Sensor).
 The Hue Motion Sensor registers a `ZLLLightLevel` sensor (0106), a `ZLLPresence` sensor (0107) and a `ZLLTemperature` sensor (0302) in one device.
+The Hue CLIP Sensor saves scene states with status or flag for HUE rules. 
 They are presented by the following ZigBee Device ID and _Thing type_:
 
 | Device type                 | ZigBee Device ID | Thing type |
@@ -58,8 +59,12 @@ They are presented by the following ZigBee Device ID and _Thing type_:
 | Temperature Sensor          | 0x0302           | 0302       |
 | Non-Colour Controller       | 0x0820           | 0820       |
 | Non-Colour Scene Controller | 0x0830           | 0830       |
+| CLIP Generic Status Sensor  | 0x0840           | 0840       |
+| CLIP Generic Flag Sensor    | 0x0850           | 0850       |
 
 The Hue Dimmer Switch has 4 buttons and registers as a Non-Colour Controller switch, while the Hue Tap (also 4 buttons) registers as a Non-Colour Scene Controller in accordance with the ZLL standard.
+
+Also, Hue bridge support CLIP Generic Status Sensor and CLIP Generic Flag Sensor. These sensors save state for rules and calculate what actions to do. CLIP Sensor set or get by json through IP.
 
 The type of a specific device can be found in the configuration section for things in the PaperUI.
 It is part of the unique thing id which could look like:
@@ -152,7 +157,9 @@ The devices support some of the following channels:
 | daylight          | Switch             | This channel indicates whether the light level is below the daylight threshold or not.                                                  | 0106                                |
 | presence          | Switch             | This channel indicates whether a motion is detected by the sensor or not.                                                               | 0107                                |
 | temperature       | Number:Temperature | This channel shows the current temperature measured by the sensor.                                                                      | 0302                                |
-| last_updated      | DateTime           | This channel the date and time when the sensor was last updated.                                                                        | 0820, 0830, 0106, 0107, 0302        |
+| flag              | Switch             | This channel save flag state for a CLIP sensor.                                                                                         | 0850                                |
+| status            | Number             | This channel save status state for a CLIP sensor.                                                                                       | 0840                                |
+| last_updated      | DateTime           | This channel the date and time when the sensor was last updated.                                                                        | 0820, 0830, 0840, 0850, 0106, 0107, 0302|
 | battery_level     | Number             | This channel shows the battery level.                                                                                                   | 0820, 0106, 0107, 0302             |
 | battery_low       | Switch             | This channel indicates whether the battery is low or not.                                                                               | 0820, 0106, 0107, 0302             |
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/FullSensor.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/FullSensor.java
@@ -32,6 +32,8 @@ public class FullSensor extends FullHueObject {
     public static final String STATE_LIGHT_LEVEL = "lightlevel";
     public static final String STATE_DARK = "dark";
     public static final String STATE_DAYLIGHT = "daylight";
+    public static final String STATE_STATUS = "status";
+    public static final String STATE_FLAG = "flag";
 
     public static final String CONFIG_REACHABLE = "reachable";
     public static final String CONFIG_BATTERY = "battery";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -45,6 +45,8 @@ public class HueBindingConstants {
 
     public static final ThingTypeUID THING_TYPE_DIMMER_SWITCH = new ThingTypeUID(BINDING_ID, "0820");
     public static final ThingTypeUID THING_TYPE_TAP_SWITCH = new ThingTypeUID(BINDING_ID, "0830");
+    public static final ThingTypeUID THING_TYPE_CLIP_GENERIC_STATUS = new ThingTypeUID(BINDING_ID, "0840");
+    public static final ThingTypeUID THING_TYPE_CLIP_GENERIC_FLAG = new ThingTypeUID(BINDING_ID, "0850");
     public static final ThingTypeUID THING_TYPE_PRESENCE_SENSOR = new ThingTypeUID(BINDING_ID, "0107");
     public static final ThingTypeUID THING_TYPE_TEMPERATURE_SENSOR = new ThingTypeUID(BINDING_ID, "0302");
     public static final ThingTypeUID THING_TYPE_LIGHT_LEVEL_SENSOR = new ThingTypeUID(BINDING_ID, "0106");
@@ -67,6 +69,8 @@ public class HueBindingConstants {
     public static final String CHANNEL_LIGHT_LEVEL = "light_level";
     public static final String CHANNEL_DARK = "dark";
     public static final String CHANNEL_DAYLIGHT = "daylight";
+    public static final String CHANNEL_STATUS = "status";
+    public static final String CHANNEL_FLAG = "flag";
 
     // List all triggers
     public static final String EVENT_DIMMER_SWITCH = "dimmer_switch_event";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBridge.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBridge.java
@@ -364,6 +364,24 @@ public class HueBridge {
     }
 
     /**
+     * Changes the state of a clip sensor.
+     *
+     * @param sensor sensor
+     * @param update changes to the state
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified sensor no longer exists
+     * @throws DeviceOffException thrown if the specified sensor is turned off
+     * @throws IOException if the bridge cannot be reached
+     */
+    public CompletableFuture<Result> setSensorState(FullSensor sensor, StateUpdate update) {
+        requireAuthentication();
+
+        String body = update.toJson();
+        return http.putAsync(getRelativeURL("sensors/" + enc(sensor.getId()) + "/state"), body, update.getMessageDelay(),
+                scheduler);
+    }    
+    
+    /**
      * Changes the config of a sensor.
      *
      * @param sensor sensor

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueThingHandlerFactory.java
@@ -41,6 +41,7 @@ import org.openhab.binding.hue.internal.handler.sensors.LightLevelHandler;
 import org.openhab.binding.hue.internal.handler.sensors.PresenceHandler;
 import org.openhab.binding.hue.internal.handler.sensors.TapSwitchHandler;
 import org.openhab.binding.hue.internal.handler.sensors.TemperatureHandler;
+import org.openhab.binding.hue.internal.handler.sensors.ClipHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 
@@ -60,7 +61,7 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
             Stream.of(HueBridgeHandler.SUPPORTED_THING_TYPES.stream(), HueLightHandler.SUPPORTED_THING_TYPES.stream(),
                     DimmerSwitchHandler.SUPPORTED_THING_TYPES.stream(), TapSwitchHandler.SUPPORTED_THING_TYPES.stream(),
                     PresenceHandler.SUPPORTED_THING_TYPES.stream(), TemperatureHandler.SUPPORTED_THING_TYPES.stream(),
-                    LightLevelHandler.SUPPORTED_THING_TYPES.stream()).flatMap(i -> i).collect(Collectors.toSet()));
+                    LightLevelHandler.SUPPORTED_THING_TYPES.stream(), ClipHandler.SUPPORTED_THING_TYPES.stream()).flatMap(i -> i).collect(Collectors.toSet()));
 
     private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
@@ -76,7 +77,8 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
                 || TapSwitchHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
                 || PresenceHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
                 || TemperatureHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
-                || LightLevelHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+                || LightLevelHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
+                || ClipHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             ThingUID hueSensorUID = getSensorUID(thingTypeUID, thingUID, configuration, bridgeUID);
             return super.createThing(thingTypeUID, configuration, hueSensorUID, bridgeUID);
         }
@@ -133,6 +135,8 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
             return new TemperatureHandler(thing);
         } else if (LightLevelHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
             return new LightLevelHandler(thing);
+        } else if (ClipHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            return new ClipHandler(thing);            
         } else {
             return null;
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
@@ -196,4 +196,27 @@ public class StateUpdate extends ConfigUpdate {
         return this;
     }
 
+    /**
+     * Turn sensor flag on or off.
+     *
+     * @param flag on if true, off otherwise
+     * @return this object for chaining calls
+     */
+    
+    public StateUpdate setFlag(boolean flag) {
+        commands.add(new Command("flag", flag));
+        return this;
+    }
+    
+    /**
+     * Set status of sensor.
+     *
+     * @param status status 
+     * @return this object for chaining calls
+     */
+    public StateUpdate setStatus(int status) {
+        commands.add(new Command("status", status));
+        return this;
+    }
+    
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -45,6 +45,7 @@ import org.openhab.binding.hue.internal.handler.sensors.LightLevelHandler;
 import org.openhab.binding.hue.internal.handler.sensors.PresenceHandler;
 import org.openhab.binding.hue.internal.handler.sensors.TapSwitchHandler;
 import org.openhab.binding.hue.internal.handler.sensors.TemperatureHandler;
+import org.openhab.binding.hue.internal.handler.sensors.ClipHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,7 @@ import org.slf4j.LoggerFactory;
  * @author Denis Dudnik - switched to internally integrated source of Jue library
  * @author Samuel Leisering - Added support for sensor API
  * @author Christoph Weitkamp - Added support for sensor API
+ * @author Meng Yiqi - Added support for CLIP sensor
  */
 @NonNullByDefault
 public class HueLightDiscoveryService extends AbstractDiscoveryService
@@ -66,7 +68,8 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(Stream
             .of(HueLightHandler.SUPPORTED_THING_TYPES.stream(), DimmerSwitchHandler.SUPPORTED_THING_TYPES.stream(),
                     TapSwitchHandler.SUPPORTED_THING_TYPES.stream(), PresenceHandler.SUPPORTED_THING_TYPES.stream(),
-                    TemperatureHandler.SUPPORTED_THING_TYPES.stream(), LightLevelHandler.SUPPORTED_THING_TYPES.stream())
+                    TemperatureHandler.SUPPORTED_THING_TYPES.stream(), LightLevelHandler.SUPPORTED_THING_TYPES.stream(),
+                    ClipHandler.SUPPORTED_THING_TYPES.stream())
             .flatMap(i -> i).collect(Collectors.toSet()));
 
     private final Logger logger = LoggerFactory.getLogger(HueLightDiscoveryService.class);
@@ -84,6 +87,8 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
             new SimpleEntry<>("color_temperature_light", "0220"),
             new SimpleEntry<>("zllswitch", "0820"),
             new SimpleEntry<>("zgpswitch", "0830"),
+            new SimpleEntry<>("clipgenericstatus", "0840"),
+            new SimpleEntry<>("clipgenericflag", "0850"),
             new SimpleEntry<>("zllpresence", "0107"),
             new SimpleEntry<>("zlltemperature", "0302"),
             new SimpleEntry<>("zlllightlevel", "0106")
@@ -206,7 +211,6 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
     private @Nullable ThingTypeUID getThingTypeUID(FullHueObject hueObject) {
         String thingTypeId = TYPE_TO_ZIGBEE_ID_MAP
                 .get(hueObject.getType().replaceAll(NORMALIZE_ID_REGEX, "_").toLowerCase());
-
         return thingTypeId != null ? new ThingTypeUID(BINDING_ID, thingTypeId) : null;
     }
 
@@ -220,7 +224,6 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         ThingTypeUID thingTypeUID = getThingTypeUID(sensor);
 
         String modelId = sensor.getNormalizedModelID();
-
         if (thingUID != null && thingTypeUID != null) {
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -285,6 +285,24 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     }
 
     @Override
+    public void updateSensorState(FullSensor sensor, StateUpdate stateUpdate) {
+        if (hueBridge != null) {
+            hueBridge.setSensorState(sensor, stateUpdate).thenAccept(result -> {
+                try {
+                    hueBridge.handleErrors(result);
+                } catch (Exception e) {
+                    handleStateUpdateException(sensor, stateUpdate, e);
+                }
+            }).exceptionally(e -> {
+                handleStateUpdateException(sensor, stateUpdate, e);
+                return null;
+            });
+        } else {
+            logger.warn("No bridge connected or selected. Cannot set sensor state.");
+        }
+    }
+    
+    @Override
     public void updateSensorConfig(FullSensor sensor, ConfigUpdate configUpdate) {
         if (hueBridge != null) {
             hueBridge.updateSensorConfig(sensor, configUpdate).thenAccept(result -> {
@@ -325,6 +343,20 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         }
     }
 
+    private void handleStateUpdateException(FullSensor sensor, StateUpdate stateUpdate, Throwable e) {
+        if (e instanceof IOException) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } else if (e instanceof EntityNotAvailableException) {
+            logger.debug("Error while accessing sensor: {}", e.getMessage(), e);
+            notifySensorStatusListeners(sensor, STATE_GONE);
+        } else if (e instanceof ApiException) {
+            // This should not happen - if it does, it is most likely some bug that should be reported.
+            logger.warn("Error while accessing sensor: {}", e.getMessage(), e);
+        } else if (e instanceof IllegalStateException) {
+            logger.trace("Error while accessing sensor: {}", e.getMessage());
+        }
+    }
+    
     private void handleConfigUpdateException(FullSensor sensor, ConfigUpdate configUpdate, Throwable e) {
         if (e instanceof IOException) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -94,4 +94,12 @@ public interface HueClient {
      * @param configUpdate the config update
      */
     void updateSensorConfig(FullSensor sensor, ConfigUpdate configUpdate);
+
+    /**
+     * Updates the given sensor.
+     *
+     * @param sensor the sensor to be updated
+     * @param stateUpdate the state update
+     */    
+	void updateSensorState(FullSensor sensor, StateUpdate stateUpdate);
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -41,6 +41,7 @@ import org.openhab.binding.hue.internal.FullHueObject;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.SensorConfigUpdate;
+import org.openhab.binding.hue.internal.StateUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,7 +146,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
                 return null;
             }
             ThingHandler handler = bridge.getHandler();
-            if (handler instanceof HueClient) {
+            if (handler instanceof HueBridgeHandler) {
                 hueClient = (HueClient) handler;
                 hueClient.registerSensorStatusListener(this);
             } else {
@@ -157,9 +158,44 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // no commands
-    }
+        handleCommand(channelUID.getId(), command);
+    }    
+    
+    public void handleCommand(String channel, Command command) {
+        //updateSensorState
+        FullSensor sensor = getSensor();
+        if (  sensor == null) {
+            logger.debug("hue sensor not known on bridge. Cannot handle command.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-wrong-light-id");
+            return;
+        }
+        
+        HueClient hueBridge = getHueClient();
+        if (hueBridge == null) {
+            logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
+            return;
+        }
 
+        StateUpdate sensorState = new StateUpdate();
+        switch (channel)
+        {
+        case  STATE_STATUS: 
+            sensorState = sensorState.setStatus(((DecimalType) command).intValue());
+            break;   
+        case STATE_FLAG:
+            sensorState = sensorState.setFlag(OnOffType.ON.equals(command));
+            break;
+        }
+   
+        if (sensorState != null) {
+            hueBridge.updateSensorState(sensor, sensorState);
+        } 
+        else {
+          logger.warn("Command sent to an unknown channel id: {}:{}", getThing().getUID(), channel);
+        }
+    }
+    
     @Override
     public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         SensorConfigUpdate configUpdate = doConfigurationUpdate(configurationParameters);
@@ -225,6 +261,21 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
                 // do nothing
             }
         }
+        
+        Object status = sensor.getState().get(STATE_STATUS);
+        if (status != null) {
+            try { DecimalType value = new DecimalType(String.valueOf(status));
+            updateState(STATE_STATUS, value);} catch (DateTimeParseException e) {
+                // do nothing
+            }
+        }
+        Object flag = sensor.getState().get(STATE_FLAG);
+        if (flag != null) {
+            try {boolean value = Boolean.parseBoolean(String.valueOf(flag));
+            updateState(CHANNEL_FLAG, value ? OnOffType.ON : OnOffType.OFF);} catch (DateTimeParseException e) {
+                // do nothing
+            }
+        }  
 
         Object battery = sensor.getConfig().get(CONFIG_BATTERY);
         if (battery != null) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/ClipHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/ClipHandler.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hue.internal.handler.sensors;
+
+import static org.openhab.binding.hue.internal.HueBindingConstants.*;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.openhab.binding.hue.internal.FullSensor;
+import org.openhab.binding.hue.internal.HueBridge;
+import org.openhab.binding.hue.internal.SensorConfigUpdate;
+import org.openhab.binding.hue.internal.handler.HueSensorHandler;
+
+/**
+ * CLIP Sensor
+ *
+ * @author Meng Yiqi - Initial contribution
+ */
+@NonNullByDefault
+public class ClipHandler extends HueSensorHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream.of(THING_TYPE_CLIP_GENERIC_STATUS, THING_TYPE_CLIP_GENERIC_FLAG).collect(Collectors.toSet());
+    
+    public ClipHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    protected SensorConfigUpdate doConfigurationUpdate(Map<String, Object> configurationParameters) {
+         return new SensorConfigUpdate();
+    }
+
+    protected void doSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor, Configuration config) {
+    }
+}

--- a/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/CLIPGenericFlagSensor.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/CLIPGenericFlagSensor.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- CLIP Generic Flag Sensor -->
+	<thing-type id="0850">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+
+		<label>CLIP Generic Flag Sensor</label>
+		<description>A generic sensor object for IP sensor use.</description>
+
+		<channels>
+			<channel id="flag" typeId="flag" />
+			<channel id="last_updated" typeId="last_updated" />
+		</channels>
+
+		<representation-property>uniqueId</representation-property>
+
+		<config-description>
+			<parameter name="sensorId" type="text">
+				<label>Sensor ID</label>
+				<description>The identifier that is used within the hue bridge.</description>
+				<required>true</required>
+			</parameter>
+			<parameter name="on" type="boolean">
+				<label>Sensor Status</label>
+				<description>Enables or disables the sensor.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/CLIPGenericStatusSensor.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/CLIPGenericStatusSensor.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- CLIP Generic Status Sensor -->
+	<thing-type id="0840">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+
+		<label>CLIP Generic Status Sensor</label>
+		<description>A generic sensor object for IP sensor use.</description>
+
+		<channels>
+			<channel id="status" typeId="status" />
+			<channel id="last_updated" typeId="last_updated" />
+		</channels>
+
+		<representation-property>uniqueId</representation-property>
+
+		<config-description>
+			<parameter name="sensorId" type="text">
+				<label>Sensor ID</label>
+				<description>The identifier that is used within the hue bridge.</description>
+				<required>true</required>
+			</parameter>
+			<parameter name="on" type="boolean">
+				<label>Sensor Status</label>
+				<description>Enables or disables the sensor.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/channels.xml
@@ -199,4 +199,18 @@
 		<description>The effect channel allows putting the bulb in a color looping mode.</description>
 		<category>ColorLight</category>
 	</channel-type>
+	
+	<!-- CLIP Sensor -->
+	<channel-type id="status">
+		<item-type>Number</item-type>
+		<label>Status</label>
+		<description>Status of CLIP sensor.</description>
+	</channel-type>
+
+	<channel-type id="flag">
+		<item-type>Switch</item-type>
+		<label>Flag</label>
+		<description>Flag of CLIP sensor.</description>
+	</channel-type>
+	
 </thing:thing-descriptions>


### PR DESCRIPTION
1: get/set status of CLIPGenericStatusSensor
2: get/set flag of CLIPGenericFlagSensor

HUE using CLIPGenericStatusSensor or CLIPGenericFlagSensor to save state of rules. So when you press the button on switch, you can active different lighting scenes. Wake up timer also using CLIPGenericFlagSensor. And you can add none-zigbee sensor or none-zigbee switch. You only need get/put json to url like http://192.168.0.66/api/NX5KJ0AtXMG9GpazD6j-ish-fQvJQ4FwsqXfjh7v/sensors/5. Many DIY users use CLIP sensor.

API reference: https://developers.meethue.com/develop/hue-api/supported-devices/#clipSensors