### PR TITLE
[heos] Fix logger class causing SAT error

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/handler/HeosGroupHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/handler/HeosGroupHandler.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HeosGroupHandler extends HeosThingBaseHandler {
 
-    private final Logger logger = LoggerFactory.getLogger(HeosThingBaseHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(HeosGroupHandler.class);
 
     private String gid;
     private HeosGroup heosGroup;


### PR DESCRIPTION
Fixes:

```
[ERROR] org.openhab.binding.heos.handler.HeosGroupHandler.java:[44]
Illegal class is passed to LoggerFactory#getLogger(Class). It should be one of [org.openhab.binding.heos.handler.HeosGroupHandler].
```