### PR TITLE
[mqtt] fix subscription issues

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -205,12 +205,22 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
     @Override
     public void dispose() {
-        MqttBrokerConnection connection = this.connection;
-        if (connection != null) {
-            connection.unsubscribeAll();
+        stop();
+        try {
+            unsubscribeAll().get(500, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            logger.warn("unsubcription on disposal failed for {}: ", thing.getUID(), e);
         }
+        connection = null;
         super.dispose();
     }
+
+    /**
+     * this method must unsubscribe all topics used by this thing handler
+     *
+     * @return
+     */
+    public abstract CompletableFuture<Void> unsubscribeAll();
 
     @Override
     public void updateChannelState(ChannelUID channelUID, State value) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -17,9 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -100,18 +97,16 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
 
     @Override
     public void dispose() {
-        // Stop all MQTT subscriptions
-        try {
-            channelStateByChannelUID.values().stream().map(e -> e.stop())
-                    .reduce(CompletableFuture.completedFuture(null), (a, v) -> a.thenCompose(b -> v))
-                    .get(500, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
-        }
         // Remove all state descriptions of this handler
         channelStateByChannelUID.forEach((uid, state) -> stateDescProvider.remove(uid));
-        connection = null;
         channelStateByChannelUID.clear();
         super.dispose();
+    }
+
+    @Override
+    public CompletableFuture<Void> unsubscribeAll() {
+        return CompletableFuture.allOf(channelStateByChannelUID.values().stream().map(channel -> channel.stop())
+                .toArray(CompletableFuture[]::new));
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -160,8 +160,8 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
 
     @Override
     public CompletableFuture<Void> unsubscribeAll() {
-        return CompletableFuture
-                .allOf(haComponents.values().stream().map(channel -> channel.stop()).toArray(CompletableFuture[]::new));
+        // already unsubscribed everything by calling stop()
+        return CompletableFuture.allOf();
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -17,9 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang.StringUtils;
@@ -42,9 +39,9 @@ import org.openhab.binding.mqtt.homeassistant.internal.CChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.CFactory;
 import org.openhab.binding.mqtt.homeassistant.internal.ChannelConfigurationTypeAdapterFactory;
 import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents;
+import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents.ComponentDiscovered;
 import org.openhab.binding.mqtt.homeassistant.internal.HaID;
 import org.openhab.binding.mqtt.homeassistant.internal.HandlerConfiguration;
-import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents.ComponentDiscovered;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,16 +155,13 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
 
         haComponents.values().forEach(c -> c.removeChannelTypes(channelTypeProvider));
 
-        // Unsubscribe from all components and component channel MQTT topics and more importantly
-        // remove the reference to this handler.
-        try {
-            haComponents.values().stream().map(e -> e.stop())
-                    .reduce(CompletableFuture.completedFuture(null), (a, v) -> a.thenCompose(b -> v))
-                    .get(500, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
-            // Ignore any interrupts and timeouts on finish
-        }
         super.dispose();
+    }
+
+    @Override
+    public CompletableFuture<Void> unsubscribeAll() {
+        return CompletableFuture
+                .allOf(haComponents.values().stream().map(channel -> channel.stop()).toArray(CompletableFuture[]::new));
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -33,11 +33,11 @@ import org.openhab.binding.mqtt.generic.tools.DelayedBatchProcessing;
 import org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homie.internal.homie300.Device;
 import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes;
+import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes.ReadyState;
 import org.openhab.binding.mqtt.homie.internal.homie300.DeviceCallback;
 import org.openhab.binding.mqtt.homie.internal.homie300.HandlerConfiguration;
 import org.openhab.binding.mqtt.homie.internal.homie300.Node;
 import org.openhab.binding.mqtt.homie.internal.homie300.Property;
-import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes.ReadyState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,8 +107,9 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
     @Override
     public void handleRemoval() {
         this.stop();
-        if(config.removetopics)
+        if (config.removetopics) {
             this.removeRetainedTopics();
+        }
         super.handleRemoval();
     }
 
@@ -135,6 +136,12 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         }
         delayedProcessing.join();
         device.stop();
+    }
+
+    @Override
+    public CompletableFuture<Void> unsubscribeAll() {
+        // already unsubscribed everything by calling stop()
+        return CompletableFuture.allOf();
     }
 
     @Override
@@ -216,12 +223,18 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
             });
         }
     }
+
     /**
      * Removes all retained topics related to the device
      */
     private void removeRetainedTopics() {
-        device.getRetainedTopics().stream().map(
-            d -> {return String.format("%s/%s", config.basetopic, d);}).collect(Collectors.toList()).forEach(
-                t -> this.connection.publish(t, new byte[0], 1, true));
+        MqttBrokerConnection connection = this.connection;
+        if (connection == null) {
+            logger.warn("couldn't remove retained topics for {} because connection is null", thing.getUID());
+            return;
+        }
+        device.getRetainedTopics().stream().map(d -> {
+            return String.format("%s/%s", config.basetopic, d);
+        }).collect(Collectors.toList()).forEach(t -> connection.publish(t, new byte[0], 1, true));
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -227,7 +227,9 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     public void initialize() {
         config = getConfigAs(BrokerHandlerConfig.class);
         connection = createBrokerConnection();
-        assignSSLContextProvider(config, connection, this);
-        super.initialize();
+        if (connection != null) {
+            assignSSLContextProvider(config, connection, this);
+            super.initialize();
+        }
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -223,13 +223,12 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     }
 
     @Override
-    @SuppressWarnings("null")
     public void initialize() {
         config = getConfigAs(BrokerHandlerConfig.class);
-        connection = createBrokerConnection();
-        if (connection != null) {
-            assignSSLContextProvider(config, connection, this);
-            super.initialize();
-        }
+        final MqttBrokerConnection connection = createBrokerConnection();
+        assignSSLContextProvider(config, connection, this);
+        this.connection = connection;
+
+        super.initialize();
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -223,6 +223,7 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     }
 
     @Override
+    @SuppressWarnings("null")
     public void initialize() {
         config = getConfigAs(BrokerHandlerConfig.class);
         connection = createBrokerConnection();

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -111,7 +111,12 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     @Override
     public void dispose() {
         try {
-            connection.stop().get(1000, TimeUnit.MILLISECONDS);
+            if (connection != null) {
+                connection.stop().get(1000, TimeUnit.MILLISECONDS);
+            } else {
+                logger.warn("Trying to dispose handler {} but connection is already null. Most likely this is a bug.",
+                        thing.getUID());
+            }
         } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
         }
         super.dispose();


### PR DESCRIPTION
Fixes #5786 
Fixes #5799 

After the refactoring from single connections to a shared connectionall subscriptions on a connections were cancelled after a thing on the broker/bridge was disposed. Also on disposal of the bridge it was not made sure that all home subscriptions were removed, resulting in multiuple subscription after the thing was re-initialized.

Also fixed some potential NPE.
 
Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
