### PR TITLE
[tradfri] Drop support for gateway below firmware version 1.2.42

### DIFF
--- a/bundles/org.openhab.binding.tradfri/README.md
+++ b/bundles/org.openhab.binding.tradfri/README.md
@@ -6,10 +6,9 @@ This binding integrates the IKEA TRÅDFRI gateway and devices connected to it (s
 
 Beside the gateway (thing type "gateway"), the binding currently supports colored bulbs, dimmable warm white bulbs as well as white spectrum bulbs and control outlets.
 The binding also supports read-only data from remote controls and motion sensors (e.g. the battery status).
-The TRÅDFRI controller and sensor devices currently cannot be observed right away.
-We assume that they are communicating directly with the bulbs or lamps without routing their commands through the gateway.
+The TRÅDFRI controller and sensor devices currently cannot be observed right away because they are communicating directly with the bulbs or lamps without routing their commands through the gateway.
 This makes it nearly impossible to trigger events for pressed buttons.
-We only can access some static data like the present status or battery level. 
+We only can access some static data like the present status or battery level.
 
 The thing type ids are defined according to the lighting devices defined for ZigBee LightLink ([see page 24, table 2](https://www.nxp.com/documents/user_manual/JN-UG-3091.pdf).
 These are:
@@ -40,8 +39,9 @@ The following matrix lists the capabilities (channels) for each of the supported
 
 For first pairing - the gateway requires a `host` parameter for the hostname or IP address and a `code`, which is the security code that is printed on the bottom of the gateway.
 Optionally, a `port` can be configured, but any standard gateway uses the default port 5684.
+The gateway requires at least firmware version 1.2.42 to connect to this binding.
 
-The `code` is used during the initialization for retrieving unique identity and pre-shared key from the gateway (fw version 1.2.0042 onwards) and then it's discarded from the configuration. The newly created authentication data is stored in advanced parameters `identity` and `preSharedKey`.
+The `code` is used during the initialization for retrieving unique identity and pre-shared key from the gateway and then it's discarded from the configuration. The newly created authentication data is stored in advanced parameters `identity` and `preSharedKey`.
 On each initialization if the code is present in the thing configuration - the `identity` and `preSharedKey` are recreated and the `code` is again discarded.
 
 The devices require only a single (integer) parameter, which is their instance id. Unfortunately, this is not displayed anywhere in the IKEA app, but it seems that they are sequentially numbered starting with 65537 for the first device. If in doubt, use the auto-discovered things to find out the correct instance ids.
@@ -49,14 +49,14 @@ The devices require only a single (integer) parameter, which is their instance i
 ## Channels
 
 The dimmable bulbs support the `brightness` channel.
-The white spectrum bulbs additionally also support the `color_temperature` channel. 
+The white spectrum bulbs additionally also support the `color_temperature` channel.
 
 Full color bulbs support the `color_temperature` and `color` channels.
 Brightness can be changed with the `color` channel.
 
 The remote control and the motion sensor supports the `battery_level` and `battery_low` channels for reading the battery status.
 
-The control outlet supports the 'power' channel.
+The control outlet supports the `power` channel.
 
 Refer to the matrix above.
 
@@ -90,7 +90,7 @@ Dimmer Light1 { channel="tradfri:0100:mygateway:myDimmableBulb:brightness" }
 Dimmer Light2_Brightness { channel="tradfri:0220:mygateway:myColorTempBulb:brightness" }
 Dimmer Light2_ColorTemperature { channel="tradfri:0220:mygateway:myColorTempBulb:color_temperature" }
 Color ColorLight { channel="tradfri:0210:mygateway:myColorBulb:color" }
-Number RemoteControlBatteryLevel { channel="tradfri:0830:mygateway:myRemoteControl:battery_level" } 
+Number RemoteControlBatteryLevel { channel="tradfri:0830:mygateway:myRemoteControl:battery_level" }
 Switch RemoteControlBatteryLow { channel="tradfri:0830:mygateway:myRemoteControl:battery_low" }
 Switch ControlOutlet { channel="tradfri:0010:mygateway:myControlOutlet:power" }
 ```


### PR DESCRIPTION
This PR drops the support for the tradfri gateway below firmware version 1.2.42.
Fixes #5489.
