### PR TITLE
[mqtt] fix wrong topic in logger

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -122,7 +122,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         future.exceptionally(e -> {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
             return false;
-        }).thenRun(() -> logger.debug("Successfully published value {} to topic {}", command, data.getStateTopic()));
+        }).thenRun(() -> logger.debug("Successfully published value {} to topic {}", command, data.getCommandTopic()));
     }
 
     @Override


### PR DESCRIPTION
Resolves #5819 

Values are published to the commandTopic, not the stateTopic. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
