### PR TITLE
[openweathermap] New Feature: visibility channel.

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/README.md
+++ b/bundles/org.openhab.binding.openweathermap/README.md
@@ -185,6 +185,7 @@ Number:Angle localCurrentWindDirection "Current wind direction [%d %unit%]" <win
 Number:Dimensionless localCurrentCloudiness "Current cloudiness [%d %unit%]" <clouds> { channel="openweathermap:weather-and-forecast:api:local:current#cloudiness" }
 Number:Length localCurrentRainVolume "Current rain volume [%.1f %unit%]" <rain> { channel="openweathermap:weather-and-forecast:api:local:current#rain" }
 Number:Length localCurrentSnowVolume "Current snow volume [%.1f %unit%]" <snow> { channel="openweathermap:weather-and-forecast:api:local:current#snow" }
+Number:Length localCurrentVisibility "Current visibility [%.1f km]" <visibility> { channel="openweathermap:weather-and-forecast:api:local:current#visibility" }
 
 DateTime localDailyForecastTodayTimestamp "Timestamp of forecast [%1$tY-%1$tm-%1$td]" <time> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#time-stamp" }
 String localDailyForecastTodayCondition "Condition for today [%s]" <sun_clouds> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#condition" }
@@ -258,6 +259,7 @@ sitemap demo label="OpenWeatherMap" {
         Text item=localCurrentCloudiness
         Text item=localCurrentRainVolume
         Text item=localCurrentSnowVolume
+        Text item=localCurrentVisibility
     }
     Frame label="Local forecast for today" {
         Text item=localDailyForecastTodayTimestamp

--- a/bundles/org.openhab.binding.openweathermap/README.md
+++ b/bundles/org.openhab.binding.openweathermap/README.md
@@ -95,6 +95,7 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 | current          | cloudiness     | Number:Dimensionless | Current cloudiness.                                                     |
 | current          | rain           | Number:Length        | Rain volume of the last hour.                                           |
 | current          | snow           | Number:Length        | Snow volume of the last hour.                                           |
+| current          | visibility     | Number:Length        | Current visibility.                                                     |
 
 **Attention**: Rain item is showing "1h" in the case when data are received from weather stations directly.
 The fact is that some METAR stations do not have precipitation indicators or do not measure precipitation conditions due to some other technical reasons.

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
@@ -77,6 +77,7 @@ public class OpenWeatherMapBindingConstants {
     public static final String CHANNEL_CLOUDINESS = "cloudiness";
     public static final String CHANNEL_RAIN = "rain";
     public static final String CHANNEL_SNOW = "snow";
+    public static final String CHANNEL_VISIBILITY = "visibility";
     public static final String CHANNEL_UVINDEX = "uvindex";
 
     // List of all configuration

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -299,7 +300,7 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                             MILLI(METRE));
                     break;
                 case CHANNEL_VISIBILITY:
-                    state = getQuantityTypeState(weatherData.getVisibility() * 0.001, KILO(METRE));
+                    state = new QuantityType<>(weatherData.getVisibility(), METRE).toUnit(KILO(METRE));
                     break;
             }
             logger.debug("Update channel '{}' of group '{}' with new state '{}'.", channelId, channelGroupId, state);

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -298,6 +298,9 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getQuantityTypeState(weatherData.getSnow() == null ? 0 : weatherData.getSnow().getVolume(),
                             MILLI(METRE));
                     break;
+                case CHANNEL_VISIBILITY:
+                    state = getQuantityTypeState(weatherData.getVisibility() * 0.001, KILO(METRE));
+                    break;
             }
             logger.debug("Update channel '{}' of group '{}' with new state '{}'.", channelId, channelGroupId, state);
             updateState(channelUID, state);

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/ESH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/ESH-INF/thing/channel-types.xml
@@ -35,6 +35,7 @@
 			<channel id="cloudiness" typeId="cloudiness" />
 			<channel id="rain" typeId="rain" />
 			<channel id="snow" typeId="snow" />
+			<channel id="visibility" typeId="visibility" />
 		</channels>
 	</channel-group-type>
 
@@ -309,6 +310,13 @@
 		<label>Forecasted UV Index</label>
 		<description>Forecasted UV Index.</description>
 		<state readOnly="true" pattern="%.1f" />
+	</channel-type>
+
+	<channel-type id="visibility">
+		<item-type>Number</item-type>
+		<label>Visibility</label>
+		<description>Visibility.</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/ESH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/ESH-INF/thing/channel-types.xml
@@ -313,9 +313,9 @@
 	</channel-type>
 
 	<channel-type id="visibility">
-		<item-type>Number</item-type>
+		<item-type>Number:Length</item-type>
 		<label>Visibility</label>
-		<description>Visibility.</description>
+		<description>Current visibility.</description>
 		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 


### PR DESCRIPTION
Visibility is missing in last commit, but I have found visibility supported in "OpenWeatherMapJsonWeatherData.java", not finished in other files. So I finish that.

I convert returned value from meter to kilometer. Because other weather sites (weatherunderground etc.) return kilometer, maybe we want show all visibilities in a single chart.