### PR TITLE
[HueEmulation] Fix #5835

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -97,13 +97,14 @@ public class HueEmulationService implements EventHandler {
                 return;
             }
 
-            InputStream stream = requestContext.getEntityStream();
-            String body = stream != null
-                    ? new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"))
-                    : "";
+            // InputStream stream = requestContext.getEntityStream();
+            // String body = stream != null
+            //         ? new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"))
+            //         : "";
 
-            logger.debug("REST request {} {}: {}", requestContext.getMethod(), requestContext.getUriInfo().getPath(),
-                    body);
+            // logger.debug("REST request {} {}: {}", requestContext.getMethod(), requestContext.getUriInfo().getPath(),
+            //         body);
+            logger.debug("REST request {} {}", requestContext.getMethod(), requestContext.getUriInfo().getPath());
             logger.debug("REST response: {}", responseContext.getEntity());
         }
 


### PR DESCRIPTION
`getEnityStream` in the log interceptor seems to consume the input stream, and that is causing `java.lang.IllegalStateException: Entity input stream has already been closed.` exceptions.

For now the received http body will not be printed in debug mode.

Signed-of-by: David Graeff <david.graeff@web.de>

PS: No I cannot fix the signed-off-by message. This is a web edit.