### PR TITLE
[lutron] Add delay parameter for command rate throttling

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -77,6 +77,11 @@ Note that the handler will wait up to 30 seconds for a heartbeat response before
 The optional advanced parameter `reconnect` can be used to set the connection retry interval, in minutes.
 It also defaults to 5.
 
+The optional advanced parameter `delay` can be used to set a delay (in milliseconds) between transmission of integration commands to the bridge device.
+This may be used for command send rate throttling.
+It can be set to an integer value between 0 and 250 ms, and defaults to 0 (no delay).
+It is recommended to leave it set to 0 unless you experience problems with commands sent to Caseta hubs being dropped/ignored.
+
 The optional advanced parameter `discoveryFile` can be set to force the device discovery service to read the Lutron configuration XML from a local file rather than retrieving it via HTTP from the RadioRA 2 or HomeWorks QS bridge device.
 This is useful in the case of some older Lutron software versions, where the discovery service may have problems retrieving the file from the bridge device.
 Note that the user which openHAB runs under must have permission to read the file.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/IPBridgeConfig.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/IPBridgeConfig.java
@@ -27,10 +27,11 @@ public class IPBridgeConfig {
     public String discoveryFile;
     public int reconnect;
     public int heartbeat;
+    public int delay = 0;
 
     public boolean sameConnectionParameters(IPBridgeConfig config) {
         return StringUtils.equals(ipAddress, config.ipAddress) && StringUtils.equals(user, config.user)
                 && StringUtils.equals(password, config.password) && (reconnect == config.reconnect)
-                && (heartbeat == config.heartbeat);
+                && (heartbeat == config.heartbeat) && (delay == config.delay);
     }
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -78,6 +78,7 @@ public class IPBridgeHandler extends BaseBridgeHandler {
     private IPBridgeConfig config;
     private int reconnectInterval;
     private int heartbeatInterval;
+    private int sendDelay;
 
     private TelnetSession session;
     private BlockingQueue<LutronCommand> sendQueue = new LinkedBlockingQueue<>();
@@ -138,6 +139,7 @@ public class IPBridgeHandler extends BaseBridgeHandler {
         if (validConfiguration(this.config)) {
             reconnectInterval = (config.reconnect > 0) ? config.reconnect : DEFAULT_RECONNECT_MINUTES;
             heartbeatInterval = (config.heartbeat > 0) ? config.heartbeat : DEFAULT_HEARTBEAT_MINUTES;
+            sendDelay = (config.delay < 0) ? 0 : config.delay;
 
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Connecting");
             scheduler.submit(this::connect); // start the async connect task
@@ -236,6 +238,9 @@ public class IPBridgeHandler extends BaseBridgeHandler {
 
                     // reconnect() will start a new thread; terminate this one
                     break;
+                }
+                if (sendDelay > 0) {
+                    Thread.sleep(sendDelay); // introduce delay to throttle send rate
                 }
             }
         } catch (InterruptedException e) {

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -40,6 +40,13 @@
 				<default>5</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="delay" type="integer" min="0" max="250" unit="ms">
+				<label>Send delay</label>
+				<description>The delay in milliseconds between sending integration commands (for throttling)</description>
+				<unitLabel>ms</unitLabel>
+				<default>0</default>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="discoveryFile" type="text">
 				<label>Discovery Data File</label>
 				<description>File to read device discovery information from (for debugging)</description>


### PR DESCRIPTION
This PR adds support for a "delay" parameter to the ipbridge thing. 

From the updated README.md:
```The optional advanced parameter `delay` can be used to set a delay (in milliseconds) between transmission of integration commands to the bridge device. This may be used for command send rate throttling. It can be set to an integer value between 0 and 250 ms, and defaults to 0 (no delay). It is recommended to leave it set to 0 unless you experience problems with commands sent to Caseta hubs being dropped/ignored.```

This change is being made in response to Issue #6012, which contains a report of problems with commands being dropped when sent to a Caseta PRO hub in large numbers.  Since so far this problem seems to be rare, the default for the new delay parameter is left at 0, which results in no change in behavior from before.  We may choose to revisit this default in the future.

Note that this PR will not yet close 6012, since some additional testing will be required to determine which delay values are recommended, and in what situations.