### PR TITLE
[lutron] Fix for stack trace in log from malformed responses

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -368,8 +368,10 @@ public class IPBridgeHandler extends BaseBridgeHandler {
                 if (handler != null) {
                     try {
                         handler.handleUpdate(type, paramString.split(","));
-                    } catch (Exception e) {
-                        logger.warn("Error processing update: {}", e.getMessage(), e);
+                    } catch (NumberFormatException e) {
+                        logger.warn("Number format exception parsing update: {}", line);
+                    } catch (RuntimeException e) {
+                        logger.warn("Runtime exception while processing update: {}", line, e);
                     }
                 } else {
                     logger.debug("No thing configured for integration ID {}", integrationId);


### PR DESCRIPTION
This is a partial fix for #5898. The change catches a number format exception that sometimes results from the bridge handler passing through a malformed response, and just logs the bad response.  It seems the bridge handler may sometimes receive these bad responses from Caseta hubs when initially establishing a connection.
