### PR TITLE
[mqtt][homie] fix integration tests

### DIFF
--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -70,10 +70,12 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	io.netty.handler;version='[4.1.34,4.1.35)',\
 	io.netty.resolver;version='[4.1.34,4.1.35)',\
 	io.netty.transport;version='[4.1.34,4.1.35)',\
-	org.apache.servicemix.bundles.commons-codec;version='[1.3.0,1.3.1)',\
 	org.openhab.io.mqttembeddedbroker;version='[2.5.0,2.5.1)',\
-	io.moquette.moquette-broker;version='[0.12.1,0.12.2)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	jaxb-api;version='[2.2.11,2.2.12)',\
+	slf4j.simple;version='[1.7.21,1.7.22)',\
+	moquette-broker;version='[0.13.0,0.13.1)',\
+	org.apache.commons.codec;version='[1.10.0,1.10.1)'
+-runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
@@ -39,9 +39,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openhab.osgiify</groupId>
-      <artifactId>io.moquette.moquette-broker</artifactId>
-      <version>0.12.1</version>
+      <groupId>com.github.j-n-k</groupId>
+      <artifactId>moquette-broker</artifactId>
+      <version>0.13.0.OH2</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -122,12 +122,11 @@ public class HomieImplementationTest extends JavaOSGiTest {
         final String testNode = DEVICE_TOPIC + "/testnode";
         futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes()));
         futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes()));
-        futures.add(embeddedConnection.publish(testNode + "/$properties",
-                "temperature,doorbell,testRetain".getBytes()));
+        futures.add(embeddedConnection.publish(testNode + "/$properties", "temperature,doorbell,testRetain".getBytes()));
 
         // Add homie property topics
         final String property = testNode + "/temperature";
-        futures.add(embeddedConnection.publish(property, "10".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property, "10".getBytes()));
         futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes()));
         futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes()));
         futures.add(embeddedConnection.publish(property + "/$unit", "°C".getBytes(StandardCharsets.UTF_8)));
@@ -146,12 +145,9 @@ public class HomieImplementationTest extends JavaOSGiTest {
 
         this.propertyTestTopic = testNode + "/testRetain";
         futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes()));
-        futures.add(
-                embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes()));
-        futures.add(
-                embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype",
-                "boolean".getBytes()));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes()));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes()));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype", "boolean".getBytes()));
 
         registeredTopics = futures.size();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
@@ -161,10 +157,6 @@ public class HomieImplementationTest extends JavaOSGiTest {
 
     @After
     public void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
-/*        if (publishConnection != null) {
-            publishConnection.removeConnectionObserver(failIfChange);
-            publishConnection.stop().get(500, TimeUnit.MILLISECONDS);
-        }*/
         if (connection != null) {
             connection.removeConnectionObserver(failIfChange);
             connection.stop().get(500, TimeUnit.MILLISECONDS);

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -18,6 +18,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,6 +44,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
+import org.openhab.binding.mqtt.generic.ChannelState;
+import org.openhab.binding.mqtt.generic.tools.ChildMap;
+import org.openhab.binding.mqtt.generic.tools.WaitForTopicValue;
 import org.openhab.binding.mqtt.homie.internal.handler.HomieThingHandler;
 import org.openhab.binding.mqtt.homie.internal.homie300.Device;
 import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes;
@@ -53,12 +58,6 @@ import org.openhab.binding.mqtt.homie.internal.homie300.Property;
 import org.openhab.binding.mqtt.homie.internal.homie300.PropertyAttributes;
 import org.openhab.binding.mqtt.homie.internal.homie300.PropertyAttributes.DataTypeEnum;
 import org.openhab.binding.mqtt.homie.internal.homie300.PropertyHelper;
-import org.openhab.binding.mqtt.generic.ChannelState;
-import org.openhab.binding.mqtt.generic.tools.ChildMap;
-import org.openhab.binding.mqtt.generic.tools.WaitForTopicValue;
-import org.osgi.service.cm.ConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A full implementation test, that starts the embedded MQTT broker and publishes a homie device tree.
@@ -89,7 +88,8 @@ public class HomieImplementationTest extends JavaOSGiTest {
      * Create an observer that fails the test as soon as the broker client connection changes its connection state
      * to something else then CONNECTED.
      */
-    private MqttConnectionObserver failIfChange = (state, error) -> assertThat(state, is(MqttConnectionState.CONNECTED));
+    private MqttConnectionObserver failIfChange = (state, error) -> assertThat(state,
+            is(MqttConnectionState.CONNECTED));
 
     private String propertyTestTopic;
 
@@ -99,62 +99,72 @@ public class HomieImplementationTest extends JavaOSGiTest {
         initMocks(this);
         mqttService = getService(MqttService.class);
 
-        // Wait for the EmbeddedBrokerService internal connection to be connected
         embeddedConnection = new EmbeddedBrokerTools().waitForConnection(mqttService);
+        embeddedConnection.setQos(1);
+        embeddedConnection.setRetain(true);
 
         connection = new MqttBrokerConnection(embeddedConnection.getHost(), embeddedConnection.getPort(),
                 embeddedConnection.isSecure(), "homie");
         connection.setQos(1);
-        connection.start().get(200, TimeUnit.MILLISECONDS);
+        connection.setPersistencePath(Paths.get("subconn"));
+        connection.start().get(500, TimeUnit.MILLISECONDS);
         assertThat(connection.connectionState(), is(MqttConnectionState.CONNECTED));
         // If the connection state changes in between -> fail
         connection.addConnectionObserver(failIfChange);
 
-        embeddedConnection.setRetain(true);
-        embeddedConnection.setQos(1);
-
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$homie", "3.0".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$name", "Name".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$state", "ready".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$nodes", "testnode".getBytes()));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$homie", "3.0".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$name", "Name".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$state", "ready".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$nodes", "testnode".getBytes(StandardCharsets.UTF_8)));
 
         // Add homie node topics
         final String testNode = DEVICE_TOPIC + "/testnode";
-        futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes()));
-        futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes()));
-        futures.add(
-                embeddedConnection.publish(testNode + "/$properties", "temperature,doorbell,testRetain".getBytes()));
+        futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(testNode + "/$properties",
+                "temperature,doorbell,testRetain".getBytes(StandardCharsets.UTF_8)));
 
         // Add homie property topics
         final String property = testNode + "/temperature";
-        futures.add(embeddedConnection.publish(property, "10".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$unit", "°C".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$datatype", "float".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes()));
+        futures.add(embeddedConnection.publish(property, "10".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$unit", "°C".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$datatype", "float".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes(StandardCharsets.UTF_8)));
 
         final String propertyBellTopic = testNode + "/doorbell";
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype", "boolean".getBytes()));
+        futures.add(
+                embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes(StandardCharsets.UTF_8)));
+        futures.add(
+                embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes(StandardCharsets.UTF_8)));
+        futures.add(
+                embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype",
+                "boolean".getBytes(StandardCharsets.UTF_8)));
 
         this.propertyTestTopic = testNode + "/testRetain";
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype", "boolean".getBytes()));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes(StandardCharsets.UTF_8)));
+        futures.add(
+                embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes(StandardCharsets.UTF_8)));
+        futures.add(
+                embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype",
+                "boolean".getBytes(StandardCharsets.UTF_8)));
 
         registeredTopics = futures.size();
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(200, TimeUnit.MILLISECONDS);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
-        scheduler = new ScheduledThreadPoolExecutor(4);
+        scheduler = new ScheduledThreadPoolExecutor(6);
     }
 
     @After
     public void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
+/*        if (publishConnection != null) {
+            publishConnection.removeConnectionObserver(failIfChange);
+            publishConnection.stop().get(500, TimeUnit.MILLISECONDS);
+        }*/
         if (connection != null) {
             connection.removeConnectionObserver(failIfChange);
             connection.stop().get(500, TimeUnit.MILLISECONDS);
@@ -164,16 +174,18 @@ public class HomieImplementationTest extends JavaOSGiTest {
 
     @Test
     public void retrieveAllTopics() throws InterruptedException, ExecutionException, TimeoutException {
-        CountDownLatch c = new CountDownLatch(registeredTopics);
-        connection.subscribe(DEVICE_TOPIC + "/#", (topic, payload) -> c.countDown()).get(200, TimeUnit.MILLISECONDS);
-        assertTrue("Connection " + connection.getClientId() + " not retrieving all topics",
-                c.await(1000, TimeUnit.MILLISECONDS));
+        // four topics are not under /testnode !
+        CountDownLatch c = new CountDownLatch(registeredTopics - 4);
+        connection.subscribe(DEVICE_TOPIC + "/testnode/#", (topic, payload) -> c.countDown()).get(5000,
+                TimeUnit.MILLISECONDS);
+        assertTrue("Connection " + connection.getClientId() + " not retrieving all topics ",
+                c.await(5000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void retrieveOneAttribute() throws InterruptedException, ExecutionException {
         WaitForTopicValue watcher = new WaitForTopicValue(connection, DEVICE_TOPIC + "/$homie");
-        assertThat(watcher.waitForTopicValue(100), is("3.0"));
+        assertThat(watcher.waitForTopicValue(1000), is("3.0"));
     }
 
     @SuppressWarnings("null")
@@ -189,23 +201,23 @@ public class HomieImplementationTest extends JavaOSGiTest {
         // Create a scheduler
         ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(4);
 
-        property.subscribe(connection, scheduler, 100).get();
+        property.subscribe(connection, scheduler, 500).get();
 
         assertThat(property.attributes.settable, is(true));
         assertThat(property.attributes.retained, is(true));
         assertThat(property.attributes.name, is("Testprop"));
         assertThat(property.attributes.unit, is("°C"));
         assertThat(property.attributes.datatype, is(DataTypeEnum.float_));
-        assertThat(property.attributes.format, is("-100:100"));
-        verify(property).attributesReceived();
+        waitForAssert(()->assertThat(property.attributes.format, is("-100:100")));
+        verify(property, timeout(500).atLeastOnce()).attributesReceived();
 
         // Receive property value
         ChannelState channelState = spy(property.getChannelState());
         PropertyHelper.setChannelState(property, channelState);
 
-        property.startChannel(connection, scheduler, 200).get();
+        property.startChannel(connection, scheduler, 500).get();
         verify(channelState).start(any(), any(), anyInt());
-        verify(channelState).processMessage(any(), any());
+        verify(channelState, timeout(500)).processMessage(any(), any());
         verify(callback).updateChannelState(any(), any());
 
         assertThat(property.getChannelState().getCache().getChannelState(), is(new DecimalType(10)));
@@ -246,7 +258,7 @@ public class HomieImplementationTest extends JavaOSGiTest {
 
         // initialize the device, subscribe and wait.
         device.initialize(BASE_TOPIC, DEVICE_ID, Collections.emptyList());
-        device.subscribe(connection, scheduler, 200).get();
+        device.subscribe(connection, scheduler, 1500).get();
 
         assertThat(device.isInitialized(), is(true));
 
@@ -304,7 +316,7 @@ public class HomieImplementationTest extends JavaOSGiTest {
         WaitForTopicValue watcher = new WaitForTopicValue(embeddedConnection, propertyTestTopic + "/set");
         // Watch the topic. Publish a retain=false value to MQTT
         property.getChannelState().publishValue(OnOffType.OFF).get();
-        assertThat(watcher.waitForTopicValue(50), is("false"));
+        assertThat(watcher.waitForTopicValue(1000), is("false"));
 
         // Publish a retain=false value to MQTT.
         property.getChannelState().publishValue(OnOffType.ON).get();

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -122,7 +122,8 @@ public class HomieImplementationTest extends JavaOSGiTest {
         final String testNode = DEVICE_TOPIC + "/testnode";
         futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes()));
         futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes()));
-        futures.add(embeddedConnection.publish(testNode + "/$properties", "temperature,doorbell,testRetain".getBytes()));
+        futures.add(
+                embeddedConnection.publish(testNode + "/$properties", "temperature,doorbell,testRetain".getBytes()));
 
         // Add homie property topics
         final String property = testNode + "/temperature";
@@ -134,14 +135,10 @@ public class HomieImplementationTest extends JavaOSGiTest {
         futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes()));
 
         final String propertyBellTopic = testNode + "/doorbell";
-        futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes()));
-        futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes()));
-        futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype",
-                "boolean".getBytes()));
+        futures.add(embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes()));
+        futures.add(embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes()));
+        futures.add(embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes()));
+        futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype", "boolean".getBytes()));
 
         this.propertyTestTopic = testNode + "/testRetain";
         futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes()));

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -113,45 +113,45 @@ public class HomieImplementationTest extends JavaOSGiTest {
         connection.addConnectionObserver(failIfChange);
 
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$homie", "3.0".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$name", "Name".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$state", "ready".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$nodes", "testnode".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$homie", "3.0".getBytes()));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$name", "Name".getBytes()));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$state", "ready".getBytes()));
+        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$nodes", "testnode".getBytes()));
 
         // Add homie node topics
         final String testNode = DEVICE_TOPIC + "/testnode";
-        futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes()));
+        futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes()));
         futures.add(embeddedConnection.publish(testNode + "/$properties",
-                "temperature,doorbell,testRetain".getBytes(StandardCharsets.UTF_8)));
+                "temperature,doorbell,testRetain".getBytes()));
 
         // Add homie property topics
         final String property = testNode + "/temperature";
         futures.add(embeddedConnection.publish(property, "10".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes()));
+        futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes()));
         futures.add(embeddedConnection.publish(property + "/$unit", "°C".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(property + "/$datatype", "float".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(property + "/$datatype", "float".getBytes()));
+        futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes()));
 
         final String propertyBellTopic = testNode + "/doorbell";
         futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes(StandardCharsets.UTF_8)));
+                embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes()));
         futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes(StandardCharsets.UTF_8)));
+                embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes()));
         futures.add(
-                embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes(StandardCharsets.UTF_8)));
+                embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes()));
         futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype",
-                "boolean".getBytes(StandardCharsets.UTF_8)));
+                "boolean".getBytes()));
 
         this.propertyTestTopic = testNode + "/testRetain";
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes()));
         futures.add(
-                embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes(StandardCharsets.UTF_8)));
+                embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes()));
         futures.add(
-                embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes(StandardCharsets.UTF_8)));
+                embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes()));
         futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype",
-                "boolean".getBytes(StandardCharsets.UTF_8)));
+                "boolean".getBytes()));
 
         registeredTopics = futures.size();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Fixes #5905

I reworked the tests a little bit and now they succeed when using an external broker (just change the address of the publishConnection from `embeddedConnection.getHost()` to the IP/hostname of an external broker).

What I can tell is that the subscription to 'homie/#' is obviously received by moquette but NO topics are send back to the client. When using my loccal mosquitto, this works. I'm out of ideas why this happens. Either paho is really sending the messages with QoS 0 (specs allow the broker to discard those, even if retained and moquette is known to do so), moquette is ignoring teh retained flag or not properly expanding the subscription wildcard.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
