### PR TITLE
[milight] Update README.md to include manual Thing defintion options 'repeat' and 'delayTime'

### DIFF
--- a/bundles/org.openhab.binding.milight/README.md
+++ b/bundles/org.openhab.binding.milight/README.md
@@ -38,7 +38,7 @@ configuration file.
 iBox and iBox2 have the version 6, older milight bridges have the version 3.
 The ID is the MAC address of the bridge in hexadecimal digits.
 
-    Bridge milight:bridgeV3:mybridge [ host="192.168.0.70", bridgeid="ACCF23A6C0B4", passwordByte1=0, passwordByte2=0 ] {
+    Bridge milight:bridgeV3:mybridge [ host="192.168.0.70", bridgeid="ACCF23A6C0B4", passwordByte1=0, passwordByte2=0, repeat=2, delayTime=75 ] {
         Thing whiteLed myWhite [ zone="0" ]
         Thing rgbwwLed myRGB [ zone="4" ]
         Thing rgbLed myOldRGB [ zone="1" ]
@@ -48,6 +48,14 @@ The Thing configuration for the bridge uses the following syntax
 
 * Bridge milight:bridgeV3:<any name> &lsqb host="<IP-Address of bridge>", bridgeid="<mac>" &rsqb
 * Bridge milight:bridgeV6:<any name> &lsqb host="<IP-Address of bridge>", bridgeid="<mac>", passwordByte1="<0-255>", passwordByte2="<0-255>" &rsqb
+    
+Optionally, the following parameters can be added
+
+* repeat=<integer> (defaults to 1, if not defined)
+  Usually the bridge receives all commands albeit UDP is used. But the actual bulbs might be slightly out of bridge radio range and it sometimes helps to send commands multiple times.
+* delayTime=<integer for ms> (defaults to 100, if not defined)
+  Time to wait before sending another command to the bridge. It is safe to have a wait time of 1/10s but usually sufficient to just wait 50ms. If the value is too high, commands queue up.
+
 
 The Thing configuration for the bulbs uses the following syntax:
 &lsqbThing&rsqb <type of bulb> <any name> &lsqb zone="<0-4>" &rsqb


### PR DESCRIPTION
Addition of 'repeat' and 'delayTime' description for manual Thing configuration, as this is not obvious either from the Docs or the Paper UI titles of these options.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
