### PR TITLE
[siemensrds] RdsCloudHandler initialization made asynchronous; Fewer logger.info()…

### DIFF
--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsAccessToken.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsAccessToken.java
@@ -114,7 +114,7 @@ class RdsAccessToken {
             String json = httpGetTokenJson(apiKey, user, password);
             return GSON.fromJson(json, RdsAccessToken.class);
         } catch (JsonSyntaxException | RdsCloudException | IOException e) {
-            LOGGER.warn("token creation error \"{}\"", e.getMessage(), e);
+            LOGGER.warn("create {}: \"{}\"", e.getClass().getName(), e.getMessage());
             return null;
         }
     }

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsCloudHandler.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsCloudHandler.java
@@ -53,19 +53,19 @@ public class RdsCloudHandler extends BaseBridgeHandler {
 
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing configuration, status => offline!");
+                    "missing configuration");
             return;
         }
 
         if (config.userEmail.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing email address, status => offline!");
+                    "missing email address");
             return;
         }
 
         if (config.userPassword.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing password, status => offline!");
+                    "missing password");
             return;
         }
 
@@ -74,7 +74,7 @@ public class RdsCloudHandler extends BaseBridgeHandler {
 
         if (config.pollingInterval < FAST_POLL_INTERVAL || config.pollingInterval > LAZY_POLL_INTERVAL) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    String.format("polling interval out of range [%d..%d], status => offline!", FAST_POLL_INTERVAL,
+                    String.format("polling interval out of range [%d..%d]", FAST_POLL_INTERVAL,
                             LAZY_POLL_INTERVAL));
             return;
         }
@@ -104,12 +104,13 @@ public class RdsCloudHandler extends BaseBridgeHandler {
 
         if (accessToken != null) {
             if (getThing().getStatus() != ThingStatus.ONLINE) {
-                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "server responded, status => online..");
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, 
+                        "cloud server responded");
             }
         } else {
             if (getThing().getStatus() == ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "server authentication error, status => offline!");
+                        "cloud server authentication error");
             }
         }
     }

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsCloudHandler.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsCloudHandler.java
@@ -78,8 +78,6 @@ public class RdsCloudHandler extends BaseBridgeHandler {
                             LAZY_POLL_INTERVAL));
             return;
         }
-
-        refreshToken();
     }
 
     @Override

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
@@ -129,9 +129,9 @@ class RdsDataPoints {
                 LOGGER.trace("create: response={}", json);
             }
 
-            return GSON.fromJson(json, RdsDataPoints.class);
+            return GSON.fromJson(json, RdsDataPoints.class); 
         } catch (JsonSyntaxException | RdsCloudException | IOException e) {
-            LOGGER.warn("point list creation error \"{}\"", e.getMessage(), e);
+            LOGGER.warn("create {}: \"{}\"", e.getClass().getName(), e.getMessage());
             return null;
         }
     }
@@ -324,6 +324,15 @@ class RdsDataPoints {
                         set.add(String.format("\"%s\"", pointId));
                     }
                 }
+
+                for (Map.Entry<String, BasePoint> entry : points.entrySet()) {
+                    BasePoint point = entry.getValue();
+                    if (point != null && point.memberName != null && point.memberName.equals("Online")) {
+                        set.add(String.format("\"%s\"", entry.getKey()));
+                        break;
+                    }
+                }
+
                 valueFilter = String.join(",", set);
             }
 
@@ -371,7 +380,7 @@ class RdsDataPoints {
 
             return true;
         } catch (JsonSyntaxException | RdsCloudException | IOException e) {
-            LOGGER.warn("refresh: error \"{}\"", e.getMessage());
+            LOGGER.warn("refresh {}: \"{}\"", e.getClass().getName(), e.getMessage());
             return false;
         }
     }

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
@@ -300,7 +300,7 @@ class RdsDataPoints {
             try {
                 httpSetPointValueJson(apiKey, token, pointId, json);
             } catch (RdsCloudException | IOException e) {
-                LOGGER.warn("setValue: error \"{}\"", e.getMessage(), e);
+                LOGGER.warn("setValue {} {}: \"{}\"", hierarchyName, e.getClass().getName(), e.getMessage());
                 return;
             }
         } else {

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDiscoveryService.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDiscoveryService.java
@@ -65,6 +65,9 @@ public class RdsDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     protected void startScan() {
+        if (cloud.getThing().getStatus() != ThingStatus.ONLINE) {
+            cloud.getToken();
+        }
         if (cloud.getThing().getStatus() == ThingStatus.ONLINE) {
             discoverPlants();
         }
@@ -72,8 +75,7 @@ public class RdsDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     protected void startBackgroundDiscovery() {
-        String msg = "start background discovery..";
-        logger.info(msg);
+        logger.debug("start background discovery..");
 
         if (discoveryScheduler == null || discoveryScheduler.isCancelled()) {
             discoveryScheduler = scheduler.scheduleWithFixedDelay(this::startScan, 10, 
@@ -83,8 +85,7 @@ public class RdsDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     protected void stopBackgroundDiscovery() {
-        String msg = "stop background discovery..";
-        logger.info(msg);
+        logger.debug("stop background discovery..");
 
         if (discoveryScheduler != null && !discoveryScheduler.isCancelled()) {
             discoveryScheduler.cancel(true);

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
@@ -108,8 +108,6 @@ public class RdsHandler extends BaseThingHandler {
             int pollInterval = cloud.getPollInterval();
 
             if (pollInterval > 0) {
-                logger.info("creating polling timers..");
-
                 // create a "lazy" polling scheduler
                 if (lazyPollingScheduler == null || lazyPollingScheduler.isCancelled()) {
                     lazyPollingScheduler = scheduler.scheduleWithFixedDelay(this::lazyPollingSchedulerExecute,
@@ -139,8 +137,6 @@ public class RdsHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
-        logger.info("disposing polling timers..");
-
         // clean up the lazy polling scheduler
         if (lazyPollingScheduler != null && !lazyPollingScheduler.isCancelled()) {
             lazyPollingScheduler.cancel(true);
@@ -196,6 +192,8 @@ public class RdsHandler extends BaseThingHandler {
             return;
         }
 
+        String token = cloud.getToken();
+
         if (cloud.getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
                     "cloud handler offline, status => offline!");
@@ -203,7 +201,6 @@ public class RdsHandler extends BaseThingHandler {
         }
 
         String apiKey = cloud.getApiKey();
-        String token = cloud.getToken();
 
         if (points == null || (!points.refresh(apiKey, token))) {
             points = RdsDataPoints.create(apiKey, token, config.plantId);

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
@@ -74,7 +74,7 @@ public class RdsHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING, "pending..");
+        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING);
 
         config = getConfigAs(RdsConfiguration.class);
 
@@ -209,7 +209,7 @@ public class RdsHandler extends BaseThingHandler {
         if (points == null) {
             if (getThing().getStatus() == ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        String.format("cloud server has no info this device"));
+                        "cloud server has no info this device");
             }
             return;
         }
@@ -217,14 +217,14 @@ public class RdsHandler extends BaseThingHandler {
         if (!points.isOnline()) {
             if (getThing().getStatus() == ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        String.format("cloud server reports device offline"));
+                        "cloud server reports device offline");
             }
             return;
         }
 
         if (getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE,
-                    String.format("received info from cloud server"));
+                    "received info from cloud server");
         }
 
         for (ChannelMap chan : CHAN_MAP) {

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandler.java
@@ -74,13 +74,13 @@ public class RdsHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING, "status => unknown..");
+        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING, "pending..");
 
         config = getConfigAs(RdsConfiguration.class);
 
         if (config == null || config.plantId == null || config.plantId.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing Plant Id, status => offline!");
+                    "missing Plant Id");
             return;
         }
 
@@ -88,13 +88,13 @@ public class RdsHandler extends BaseThingHandler {
 
         if (cloud == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing cloud handler, status => offline!");
+                    "missing cloud server handler");
             return;
         }
 
         if (cloud.getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
-                    "cloud handler not online, status => offline!");
+                    "cloud server offline");
             return;
         }
 
@@ -188,7 +188,7 @@ public class RdsHandler extends BaseThingHandler {
 
         if (cloud == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "missing cloud handler, status => offline!");
+                    "missing cloud server handler");
             return;
         }
 
@@ -196,7 +196,7 @@ public class RdsHandler extends BaseThingHandler {
 
         if (cloud.getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
-                    "cloud handler offline, status => offline!");
+                    "cloud server offline");
             return;
         }
 
@@ -209,7 +209,7 @@ public class RdsHandler extends BaseThingHandler {
         if (points == null) {
             if (getThing().getStatus() == ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        String.format("server has no info for %s, status => offline!", getThing().getLabel()));
+                        String.format("cloud server has no info this device"));
             }
             return;
         }
@@ -217,14 +217,14 @@ public class RdsHandler extends BaseThingHandler {
         if (!points.isOnline()) {
             if (getThing().getStatus() == ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        String.format("server reports %s offline, status => offline!", getThing().getLabel()));
+                        String.format("cloud server reports device offline"));
             }
             return;
         }
 
         if (getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE,
-                    String.format("received info for %s from cloud server, status => online..", getThing().getLabel()));
+                    String.format("received info from cloud server"));
         }
 
         for (ChannelMap chan : CHAN_MAP) {
@@ -349,7 +349,7 @@ public class RdsHandler extends BaseThingHandler {
     }
 
     /*
-     * private method: returns the cloud handler
+     * private method: returns the cloud server handler
      */
     private RdsCloudHandler getCloudHandler() {
         @Nullable Bridge b;

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsPlants.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsPlants.java
@@ -66,7 +66,7 @@ class RdsPlants {
             String json = RdsDataPoints.httpGenericGetJson(apiKey, token, URL_PLANTS);
             return GSON.fromJson(json, RdsPlants.class);
         } catch (JsonSyntaxException | RdsCloudException | IOException e) {
-            LOGGER.warn("plant list creation error \"{}\"", e.getMessage(), e);
+            LOGGER.warn("create {}: \"{}\"", e.getClass().getName(), e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
This is a minor performance improvement:

1) The RdsCloudHandler initialization would directly call the remote Siemens cloud server to create an access token, and this could sometimes take more than 5 seconds to respond, so it would result in a warning from the openHAB core. In this revised version the initialization returns immediately, and the call for the access token is done asynchronously only when an access token is actually first required.

2) This revised version makes fewer logger.info messages; (downgraded to logger.debug messages)