### PR TITLE
Improve itests reliability when hostname resolution is slow

### DIFF
--- a/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
+++ b/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
@@ -233,7 +233,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
         // This will ensure that the configuration is read before the channelLinked() method in FeedHandler is called !
         waitForAssert(() -> {
             assertThat(feedThing.getStatus(), anyOf(is(ONLINE), is(OFFLINE)));
-        }, 30000, DFL_SLEEP_TIME);
+        }, 60000, DFL_SLEEP_TIME);
         initializeItem(channelUID);
     }
 
@@ -401,7 +401,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
         waitForAssert(() -> {
             assertThat(feedThing.getStatus(), is(equalTo(OFFLINE)));
             assertThat(feedThing.getStatusInfo().getStatusDetail(), is(equalTo(ThingStatusDetail.COMMUNICATION_ERROR)));
-        });
+        }, 30000, DFL_SLEEP_TIME);
     }
 
     @Test

--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -218,8 +218,9 @@ public class NtpOSGiTest extends JavaOSGiTest {
         assertFormat(testItemState, DateTimeType.DATE_PATTERN_WITH_TZ_AND_MS);
         ZonedDateTime timeZoneFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
                 .getZonedDateTime();
-        
-        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules().getOffset(timeZoneFromItemRegistry.toInstant());
+
+        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules()
+                .getOffset(timeZoneFromItemRegistry.toInstant());
         assertEquals(expectedOffset, timeZoneFromItemRegistry.getOffset());
     }
 
@@ -231,7 +232,8 @@ public class NtpOSGiTest extends JavaOSGiTest {
         ZonedDateTime timeZoneIdFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
                 .getZonedDateTime();
 
-        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules().getOffset(timeZoneIdFromItemRegistry.toInstant());
+        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules()
+                .getOffset(timeZoneIdFromItemRegistry.toInstant());
         assertEquals(expectedOffset, timeZoneIdFromItemRegistry.getOffset());
     }
 
@@ -476,7 +478,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         }
         waitForAssert(() -> {
             assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, ntpThing.getStatusInfo().getStatusDetail());
-        });
+        }, 60000, DFL_SLEEP_TIME);
     }
 
     private void assertEventIsReceived(UpdateEventType updateEventType, String channelID, String acceptedItemType) {


### PR DESCRIPTION
DNS lookup of invalid hosts may take quite some time when using slow DNS servers.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
