### PR TITLE
[enocean] Add enocean A5-14-0A profile

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/EnOceanBindingConstants.java
@@ -88,6 +88,7 @@ public class EnOceanBindingConstants {
     public final static String CHANNEL_FANSPEEDSTAGE = "fanSpeedStage";
     public final static String CHANNEL_OCCUPANCY = "occupancy";
     public final static String CHANNEL_MOTIONDETECTION = "motionDetection";
+    public final static String CHANNEL_VIBRATION = "vibration";
     public final static String CHANNEL_ILLUMINATION = "illumination";
     public final static String CHANNEL_COUNTER = "counter";
     public final static String CHANNEL_CURRENTNUMBER = "currentNumber";
@@ -173,6 +174,8 @@ public class EnOceanBindingConstants {
                             new ChannelTypeUID(BINDING_ID, CHANNEL_OCCUPANCY), CoreItemFactory.SWITCH));
                     put(CHANNEL_MOTIONDETECTION, new EnOceanChannelDescription(
                             new ChannelTypeUID(BINDING_ID, CHANNEL_MOTIONDETECTION), CoreItemFactory.SWITCH));
+                    put(CHANNEL_VIBRATION, new EnOceanChannelDescription(
+                            new ChannelTypeUID(BINDING_ID, CHANNEL_VIBRATION), CoreItemFactory.SWITCH));
                     put(CHANNEL_ILLUMINATION, new EnOceanChannelDescription(
                             new ChannelTypeUID(BINDING_ID, CHANNEL_ILLUMINATION), CoreItemFactory.NUMBER));
                     put(CHANNEL_COUNTER, new EnOceanChannelDescription(new ChannelTypeUID(BINDING_ID, CHANNEL_COUNTER),

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14_0A.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_14/A5_14_0A.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.enocean.internal.eep.A5_14;
+
+import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
+
+import java.util.function.Function;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.enocean.internal.messages.ERP1Message;
+
+/**
+ * Window/Door-Sensor with States Open/Closed/Tilt, Supply voltage monitor and
+ * vibration alarm.
+ *
+ * @author Stefan Schimanski - Initial contribution
+ */
+public class A5_14_0A extends A5_14_09 {
+    public A5_14_0A(ERP1Message packet) {
+        super(packet);
+    }
+
+    private State getVibration() {
+        boolean alarm = getBit(getDB_0(), 0);
+        return alarm ? OnOffType.ON : OnOffType.OFF;
+    }
+
+    @Override
+    protected State convertToStateImpl(String channelId, String channelTypeId, Function<String, State> getCurrentStateFunc,
+            Configuration config) {
+        if (channelId.equals(CHANNEL_VIBRATION)) {
+                return getVibration();
+        }
+
+        return super.convertToStateImpl(channelId, channelTypeId, getCurrentStateFunc, config);
+    }
+}

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
@@ -104,6 +104,7 @@ import org.openhab.binding.enocean.internal.eep.A5_12.A5_12_03;
 import org.openhab.binding.enocean.internal.eep.A5_14.A5_14_01;
 import org.openhab.binding.enocean.internal.eep.A5_14.A5_14_01_ELTAKO;
 import org.openhab.binding.enocean.internal.eep.A5_14.A5_14_09;
+import org.openhab.binding.enocean.internal.eep.A5_14.A5_14_0A;
 import org.openhab.binding.enocean.internal.eep.A5_20.A5_20_04;
 import org.openhab.binding.enocean.internal.eep.A5_38.A5_38_08_Blinds;
 import org.openhab.binding.enocean.internal.eep.A5_38.A5_38_08_Dimming;
@@ -161,7 +162,7 @@ public enum EEPType {
             CHANNEL_GENERIC_COLOR, CHANNEL_GENERIC_TEACHINCMD),
     Generic4BS(RORG._4BS, 0xFF, 0xFF, false, Generic4BS.class, THING_TYPE_GENERICTHING, CHANNEL_GENERIC_SWITCH,
             CHANNEL_GENERIC_ROLLERSHUTTER, CHANNEL_GENERIC_DIMMER, CHANNEL_GENERIC_NUMBER, CHANNEL_GENERIC_STRING,
-            CHANNEL_GENERIC_COLOR, CHANNEL_GENERIC_TEACHINCMD),
+            CHANNEL_GENERIC_COLOR, CHANNEL_GENERIC_TEACHINCMD, CHANNEL_VIBRATION),
     GenericVLD(RORG.VLD, 0xFF, 0xFF, false, GenericVLD.class, THING_TYPE_GENERICTHING, CHANNEL_GENERIC_SWITCH,
             CHANNEL_GENERIC_ROLLERSHUTTER, CHANNEL_GENERIC_DIMMER, CHANNEL_GENERIC_NUMBER, CHANNEL_GENERIC_STRING,
             CHANNEL_GENERIC_COLOR, CHANNEL_GENERIC_TEACHINCMD),
@@ -186,6 +187,8 @@ public enum EEPType {
             CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT),
     MechanicalHandle02(RORG._4BS, 0x14, 0x09, false, A5_14_09.class, THING_TYPE_MECHANICALHANDLE,
             CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT, CHANNEL_BATTERY_VOLTAGE),
+    MechanicalHandle03(RORG._4BS, 0x14, 0x0A, false, A5_14_0A.class, THING_TYPE_MECHANICALHANDLE,
+            CHANNEL_WINDOWHANDLESTATE, CHANNEL_CONTACT, CHANNEL_VIBRATION, CHANNEL_BATTERY_VOLTAGE),
 
     ContactAndSwitch01(RORG._1BS, 0x00, 0x01, false, D5_00_01.class, THING_TYPE_CONTACT, CHANNEL_CONTACT),
     ContactAndSwitch02(RORG._4BS, 0x14, 0x01, false, A5_14_01.class, THING_TYPE_CONTACT, CHANNEL_BATTERY_VOLTAGE,

--- a/bundles/org.openhab.binding.enocean/src/main/resources/ESH-INF/thing/MechanicalHandle.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/ESH-INF/thing/MechanicalHandle.xml
@@ -26,6 +26,7 @@
 					<option value="F6_10_00">F6-10-00</option>
 					<option value="F6_10_01">F6-10-01</option>
 					<option value="A5_14_09">A5-14-09</option>
+					<option value="A5_14_0A">A5-14-0A</option>
 				</options>
 				<limitToOptions>true</limitToOptions>
 				<required>true</required>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/ESH-INF/thing/channels.xml
@@ -242,6 +242,14 @@
 		<state readOnly="true" />
 	</channel-type>
 
+	<channel-type id="vibration">
+		<item-type>Switch</item-type>
+		<label>Vibration Alarm</label>
+		<description>Vibration alarm state.</description>
+		<category>Switch</category>
+		<state readOnly="true" />
+	</channel-type>
+
 	<channel-type id="illumination">
 		<item-type>Number:Illuminance</item-type>
 		<label>Lux</label>


### PR DESCRIPTION
This adds the A5-14-0A epp (compare https://www.enocean-alliance.org/wp-content/uploads/2018/02/EEP268_R3_Feb022018_public.pdf) which extends A5-14-09 with a vibration channel through the DB0.0 bit.

This profile is implemented e.g. by:
- Maco mTRONIC multi sensor
- Eltako ftkb-hg