### PR TITLE
[systeminfo] Fix typo and reduce log level

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
@@ -124,7 +124,7 @@ public class SysteminfoHandler extends BaseThingHandler {
             logger.debug("Systeminfo implementation is instantiated!");
             return true;
         } catch (Exception e) {
-            logger.error("Cannot instantate Systeminfo object!", e);
+            logger.warn("Cannot instantiate Systeminfo object!", e);
             return false;
         }
     }


### PR DESCRIPTION
Fix the typographical error 'instantate' and reduce the log level on the call from ERROR to WARN.

Found this defect while reading #5921.