### PR TITLE
[nest] Fix integration tests fail on Windows

### DIFF
--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -14,6 +14,8 @@ Fragment-Host: org.openhab.binding.nest
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'
 
+-runproperties: logback.configurationFile=file:${.}/logback.xml
+
 #
 # done
 #

--- a/itests/org.openhab.binding.nest.tests/logback.xml
+++ b/itests/org.openhab.binding.nest.tests/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.eclipse.jetty" level="info">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/handler/NestThingHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/handler/NestThingHandlerOSGiTest.java
@@ -260,7 +260,8 @@ public abstract class NestThingHandlerOSGiTest extends JavaOSGiTest {
     }
 
     protected void putStreamingEventData(String json) throws IOException {
-        String singleLineJson = json.replaceAll("\n\\s+", "").replaceAll("\n", "");
+        String singleLineJson = json.replaceAll("\n\r\\s+", "").replaceAll("\n\\s+", "").replaceAll("\n\r", "")
+                .replaceAll("\n", "");
         servlet.queueEvent(PUT, singleLineJson);
     }
 

--- a/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
+++ b/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/internal/data/NestDataUtil.java
@@ -12,12 +12,13 @@
  */
 package org.openhab.binding.nest.internal.data;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.stream.Collectors;
 
 import javax.measure.Unit;
 import javax.measure.quantity.Temperature;
@@ -89,13 +90,7 @@ public final class NestDataUtil {
 
     public static String fromFile(String fileName) throws IOException {
         try (Reader reader = openDataReader(fileName)) {
-            StringWriter writer = new StringWriter();
-            char[] buffer = new char[1024 * 4];
-            int n = 0;
-            while (-1 != (n = reader.read(buffer))) {
-                writer.write(buffer, 0, n);
-            }
-            return writer.toString();
+            return new BufferedReader(reader).lines().parallel().collect(Collectors.joining("\n"));
         }
     }
 


### PR DESCRIPTION
* Convert line endings read from files so tests work on Linux/Windows
* Reduce logging output by suppressing org.eclipse.jetty with logback configuration

Fixes #5906