### PR TITLE
Use random available org.osgi.service.http.port in itests

### DIFF
--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -16,7 +16,7 @@ Fragment-Host: org.openhab.binding.feed
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'
 
--runvm: -Dorg.osgi.service.http.port=9090
+-runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
 
 #
 # done

--- a/itests/org.openhab.binding.feed.tests/pom.xml
+++ b/itests/org.openhab.binding.feed.tests/pom.xml
@@ -13,6 +13,10 @@
 
   <name>openHAB Add-ons :: Integration Tests :: Feed Binding Tests</name>
 
+  <properties>
+    <org.osgi.service.http.port>9090</org.osgi.service.http.port>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
@@ -36,5 +40,28 @@
       </exclusions>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <portNames>
+                <portName>org.osgi.service.http.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
+++ b/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
@@ -69,7 +69,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
     // Servlet URL configuration
     private static final String MOCK_SERVLET_PROTOCOL = "http";
     private static final String MOCK_SERVLET_HOSTNAME = "localhost";
-    private static final int MOCK_SERVLET_PORT = 9090;
+    private static final int MOCK_SERVLET_PORT = Integer.getInteger("org.osgi.service.http.port", 8080);
     private static final String MOCK_SERVLET_PATH = "/test/feed";
 
     // Files used for the test as input. They are located in /src/test/resources directory

--- a/itests/org.openhab.io.hueemulation.tests/itest.bndrun
+++ b/itests/org.openhab.io.hueemulation.tests/itest.bndrun
@@ -17,6 +17,8 @@ Fragment-Host: org.openhab.io.hueemulation
 
 -runproperties: logback.configurationFile=file:${.}/logback.xml
 
+-runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+
 #
 # done
 #

--- a/itests/org.openhab.io.hueemulation.tests/pom.xml
+++ b/itests/org.openhab.io.hueemulation.tests/pom.xml
@@ -13,6 +13,10 @@
 
   <name>openHAB Add-ons :: Integration Tests :: Hue Emulation Service Tests</name>
 
+  <properties>
+    <org.osgi.service.http.port>9090</org.osgi.service.http.port>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
@@ -25,5 +29,28 @@
       <version>2.5.2</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <portNames>
+                <portName>org.osgi.service.http.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/itests/org.openhab.io.hueemulation.tests/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
+++ b/itests/org.openhab.io.hueemulation.tests/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationServiceOSGiTest.java
@@ -86,7 +86,8 @@ public class HueEmulationServiceOSGiTest extends JavaOSGiTest {
         waitFor(() -> !hueService.cs.ds.config.ipaddress.isEmpty(), 5000, 100);
 
         String ipAddress = hueService.cs.ds.config.ipaddress;
-        int port = hueService.cs.config.discoveryHttpPort == 0 ? 8080 : hueService.cs.config.discoveryHttpPort;
+        int port = hueService.cs.config.discoveryHttpPort == 0 ? Integer.getInteger("org.osgi.service.http.port", 8080)
+                : hueService.cs.config.discoveryHttpPort;
         String url = "http://" + ipAddress + ":" + port + "/description.xml";
 
         waitForAssert(() -> {


### PR DESCRIPTION
Hard coded ports may not be available on each computer or when running builds in parallel. Instead assign a random available port. In Eclipse the default port is still used because it doesn't execute the build-helper-maven-plugin goal.
