### PR TITLE
DynamicStateDescriptionProvider fixes

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
@@ -102,7 +102,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
         }
         ThingRegistry thingRegistry = this.thingRegistry;
         if (thingRegistry == null) {
-            return originalStateDescription;
+            return null;
         }
         if (CHANNEL_TYPE_BLUETHOOTH_MAC.equals(channel.getChannelTypeUID())) {
             EchoHandler handler = (EchoHandler) findHandler(channel);
@@ -266,6 +266,6 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                     .withOptions(options).build().toStateDescription();
             return result;
         }
-        return originalStateDescription;
+        return null;
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwDynamicStateDescriptionProvider.java
@@ -72,7 +72,7 @@ public class OwDynamicStateDescriptionProvider implements DynamicStateDescriptio
             logger.trace("returning new stateDescription for {}", channel.getUID());
             return descriptions.get(channel.getUID());
         } else {
-            return originalStateDescription;
+            return null;
         }
     }
 }


### PR DESCRIPTION
Don't return `originalStateDescription` as the service code depends on it being null if the specific provider called isn't handling the channel. See #3619