### PR TITLE
[spotify] Removed unnecessary cast setting volume

### DIFF
--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
@@ -110,12 +110,8 @@ class SpotifyHandleCommands {
                 }
             case CHANNEL_DEVICEVOLUME:
                 if (command instanceof DecimalType) {
-                    final PercentType volume = new PercentType(((DecimalType) command).intValue());
-
-                    spotifyApi.setVolume(deviceId, volume.intValue());
-                    commandRun = true;
-                } else if (command instanceof PercentType) {
-                    final PercentType volume = (PercentType) command;
+                    final PercentType volume = command instanceof PercentType ? (PercentType) command
+                            : new PercentType(((DecimalType) command).intValue());
 
                     spotifyApi.setVolume(deviceId, volume.intValue());
                     commandRun = true;


### PR DESCRIPTION
In setting volume a check on DecimalType was done before PercentType. However PercentType is a subclass of DecimalType so that code will never be reached and a PercentType command is always uncessary converted to a PercentType. The converting to PrecentType is to enforce a range check on the int value.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>
