### PR TITLE
[mqttembeddedbroker] bump moquette  to 0.13.0.OH2

### DIFF
--- a/bundles/org.openhab.io.mqttembeddedbroker/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.mqttembeddedbroker/src/main/feature/feature.xml
@@ -13,7 +13,8 @@
         <bundle dependency="true">mvn:io.netty/netty-resolver/4.1.34.Final</bundle>
         <bundle dependency="true">mvn:io.netty/netty-handler/4.1.34.Final</bundle>
         <bundle dependency="true">mvn:com.h2database/h2-mvstore/1.4.199</bundle>
-        <bundle dependency="true">mvn:org.openhab.osgiify/io.moquette.moquette-broker/0.12.1</bundle>
+        <bundle dependency="true">mvn:commons-codec/commons-codec/1.10</bundle>
+        <bundle dependency="true">mvn:com.github.j-n-k/moquette-broker/0.13.0.OH2</bundle>
         <bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.io.mqttembeddedbroker/${project.version}</bundle>
     </feature>
 </features>

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/.classpath
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/.classpath
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/.project
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.io.mqttembeddedbroker.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/NOTICE
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
@@ -1,0 +1,65 @@
+-include: ../itest-common.bndrun
+
+Bundle-SymbolicName: ${project.artifactId}
+Fragment-Host: org.openhab.io.mqttembeddedbroker
+
+-runrequires: \
+  bnd.identity;id='org.openhab.io.mqttembeddedbroker.tests'
+
+# We would like to use the "volatile" storage only
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
+#
+# done
+#
+-runbundles: \
+	jaxb-api;version='[2.2.11,2.2.12)',\
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
+	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	com.google.gson;version='[2.8.2,2.8.3)',\
+	com.h2database.mvstore;version='[1.4.199,1.4.200)',\
+	io.netty.buffer;version='[4.1.34,4.1.35)',\
+	io.netty.codec;version='[4.1.34,4.1.35)',\
+	io.netty.codec-mqtt;version='[4.1.34,4.1.35)',\
+	io.netty.common;version='[4.1.34,4.1.35)',\
+	io.netty.handler;version='[4.1.34,4.1.35)',\
+	io.netty.resolver;version='[4.1.34,4.1.35)',\
+	io.netty.transport;version='[4.1.34,4.1.35)',\
+	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
+	moquette-broker;version='[0.13.0,0.13.1)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
+	org.apache.commons.io;version='[2.2.0,2.2.1)',\
+	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
+	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
+	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
+	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
+	org.eclipse.jetty.http;version='[9.4.11,9.4.12)',\
+	org.eclipse.jetty.io;version='[9.4.11,9.4.12)',\
+	org.eclipse.jetty.security;version='[9.4.11,9.4.12)',\
+	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
+	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
+	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
+	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
+	org.objenesis;version='[2.6.0,2.6.1)',\
+	org.openhab.core;version='[2.5.0,2.5.1)',\
+	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
+	org.openhab.core.io.transport.mqtt;version='[2.5.0,2.5.1)',\
+	org.openhab.core.test;version='[2.5.0,2.5.1)',\
+	org.openhab.io.mqttembeddedbroker;version='[2.5.0,2.5.1)',\
+	org.openhab.io.mqttembeddedbroker.tests;version='[2.5.0,2.5.1)',\
+	org.osgi.service.event;version='[1.4.0,1.4.1)',\
+	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
+	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.openhab.addons.bundles</groupId>
-    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <groupId>org.openhab.addons.itests</groupId>
+    <artifactId>org.openhab.addons.reactor.itests</artifactId>
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>org.openhab.io.mqttembeddedbroker</artifactId>
+  <artifactId>org.openhab.io.mqttembeddedbroker.tests</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: IO :: MQTT Broker Moquette</name>
+  <name>openHAB Add-ons :: Integration Tests :: MQTT Embeddedbroker</name>
 
   <properties>
     <netty.version>4.1.34.Final</netty.version>
@@ -19,10 +19,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.io.mqttembeddedbroker</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.j-n-k</groupId>
       <artifactId>moquette-broker</artifactId>
       <version>0.13.0.OH2</version>
-      <scope>compile</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -38,54 +42,45 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.h2database/h2-mvstore -->
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2-mvstore</artifactId>
-      <version>1.4.199</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2-mvstore</artifactId>
+      <version>1.4.199</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-mqtt</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
       <version>${netty.version}</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.mqttembeddedbroker;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
+import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
+import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionState;
+import org.eclipse.smarthome.io.transport.mqtt.MqttService;
+import org.eclipse.smarthome.io.transport.mqtt.MqttServiceObserver;
+import org.openhab.io.mqttembeddedbroker.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A full implementation test, that starts the embedded MQTT broker and publishes a homeassistant MQTT discovery device
+ * tree.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class EmbeddedBrokerTools {
+    private final Logger logger = LoggerFactory.getLogger(EmbeddedBrokerTools.class);
+    public @Nullable MqttBrokerConnection embeddedConnection = null;
+
+    /**
+     * Request the embedded broker connection from the {@link MqttService} and wait for a connection to be established.
+     *
+     * @throws InterruptedException
+     */
+    public MqttBrokerConnection waitForConnection(MqttService mqttService) throws InterruptedException {
+        embeddedConnection = mqttService.getBrokerConnection(Constants.CLIENTID);
+        if (embeddedConnection == null) {
+            Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+            MqttServiceObserver observer = new MqttServiceObserver() {
+
+                @Override
+                public void brokerAdded(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                    if (brokerID.equals(Constants.CLIENTID)) {
+                        embeddedConnection = broker;
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void brokerRemoved(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                }
+
+            };
+            mqttService.addBrokersListener(observer);
+            assertTrue("Wait for embedded connection client failed", semaphore.tryAcquire(700, TimeUnit.MILLISECONDS));
+        }
+        MqttBrokerConnection embeddedConnection = this.embeddedConnection;
+        if (embeddedConnection == null) {
+            throw new IllegalStateException();
+        }
+
+        logger.warn("waitForConnection {}", embeddedConnection.connectionState());
+        Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+        MqttConnectionObserver mqttConnectionObserver = (state, error) -> {
+            if (state == MqttConnectionState.CONNECTED) {
+                semaphore.release();
+            }
+        };
+        embeddedConnection.addConnectionObserver(mqttConnectionObserver);
+        if (embeddedConnection.connectionState() == MqttConnectionState.CONNECTED) {
+            semaphore.release();
+        }
+        assertTrue("Connection " + embeddedConnection.getClientId() + " failed. State: "
+                + embeddedConnection.connectionState(), semaphore.tryAcquire(500, TimeUnit.MILLISECONDS));
+        return embeddedConnection;
+    }
+
+}

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.mqttembeddedbroker;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
+import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
+import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionState;
+import org.eclipse.smarthome.io.transport.mqtt.MqttService;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Moquette test
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+public class MoquetteTest extends JavaOSGiTest {
+    private static final String TEST_TOPIC = "testtopic";
+
+    private MqttService mqttService;
+    private MqttBrokerConnection embeddedConnection;
+    private MqttBrokerConnection clientConnection;
+
+    /**
+     * Create an observer that fails the test as soon as the broker client connection changes its connection state
+     * to something else then CONNECTED.
+     */
+    private MqttConnectionObserver failIfChange = (state, error) -> assertThat(state,
+            is(MqttConnectionState.CONNECTED));
+
+    @Before
+    public void setUp() throws InterruptedException, ExecutionException, TimeoutException {
+        registerVolatileStorageService();
+        initMocks(this);
+        mqttService = getService(MqttService.class);
+
+        // Wait for the EmbeddedBrokerService internal connection to be connected
+        embeddedConnection = new EmbeddedBrokerTools().waitForConnection(mqttService);
+        embeddedConnection.setQos(1);
+        embeddedConnection.setRetain(true);
+
+        clientConnection = new MqttBrokerConnection(embeddedConnection.getHost(), embeddedConnection.getPort(),
+                embeddedConnection.isSecure(), "client");
+        clientConnection.setQos(1);
+        clientConnection.start().get(500, TimeUnit.MILLISECONDS);
+        assertThat(clientConnection.connectionState(), is(MqttConnectionState.CONNECTED));
+        // If the connection state changes in between -> fail
+        clientConnection.addConnectionObserver(failIfChange);
+    }
+
+    @After
+    public void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
+        if (clientConnection != null) {
+            clientConnection.removeConnectionObserver(failIfChange);
+            clientConnection.stop().get(500, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Test
+    public void singleTopic() throws InterruptedException, ExecutionException, TimeoutException {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        futures.add(embeddedConnection.publish(TEST_TOPIC, "testPayload".getBytes(StandardCharsets.UTF_8)));
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        CountDownLatch c = new CountDownLatch(1);
+        futures.clear();
+        futures.add(clientConnection.subscribe(TEST_TOPIC, (topic, payload) -> c.countDown()));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        assertTrue(c.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void multipleTopicsWithSingleSubscription()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8)));
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        CountDownLatch c = new CountDownLatch(2);
+        futures.clear();
+        futures.add(clientConnection.subscribe(TEST_TOPIC + "/1", (topic, payload) -> c.countDown()));
+        futures.add(clientConnection.subscribe(TEST_TOPIC + "/2", (topic, payload) -> c.countDown()));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        assertTrue(c.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void multipleTopicsWithHashWildcardSubscription()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8)));
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        CountDownLatch c = new CountDownLatch(2);
+        futures.clear();
+        futures.add(clientConnection.subscribe(TEST_TOPIC + "/#", (topic, payload) -> c.countDown()));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        assertTrue(c.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void multipleTopicsWithPlusWildcardSubscription()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8)));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8)));
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        CountDownLatch c = new CountDownLatch(2);
+        futures.clear();
+        futures.add(clientConnection.subscribe(TEST_TOPIC + "/+", (topic, payload) -> c.countDown()));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
+
+        assertTrue(c.await(1000, TimeUnit.MILLISECONDS));
+    }
+}

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -29,6 +29,7 @@
     <module>org.openhab.binding.tradfri.tests</module>
     <module>org.openhab.binding.wemo.tests</module>
     <module>org.openhab.io.hueemulation.tests</module>
+    <module>org.openhab.io.mqttembeddedbroker.tests</module>
     <module>org.openhab.persistence.mapdb.tests</module>
   </modules>
 


### PR DESCRIPTION
Fixes #5981 

The latest release version 0.12.1 has a bug with subscriptions which renders the module useless for other openHAB addons. Until a new release is available that includes the fix we use our own version.

Also add some integration tests that at least ensure that the broker is coming up and accepts publications and subscriptions. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
