### PR TITLE
[daikin] Fixed ESH-INF xml

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="daikin"
-				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
-				xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+<binding:binding id="daikin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Daikin Binding</name>
 	<description>This is the binding for Daikin A/C units.</description>

--- a/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/config/config.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
-		https://openhab.org/schemas/config-description-1.0.0.xsd">
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:daikin:config">
 			<parameter name="host" type="text" required="true">


### PR DESCRIPTION
Due to indentation on tags the things don't show up in PaperUI. This seems to be related to usage of spaces and tabs in tags. This problem occurs when using this binding in a openHAB 2.4.0 installation.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>
