### PR TITLE
[WIP] Test if Jenkins PR build works after overriding repositories section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,47 @@
     <feature.directory>src/main/feature/feature.xml</feature.directory>
   </properties>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter</id>
+      <name>JCenter Repository</name>
+      <url>https://jcenter.bintray.com</url>
+    </repository>
+
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>openhab-release</id>
+      <name>openHAB Release Repository</name>
+      <url>${oh.repo.releaseBaseUrl}/libs-release</url>
+    </repository>
+
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+      <id>openhab-snapshot</id>
+      <name>openHAB Snapshot Repository</name>
+      <url>${oh.repo.snapshotBaseUrl}/libs-snapshot</url>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
It looks like Jenkins for some reason only uses the repositories defined in the [snapshot profile](https://github.com/openhab/infrastructure/blob/536ce58a12e0b13c02db456200a260b9411a0b28/pom.xml#L105-L126).
Let's see if the PR build succeeds when we override the repositories section.