### PR TITLE
[ambientweather] Small improvements

### DIFF
--- a/bundles/org.openhab.binding.ambientweather/README.md
+++ b/bundles/org.openhab.binding.ambientweather/README.md
@@ -18,19 +18,12 @@ Other stations can be added relatively easily with changes in just several place
 
 Automatic discovery is currently not supported due to the lack of weather station model information in the Ambient Weather API.
 
-## Binding Configuration
-
-No binding configuration is needed.
-
 ## Thing Configuration
 
 ### Bridge Thing Configuration
 
 The Bridge thing requires a valid application Key and API key.
-Application and API keys can be obtained through your `ambientweather.net` dashboard.
-For the application key, you will need to send an email to the Ambient Weather support email address on your dashboard.
-Please indicate in your request that the application key is for openHAB.
-The application key requests usually are fulfilled within 24 hours.
+Application and API keys can be obtained on the *My Account* page of your `ambientweather.net` dashboard.
 
 ### Weather Station Thing Configuration
 

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/handler/AmbientWeatherEventListener.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/handler/AmbientWeatherEventListener.java
@@ -272,7 +272,9 @@ public class AmbientWeatherEventListener {
         try {
             EventSubscribedJson subscribed = gson.fromJson(jsonData, EventSubscribedJson.class);
             if (subscribed.invalidApiKeys != null) {
-                logger.debug("Listener: Invalid keys!! invalidApiKeys={}", subscribed.invalidApiKeys.toString());
+                logger.info("Listener: Invalid keys!! invalidApiKeys={}", subscribed.invalidApiKeys.toString());
+                bridgeHandler.markBridgeOffline("Invalid API keys");
+                return;
             }
 
             if (subscribed.devices != null && subscribed.devices instanceof ArrayList) {

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/handler/AmbientWeatherEventListener.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/handler/AmbientWeatherEventListener.java
@@ -272,7 +272,7 @@ public class AmbientWeatherEventListener {
         try {
             EventSubscribedJson subscribed = gson.fromJson(jsonData, EventSubscribedJson.class);
             if (subscribed.invalidApiKeys != null) {
-                logger.info("Listener: Invalid keys!! invalidApiKeys={}", subscribed.invalidApiKeys.toString());
+                logger.info("Listener: Invalid keys!! invalidApiKeys={}", subscribed.invalidApiKeys);
                 bridgeHandler.markBridgeOffline("Invalid API keys");
                 return;
             }


### PR DESCRIPTION
The process for requesting application keys has changed. Instead of emailing Ambient Weather support, application keys can be created using the same user interface that's used for API keys.

It's possible for an API to become invalid after it was determined to be valid during binding initialization. This change improves the user experience when that scenario occurs.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
