### PR TITLE
Fix Travis CI not failing on SAT errors

### DIFF
--- a/buildci.sh
+++ b/buildci.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail # exit build with error when pipes fail
+
 function prevent_timeout() {
     local i=0
     while [[ -e /proc/$1 ]]; do
@@ -14,7 +16,6 @@ function print_reactor_summary() {
 }
 
 function mvnp() {
-    set -o pipefail # exit build with error when pipes fail
     local command=(mvn $@)
     exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
 	stdbuf -o0 grep -vE "Download(ed|ing) from [a-z.]+: https:" | # filter out downloads
@@ -50,7 +51,7 @@ if [[ ! -z "$CHANGED_DIR" ]] && [[ -e "bundles/$CHANGED_DIR" ]]; then
     echo "Single addon pull request: Building $CHANGED_DIR"
     echo "MAVEN_OPTS='-Xms1g -Xmx2g -Dorg.slf4j.simpleLogger.log.org.openhab.tools.analysis.report.ReportUtility=DEBUG -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN'" > ~/.mavenrc
     cd "bundles/$CHANGED_DIR"
-    mvn clean install -B 2>&1 | 
+    mvn clean install -B 2>&1 |
 	    stdbuf -o0 grep -vE "Download(ed|ing) from [a-z.]+: https:" | # Filter out Download(s)
 	    stdbuf -o0 grep -v "target/code-analysis" | # filter out some debug code from reporting utility
 	    tee ${CDIR}/.build.log


### PR DESCRIPTION
When Travis builds a single add-on it does run SAT but doesn't properly fail the build on errors. So you'll then only find out about this when Jenkins also completes building. By that time the PR might already have been merged. So it's better to prevent this from happening and save everyone some time. :wink: 

Example: https://github.com/openhab/openhab2-addons/pull/2886
Fix: https://github.com/openhab/openhab2-addons/pull/6061