### PR TITLE
removed non-existent repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>osgiify</id>
-      <url>https://dl.bintray.com/openhab/mvn/openhab-osgiify</url>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
This url is invalid (gives a 404). The osgiify artifacts are available in the standard openHAB Bintray repo under https://dl.bintray.com/openhab/mvn/org/openhab/osgiify/.

Signed-off-by: Kai Kreuzer <kai@openhab.org>