### PR TITLE
[skeleton] Use correct repository URL for the archetype

### DIFF
--- a/bundles/archetype-settings.xml
+++ b/bundles/archetype-settings.xml
@@ -9,7 +9,7 @@
             <repositories>
                 <repository>
                     <id>archetype</id>
-                    <url>https://openhab.jfrog.io/openhab/webapp/#/builds/openHAB-Core/</url>
+                    <url>https://openhab.jfrog.io/openhab/libs-snapshot</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
Currently, the skeleton script fails as described here: https://github.com/openhab/openhab2-addons/issues/5849.
Originally the URL was pointing to the artifactory UI.
I changed it to the actual repository.