### PR TITLE
[daikin] Fix broken zone updating

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseZoneInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseZoneInfo.java
@@ -59,7 +59,7 @@ public class AirbaseZoneInfo {
 
     public Map<String, String> getParamString() {
         Map<String, String> params = new LinkedHashMap<>();
-        String onoffstring = IntStream.range(0, zone.length).mapToObj(idx -> zone[idx] ? "1" : "0").collect(Collectors.joining("%3b"));
+        String onoffstring = IntStream.range(1, zone.length).mapToObj(idx -> zone[idx] ? "1" : "0").collect(Collectors.joining("%3b"));
         params.put("zone_name", zonenames);
         params.put("zone_onoff", onoffstring);
 


### PR DESCRIPTION
Signed-off-by: Paul Smedley <paul@smedley.id.au>

<!--
Fix broken zone updating. The array was starting from 0 and sending 9 zones to the controller - only 1 through 8 are supported. Start the zone onoff string from 1 instead of 0.
-->

<!-- TITLE -->

<!--
[daikin] Fix broken zone updating
-->

<!-- DESCRIPTION -->

<!--
Minor fix for zone on Daikin Airbase
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
