### PR TITLE
[mqtt] homeassisant: Group components by device

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -34,6 +34,7 @@ import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.openhab.binding.mqtt.generic.internal.MqttThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -51,19 +52,16 @@ import org.osgi.service.component.annotations.Reference;
 @Component(immediate = false, service = { ThingTypeProvider.class, ChannelTypeProvider.class,
         ChannelGroupTypeProvider.class, MqttChannelTypeProvider.class })
 public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupTypeProvider, ChannelTypeProvider {
-    private @NonNullByDefault({}) ThingTypeRegistry typeRegistry;
+    private final ThingTypeRegistry typeRegistry;
 
     private final Map<ChannelTypeUID, ChannelType> types = new HashMap<>();
     private final Map<ChannelGroupTypeUID, ChannelGroupType> groups = new HashMap<>();
     private final Map<ThingTypeUID, ThingType> things = new HashMap<>();
 
-    @Reference
-    protected void setTypeRegistry(ThingTypeRegistry provider) {
-        this.typeRegistry = provider;
-    }
-
-    protected void unsetTypeRegistry(ThingTypeRegistry provider) {
-        this.typeRegistry = null;
+    @Activate
+    public MqttChannelTypeProvider(@Reference ThingTypeRegistry typeRegistry) {
+        super();
+        this.typeRegistry = typeRegistry;
     }
 
     @Override
@@ -92,7 +90,7 @@ public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupT
         return things.values();
     }
 
-    public Set<@NonNull ThingTypeUID> getThingTypesUIDs() {
+    public Set<@NonNull ThingTypeUID> getThingTypeUIDs() {
         return things.keySet();
     }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -137,7 +137,7 @@ public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupT
                 .withChannelDefinitions(baseType.getChannelDefinitions())
                 .withExtensibleChannelTypeIds(baseType.getExtensibleChannelTypeIds())
                 .withSupportedBridgeTypeUIDs(baseType.getSupportedBridgeTypeUIDs())
-                .withProperties(baseType.getProperties()).isListed(baseType.isListed());
+                .withProperties(baseType.getProperties()).isListed(false);
 
         String representationProperty = baseType.getRepresentationProperty();
         if (representationProperty != null) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -12,22 +12,30 @@
  */
 package org.openhab.binding.mqtt.generic;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.thing.type.ThingType;
+import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
+import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.openhab.binding.mqtt.generic.internal.MqttThingHandlerFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * An MQTT Extension might want to provide additional, dynamic channel types, based on auto-discovery.
@@ -40,11 +48,23 @@ import org.osgi.service.component.annotations.Component;
  *
  */
 @NonNullByDefault
-@Component(immediate = false, service = { ChannelTypeProvider.class, ChannelGroupTypeProvider.class,
-        MqttChannelTypeProvider.class })
-public class MqttChannelTypeProvider implements ChannelGroupTypeProvider, ChannelTypeProvider {
+@Component(immediate = false, service = { ThingTypeProvider.class, ChannelTypeProvider.class,
+        ChannelGroupTypeProvider.class, MqttChannelTypeProvider.class })
+public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupTypeProvider, ChannelTypeProvider {
+    private @NonNullByDefault({}) ThingTypeRegistry typeRegistry;
+
     private final Map<ChannelTypeUID, ChannelType> types = new HashMap<>();
     private final Map<ChannelGroupTypeUID, ChannelGroupType> groups = new HashMap<>();
+    private final Map<ThingTypeUID, ThingType> things = new HashMap<>();
+
+    @Reference
+    protected void setTypeRegistry(ThingTypeRegistry provider) {
+        this.typeRegistry = provider;
+    }
+
+    protected void unsetTypeRegistry(ThingTypeRegistry provider) {
+        this.typeRegistry = null;
+    }
 
     @Override
     public @Nullable Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
@@ -67,6 +87,20 @@ public class MqttChannelTypeProvider implements ChannelGroupTypeProvider, Channe
         return groups.values();
     }
 
+    @Override
+    public Collection<@NonNull ThingType> getThingTypes(@Nullable Locale locale) {
+        return things.values();
+    }
+
+    public Set<@NonNull ThingTypeUID> getThingTypesUIDs() {
+        return things.keySet();
+    }
+
+    @Override
+    public @Nullable ThingType getThingType(ThingTypeUID thingTypeUID, @Nullable Locale locale) {
+        return things.get(thingTypeUID);
+    }
+
     public void removeChannelType(ChannelTypeUID uid) {
         types.remove(uid);
     }
@@ -81,5 +115,47 @@ public class MqttChannelTypeProvider implements ChannelGroupTypeProvider, Channe
 
     public void setChannelType(ChannelTypeUID uid, ChannelType type) {
         types.put(uid, type);
+    }
+
+    public void removeThingType(ThingTypeUID uid) {
+        things.remove(uid);
+    }
+
+    public void setThingType(ThingTypeUID uid, ThingType type) {
+        things.put(uid, type);
+    }
+
+    public void setThingTypeIfAbsent(ThingTypeUID uid, ThingType type) {
+        things.putIfAbsent(uid, type);
+    }
+
+    public ThingTypeBuilder derive(ThingTypeUID newTypeId, ThingTypeUID baseTypeId) {
+        ThingType baseType = typeRegistry.getThingType(baseTypeId);
+
+        ThingTypeBuilder result = ThingTypeBuilder.instance(newTypeId, baseType.getLabel())
+                .withChannelGroupDefinitions(baseType.getChannelGroupDefinitions())
+                .withChannelDefinitions(baseType.getChannelDefinitions())
+                .withExtensibleChannelTypeIds(baseType.getExtensibleChannelTypeIds())
+                .withSupportedBridgeTypeUIDs(baseType.getSupportedBridgeTypeUIDs())
+                .withProperties(baseType.getProperties()).isListed(baseType.isListed());
+
+        String representationProperty = baseType.getRepresentationProperty();
+        if (representationProperty != null) {
+            result = result.withRepresentationProperty(representationProperty);
+        }
+        URI configDescriptionURI = baseType.getConfigDescriptionURI();
+        if (configDescriptionURI != null) {
+            result = result.withConfigDescriptionURI(configDescriptionURI);
+        }
+        String category = baseType.getCategory();
+        if (category != null) {
+            result = result.withCategory(category);
+        }
+        String description = baseType.getDescription();
+        if (description != null) {
+            result = result.withDescription(description);
+        }
+
+        return result;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttThingHandlerFactory.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -27,7 +28,6 @@ import org.eclipse.smarthome.core.transform.TransformationHelper;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.handler.HomeAssistantThingHandler;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -50,7 +50,12 @@ public class MqttThingHandlerFactory extends BaseThingHandlerFactory implements 
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
-        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID) || isHomeassistantDynamicType(thingTypeUID);
+    }
+
+    private boolean isHomeassistantDynamicType(ThingTypeUID thingTypeUID) {
+        return StringUtils.equals(MqttBindingConstants.BINDING_ID, thingTypeUID.getBindingId())
+                && StringUtils.startsWith(thingTypeUID.getId(), MqttBindingConstants.HOMEASSISTANT_MQTT_THING.getId());
     }
 
     @Activate
@@ -78,7 +83,7 @@ public class MqttThingHandlerFactory extends BaseThingHandlerFactory implements 
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(MqttBindingConstants.HOMEASSISTANT_MQTT_THING)) {
+        if (supportsThingType(thingTypeUID)) {
             return new HomeAssistantThingHandler(thing, typeProvider, this, 10000, 2000);
         }
         return null;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
@@ -19,8 +19,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelGroupUID;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
@@ -29,9 +31,11 @@ import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
+import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.CFactory.ComponentConfiguration;
+import org.openhab.binding.mqtt.homeassistant.internal.handler.HomeAssistantThingHandler;
 
 /**
  * A HomeAssistant component is comparable to an ESH channel group.
@@ -56,6 +60,9 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
     protected final String channelConfigurationJson;
     protected final C channelConfiguration;
 
+    protected boolean configSeen;
+    protected @Nullable CChannel availablityChannel;
+
     /**
      * Provide a thingUID and HomeAssistant topic ID to determine the ESH channel group UID and type.
      *
@@ -77,10 +84,40 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
 
         this.channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, groupId);
         this.channelGroupUID = new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
+
+        this.configSeen = false;
+
+        if (StringUtils.isNotBlank(this.channelConfiguration.availability_topic)) {
+            OnOffValue value = new OnOffValue(this.channelConfiguration.payload_available,
+                    this.channelConfiguration.payload_not_available);
+
+            availablityChannel = buildChannel(HomeAssistantThingHandler.AVAILABILITY_CHANNEL, value,
+                    channelConfiguration.name + " availability").listener(componentConfiguration.getUpdateListener())//
+                            .stateTopic(channelConfiguration.availability_topic)//
+                            .build(false);
+        }
     }
 
     protected CChannel.Builder buildChannel(String channelID, Value valueState, String label) {
         return new CChannel.Builder(this, componentConfiguration, channelID, valueState, label);
+    }
+
+    public void setConfigSeen() {
+        this.configSeen = true;
+    }
+
+    private @Nullable OnOffType getAvailability() {
+        @Nullable
+        CChannel channel = this.availablityChannel;
+
+        if (channel == null) {
+            return OnOffType.ON;
+        }
+        return channel.getState().getCache().getChannelState().as(OnOffType.class);
+    }
+
+    public boolean isActive() {
+        return this.configSeen && getAvailability() == OnOffType.ON;
     }
 
     /**
@@ -93,8 +130,14 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      */
     public CompletableFuture<@Nullable Void> start(MqttBrokerConnection connection, ScheduledExecutorService scheduler,
             int timeout) {
-        return channels.values().stream().map(v -> v.start(connection, scheduler, timeout))
-                .reduce(CompletableFuture.completedFuture(null), (f, v) -> f.thenCompose(b -> v));
+        CompletableFuture<@Nullable Void> all = CompletableFuture.completedFuture(null);
+
+        if (availablityChannel != null) {
+            all = all.thenCompose(v -> availablityChannel.start(connection, scheduler, timeout));
+        }
+
+        return channels.values().stream().map(v -> v.start(connection, scheduler, timeout)).reduce(all,
+                (f, v) -> f.thenCompose(b -> v));
     }
 
     /**
@@ -104,8 +147,12 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      *         exceptionally on errors.
      */
     public CompletableFuture<@Nullable Void> stop() {
-        return channels.values().stream().map(v -> v.stop()).reduce(CompletableFuture.completedFuture(null),
-                (f, v) -> f.thenCompose(b -> v));
+        CompletableFuture<@Nullable Void> all = CompletableFuture.completedFuture(null);
+
+        if (availablityChannel != null) {
+            all = all.thenCompose(v -> availablityChannel.stop());
+        }
+        return channels.values().stream().map(v -> v.stop()).reduce(all, (f, v) -> f.thenCompose(b -> v));
     }
 
     /**
@@ -191,6 +238,9 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      * to the MQTT broker got lost.
      */
     public void resetState() {
+        if (availablityChannel != null) {
+            availablityChannel.resetState();
+        }
         channels.values().forEach(c -> c.resetState());
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -21,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ChannelGroupUID;
@@ -76,15 +73,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
 
         this.haID = componentConfiguration.getHaID();
 
-        String groupId = channelConfiguration.unique_id;
-        if (groupId == null || StringUtils.isBlank(groupId)) {
-            groupId = this.haID.getFallbackGroupId();
-        }
-        try {
-            groupId = URLEncoder.encode(groupId, "UTF-8").replace(".", "%2E");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        String groupId = this.haID.getGroupId(channelConfiguration.unique_id);
 
         this.channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, groupId);
         this.channelGroupUID = new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/BaseChannelConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/BaseChannelConfiguration.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.util.UIDUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.JsonAdapter;
@@ -136,11 +135,7 @@ public abstract class BaseChannelConfiguration {
         if (result == null) {
             result = unique_id;
         }
-        try {
-            return URLEncoder.encode(result != null ? result : defaultId, "UTF-8").replace(".", "%2E");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return UIDUtils.encode(result != null ? result : defaultId);
     }
 
     public Map<String, Object> appendToProperties(Map<String, Object> properties) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/BaseChannelConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/BaseChannelConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -110,6 +112,35 @@ public abstract class BaseChannelConfiguration {
     static class Connection {
         protected @Nullable String type;
         protected @Nullable String identifier;
+    }
+
+    public String getThingName() {
+        @Nullable
+        String result = null;
+
+        if (this.device != null) {
+            result = this.device.name;
+        }
+        if (result == null) {
+            result = name;
+        }
+        return result;
+    }
+
+    public String getThingId(String defaultId) {
+        @Nullable
+        String result = null;
+        if (this.device != null) {
+            result = this.device.getId();
+        }
+        if (result == null) {
+            result = unique_id;
+        }
+        try {
+            return URLEncoder.encode(result != null ? result : defaultId, "UTF-8").replace(".", "%2E");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Map<String, Object> appendToProperties(Map<String, Object> properties) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
@@ -13,10 +13,13 @@
 package org.openhab.binding.mqtt.homeassistant.internal;
 
 import java.lang.ref.WeakReference;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -25,6 +28,7 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
+import org.openhab.binding.mqtt.homeassistant.internal.util.FutureCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +55,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     private WeakReference<@Nullable MqttBrokerConnection> connectionRef = new WeakReference<>(null);
     protected @NonNullByDefault({}) ComponentDiscovered discoveredListener;
     private int discoverTime;
-    private String topic = "";
+    private Set<String> topics = new HashSet<>();
 
     /**
      * Implement this to get notified of new components
@@ -82,10 +86,16 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         if (!topic.endsWith("/config")) {
             return;
         }
+
         HaID haID = new HaID(topic);
         String config = new String(payload);
-        AbstractComponent<?> component = CFactory.createComponent(thingUID, haID, config, updateListener, gson,
-                transformationServiceProvider);
+
+        AbstractComponent<?> component = null;
+
+        if (config.length() > 0) {
+            component = CFactory.createComponent(thingUID, haID, config, updateListener, gson,
+                    transformationServiceProvider);
+        }
         if (component != null) {
             logger.trace("Found HomeAssistant thing {} component {}", haID.objectID, haID.component);
             if (discoveredListener != null) {
@@ -115,15 +125,16 @@ public class DiscoverComponents implements MqttMessageSubscriber {
      *         Completes immediately if the timeout is disabled.
      */
     public CompletableFuture<@Nullable Void> startDiscovery(MqttBrokerConnection connection, int discoverTime,
-            HaID topicDescription, ComponentDiscovered componentsDiscoveredListener) {
+            Set<HaID> topicDescriptions, ComponentDiscovered componentsDiscoveredListener) {
 
-        this.topic = topicDescription.getTopic("config");
+        this.topics = topicDescriptions.stream().map(id -> id.getTopic("config")).collect(Collectors.toSet());
         this.discoverTime = discoverTime;
         this.discoveredListener = componentsDiscoveredListener;
         this.connectionRef = new WeakReference<>(connection);
 
         // Subscribe to the wildcard topic and start receive MQTT retained topics
-        connection.subscribe(topic, this).thenRun(this::subscribeSuccess).exceptionally(this::subscribeFail);
+        this.topics.parallelStream().map(t -> connection.subscribe(t, this)).collect(FutureCollector.allOf())
+                .thenRun(this::subscribeSuccess).exceptionally(this::subscribeFail);
 
         return discoverFinishedFuture;
     }
@@ -134,7 +145,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         if (connection != null && discoverTime > 0) {
             this.stopDiscoveryFuture = scheduler.schedule(() -> {
                 this.stopDiscoveryFuture = null;
-                connection.unsubscribe(topic, this);
+                this.topics.parallelStream().forEach(t -> connection.unsubscribe(t, this));
                 this.discoveredListener = null;
                 discoverFinishedFuture.complete(null);
             }, discoverTime, TimeUnit.MILLISECONDS);
@@ -153,7 +164,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         this.discoveredListener = null;
         final MqttBrokerConnection connection = connectionRef.get();
         if (connection != null) {
-            connection.unsubscribe(topic, this);
+            this.topics.parallelStream().forEach(t -> connection.unsubscribe(t, this));
             connectionRef.clear();
         }
         discoverFinishedFuture.completeExceptionally(e);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
@@ -97,6 +97,8 @@ public class DiscoverComponents implements MqttMessageSubscriber {
                     transformationServiceProvider);
         }
         if (component != null) {
+            component.setConfigSeen();
+
             logger.trace("Found HomeAssistant thing {} component {}", haID.objectID, haID.component);
             if (discoveredListener != null) {
                 discoveredListener.componentDiscovered(haID, component);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -185,16 +187,26 @@ public class HaID {
      * The default group id is the unique_id of the component, given in the config-json.
      * If the unique id is not set, then a fallback is constructed from the HaID information.
      *
-     * @return fallback group id
+     * @return group id
      */
-    public String getFallbackGroupId() {
-        StringBuilder str = new StringBuilder();
+    public String getGroupId(@Nullable final String uniqueId) {
+        String result = uniqueId;
 
-        if (StringUtils.isNotBlank(nodeID)) {
-            str.append(nodeID).append('_');
+        if (StringUtils.isBlank(result)) {
+            StringBuilder str = new StringBuilder();
+
+            if (StringUtils.isNotBlank(nodeID)) {
+                str.append(nodeID).append('_');
+            }
+            str.append(objectID).append('_').append(component);
+            result = str.toString();
         }
-        str.append(objectID).append('_').append(component);
-        return str.toString();
+
+        try {
+            return URLEncoder.encode(result, "UTF-8").replace(".", "%2E");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -109,9 +109,9 @@ public class HaID {
      * @return newly created HaID
      */
     public static HaID fromConfig(String baseTopic, Configuration config) {
-        String objectID = (String) config.get("objectid");
-        String nodeID = (String) config.getProperties().getOrDefault("nodeid", "");
         String component = (String) config.get("component");
+        String nodeID = (String) config.getProperties().getOrDefault("nodeid", "");
+        String objectID = (String) config.get("objectid");
         return new HaID(baseTopic, objectID, nodeID, component);
     }
 
@@ -145,41 +145,40 @@ public class HaID {
     public static Collection<HaID> fromConfig(HandlerConfiguration config) {
         Collection<HaID> result = new ArrayList<>();
 
-        for (String objectID : config.objectid.split("\\s?,\\s?")) {
-            String nodeID = "";
+        for (String topic : config.topics) {
+            String[] parts = topic.split("/");
 
-            if (StringUtils.contains(objectID, '/')) {
-                String[] parts = objectID.split("/");
-
-                if (parts.length != 2) {
+            switch (parts.length) {
+                case 2:
+                    result.add(new HaID(config.basetopic, parts[1], "", parts[0]));
+                    break;
+                case 3:
+                    result.add(new HaID(config.basetopic, parts[2], parts[1], parts[0]));
+                    break;
+                default:
                     throw new IllegalArgumentException(
-                            "Bad configuration. objectid must be <objectId> or <nodeId>/<objectId>!");
-                }
-                nodeID = parts[0];
-                objectID = parts[1];
+                            "Bad configuration. topic must be <component>/<objectId> or <component>/<nodeId>/<objectId>!");
             }
-            result.add(new HaID(config.basetopic, objectID, nodeID, "+"));
         }
         return result;
     }
 
     /**
-     * Return the object ID to put into the HandlerConfiguration for this component.
+     * Return the topic to put into the HandlerConfiguration for this component.
      * <p>
      * <code>objectid</code> in the thing configuration will be
      * <code>nodeID/objectID<code> from the HaID, if <code>nodeID</code> is not empty.
      * <p>
-     * <code>component</code> value will not be preserved.
      *
-     * @return the object id
+     * @return the short topic.
      */
-    public String toOjectId() {
+    public String toShortTopic() {
         String objectID = this.objectID;
         if (StringUtils.isNotBlank(nodeID)) {
             objectID = nodeID + "/" + objectID;
         }
 
-        return objectID;
+        return component + "/" + objectID;
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -21,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.util.UIDUtils;
 
 /**
  * HomeAssistant MQTT components use a specific MQTT topic layout,
@@ -192,7 +191,8 @@ public class HaID {
     public String getGroupId(@Nullable final String uniqueId) {
         String result = uniqueId;
 
-        if (StringUtils.isBlank(result)) {
+        // the null test is only here so the compile knows, result is not null afterwards
+        if (result == null || StringUtils.isBlank(result)) {
             StringBuilder str = new StringBuilder();
 
             if (StringUtils.isNotBlank(nodeID)) {
@@ -202,11 +202,7 @@ public class HaID {
             result = str.toString();
         }
 
-        try {
-            return URLEncoder.encode(result, "UTF-8").replace(".", "%2E");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return UIDUtils.encode(result);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HandlerConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HandlerConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -31,21 +33,44 @@ public class HandlerConfiguration {
      * The MQTT prefix topic
      */
     public String basetopic;
+
     /**
      * hint: cannot be final, or <code>getConfigAs</code> will not work.
-     * The object id. This is comparable to a Homie Device.
-     * For multiple components in one thing, this is a comma separated list of object ids.
+     * List of configuration topics.
+     * <ul>
+     * <li>
+     * Each topic is gets the base topic prepended.
+     * </li>
+     * <li>
+     * each topic has:
+     * <ol>
+     * <li>
+     * <code>component</code> (e.g. "switch", "light", ...)
+     * </li>
+     * <li>
+     * <code>node_id</code> (optional)
+     * </li>
+     * <li>
+     * <code>object_id</code> This is only to allow for separate topics for each device
+     * </li>
+     * <li>
+     * "config"
+     * </li>
+     * </ol>
+     * </li>
+     * </ul>
+     *
      */
-    public String objectid;
+    public List<String> topics;
 
     public HandlerConfiguration() {
-        this("homeassistant", "");
+        this("homeassistant", Collections.emptyList());
     }
 
-    public HandlerConfiguration(String basetopic, String objectid) {
+    public HandlerConfiguration(String basetopic, List<String> topics) {
         super();
         this.basetopic = basetopic;
-        this.objectid = objectid;
+        this.topics = topics;
     }
 
     /**
@@ -56,7 +81,7 @@ public class HandlerConfiguration {
      */
     public <T extends Map<String, Object>> T appendToProperties(T properties) {
         properties.put("basetopic", basetopic);
-        properties.put("objectid", objectid);
+        properties.put("topics", topics);
         return properties;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HandlerConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HandlerConfiguration.java
@@ -34,6 +34,7 @@ public class HandlerConfiguration {
     /**
      * hint: cannot be final, or <code>getConfigAs</code> will not work.
      * The object id. This is comparable to a Homie Device.
+     * For multiple components in one thing, this is a comma separated list of object ids.
      */
     public String objectid;
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.mqtt.homeassistant.internal.discovery;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -23,14 +24,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.discovery.AbstractMQTTDiscovery;
 import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryService;
+import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.BaseChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.ChannelConfigurationTypeAdapterFactory;
@@ -54,7 +59,8 @@ import com.google.gson.GsonBuilder;
 @NonNullByDefault
 public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     private final Logger logger = LoggerFactory.getLogger(HomeAssistantDiscovery.class);
-    protected final Map<String, Set<String>> componentsPerThingID = new TreeMap<>();
+    protected final Map<String, Set<HaID>> componentsPerThingID = new TreeMap<>();
+    protected final Map<String, ThingUID> thingIDPerTopic = new TreeMap<>();
     private @Nullable ScheduledFuture<?> future;
     private final Gson gson;
 
@@ -74,14 +80,17 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
     static final String BASE_TOPIC = "homeassistant";
 
+    @NonNullByDefault({})
+    protected MqttChannelTypeProvider typeProvider;
+
+    @NonNullByDefault({})
+    protected MQTTTopicDiscoveryService mqttTopicDiscovery;
+
     public HomeAssistantDiscovery() {
         super(Stream.of(MqttBindingConstants.HOMEASSISTANT_MQTT_THING).collect(Collectors.toSet()), 3, true,
                 BASE_TOPIC + "/#");
         this.gson = new GsonBuilder().registerTypeAdapterFactory(new ChannelConfigurationTypeAdapterFactory()).create();
     }
-
-    @NonNullByDefault({})
-    protected MQTTTopicDiscoveryService mqttTopicDiscovery;
 
     @Reference
     public void setMQTTTopicDiscoveryService(MQTTTopicDiscoveryService service) {
@@ -98,12 +107,13 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         return mqttTopicDiscovery;
     }
 
-    /**
-     * @param topic A topic like "homeassistant/binary_sensor/garden/config"
-     * @return Returns the "mydevice" part of the example
-     */
-    public static HaID determineTopicParts(String topic) {
-        return new HaID(topic);
+    @Reference
+    protected void setTypeProvider(MqttChannelTypeProvider provider) {
+        this.typeProvider = provider;
+    }
+
+    protected void unsetTypeProvider(MqttChannelTypeProvider provider) {
+        this.typeProvider = null;
     }
 
     /**
@@ -119,6 +129,11 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     }
 
     @Override
+    public Set<@NonNull ThingTypeUID> getSupportedThingTypes() {
+        return typeProvider.getThingTypesUIDs();
+    }
+
+    @Override
     public void receivedMessage(ThingUID connectionBridge, MqttBrokerConnection connection, String topic,
             byte[] payload) {
         // For HomeAssistant we need to subscribe to a wildcard topic, because topics can either be:
@@ -129,14 +144,6 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
             return;
         }
 
-        // We will of course find multiple of the same unique Thing IDs, for each different component another one.
-        // Therefore the components are assembled into a list and given to the DiscoveryResult label for the user to
-        // easily recognize object capabilities.
-        HaID topicParts = determineTopicParts(topic);
-        final String thingID = topicParts.getFallbackGroupId();
-        final ThingUID thingUID = new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge,
-                thingID);
-
         // Reset the found-component timer.
         // We will collect components for the thing label description for another 2 seconds.
         final ScheduledFuture<?> future = this.future;
@@ -145,23 +152,37 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         }
         this.future = scheduler.schedule(componentsPerThingID::clear, 2, TimeUnit.SECONDS);
 
-        // We need to keep track of already found component topics for a specific object_id/node_id
-        Set<String> components = componentsPerThingID.getOrDefault(thingID, new HashSet<>());
-        if (components.contains(topicParts.component)) {
-            logger.trace("Discovered an already known component {}", topicParts.component);
-            return; // If we already know about this object component, ignore the discovered topic.
-        }
-        components.add(topicParts.component);
-        componentsPerThingID.put(thingID, components);
-
-        final String componentNames = components.stream().map(c -> HA_COMP_TO_NAME.getOrDefault(c, c))
-                .collect(Collectors.joining(","));
-
         BaseChannelConfiguration config = BaseChannelConfiguration
                 .fromString(new String(payload, StandardCharsets.UTF_8), gson);
 
+        // We will of course find multiple of the same unique Thing IDs, for each different component another one.
+        // Therefore the components are assembled into a list and given to the DiscoveryResult label for the user to
+        // easily recognize object capabilities.
+
+        HaID haID = new HaID(topic);
+        final String thingID = config.getThingId(haID.objectID);
+
+        final ThingTypeUID typeID = new ThingTypeUID(MqttBindingConstants.BINDING_ID,
+                MqttBindingConstants.HOMEASSISTANT_MQTT_THING.getId() + "_" + thingID);
+
+        ThingType type = typeProvider.derive(typeID, MqttBindingConstants.HOMEASSISTANT_MQTT_THING).build();
+        typeProvider.setThingTypeIfAbsent(typeID, type);
+
+        final ThingUID thingUID = new ThingUID(typeID, connectionBridge, thingID);
+
+        thingIDPerTopic.put(topic, thingUID);
+
+        // We need to keep track of already found component topics for a specific thing
+        Set<HaID> components = componentsPerThingID.computeIfAbsent(thingID, key -> new HashSet<>());
+        components.add(haID);
+
+        final String componentNames = components.stream().map(id -> id.component)
+                .map(c -> HA_COMP_TO_NAME.getOrDefault(c, c)).collect(Collectors.joining(", "));
+
+        final String objectids = components.stream().map(id -> id.toOjectId()).collect(Collectors.joining(","));
+
         Map<String, Object> properties = new HashMap<>();
-        HandlerConfiguration handlerConfig = topicParts.toHandlerConfiguration();
+        HandlerConfiguration handlerConfig = new HandlerConfiguration(haID.baseTopic, objectids);
         properties = handlerConfig.appendToProperties(properties);
         properties = config.appendToProperties(properties);
         // First remove an already discovered thing with the same ID
@@ -169,7 +190,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         // Because we need the new properties map with the updated "components" list
         thingDiscovered(DiscoveryResultBuilder.create(thingUID).withProperties(properties)
                 .withRepresentationProperty("objectid").withBridge(connectionBridge)
-                .withLabel(config.name + " (" + componentNames + ")").build());
+                .withLabel(config.getThingName() + " (" + componentNames + ")").build());
     }
 
     @Override
@@ -177,9 +198,18 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         if (!topic.endsWith("/config")) {
             return;
         }
-        final String thingID = determineTopicParts(topic).objectID;
-        componentsPerThingID.remove(thingID);
-        thingRemoved(new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge, thingID));
+        if (thingIDPerTopic.containsKey(topic)) {
+            ThingUID thingUID = thingIDPerTopic.remove(topic);
+            final String thingID = thingUID.getId();
+
+            HaID haID = new HaID(topic);
+
+            Set<HaID> components = componentsPerThingID.getOrDefault(thingID, Collections.emptySet());
+            components.remove(haID);
+            if (components.isEmpty()) {
+                thingRemoved(thingUID);
+            }
+        }
     }
 
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -16,13 +16,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -87,8 +87,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     protected MQTTTopicDiscoveryService mqttTopicDiscovery;
 
     public HomeAssistantDiscovery() {
-        super(Stream.of(MqttBindingConstants.HOMEASSISTANT_MQTT_THING).collect(Collectors.toSet()), 3, true,
-                BASE_TOPIC + "/#");
+        super(null, 3, true, BASE_TOPIC + "/#");
         this.gson = new GsonBuilder().registerTypeAdapterFactory(new ChannelConfigurationTypeAdapterFactory()).create();
     }
 
@@ -114,18 +113,6 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
     protected void unsetTypeProvider(MqttChannelTypeProvider provider) {
         this.typeProvider = null;
-    }
-
-    /**
-     * Returns true if the version is something like "3.x". We accept
-     * version 3 up to but not including version 4 of the homie spec.
-     */
-    public static boolean checkVersion(String versionString) {
-        String[] strings = versionString.split("\\.");
-        if (strings.length < 2) {
-            return false;
-        }
-        return strings[0].equals("3");
     }
 
     @Override
@@ -179,10 +166,10 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         final String componentNames = components.stream().map(id -> id.component)
                 .map(c -> HA_COMP_TO_NAME.getOrDefault(c, c)).collect(Collectors.joining(", "));
 
-        final String objectids = components.stream().map(id -> id.toOjectId()).collect(Collectors.joining(","));
+        final List<String> topics = components.stream().map(id -> id.toShortTopic()).collect(Collectors.toList());
 
         Map<String, Object> properties = new HashMap<>();
-        HandlerConfiguration handlerConfig = new HandlerConfiguration(haID.baseTopic, objectids);
+        HandlerConfiguration handlerConfig = new HandlerConfiguration(haID.baseTopic, topics);
         properties = handlerConfig.appendToProperties(properties);
         properties = config.appendToProperties(properties);
         // First remove an already discovered thing with the same ID

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -58,6 +58,7 @@ import com.google.gson.GsonBuilder;
 @Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.mqttha")
 @NonNullByDefault
 public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
+    @SuppressWarnings("unused")
     private final Logger logger = LoggerFactory.getLogger(HomeAssistantDiscovery.class);
     protected final Map<String, Set<HaID>> componentsPerThingID = new TreeMap<>();
     protected final Map<String, ThingUID> thingIDPerTopic = new TreeMap<>();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -117,7 +117,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
     @Override
     public Set<@NonNull ThingTypeUID> getSupportedThingTypes() {
-        return typeProvider.getThingTypesUIDs();
+        return typeProvider.getThingTypeUIDs();
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -116,8 +116,8 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     @Override
     public void initialize() {
         config = getConfigAs(HandlerConfiguration.class);
-        if (StringUtils.isEmpty(config.objectid)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Device ID unknown");
+        if (CollectionUtils.isEmpty(config.topics)) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "IDevice topic unknown");
             return;
         }
         discoveryHomeAssistantIDs.addAll(HaID.fromConfig(config));

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/util/FutureCollector.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/util/FutureCollector.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.homeassistant.internal.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Collector to combine a stream of CompletableFutures.
+ *
+ * @author Jochen Klein - Initial contribution
+ *
+ */
+public class FutureCollector {
+
+    public static <X> Collector<CompletableFuture<X>, Set<CompletableFuture<X>>, CompletableFuture<Void>> allOf() {
+        return Collector.<CompletableFuture<X>, Set<CompletableFuture<X>>, CompletableFuture<Void>> of(
+                (Supplier<Set<CompletableFuture<X>>>) HashSet::new, Set::add, (left, right) -> {
+                    left.addAll(right);
+                    return left;
+                }, a -> {
+                    return CompletableFuture.allOf(a.toArray(new CompletableFuture[a.size()]));
+                }, Collector.Characteristics.UNORDERED);
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
@@ -10,6 +10,11 @@
 			<description>Type of the channel group.</description>
 			<default></default>
 		</parameter>
+        <parameter name="component" type="text" readOnly="true" required="true">
+            <label>Component</label>
+            <description>HomeAssistant component type (e.g. binary_sensor, switch, light)</description>
+            <default></default>
+        </parameter>
 		<parameter name="nodeid" type="text" readOnly="true">
 			<label>Node ID</label>
 			<description>Optional node name of the component</description>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/thing/homeassistant-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/thing/homeassistant-thing.xml
@@ -12,9 +12,9 @@
 		<label>HomeAssistant MQTT Component</label>
 		<description>You need a configured Broker first. This Thing represents a device, that follows the "HomeAssistant MQTT Component" specification.</description>
 		<config-description>
-			<parameter name="objectid" type="text" required="true">
-				<label>Object ID</label>
-				<description>HomeAssistant Object ID</description>
+			<parameter name="topics" type="text" required="true" multiple="true">
+				<label>MQTT config topic</label>
+				<description>List of HomeAssistant configuration topics (e.g. /homeassistant/switch/4711/config)</description>
 			</parameter>
 
 			<parameter name="basetopic" type="text" required="true">

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HAConfigurationTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HAConfigurationTests.java
@@ -20,8 +20,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
+import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.junit.Test;
+import org.openhab.binding.mqtt.homeassistant.internal.BaseChannelConfiguration.Connection;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -64,14 +67,21 @@ public class HAConfigurationTests {
         assertThat(config.payload_not_available, is("G"));
 
         assertThat(config.device, is(notNullValue()));
-        assertThat(config.device.identifiers, contains("H"));
-        assertThat(config.device.connections, is(notNullValue()));
-        assertThat(config.device.connections.get(0).type, is("I1"));
-        assertThat(config.device.connections.get(0).identifier, is("I2"));
-        assertThat(config.device.name, is("J"));
-        assertThat(config.device.model, is("K"));
-        assertThat(config.device.sw_version, is("L"));
-        assertThat(config.device.manufacturer, is("M"));
+
+        BaseChannelConfiguration.Device device = config.device;
+        if (device != null) {
+            assertThat(device.identifiers, contains("H"));
+            assertThat(device.connections, is(notNullValue()));
+            List<@NonNull Connection> connections = device.connections;
+            if (connections != null) {
+                assertThat(connections.get(0).type, is("I1"));
+                assertThat(connections.get(0).identifier, is("I2"));
+            }
+            assertThat(device.name, is("J"));
+            assertThat(device.model, is("K"));
+            assertThat(device.sw_version, is("L"));
+            assertThat(device.manufacturer, is("M"));
+        }
     }
 
     @Test
@@ -84,8 +94,12 @@ public class HAConfigurationTests {
         assertThat(config.availability_topic, is("D/E"));
         assertThat(config.state_topic, is("O/D/"));
         assertThat(config.command_topic, is("P~Q"));
-        assertThat(config.device.identifiers, contains("H"));
+        assertThat(config.device, is(notNullValue()));
 
+        BaseChannelConfiguration.Device device = config.device;
+        if (device != null) {
+            assertThat(device.identifiers, contains("H"));
+        }
     }
 
     @Test
@@ -95,7 +109,6 @@ public class HAConfigurationTests {
         ComponentFan.ChannelConfiguration config = BaseChannelConfiguration.fromString(json, gson,
                 ComponentFan.ChannelConfiguration.class);
         assertThat(config.name, is("Bedroom Fan"));
-
     }
 
     @Test
@@ -104,8 +117,12 @@ public class HAConfigurationTests {
 
         ComponentFan.ChannelConfiguration config = BaseChannelConfiguration.fromString(json, gson,
                 ComponentFan.ChannelConfiguration.class);
-        assertThat(config.device.identifiers, is(Arrays.asList("A", "B", "C")));
+        assertThat(config.device, is(notNullValue()));
 
+        BaseChannelConfiguration.Device device = config.device;
+        if (device != null) {
+            assertThat(device.identifiers, is(Arrays.asList("A", "B", "C")));
+        }
     }
 
     @Test
@@ -114,7 +131,11 @@ public class HAConfigurationTests {
 
         ComponentFan.ChannelConfiguration config = BaseChannelConfiguration.fromString(json, gson,
                 ComponentFan.ChannelConfiguration.class);
-        assertThat(config.device.identifiers, is(Arrays.asList("A")));
+        assertThat(config.device, is(notNullValue()));
 
+        BaseChannelConfiguration.Device device = config.device;
+        if (device != null) {
+            assertThat(device.identifiers, is(Arrays.asList("A")));
+        }
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
@@ -17,6 +17,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.junit.Test;
@@ -39,10 +40,11 @@ public class HaIDTests {
 
         assertThat(restore, is(subject));
 
-        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic, subject.toOjectId());
+        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic,
+                Collections.singletonList(subject.toShortTopic()));
 
         Collection<HaID> restoreList = HaID.fromConfig(haConfig);
-        assertThat(restoreList, hasItem(new HaID("homeassistant/+/name/config")));
+        assertThat(restoreList, hasItem(new HaID("homeassistant/switch/name/config")));
     }
 
     @Test
@@ -61,10 +63,11 @@ public class HaIDTests {
 
         assertThat(restore, is(subject));
 
-        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic, subject.toOjectId());
+        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic,
+                Collections.singletonList(subject.toShortTopic()));
 
         Collection<HaID> restoreList = HaID.fromConfig(haConfig);
-        assertThat(restoreList, hasItem(new HaID("homeassistant/+/node/name/config")));
+        assertThat(restoreList, hasItem(new HaID("homeassistant/switch/node/name/config")));
     }
 
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
@@ -13,12 +13,13 @@
 package org.openhab.binding.mqtt.homeassistant.internal;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.junit.Test;
-import org.openhab.binding.mqtt.homeassistant.internal.HaID;
-import org.openhab.binding.mqtt.homeassistant.internal.HandlerConfiguration;
 
 public class HaIDTests {
 
@@ -38,10 +39,10 @@ public class HaIDTests {
 
         assertThat(restore, is(subject));
 
-        HandlerConfiguration haConfig = subject.toHandlerConfiguration();
+        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic, subject.toOjectId());
 
-        restore = HaID.fromConfig(haConfig);
-        assertThat(restore, is(new HaID("homeassistant/+/name/config")));
+        Collection<HaID> restoreList = HaID.fromConfig(haConfig);
+        assertThat(restoreList, hasItem(new HaID("homeassistant/+/name/config")));
     }
 
     @Test
@@ -60,10 +61,10 @@ public class HaIDTests {
 
         assertThat(restore, is(subject));
 
-        HandlerConfiguration haConfig = subject.toHandlerConfiguration();
+        HandlerConfiguration haConfig = new HandlerConfiguration(subject.baseTopic, subject.toOjectId());
 
-        restore = HaID.fromConfig(haConfig);
-        assertThat(restore, is(new HaID("homeassistant/+/node/name/config")));
+        Collection<HaID> restoreList = HaID.fromConfig(haConfig);
+        assertThat(restoreList, hasItem(new HaID("homeassistant/+/node/name/config")));
     }
 
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
@@ -40,6 +40,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
+import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.TypeParser;
@@ -50,25 +51,23 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.openhab.binding.mqtt.generic.ChannelState;
-import org.openhab.binding.mqtt.homie.ChannelStateHelper;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
-import org.openhab.binding.mqtt.homie.ThingHandlerHelper;
-import org.openhab.binding.mqtt.homie.internal.handler.ThingChannelConstants;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
 import org.openhab.binding.mqtt.generic.mapping.SubscribeFieldToMQTTtopic;
 import org.openhab.binding.mqtt.generic.tools.ChildMap;
 import org.openhab.binding.mqtt.generic.tools.DelayedBatchProcessing;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
+import org.openhab.binding.mqtt.homie.ChannelStateHelper;
+import org.openhab.binding.mqtt.homie.ThingHandlerHelper;
 import org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants;
-import org.openhab.binding.mqtt.homie.internal.handler.HomieThingHandler;
 import org.openhab.binding.mqtt.homie.internal.homie300.Device;
 import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes;
+import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes.ReadyState;
 import org.openhab.binding.mqtt.homie.internal.homie300.Node;
 import org.openhab.binding.mqtt.homie.internal.homie300.NodeAttributes;
 import org.openhab.binding.mqtt.homie.internal.homie300.Property;
 import org.openhab.binding.mqtt.homie.internal.homie300.PropertyAttributes;
-import org.openhab.binding.mqtt.homie.internal.homie300.DeviceAttributes.ReadyState;
 import org.openhab.binding.mqtt.homie.internal.homie300.PropertyAttributes.DataTypeEnum;
 
 /**
@@ -94,9 +93,12 @@ public class HomieThingHandlerTests {
     @Mock
     private ScheduledFuture<?> scheduledFuture;
 
+    @Mock
+    private ThingTypeRegistry thingTypeRegistry;
+
     private HomieThingHandler thingHandler;
 
-    private final MqttChannelTypeProvider channelTypeProvider = new MqttChannelTypeProvider();
+    private final MqttChannelTypeProvider channelTypeProvider = new MqttChannelTypeProvider(thingTypeRegistry);
 
     private final String deviceID = ThingChannelConstants.testHomieThing.getId();
     private final String deviceTopic = "homie/" + deviceID;

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
@@ -16,6 +16,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -77,9 +80,13 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing,
                 scheduler, null, gson, transformationServiceProvider));
 
-        HandlerConfiguration config = new HandlerConfiguration("homeassistant", "object");
+        HandlerConfiguration config = new HandlerConfiguration("homeassistant",
+                Collections.singletonList("switch/object"));
 
-        discover.startDiscovery(connection, 50, HaID.fromConfig(config), discovered).get(100, TimeUnit.MILLISECONDS);
+        Set<HaID> discoveryIds = new HashSet<>();
+        discoveryIds.addAll(HaID.fromConfig(config));
+
+        discover.startDiscovery(connection, 50, discoveryIds, discovered).get(100, TimeUnit.MILLISECONDS);
 
     }
 }

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
@@ -14,7 +14,6 @@ package org.openhab.binding.mqtt;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/HomeAssistantMQTTImplementationTest.java
@@ -20,6 +20,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,11 +173,12 @@ public class HomeAssistantMQTTImplementationTest extends JavaOSGiTest {
 
         // Start the discovery for 100ms. Forced timeout after 300ms.
         HaID haID = new HaID(testObjectTopic);
-        CompletableFuture<Void> future = discover.startDiscovery(connection, 100, haID, cd).thenRun(() -> {
-        }).exceptionally(e -> {
-            failure = e;
-            return null;
-        });
+        CompletableFuture<Void> future = discover.startDiscovery(connection, 100, Collections.singleton(haID), cd)
+                .thenRun(() -> {
+                }).exceptionally(e -> {
+                    failure = e;
+                    return null;
+                });
 
         assertTrue(latch.await(300, TimeUnit.MILLISECONDS));
         future.get(100, TimeUnit.MILLISECONDS);

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
@@ -12,17 +12,9 @@
  */
 package org.openhab.binding.mqtt;
 
-import static org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants.*;
+import static org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants.HOMEASSISTANT_MQTT_THING;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 
 /**
  * Static test definitions, like thing, bridge and channel definitions


### PR DESCRIPTION
This will group components into things by device.

The component configuration may contain device information.
If multiple components with the same device information are discovered, then they are created as groups in one thing.

Additionally, the complete topic (including the component parts) is used in the thing and component configuration to allow the same object_id to be used for different components by the devices.
See: https://www.home-assistant.io/docs/mqtt/discovery/:

- <object_id>: The ID of the device. This is only to allow for separate topics for each device and is not used for the entity_id.

I do not have many devices to test: Please, everybody also test and give feedback

This should fix #5632 