### PR TITLE
[nibeheatpump] Consider local settings for formatted values in unit tests

### DIFF
--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerNibe2StateTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerNibe2StateTest.java
@@ -12,6 +12,14 @@
  */
 package org.openhab.binding.nibeheatpump.internal.handler;
 
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,13 +28,6 @@ import org.junit.runners.Parameterized;
 import org.openhab.binding.nibeheatpump.internal.models.PumpModel;
 import org.openhab.binding.nibeheatpump.internal.models.VariableInformation;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
-
 /**
  * Tests cases for {@link NibeHeatPumpHandler}.
  *
@@ -34,55 +35,55 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 public class NibeHeatPumpHandlerNibe2StateTest {
+
+    // we need to get the decimal separator of the default locale for our tests
+    private static final char SEP = new DecimalFormatSymbols().getDecimalSeparator();
+    private static final String METHOD_NAME = "convertNibeValueToState";
+
     private NibeHeatPumpHandler product; // the class under test
     private Method m;
-    private static String METHOD_NAME = "convertNibeValueToState";
-    private Class[] parameterTypes;
+    private Class<?>[] parameterTypes;
     private Object[] parameters;
-
     private int fCoilAddress;
-
     private int fValue;
-
     private String fFormat;
-
     private String fType;
-
     private String fExpected;
 
     @Parameterized.Parameters(name = "{index}: f({0}, {1}, {3})={4}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                { 47028, 0xFF, "%d", "Number", "-1" },
-                { 47028, 0x7F, "%d", "Number", "127" },
-                { 47028, 0x80, "%d", "Number", "-128" },
-                { 48132, 1966080, "%s", "String", "0" },
-                { 47028, 0xFF, "%d", "Number", "-1" },
-                { 43009, 0x011F, "%.1f", "Number", "28.7" },
-                { 43009, 0x7FFF, "%.1f", "Number", "3276.7" },
-                { 43009, 0x8000, "%.1f", "Number", "-3276.8" },
-                { 40004, 0xFFFF, "%.1f", "Number", "-0.1" },
-                { 40004, 0xFFFF, "%.1f", "Number", "-0.1" },
-                { 43416, 0xFFFFFFFF, "%d", "Number", "4294967295" },
-                { 47418, 0x004B, "%d", "Number", "75" },
-                { 43514, 0x0007, "%d", "Number", "7" },
-                { 47291, 0xFFFF, "%d", "Number", "65535" },
-                { 42437, 0xFFFFFFFF, "%.1f", "Number", "429496729.5" },
-                { 42504, 0xFFFFFFFF, "%d", "Number", "4294967295" },
-                { 43081, 196, "%.1f", "Number", "19.6"},
-                { 43424, 1685, "%d", "Number", "1685"},
-                { 43416, 4857, "%d", "Number", "4857"},
-                { 43420, 9487, "%d", "Number", "9487"},
-                { 40940, (byte)0xFF, "%.1f", "Number", "-0.1"},
-                { 40940, 0x80000000, "%.1f", "Number", "-214748364.8"},
-                { 40940, 0x7FFFFFFF, "%.1f", "Number", "214748364.7"},
-                { 40940, (short)0xFFFF, "%.1f", "Number", "-0.1"},
-                { 40940, (byte)0xFF, "%.1f", "Number", "-0.1"},
-                { 40940, 0xFFFF, "%.1f", "Number", "6553.5"},
+        return Arrays.asList(new Object[][] { //
+                { 47028, 0xFF, "%d", "Number", "-1" }, //
+                { 47028, 0x7F, "%d", "Number", "127" }, //
+                { 47028, 0x80, "%d", "Number", "-128" }, //
+                { 48132, 1966080, "%s", "String", "0" }, //
+                { 47028, 0xFF, "%d", "Number", "-1" }, //
+                { 43009, 0x011F, "%.1f", "Number", "28" + SEP + "7" }, //
+                { 43009, 0x7FFF, "%.1f", "Number", "3276" + SEP + "7" }, //
+                { 43009, 0x8000, "%.1f", "Number", "-3276" + SEP + "8" }, //
+                { 40004, 0xFFFF, "%.1f", "Number", "-0" + SEP + "1" }, //
+                { 40004, 0xFFFF, "%.1f", "Number", "-0" + SEP + "1" }, //
+                { 43416, 0xFFFFFFFF, "%d", "Number", "4294967295" }, //
+                { 47418, 0x004B, "%d", "Number", "75" }, //
+                { 43514, 0x0007, "%d", "Number", "7" }, //
+                { 47291, 0xFFFF, "%d", "Number", "65535" }, //
+                { 42437, 0xFFFFFFFF, "%.1f", "Number", "429496729" + SEP + "5" }, //
+                { 42504, 0xFFFFFFFF, "%d", "Number", "4294967295" }, //
+                { 43081, 196, "%.1f", "Number", "19" + SEP + "6" }, //
+                { 43424, 1685, "%d", "Number", "1685" }, //
+                { 43416, 4857, "%d", "Number", "4857" }, //
+                { 43420, 9487, "%d", "Number", "9487" }, //
+                { 40940, (byte) 0xFF, "%.1f", "Number", "-0" + SEP + "1" }, //
+                { 40940, 0x80000000, "%.1f", "Number", "-214748364" + SEP + "8" }, //
+                { 40940, 0x7FFFFFFF, "%.1f", "Number", "214748364" + SEP + "7" }, //
+                { 40940, (short) 0xFFFF, "%.1f", "Number", "-0" + SEP + "1" }, //
+                { 40940, (byte) 0xFF, "%.1f", "Number", "-0" + SEP + "1" }, //
+                { 40940, 0xFFFF, "%.1f", "Number", "6553" + SEP + "5" } //
         });
     }
 
-    public NibeHeatPumpHandlerNibe2StateTest(final int coilAddress, final int value, final String format, final String type, final String expected) {
+    public NibeHeatPumpHandlerNibe2StateTest(final int coilAddress, final int value, final String format,
+            final String type, final String expected) {
         this.fCoilAddress = coilAddress;
         this.fValue = value;
         this.fFormat = format;


### PR DESCRIPTION
- Consider local settings for formatted values in unit tests

Prevents errors like these:
```
[ERROR] convertNibeValueToStateTest[5: f(43.009, 287, Number)=28.7](org.openhab.binding.nibeheatpump.internal.handler.NibeHeatPumpHandlerNibe2StateTest)  Time elapsed: 0.025 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<28[.]7> but was:<28[,]7>
	at org.openhab.binding.nibeheatpump.internal.handler.NibeHeatPumpHandlerNibe2StateTest.convertNibeValueToStateTest(NibeHeatPumpHandlerNibe2StateTest.java:113)
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
