### PR TITLE
[solarlog] Fix typo in solarlog binding documentation

### DIFF
--- a/bundles/org.openhab.binding.solarlog/README.md
+++ b/bundles/org.openhab.binding.solarlog/README.md
@@ -43,7 +43,7 @@ consyieldyesterday  | Wh | 112 Total consumption for the previous day; all of th
 consyieldmonth      | Wh | 113 Total consumption for the month; all of the consumption meters
 consyieldyear       | Wh | 114 Total consumption for the year; all of the consumption meters
 consyieldtotal      | Wh | 115 Accumulated total consumption, all Consumption meter
-totalPower          | Wp | 116 Installed generator power
+totalpower          | Wp | 116 Installed generator power
 
 ## More information
 


### PR DESCRIPTION
This pull request fixes a typo in the solarlog binding documentation related to the totalpower data point. It is now consistent with the channel name.