### PR TITLE
[snmp] add float support

### DIFF
--- a/bundles/org.openhab.binding.snmp/README.md
+++ b/bundles/org.openhab.binding.snmp/README.md
@@ -88,7 +88,8 @@ Using`TRAP` channels requires configuring the receiving port (see "Binding confi
 
 The `datatype` parameter is needed in some special cases where data is written to the target.
 The default `datatype` for `number` channels is `UINT32`, representing an unsigned integer with 32 bit length.
-Alternatively `INT32` (signed integer with 32 bit length) or `COUNTER64` (unsigned integer with 64 bit length) can be set.
+Alternatively `INT32` (signed integer with 32 bit length), `COUNTER64` (unsigned integer with 64 bit length) or `FLOAT` (floating point number) can be set.
+Floating point numbers have to be supplied (and will be send) as strings.
 For `string` channels the default `datatype` is `STRING` (i.e. the item's will be sent as a string).
 If it is set to `IPADDRESS`, an SNMP IP address object is constructed from the item's value.
 

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpDatatype.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpDatatype.java
@@ -22,6 +22,7 @@ public enum SnmpDatatype {
     INT32,
     UINT32,
     COUNTER64,
+    FLOAT,
     STRING,
     IPADDRESS
 }

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -289,7 +289,11 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
                 }
                 if (CHANNEL_TYPE_UID_NUMBER.equals(channel.getChannelTypeUID())) {
                     try {
-                        state = new DecimalType(value.toLong());
+                        if (channelConfig.datatype == SnmpDatatype.FLOAT) {
+                            state = new DecimalType(value.toString());
+                        } else {
+                            state = new DecimalType(value.toLong());
+                        }
                     } catch (UnsupportedOperationException e) {
                         logger.warn("could not convert {} to number for channel {}", value, channelUID);
                         return;
@@ -339,6 +343,7 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
                     return new Counter64((new DecimalType(((StringType) command).toString())).longValue());
                 }
                 break;
+            case FLOAT:
             case STRING:
                 if (command instanceof DecimalType) {
                     return new OctetString(((DecimalType) command).toString());

--- a/bundles/org.openhab.binding.snmp/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.snmp/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -83,6 +83,7 @@
 					<option value="UINT32">Unsigned Integer (32 bit)</option>
 					<option value="INT32">Integer (32 bit)</option>
 					<option value="COUNTER64">Counter (64 bit)</option>
+					<option value="FLOAT">Float</option>
 				</options>
 				<default>UINT32</default>
 				<limitToOptions>true</limitToOptions>

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -118,9 +118,16 @@ public class SnmpTargetHandlerTest extends JavaTest {
         assertTrue(variable.getVariable() instanceof Counter64);
         assertEquals(10000, ((Counter64) variable.getVariable()).toInt());
 
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpDatatype.FLOAT,
+                new DecimalType("12.4"), true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals("12.4", variable.getVariable().toString());
+
         variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpDatatype.INT32,
                 new StringType(TEST_STRING), false);
         assertNull(variable);
+
     }
 
     @Test
@@ -194,6 +201,16 @@ public class SnmpTargetHandlerTest extends JavaTest {
         ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
         thingHandler.onResponse(event);
         verify(thingHandlerCallback, never()).stateUpdated(eq(CHANNEL_UID), any());
+    }
+
+    @Test
+    public void testNumberChannelsProperlyUpdatingFloatValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpChannelMode.READ, SnmpDatatype.FLOAT);
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new OctetString("12.4"))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(new DecimalType("12.4")));
     }
 
     private VariableBinding handleCommandSwitchChannel(SnmpDatatype datatype, Command command, String onValue,


### PR DESCRIPTION
SNMP does not support floating point numbers. Some devices use strings with the formatted number as a workaround. This PR adds support for that.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>