### PR TITLE
[snmp] add hexstring channel datatype

### DIFF
--- a/bundles/org.openhab.binding.snmp/README.md
+++ b/bundles/org.openhab.binding.snmp/README.md
@@ -92,6 +92,7 @@ Alternatively `INT32` (signed integer with 32 bit length), `COUNTER64` (unsigned
 Floating point numbers have to be supplied (and will be send) as strings.
 For `string` channels the default `datatype` is `STRING` (i.e. the item's will be sent as a string).
 If it is set to `IPADDRESS`, an SNMP IP address object is constructed from the item's value.
+The `HEXSTRING` datatype converts a hexadecimal string (e.g. `aa bb 11`) to the respective octet string before sending data to the target (and vice versa for receiving data).
 
 `switch`-type channels send a pre-defined value if they receive `ON` or `OFF` command in `WRITE` or `READ_WRITE` mode.
 In `READ`, `READ_WRITE` or `TRAP` mode they change to either `ON` or `OFF` on these values.
@@ -124,11 +125,12 @@ demo.things:
 ```
 Thing snmp:target:router [ hostname="192.168.0.1", protocol="v2c" ] {
     Channels:
-      Type number : inBytes [ oid=".1.3.6.1.2.1.31.1.1.1.6.2", mode="READ" ]
-      Type number : outBytes [ oid=".1.3.6.1.2.1.31.1.1.1.10.2", mode="READ" ]
-      Type number : if4Status [ oid="1.3.6.1.2.1.2.2.1.7.4", mode="TRAP" ]
-      Type switch : if4Command [ oid="1.3.6.1.2.1.2.2.1.7.4", mode="READ_WRITE", datatype="UINT32", onvalue="2", offvalue="0" ]
-      Type switch : devicePresent [ oid="1.3.6.1.2.1.2.2.1.221.4.192.168.0.1", mode="READ", datatype="UINT32", onValue="1", doNotLogException="true", exceptionValue="OFF" ]
+        Type number : inBytes [ oid=".1.3.6.1.2.1.31.1.1.1.6.2", mode="READ" ]
+        Type number : outBytes [ oid=".1.3.6.1.2.1.31.1.1.1.10.2", mode="READ" ]
+        Type number : if4Status [ oid="1.3.6.1.2.1.2.2.1.7.4", mode="TRAP" ]
+        Type switch : if4Command [ oid="1.3.6.1.2.1.2.2.1.7.4", mode="READ_WRITE", datatype="UINT32", onvalue="2", offvalue="0" ]
+        Type switch : devicePresent [ oid="1.3.6.1.2.1.2.2.1.221.4.192.168.0.1", mode="READ", datatype="UINT32", onValue="1", doNotLogException="true", exceptionValue="OFF" ]
+        Type switch : valueReceived [ oid="1.3.6.1.2.1.2.2.1.221.17.5", mode="READ", datatype="HEXSTRING", onValue="00 AA 11", offValue="00 00 00" ]
 }
 ```
 
@@ -140,6 +142,7 @@ Number outBytes "Router bytes out [%d]" { channel="snmp:target:router:outBytes" 
 Number if4Status "Router interface 4 status [%d]" { channel="snmp:target:router:if4Status" }
 Switch if4Command "Router interface 4 switch [%s]" { channel="snmp:target:router:if4Command" }
 Switch devicePresent "Phone connected [%s]" { channel="snmp:target:router:devicePresent" }
+Switch receivedValue "Received 00 AA 11 [%s]" { channel="snmp:target:router:valueReceived" }
 ```
 
 demo.sitemap:
@@ -153,6 +156,7 @@ sitemap demo label="Main Menu"
         Text item=if4Status
         Switch item=if4Command
         Text item=devicePresent
+        Text item=receivedValue
     }
 }
 ```

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpDatatype.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpDatatype.java
@@ -24,5 +24,6 @@ public enum SnmpDatatype {
     COUNTER64,
     FLOAT,
     STRING,
+    HEXSTRING,
     IPADDRESS
 }

--- a/bundles/org.openhab.binding.snmp/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.snmp/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -128,6 +128,7 @@
 				<description>Content data type</description>
 				<options>
 					<option value="STRING">String</option>
+					<option value="HEXSTRING">Hex-String</option>
 					<option value="IPADDRESS">IP Address</option>
 				</options>
 				<default>STRING</default>
@@ -176,6 +177,7 @@
 					<option value="INT32">Integer (32 bit)</option>
 					<option value="COUNTER64">Counter (64 bit)</option>
 					<option value="STRING">String</option>
+					<option value="HEXSTRING">Hex-String</option>
 					<option value="IPADDRESS">IP Address</option>
 				</options>
 				<default>UINT32</default>

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.snmp.internal;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -22,14 +22,11 @@ import java.util.Collections;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 import org.snmp4j.PDU;
 import org.snmp4j.event.ResponseEvent;
 import org.snmp4j.smi.Counter64;
 import org.snmp4j.smi.Integer32;
-import org.snmp4j.smi.IpAddress;
-import org.snmp4j.smi.Null;
 import org.snmp4j.smi.OID;
 import org.snmp4j.smi.OctetString;
 import org.snmp4j.smi.UnsignedInteger32;
@@ -101,79 +98,6 @@ public class SnmpTargetHandlerTest extends AbstractSnmpTargetHandlerTest {
     }
 
     @Test
-    public void testCommandsAreProperlyHandledByStringChannel() throws IOException {
-        VariableBinding variable;
-
-        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING, SnmpDatatype.STRING,
-                new StringType(TEST_STRING), true);
-        assertEquals(new OID(TEST_OID), variable.getOid());
-        assertTrue(variable.getVariable() instanceof OctetString);
-        assertEquals(TEST_STRING, ((OctetString) variable.getVariable()).toString());
-
-        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
-                SnmpDatatype.IPADDRESS, new StringType(TEST_STRING), false);
-        assertNull(variable);
-
-        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
-                SnmpDatatype.IPADDRESS, new DecimalType(-5), false);
-        assertNull(variable);
-
-        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
-                SnmpDatatype.IPADDRESS, new StringType(TEST_ADDRESS), true);
-        assertEquals(new OID(TEST_OID), variable.getOid());
-        assertTrue(variable.getVariable() instanceof IpAddress);
-        assertEquals(TEST_ADDRESS, ((IpAddress) variable.getVariable()).toString());
-    }
-
-    @Test
-    public void testCommandsAreProperlyHandledBySwitchChannel() throws IOException {
-        VariableBinding variable;
-
-        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.ON, "on", "off", true);
-        assertEquals(new OID(TEST_OID), variable.getOid());
-        assertTrue(variable.getVariable() instanceof OctetString);
-        assertEquals("on", ((OctetString) variable.getVariable()).toString());
-
-        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.OFF, "on", "off", true);
-        assertEquals(new OID(TEST_OID), variable.getOid());
-        assertTrue(variable.getVariable() instanceof OctetString);
-        assertEquals("off", ((OctetString) variable.getVariable()).toString());
-
-        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.OFF, "on", null, false);
-        assertNull(variable);
-    }
-
-    @Test
-    public void testSwitchChannelsProperlyUpdatingOnValue() throws IOException {
-        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.STRING, "on", "off");
-        PDU responsePDU = new PDU(PDU.RESPONSE,
-                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new OctetString("on"))));
-        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
-        thingHandler.onResponse(event);
-        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.ON));
-    }
-
-    @Test
-    public void testSwitchChannelsProperlyUpdatingOffValue() throws IOException {
-        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.INT32, "0", "3");
-        PDU responsePDU = new PDU(PDU.RESPONSE,
-                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new Integer32(3))));
-        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
-        thingHandler.onResponse(event);
-        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.OFF));
-    }
-
-    @Test
-    public void testSwitchChannelsIgnoresArbitraryValue() throws IOException {
-        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223");
-        PDU responsePDU = new PDU(PDU.RESPONSE,
-                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new Counter64(17))));
-        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
-        thingHandler.onResponse(event);
-        verify(thingHandlerCallback, never()).stateUpdated(eq(CHANNEL_UID), any());
-    }
-
-    @Test
     public void testNumberChannelsProperlyUpdatingFloatValue() throws IOException {
         setup(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpChannelMode.READ, SnmpDatatype.FLOAT);
         PDU responsePDU = new PDU(PDU.RESPONSE,
@@ -181,26 +105,5 @@ public class SnmpTargetHandlerTest extends AbstractSnmpTargetHandlerTest {
         ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
         thingHandler.onResponse(event);
         verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(new DecimalType("12.4")));
-    }
-
-    @Test
-    public void testSwitchChannelSendsUndefExceptionValue() throws IOException {
-        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223");
-        PDU responsePDU = new PDU(PDU.RESPONSE,
-                Collections.singletonList(new VariableBinding(new OID(TEST_OID), Null.noSuchInstance)));
-        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
-        thingHandler.onResponse(event);
-        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(UnDefType.UNDEF));
-    }
-
-    @Test
-    public void testSwitchChannelSendsConfiguredExceptionValue() throws IOException {
-        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223",
-                "OFF");
-        PDU responsePDU = new PDU(PDU.RESPONSE,
-                Collections.singletonList(new VariableBinding(new OID(TEST_OID), Null.noSuchInstance)));
-        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
-        thingHandler.onResponse(event);
-        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.OFF));
     }
 }

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/StringChannelTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/StringChannelTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.snmp.internal;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.junit.Test;
+import org.snmp4j.PDU;
+import org.snmp4j.event.ResponseEvent;
+import org.snmp4j.smi.IpAddress;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.OctetString;
+import org.snmp4j.smi.VariableBinding;
+
+/**
+ * Tests cases for {@link SnmpTargetHandler}.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+public class StringChannelTest extends AbstractSnmpTargetHandlerTest {
+
+    @Test
+    public void testCommandsAreProperlyHandledByStringChannel() throws IOException {
+        VariableBinding variable;
+
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING, SnmpDatatype.STRING,
+                new StringType(TEST_STRING), true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals(TEST_STRING, ((OctetString) variable.getVariable()).toString());
+
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
+                SnmpDatatype.IPADDRESS, new StringType(TEST_STRING), false);
+        assertNull(variable);
+
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
+                SnmpDatatype.IPADDRESS, new DecimalType(-5), false);
+        assertNull(variable);
+
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
+                SnmpDatatype.HEXSTRING, new StringType("AA bf 11"), true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals("aa bf 11", ((OctetString) variable.getVariable()).toHexString(' '));
+
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING,
+                SnmpDatatype.IPADDRESS, new StringType(TEST_ADDRESS), true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof IpAddress);
+        assertEquals(TEST_ADDRESS, ((IpAddress) variable.getVariable()).toString());
+    }
+
+    @Test
+    public void testStringChannelsProperlyUpdatingOnHexString() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_STRING, SnmpChannelMode.READ, SnmpDatatype.HEXSTRING);
+        PDU responsePDU = new PDU(PDU.RESPONSE, Collections
+                .singletonList(new VariableBinding(new OID(TEST_OID), OctetString.fromHexStringPairs("aa11bb"))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(new StringType("aa 11 bb")));
+    }
+}

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SwitchChannelTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SwitchChannelTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.snmp.internal;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.junit.Test;
+import org.snmp4j.PDU;
+import org.snmp4j.event.ResponseEvent;
+import org.snmp4j.smi.Counter64;
+import org.snmp4j.smi.Integer32;
+import org.snmp4j.smi.Null;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.OctetString;
+import org.snmp4j.smi.VariableBinding;
+
+/**
+ * Tests cases for {@link SnmpTargetHandler}.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+public class SwitchChannelTest extends AbstractSnmpTargetHandlerTest {
+
+    @Test
+    public void testCommandsAreProperlyHandledBySwitchChannel() throws IOException {
+        VariableBinding variable;
+
+        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.ON, "on", "off", true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals("on", ((OctetString) variable.getVariable()).toString());
+
+        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.OFF, "on", "off", true);
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals("off", ((OctetString) variable.getVariable()).toString());
+
+        variable = handleCommandSwitchChannel(SnmpDatatype.STRING, OnOffType.OFF, "on", null, false);
+        assertNull(variable);
+    }
+
+    @Test
+    public void testSwitchChannelsProperlyUpdatingOnValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.STRING, "on", "off");
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new OctetString("on"))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.ON));
+    }
+
+    @Test
+    public void testSwitchChannelsProperlyUpdatingOffValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.INT32, "0", "3");
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new Integer32(3))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.OFF));
+    }
+
+    @Test
+    public void testSwitchChannelsProperlyUpdatingHexValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.HEXSTRING, "AA bb 11",
+                "cc ba 1d");
+        PDU responsePDU = new PDU(PDU.RESPONSE, Collections
+                .singletonList(new VariableBinding(new OID(TEST_OID), OctetString.fromHexStringPairs("aabb11"))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.ON));
+    }
+
+    @Test
+    public void testSwitchChannelsIgnoresArbitraryValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223");
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new Counter64(17))));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, never()).stateUpdated(eq(CHANNEL_UID), any());
+    }
+
+    @Test
+    public void testSwitchChannelSendsUndefExceptionValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223");
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), Null.noSuchInstance)));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(UnDefType.UNDEF));
+    }
+
+    @Test
+    public void testSwitchChannelSendsConfiguredExceptionValue() throws IOException {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_SWITCH, SnmpChannelMode.READ, SnmpDatatype.COUNTER64, "0", "12223",
+                "OFF");
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), Null.noSuchInstance)));
+        ResponseEvent event = new ResponseEvent("test", null, null, responsePDU, null);
+        thingHandler.onResponse(event);
+        verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(OnOffType.OFF));
+    }
+}


### PR DESCRIPTION
This adds the option of hex strings (received data is converted to hexadecimal representation). Also adds tests.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>