### PR TITLE
[systeminfo] Update dependencies and add null annotations

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/README.md
+++ b/bundles/org.openhab.binding.systeminfo/README.md
@@ -3,7 +3,7 @@
 System information Binding provides operating system and hardware information including:
 
 -   Operating system name, version and manufacturer;
--   CPU average recent load and load for last 1, 5, 15 minutes, name, description, number of physical and logical cores, running threads number, system uptime;
+-   CPU average load for last 1, 5, 15 minutes, name, description, number of physical and logical cores, running threads number, system uptime;
 -   Free, total and available memory;
 -   Free, total and available swap memory;
 -   Hard drive name, model and serial number;
@@ -81,7 +81,7 @@ In the list below, you can find, how are channel group and channels id`s related
 *   **group** `battery` (deviceIndex)
   * **channel** `name, remainingCapacity, remainingTime`
 *   **group** `cpu`
-  * **channel** `name, description, load, load1, load5, load15, uptime`
+  * **channel** `name, description, load1, load5, load15, uptime`
 *   **group** `sensors`
   * **channel** `cpuTemp, cpuVoltage, fanSpeed`
 *   **group** `network` (deviceIndex)
@@ -108,7 +108,6 @@ The binding introduces the following channels:
 
 | Channel ID         | Channel Description                                              | Supported item type | Default priority | Advanced |
 |--------------------|------------------------------------------------------------------|---------------------|------------------|----------|
-| load               | Recent load in percents                                          | Number              | High             | False    |
 | load1              | Load for the last 1 minute                                       | Number              | Medium           | True     |
 | load5              | Load for the last 5 minutes                                      | Number              | Medium           | True     |
 | load15             | Load for the last 15 minutes                                     | Number              | Medium           | True     |
@@ -207,7 +206,6 @@ Number Network_PacketsReceived    "Packets received"    <returnpipe>     { chann
 /* CPU information*/
 String CPU_Name                   "Name"                <none>           { channel="systeminfo:computer:work:cpu#name" }
 String CPU_Description            "Description"         <none>           { channel="systeminfo:computer:work:cpu#description" }
-Number CPU_Load                   "Load"                <none>           { channel="systeminfo:computer:work:cpu#load"}
 Number CPU_Load1                  "Load (1 min)"        <none>           { channel="systeminfo:computer:work:cpu#load1" }
 Number CPU_Load5                  "Load (5 min)"        <none>           { channel="systeminfo:computer:work:cpu#load5" }
 Number CPU_Load15                 "Load (15 min)"       <none>           { channel="systeminfo:computer:work:cpu#load15" }
@@ -281,7 +279,6 @@ Text label="Systeminfo" {
     Frame label="CPU Information" {
         Default item=CPU_Name
         Default item=CPU_Description
-        Default item=CPU_Load
         Default item=CPU_Load1
         Default item=CPU_Load5
         Default item=CPU_Load15

--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.3.0</version>
+      <version>5.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.3.0</version>
+      <version>5.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>3.13.0</version>
+      <version>4.0.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -4,9 +4,9 @@
 
     <feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <bundle dependency="true">mvn:net.java.dev.jna/jna/5.3.0</bundle>
-        <bundle dependency="true">mvn:net.java.dev.jna/jna-platform/5.3.0</bundle>
-        <bundle dependency="true">mvn:com.github.oshi/oshi-core/3.13.0</bundle>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna/5.4.0</bundle>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna-platform/5.4.0</bundle>
+        <bundle dependency="true">mvn:com.github.oshi/oshi-core/4.0.0</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.systeminfo/${project.version}</bundle>
     </feature>
 </features>

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoHandlerFactory.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoHandlerFactory.java
@@ -17,6 +17,8 @@ import static org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
@@ -33,13 +35,15 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Lyubomir Papazov - Pass systeminfo service to the SysteminfoHandler constructor
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.systeminfo")
 public class SysteminfoHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_COMPUTER);
 
-    private SysteminfoInterface systeminfo;
+    private @NonNullByDefault({}) SysteminfoInterface systeminfo;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -47,7 +51,7 @@ public class SysteminfoHandlerFactory extends BaseThingHandlerFactory {
     }
 
     @Override
-    protected ThingHandler createHandler(Thing thing) {
+    protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_COMPUTER)) {

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SysteminfoDiscoveryService.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SysteminfoDiscoveryService.java
@@ -19,6 +19,7 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
@@ -35,7 +36,9 @@ import org.slf4j.LoggerFactory;
  * {@link #DEFAULT_THING_LABEL}. The discovered Thing will have id - the hostname or {@link #DEFAULT_THING_ID}'
  *
  * @author Svilen Valkanov - Initial contribution
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.systeminfo")
 public class SysteminfoDiscoveryService extends AbstractDiscoveryService {
     public static final String DEFAULT_THING_ID = "unknown";

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
@@ -23,7 +23,8 @@ import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -46,39 +47,40 @@ import org.slf4j.LoggerFactory;
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Lyubomir Papzov - Separate the creation of the systeminfo object and its initialization
+ * @author Wouter Born - Add null annotations
  */
-
+@NonNullByDefault
 public class SysteminfoHandler extends BaseThingHandler {
     /**
      * Refresh interval for {@link #highPriorityChannels} in seconds.
      */
-    private BigDecimal refreshIntervalHighPriority;
+    private @NonNullByDefault({}) BigDecimal refreshIntervalHighPriority;
 
     /**
      * Refresh interval for {@link #mediumPriorityChannels} in seconds.
      */
-    private BigDecimal refreshIntervalMediumPriority;
+    private @NonNullByDefault({}) BigDecimal refreshIntervalMediumPriority;
 
     /**
      * Channels with priority configuration parameter set to High. They usually need frequent update of the state like
      * CPU load, or information about the free and used memory.
      * They are updated periodically at {@link #refreshIntervalHighPriority}.
      */
-    private Set<ChannelUID> highPriorityChannels = new HashSet<>();
+    private final Set<ChannelUID> highPriorityChannels = new HashSet<>();
 
     /**
      * Channels with priority configuration parameter set to Medium. These channels usually need update of the
      * state not so oft like battery capacity, storage used and etc.
      * They are updated periodically at {@link #refreshIntervalMediumPriority}.
      */
-    private Set<ChannelUID> mediumPriorityChannels = new HashSet<>();
+    private final Set<ChannelUID> mediumPriorityChannels = new HashSet<>();
 
     /**
      * Channels with priority configuration parameter set to Low. They represent static information or information
      * that is updated rare- e.g. CPU name, storage name and etc.
      * They are updated only at {@link #initialize()}.
      */
-    private Set<ChannelUID> lowPriorityChannels = new HashSet<>();
+    private final Set<ChannelUID> lowPriorityChannels = new HashSet<>();
 
     /**
      * Wait time for the creation of Item-Channel links in seconds. This delay is needed, because the Item-Channel
@@ -88,12 +90,12 @@ public class SysteminfoHandler extends BaseThingHandler {
 
     private SysteminfoInterface systeminfo;
 
-    ScheduledFuture<?> highPriorityTasks;
-    ScheduledFuture<?> mediumPriorityTasks;
+    private @Nullable ScheduledFuture<?> highPriorityTasks;
+    private @Nullable ScheduledFuture<?> mediumPriorityTasks;
 
     private Logger logger = LoggerFactory.getLogger(SysteminfoHandler.class);
 
-    public SysteminfoHandler(@NonNull Thing thing, SysteminfoInterface systeminfo) {
+    public SysteminfoHandler(Thing thing, @Nullable SysteminfoInterface systeminfo) {
         super(thing);
         if (systeminfo != null) {
             this.systeminfo = systeminfo;
@@ -238,13 +240,11 @@ public class SysteminfoHandler extends BaseThingHandler {
     }
 
     private void publishData(Set<ChannelUID> channels) {
-        if (channels != null) {
-            Iterator<ChannelUID> iter = channels.iterator();
-            while (iter.hasNext()) {
-                ChannelUID channeUID = iter.next();
-                if (isLinked(channeUID.getId())) {
-                    publishDataForChannel(channeUID);
-                }
+        Iterator<ChannelUID> iter = channels.iterator();
+        while (iter.hasNext()) {
+            ChannelUID channeUID = iter.next();
+            if (isLinked(channeUID.getId())) {
+                publishDataForChannel(channeUID);
             }
         }
     }
@@ -252,12 +252,7 @@ public class SysteminfoHandler extends BaseThingHandler {
     private void publishDataForChannel(ChannelUID channelUID) {
         State state = getInfoForChannel(channelUID);
         String channelID = channelUID.getId();
-        if (state != null) {
-            updateState(channelID, state);
-        } else {
-            logger.warn("Channel with ID {} cannot be updated! No information available for the selected device.",
-                    channelID);
-        }
+        updateState(channelID, state);
     }
 
     public Set<ChannelUID> getHighPriorityChannels() {
@@ -282,6 +277,7 @@ public class SysteminfoHandler extends BaseThingHandler {
      */
     private State getInfoForChannel(ChannelUID channelUID) {
         State state = null;
+
         String channelID = channelUID.getId();
         String channelIDWithoutGroup = channelUID.getIdWithoutGroup();
         String channelGroupID = channelUID.getGroupId();
@@ -291,7 +287,9 @@ public class SysteminfoHandler extends BaseThingHandler {
         // The channelGroup may contain deviceIndex. It must be deleted from the channelID, because otherwise the
         // switch will not find the correct method below.
         // All digits are deleted from the ID
-        channelID = channelGroupID.replaceAll("\\d+", "") + "#" + channelIDWithoutGroup;
+        if (channelGroupID != null) {
+            channelID = channelGroupID.replaceAll("\\d+", "") + "#" + channelIDWithoutGroup;
+        }
 
         try {
             switch (channelID) {
@@ -315,9 +313,6 @@ public class SysteminfoHandler extends BaseThingHandler {
                     break;
                 case CHANNEL_SENSORS_FAN_SPEED:
                     state = systeminfo.getSensorsFanSpeed(deviceIndex);
-                    break;
-                case CHANNEL_CPU_LOAD:
-                    state = systeminfo.getCpuLoad();
                     break;
                 case CHANNEL_CPU_LOAD_1:
                     state = systeminfo.getCpuLoad1();
@@ -465,22 +460,26 @@ public class SysteminfoHandler extends BaseThingHandler {
      * @return natural number (number >=0)
      */
     private int getDeviceIndex(ChannelUID channelUID) {
-        int deviceIndex = 0;
-        if (channelUID.getGroupId().contains(CHANNEL_GROUP_PROCESS)) {
+        String channelGroupID = channelUID.getGroupId();
+        if (channelGroupID == null) {
+            return 0;
+        }
+
+        if (channelGroupID.contains(CHANNEL_GROUP_PROCESS)) {
             // Only in this case the deviceIndex is part of the channel configuration - PID (Process Identifier)
             int pid = getPID(channelUID);
-            deviceIndex = pid;
             logger.debug("Channel with UID {} tracks process with PID: {}", channelUID, pid);
-        } else {
-            String channelGroupID = channelUID.getGroupId();
-            char lastChar = channelGroupID.charAt(channelGroupID.length() - 1);
-            if (Character.isDigit(lastChar)) {
-                // All non-digits are deleted from the ID
-                String deviceIndexPart = channelGroupID.replaceAll("\\D+", "");
-                deviceIndex = Integer.parseInt(deviceIndexPart);
-            }
+            return pid;
         }
-        return deviceIndex;
+
+        char lastChar = channelGroupID.charAt(channelGroupID.length() - 1);
+        if (Character.isDigit(lastChar)) {
+            // All non-digits are deleted from the ID
+            String deviceIndexPart = channelGroupID.replaceAll("\\D+", "");
+            return Integer.parseInt(deviceIndexPart);
+        }
+
+        return 0;
     }
 
     /**
@@ -492,14 +491,18 @@ public class SysteminfoHandler extends BaseThingHandler {
     private int getPID(ChannelUID channelUID) {
         int pid = 0;
         try {
-            Configuration channelProperties = this.thing.getChannel(channelUID.getId()).getConfiguration();
-            BigDecimal pidValue = (BigDecimal) channelProperties.get(PID_PARAM);
-            if (pidValue == null || pidValue.intValue() < 0) {
-                throw new IllegalArgumentException("Invalid value for Process Identifier.");
+            Channel channel = this.thing.getChannel(channelUID.getId());
+            if (channel != null) {
+                Configuration channelProperties = channel.getConfiguration();
+                BigDecimal pidValue = (BigDecimal) channelProperties.get(PID_PARAM);
+                if (pidValue == null || pidValue.intValue() < 0) {
+                    throw new IllegalArgumentException("Invalid value for Process Identifier.");
+                } else {
+                    pid = pidValue.intValue();
+                }
             } else {
-                pid = pidValue.intValue();
+                logger.debug("Channel does not exist ! Fall back to default value.");
             }
-
         } catch (ClassCastException e) {
             logger.debug("Channel configuration cannot be read ! Fall back to default value.", e);
         } catch (IllegalArgumentException e) {
@@ -523,17 +526,14 @@ public class SysteminfoHandler extends BaseThingHandler {
     }
 
     private boolean isConfigurationKeyChanged(Configuration currentConfig, Configuration newConfig, String key) {
-        if (currentConfig != null && newConfig != null) {
-            Object currentValue = currentConfig.get(key);
-            Object newValue = newConfig.get(key);
+        Object currentValue = currentConfig.get(key);
+        Object newValue = newConfig.get(key);
 
-            if (currentValue == null) {
-                return (newValue != null);
-            }
-
-            return !currentValue.equals(newValue);
+        if (currentValue == null) {
+            return (newValue != null);
         }
-        return true;
+
+        return !currentValue.equals(newValue);
     }
 
     @Override
@@ -586,13 +586,16 @@ public class SysteminfoHandler extends BaseThingHandler {
     }
 
     private void stopScheduledUpdates() {
-        if (highPriorityTasks != null) {
+        ScheduledFuture<?> localHighPriorityTasks = highPriorityTasks;
+        if (localHighPriorityTasks != null) {
             logger.debug("High prioriy tasks will not be run anymore !");
-            highPriorityTasks.cancel(true);
+            localHighPriorityTasks.cancel(true);
         }
-        if (mediumPriorityTasks != null) {
+
+        ScheduledFuture<?> localMediumPriorityTasks = mediumPriorityTasks;
+        if (localMediumPriorityTasks != null) {
             logger.debug("Medium prioriy tasks will not be run anymore !");
-            mediumPriorityTasks.cancel(true);
+            localMediumPriorityTasks.cancel(true);
         }
     }
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/DeviceNotFoundException.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/DeviceNotFoundException.java
@@ -14,12 +14,16 @@ package org.openhab.binding.systeminfo.internal.model;
 
 import java.io.IOException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link DeviceNotFoundException} is used to indicate that device can not be found on this hardware configuration, most
  * probably because the device is not installed.
  *
  * @author Svilen Valkanov - Initial contribution
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public class DeviceNotFoundException extends IOException {
     private static final long serialVersionUID = -707507777792259512L;
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/SysteminfoInterface.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/SysteminfoInterface.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.systeminfo.internal.model;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.StringType;
 
@@ -19,7 +21,9 @@ import org.eclipse.smarthome.core.library.types.StringType;
  * {@link SysteminfoInterface} defines the methods needed to provide this binding with the required system information.
  *
  * @author Svilen Valkanov - Initial contribution
+ * @author Wouter Born - Add null annotations
  */
+@NonNullByDefault
 public interface SysteminfoInterface {
 
     /**
@@ -68,32 +72,25 @@ public interface SysteminfoInterface {
     public DecimalType getCpuPhysicalCores();
 
     /**
-     * Get the recent average CPU load for all logical processors
-     *
-     * @return the load as percentage value /0-100/
-     */
-    public DecimalType getCpuLoad();
-
-    /**
      * Returns the system load average for the last minute.
      *
      * @return the load as a number of processes or null, if no information is available
      */
-    public DecimalType getCpuLoad1();
+    public @Nullable DecimalType getCpuLoad1();
 
     /**
      * Returns the system load average for the last 5 minutes.
      *
      * @return the load as number of processes or null, if no information is available
      */
-    public DecimalType getCpuLoad5();
+    public @Nullable DecimalType getCpuLoad5();
 
     /**
      * Returns the system load average for the last 15 minutes.
      *
      * @return the load as number of processes or null, if no information is available
      */
-    public DecimalType getCpuLoad15();
+    public @Nullable DecimalType getCpuLoad15();
 
     /**
      * Get the System uptime (time since boot).
@@ -136,14 +133,14 @@ public interface SysteminfoInterface {
      *
      * @return percent of available memory or null, if no information is available
      */
-    public DecimalType getMemoryAvailablePercent();
+    public @Nullable DecimalType getMemoryAvailablePercent();
 
     /**
      * Percents of used memory on the machine
      *
      * @return percent of used memory or null, if no information is available
      */
-    public DecimalType getMemoryUsedPercent();
+    public @Nullable DecimalType getMemoryUsedPercent();
 
     // Swap memory info
     /**
@@ -151,35 +148,35 @@ public interface SysteminfoInterface {
      *
      * @return memory size in MB or 0, if no there is no swap memory
      */
-    public DecimalType getSwapTotal();
+    public @Nullable DecimalType getSwapTotal();
 
     /**
      * Returns available size swap of memory
      *
      * @return memory size in MB or 0, if no there is no swap memory
      */
-    public DecimalType getSwapAvailable();
+    public @Nullable DecimalType getSwapAvailable();
 
     /**
      * Returns used size of swap memory
      *
      * @return memory size in MB or 0, if no there is no swap memory
      */
-    public DecimalType getSwapUsed();
+    public @Nullable DecimalType getSwapUsed();
 
     /**
      * Percents of available swap memory on the machine
      *
      * @return percent of available memory or null, if no there is no swap memory
      */
-    public DecimalType getSwapAvailablePercent();
+    public @Nullable DecimalType getSwapAvailablePercent();
 
     /**
      * Percents of used swap memory on the machine
      *
      * @return percent of used memory or null, if no there is no swap memory
      */
-    public DecimalType getSwapUsedPercent();
+    public @Nullable DecimalType getSwapUsedPercent();
 
     // Storage info
     /**
@@ -216,7 +213,7 @@ public interface SysteminfoInterface {
      * @return percent of available storage or null
      * @throws DeviceNotFoundException
      */
-    public DecimalType getStorageAvailablePercent(int deviceIndex) throws DeviceNotFoundException;
+    public @Nullable DecimalType getStorageAvailablePercent(int deviceIndex) throws DeviceNotFoundException;
 
     /**
      * Gets the percent of used storage on the logical volume
@@ -225,7 +222,7 @@ public interface SysteminfoInterface {
      * @return percent of used storage or null
      * @throws DeviceNotFoundException
      */
-    public DecimalType getStorageUsedPercent(int deviceIndex) throws DeviceNotFoundException;
+    public @Nullable DecimalType getStorageUsedPercent(int deviceIndex) throws DeviceNotFoundException;
 
     /**
      * Gets the name of the logical storage volume
@@ -354,14 +351,14 @@ public interface SysteminfoInterface {
      *
      * @return Temperature in degrees Celsius if available, null otherwise.
      */
-    public DecimalType getSensorsCpuTemperature();
+    public @Nullable DecimalType getSensorsCpuTemperature();
 
     /**
      * Get the information for the CPU voltage.
      *
      * @return Voltage in Volts if available, null otherwise.
      */
-    public DecimalType getSensorsCpuVoltage();
+    public @Nullable DecimalType getSensorsCpuVoltage();
 
     /**
      * Get fan speed
@@ -370,7 +367,7 @@ public interface SysteminfoInterface {
      * @return Speed in rpm or null if unable to measure fan speed
      * @throws DeviceNotFoundException
      */
-    public DecimalType getSensorsFanSpeed(int deviceIndex) throws DeviceNotFoundException;
+    public @Nullable DecimalType getSensorsFanSpeed(int deviceIndex) throws DeviceNotFoundException;
 
     // Battery info
     /**
@@ -380,7 +377,7 @@ public interface SysteminfoInterface {
      * @return minutes remaining charge or null, if the time is estimated as unlimited
      * @throws DeviceNotFoundException
      */
-    public DecimalType getBatteryRemainingTime(int deviceIndex) throws DeviceNotFoundException;
+    public @Nullable DecimalType getBatteryRemainingTime(int deviceIndex) throws DeviceNotFoundException;
 
     /**
      * Battery remaining capacity.
@@ -405,7 +402,7 @@ public interface SysteminfoInterface {
      * @param pid - the PID of the process
      * @throws DeviceNotFoundException - thrown if process with this PID can not be found
      */
-    public StringType getProcessName(int pid) throws DeviceNotFoundException;
+    public @Nullable StringType getProcessName(int pid) throws DeviceNotFoundException;
 
     /**
      * Returns the CPU usage of the process
@@ -414,7 +411,7 @@ public interface SysteminfoInterface {
      * @return - percentage value /0-100/
      * @throws DeviceNotFoundException - thrown if process with this PID can not be found
      */
-    public DecimalType getProcessCpuUsage(int pid) throws DeviceNotFoundException;
+    public @Nullable DecimalType getProcessCpuUsage(int pid) throws DeviceNotFoundException;
 
     /**
      * Returns the size of RAM memory only usage of the process
@@ -423,7 +420,7 @@ public interface SysteminfoInterface {
      * @return memory size in MB
      * @throws DeviceNotFoundException- thrown if process with this PID can not be found
      */
-    public DecimalType getProcessMemoryUsage(int pid) throws DeviceNotFoundException;
+    public @Nullable DecimalType getProcessMemoryUsage(int pid) throws DeviceNotFoundException;
 
     /**
      * Returns the full path of the executing process.
@@ -431,7 +428,7 @@ public interface SysteminfoInterface {
      * @param pid - the PID of the process
      * @throws DeviceNotFoundException - thrown if process with this PID can not be found
      */
-    public StringType getProcessPath(int pid) throws DeviceNotFoundException;
+    public @Nullable StringType getProcessPath(int pid) throws DeviceNotFoundException;
 
     /**
      * Returns the number of threads in this process.
@@ -439,6 +436,6 @@ public interface SysteminfoInterface {
      * @param pid - the PID of the process
      * @throws DeviceNotFoundException - thrown if process with this PID can not be found
      */
-    public DecimalType getProcessThreads(int pid) throws DeviceNotFoundException;
+    public @Nullable DecimalType getProcessThreads(int pid) throws DeviceNotFoundException;
 
 }

--- a/bundles/org.openhab.binding.systeminfo/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/resources/ESH-INF/thing/channels.xml
@@ -104,7 +104,6 @@
 		<channels>
 			<channel id="name" typeId="name" />
 			<channel id="description" typeId="description" />
-			<channel id="load" typeId="load" />
 			<channel id="load1" typeId="loadAverage" />
 			<channel id="load5" typeId="loadAverage" />
 			<channel id="load15" typeId="loadAverage" />
@@ -267,14 +266,6 @@
 		<description>Remaining capacity in percent</description>
 		<state readOnly="true" pattern="%.1f %%" />
 		<config-description-ref uri="systeminfo:channels:mediumpriority" />
-	</channel-type>
-
-	<channel-type id="load">
-		<item-type>Number</item-type>
-		<label>Load</label>
-		<description>Load in percent</description>
-		<state readOnly="true" pattern="%.1f %%" />
-		<config-description-ref uri="systeminfo:channels:highpriority" />
 	</channel-type>
 
 	<channel-type id="load_process">

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -54,13 +54,13 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	com.github.oshi.oshi-core;version='[3.13.0,3.13.1)',\
-	com.sun.jna;version='[5.3.0,5.3.1)',\
-	com.sun.jna.platform;version='[5.3.0,5.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	com.github.oshi.oshi-core;version='[4.0.0,4.0.1)',\
+	com.sun.jna;version='[5.4.0,5.4.1)',\
+	com.sun.jna.platform;version='[5.4.0,5.4.1)'

--- a/itests/org.openhab.binding.systeminfo.tests/pom.xml
+++ b/itests/org.openhab.binding.systeminfo.tests/pom.xml
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.3.0</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.3.0</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>3.13.0</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
@@ -124,10 +124,14 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
         // Unbind oshiSystemInfo service and bind the mock service to make the systeminfobinding tests independent of
         // the external OSHI library
-        systeminfoHandlerFactory.unbindSystemInfo(oshiSystemInfo);
+        if (oshiSystemInfo != null) {
+            systeminfoHandlerFactory.unbindSystemInfo(oshiSystemInfo);
+        }
         systeminfoHandlerFactory.bindSystemInfo(mockedSystemInfo);
 
-        managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
+        managedThingProvider =
+
+                getService(ThingProvider.class, ManagedThingProvider.class);
         assertThat(managedThingProvider, is(notNullValue()));
 
         thingRegistry = getService(ThingRegistry.class);
@@ -343,18 +347,6 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
         initializeThingWithChannel(channnelID, acceptedItemType);
         assertItemState(acceptedItemType, DEFAULT_TEST_ITEM_NAME, DEFAULT_CHANNEL_TEST_PRIORITY, UnDefType.UNDEF);
-    }
-
-    @Test
-    public void assertChannelCpuLoadIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD;
-        String acceptedItemType = "Number";
-
-        DecimalType mockedCpuLoadValue = new DecimalType(10.5);
-        when(mockedSystemInfo.getCpuLoad()).thenReturn(mockedCpuLoadValue);
-
-        initializeThingWithChannel(channnelID, acceptedItemType);
-        assertItemState(acceptedItemType, DEFAULT_TEST_ITEM_NAME, DEFAULT_CHANNEL_TEST_PRIORITY, mockedCpuLoadValue);
     }
 
     @Test

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
@@ -129,9 +129,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         }
         systeminfoHandlerFactory.bindSystemInfo(mockedSystemInfo);
 
-        managedThingProvider =
-
-                getService(ThingProvider.class, ManagedThingProvider.class);
+        managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
         assertThat(managedThingProvider, is(notNullValue()));
 
         thingRegistry = getService(ThingRegistry.class);


### PR DESCRIPTION
* Update oshi to 4.0.0
* Update jna to 5.4.0
* Add null annotations

The `cpu#load` channel is removed because its data is no longer provided by oshi. The `load1`, `load5` and `load15` channels can be used instead. On the Oracle JVM this information can also be obtained using [com.sun.management.OperatingSystemMXBean.getSystemCpuLoad()](https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/OperatingSystemMXBean.html#getSystemCpuLoad--).

See also:
* https://github.com/oshi/oshi/blob/master/UPGRADING.md
* https://github.com/oshi/oshi/blob/master/CHANGELOG.md#400-8102019

Fixes #5921