### PR TITLE
[sonos] Don't list SYMFONISK as choice for creating thing type

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/resources/ESH-INF/thing/SYMFONISK.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/ESH-INF/thing/SYMFONISK.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<!-- SYMFONISK Thing Type -->
-	<thing-type id="SYMFONISK">
+	<thing-type id="SYMFONISK" listed="false">
 		<label>SYMFONISK</label>
 		<description>Represents IKEA SYMFONISK speaker</description>
 


### PR DESCRIPTION
Exactly as for other Sonos thing types.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>
