### PR TITLE
[dwdunwetter] Harden thing handler to fix potential NPEs

### DIFF
--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/config/DwdUnwetterConfiguration.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/config/DwdUnwetterConfiguration.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.dwdunwetter.internal;
+package org.openhab.binding.dwdunwetter.internal.config;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,37 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class DwdUnwetterConfiguration {
-
-    private int refresh;
-
-    private int warningCount;
-
-    private String cellId = StringUtils.EMPTY;
-
-    /**
-     * Returns the Refresh in minutes.
-     *
-     * @return The refresh in Minutes
-     */
-    public int getRefresh() {
-        return refresh;
-    }
-
-    /**
-     * Returns the number of warnings to provide.
-     *
-     * @return The number of warnings to provide
-     */
-    public int getWarningCount() {
-        return warningCount;
-    }
-
-    /**
-     * Returns the cellId.
-     *
-     * @return The cellId
-     */
-    public String getCellId() {
-        return cellId;
-    }
+    public int refresh;
+    public int warningCount;
+    public String cellId = StringUtils.EMPTY;
 }

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/factory/DwdUnwetterHandlerFactory.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/factory/DwdUnwetterHandlerFactory.java
@@ -10,26 +10,25 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.dwdunwetter.internal;
+package org.openhab.binding.dwdunwetter.internal.factory;
 
-import static org.openhab.binding.dwdunwetter.internal.DwdUnwetterBindingConstants.*;
+import static org.openhab.binding.dwdunwetter.internal.DwdUnwetterBindingConstants.THING_TYPE_WARNINGS;
 
 import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.dwdunwetter.internal.handler.DwdUnwetterHandler;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * The {@link DwdUnwetterHandlerFactory} is responsible for creating things and thing
- * handlers.
+ * The {@link DwdUnwetterHandlerFactory} is responsible for creating things and thing handlers.
  *
  * @author Martin Koehler - Initial contribution
  */

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/handler/DwdUnwetterHandler.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/handler/DwdUnwetterHandler.java
@@ -53,6 +53,8 @@ public class DwdUnwetterHandler extends BaseThingHandler {
     private int warningCount;
     private @Nullable DwdWarningsData data;
 
+    private boolean inRefresh;
+
     public DwdUnwetterHandler(Thing thing) {
         super(thing);
     }
@@ -71,10 +73,12 @@ public class DwdUnwetterHandler extends BaseThingHandler {
      * The Switch Channel is switched to OFF before all other Channels are updated.
      */
     private void refresh() {
-        if (getThing().getStatus() != ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.UNKNOWN) {
+        if (inRefresh
+                || (getThing().getStatus() != ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.UNKNOWN)) {
             return;
         }
         final DwdWarningsData warningsData = this.data;
+        inRefresh = true;
         if (warningsData == null || !warningsData.refresh()) {
             return;
         }
@@ -108,6 +112,7 @@ public class DwdUnwetterHandler extends BaseThingHandler {
             }
         }
         warningsData.updateCache();
+        inRefresh = false;
     }
 
     @Override

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/handler/DwdUnwetterHandler.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/handler/DwdUnwetterHandler.java
@@ -60,7 +60,7 @@ public class DwdUnwetterHandler extends BaseThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
-            refresh();
+            scheduler.submit(this::refresh);
         }
     }
 
@@ -122,9 +122,7 @@ public class DwdUnwetterHandler extends BaseThingHandler {
 
         updateThing(editThing().withChannels(createChannels()).build());
 
-        refreshJob = scheduler.scheduleWithFixedDelay(() -> {
-            refresh();
-        }, 0, config.refresh, TimeUnit.MINUTES);
+        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, config.refresh, TimeUnit.MINUTES);
         logger.debug("Finished initializing!");
     }
 

--- a/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/DwdUnwetterHandlerTest.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/DwdUnwetterHandlerTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openhab.binding.dwdunwetter.internal.DwdUnwetterBindingConstants;
-import org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler;
+import org.openhab.binding.dwdunwetter.internal.handler.DwdUnwetterHandler;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;


### PR DESCRIPTION
- Harden thing handler to fix potential NPEs like these:

```
java.lang.NullPointerException: null
        at org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler.refresh(DwdUnwetterHandler.java:76) ~[?:?]
        at org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler.handleCommand(DwdUnwetterHandler.java:62) ~[?:?]
        at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.channelLinked(BaseThingHandler.java:229) ~[?:?]
        at org.eclipse.smarthome.core.thing.link.ThingLinkManager.lambda$0(ThingLinkManager.java:266) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
```
```
2019-08-09 17:36:57.456 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
java.util.NoSuchElementException: null
        at java.util.LinkedList$ListItr.next(LinkedList.java:890) ~[?:?]
        at java.util.List.sort(List.java:481) ~[?:?]
        at java.util.Collections.sort(Collections.java:175) ~[?:?]
        at org.openhab.binding.dwdunwetter.internal.data.DwdWarningsData.refresh(DwdWarningsData.java:206) ~[?:?]
        at org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler.refresh(DwdUnwetterHandler.java:76) ~[?:?]
        at org.openhab.binding.dwdunwetter.internal.DwdUnwetterHandler.lambda$0(DwdUnwetterHandler.java:203) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
