### PR TITLE
[lutron] Fix shade handler position update after Up/Down command

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -367,7 +367,8 @@ You can also read the current shade level from the channel.
 It is specified as a percentage, where 0% = closed and 100% = fully open. Movement delays are not currently supported.
 The shade handler should be compatible with all Lutron devices which appear to the system as shades, including roller shades, honeycomb shades, pleated shades, roman shades, tension roller shades, drapes, and Kirbe vertical drapes.
 
-**Note:** While a shade is moving, the Lutron system will report the target level for the shade rather than the actual current level.
+**Note:** While a shade is moving to a specific level because of a Percent command, the system will report the target level for the shade rather than the actual current level.
+While a shade is moving because of an Up or Down command, it will report the previous level until it stops moving.
 
 Thing configuration file example:
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/ShadeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/ShadeHandler.java
@@ -40,6 +40,8 @@ public class ShadeHandler extends LutronHandler {
     private static final Integer ACTION_STARTRAISING = 2;
     private static final Integer ACTION_STARTLOWERING = 3;
     private static final Integer ACTION_STOP = 4;
+    private static final Integer ACTION_POSITION_UPDATE = 32; // undocumented in integration protocol guide
+    private static final Integer PARAMETER_POSITION_UPDATE = 2; // undocumented in integration protocol guide
 
     private final Logger logger = LoggerFactory.getLogger(ShadeHandler.class);
 
@@ -109,13 +111,20 @@ public class ShadeHandler extends LutronHandler {
 
     @Override
     public void handleUpdate(LutronCommandType type, String... parameters) {
-        if (type == LutronCommandType.OUTPUT && parameters.length >= 2
-                && ACTION_ZONELEVEL.toString().equals(parameters[0])) {
-            BigDecimal level = new BigDecimal(parameters[1]);
-            if (getThing().getStatus() == ThingStatus.UNKNOWN) {
-                updateStatus(ThingStatus.ONLINE);
+        if (type == LutronCommandType.OUTPUT && parameters.length >= 2) {
+            if (ACTION_ZONELEVEL.toString().equals(parameters[0])) {
+                BigDecimal level = new BigDecimal(parameters[1]);
+                if (getThing().getStatus() == ThingStatus.UNKNOWN) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+                logger.trace("Shade {} received zone level: {}", getIntegrationId(), level);
+                updateState(CHANNEL_SHADELEVEL, new PercentType(level));
+            } else if (ACTION_POSITION_UPDATE.toString().equals(parameters[0])
+                    && PARAMETER_POSITION_UPDATE.toString().equals(parameters[1]) && parameters.length >= 3) {
+                BigDecimal level = new BigDecimal(parameters[2]);
+                logger.trace("Shade {} received position update: {}", getIntegrationId(), level);
+                updateState(CHANNEL_SHADELEVEL, new PercentType(level));
             }
-            updateState(CHANNEL_SHADELEVEL, new PercentType(level));
         }
     }
 }


### PR DESCRIPTION
This PR fixes a problem where the shade level channel of a shade thing would not be updated with the correct level when an Up or Down command was sent to the shade and it subsequently stopped in the full up or full down position.  This is because the main repeater uses a different response code (```~OUTPUT,<id>,32,2,<position>```) to send a position update in these cases.