### PR TITLE
[lutron] Add discovery of keypad models

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -47,11 +47,9 @@ Full discovery is supported for RadioRA 2 and HomeWorks QS systems.
 Both the main repeaters/processors themselves and the devices connected to them can be automatically discovered.
 Discovered repeaters/processors will be accessed using the default integration credentials.
 These can be changed in the bridge thing configuration.
+Discovered keypad devices should now have their model parameters automatically set to the correct value.
 
 Hubs and their connected devices in Caseta and RA2 Select systems need to be configured manually.
-
-**Remember:** Discovered keypads will not have their model parameter automatically set.
-You must manually set the model parameter for each keypad so that the correct channels for your particular keypad model will be created.
 
 ## Binding Configuration
 
@@ -155,9 +153,6 @@ You can monitor button channels for ON and OFF state changes to indicate button 
 Ditto for the indicator LED channels.
 Note, however, that version 11.6 or higher of the RadioRA 2 software may be required in order to drive keypad LED states, and then this may only be done on unbound buttons.
 
-When using auto-discovery, remember to select the correct value for the `model` parameter after accepting the keypad thing from the inbox.
-The correct channels will then be automatically configured.
-
 Component numbering: For button and LED layouts and numbering, see the Lutron Integration Protocol Guide (rev. AA) p.104 (http://www.lutron.com/TechnicalDocumentLibrary/040249.pdf).
 If you are having problems determining which channels have been created for a given keypad model, click on the thing under Configuration/Things in the Paper UI, or run the command `things show <thingUID>` (e.g. `things show lutron:keypad:radiora2:entrykeypad`) from the openHAB CLI to list the channels.
 
@@ -186,9 +181,6 @@ Tabletop seeTouch keypads use the **ttkeypad** thing.
 It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same channel types as the **keypad** thing.
 See the **keypad** section above for a full discussion of configuration and use.
 
-When using auto-discovery, remember to select the correct value for the `model` parameter after accepting the **ttkeypad** thing from the inbox.
-The correct channels will then be automatically configured.
-
 Component numbering: For button and LED layouts and numbering, see the Lutron Integration Protocol Guide (rev. AA) p.110 (http://www.lutron.com/TechnicalDocumentLibrary/040249.pdf).
 If you are having problems determining which channels have been created for a given keypad model, click on the thing under Configuration/Things in the Paper UI, or run the command `things show <thingUID>` (e.g. `things show lutron:ttkeypad:radiora2:bedroomkeypad`) from the openHAB CLI to list the channels.
 
@@ -205,9 +197,6 @@ Thing ttkeypad bedroomkeypad [ integrationId=11, model="T10RL" autorelease=true 
 International seeTouch keypads used in the Homeworks QS system use the **intlkeypad** thing.
 It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same button and led channel types as the **keypad** thing.
 See the **keypad** section above for a full discussion of configuration and use.
-
-If using auto-discovery, remember to select the correct value for the `model` parameter after accepting the **intlkeypad** thing from the inbox.
-The correct channels will then be automatically configured.
 
 To support this keypad's contact closure inputs, CCI channels named *cci1* and *cci2* are created with item type Contact and category Switch.
 They are marked as Advanced, so they will not be automatically linked to items in the Paper UI's Simple Mode.
@@ -230,9 +219,6 @@ Pico keypads use the **pico** thing.
 It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same channel types as the **keypad** and **ttkeypad** things.
 The only difference is that no LED channels will be created, since Pico keypads have no indicator LEDs.
 See the discussion above for a full discussion of configuration and use.
-
-When using auto-discovery, remember to select the correct value for the `model` parameter after accepting the **pico** thing from the inbox.
-The correct channels will then be automatically configured.
 
 Component numbering: For button layouts and numbering, see the Lutron Integration Protocol Guide (rev. AA) p.113 (http://www.lutron.com/TechnicalDocumentLibrary/040249.pdf).
 If you are having problems determining which channels have been created for a given keypad model, click on the thing under Configuration/Things in the Paper UI, or run the command `things show <thingUID>` (e.g. `things show lutron:pico:radiora2:hallpico`) from the openHAB CLI to list the channels.
@@ -261,7 +247,8 @@ To support the GRAFIK Eye's contact closure input, a CCI channel named *cci1* wi
 It is marked as Advanced, so it will not be automatically linked to items in the Paper UI's Simple Mode.
 It presents ON/OFF states the same as a keypad button.
 
-Component numbering: The buttons and LEDs on the GRAFIK Eye are numbered top to bottom, starting with the 5 scene buttons in a column on the right side of the panel, and then proceeding with the columns of buttons (if any) on the left side of the panel, working left to right. If you are having problems determining which channels have been created for a given model setting, click on the thing under Configuration/Things in the Paper UI, or run the command `things show <thingUID>` (e.g. `things show lutron:grafikeyekeypad:radiora2:theaterkeypad`) from the openHAB CLI to list the channels.
+Component numbering: The buttons and LEDs on the GRAFIK Eye are numbered top to bottom, starting with the 5 scene buttons in a column on the right side of the panel, and then proceeding with the columns of buttons (if any) on the left side of the panel, working left to right.
+If you are having problems determining which channels have been created for a given model setting, click on the thing under Configuration/Things in the Paper UI, or run the command `things show <thingUID>` (e.g. `things show lutron:grafikeyekeypad:radiora2:theaterkeypad`) from the openHAB CLI to list the channels.
 
 Supported settings for `model` parameter: 0COL, 1COL, 2COL, 3COL (default)
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/KeypadComponent.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/KeypadComponent.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.lutron.internal;
 
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
 /**
  * The {@link KeypadComponent} interface is used to access enums describing the possible components
  * in a given keypad model.
@@ -26,4 +28,6 @@ public interface KeypadComponent {
     public String channel();
 
     public String description();
+
+    public ComponentType type();
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -21,7 +21,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.ExecutionException;
@@ -44,6 +47,8 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.lutron.internal.LutronHandlerFactory;
 import org.openhab.binding.lutron.internal.discovery.project.Area;
+import org.openhab.binding.lutron.internal.discovery.project.Component;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
 import org.openhab.binding.lutron.internal.discovery.project.Device;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceGroup;
 import org.openhab.binding.lutron.internal.discovery.project.DeviceNode;
@@ -54,6 +59,12 @@ import org.openhab.binding.lutron.internal.discovery.project.OutputType;
 import org.openhab.binding.lutron.internal.discovery.project.Project;
 import org.openhab.binding.lutron.internal.discovery.project.Timeclock;
 import org.openhab.binding.lutron.internal.handler.IPBridgeHandler;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfig;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigGrafikEye;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigIntlSeetouch;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigPico;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigSeetouch;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigTabletopSeetouch;
 import org.openhab.binding.lutron.internal.xml.DbXmlInfoReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +76,7 @@ import org.slf4j.LoggerFactory;
  * @author Allan Tong - Initial contribution
  * @author Bob Adair - Added support for more output devices and keypads, VCRX, repeater virtual buttons,
  *         Timeclock, and Green Mode. Added option to read XML from file. Switched to jetty HTTP client for better
- *         exception handling.
+ *         exception handling. Added keypad model discovery.
  */
 public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
@@ -105,7 +116,7 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
         try {
             readDeviceDatabase();
         } catch (RuntimeException e) {
-            logger.warn("Runtime exception scanning for devices: {}", e.getMessage());
+            logger.warn("Runtime exception scanning for devices: {}", e.getMessage(), e);
 
             if (scanListener != null) {
                 scanListener.onErrorOccurred(null); // null so it won't log a stack trace
@@ -248,6 +259,10 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void processDevice(Device device, Stack<String> context) {
+        List<Integer> buttons;
+        KeypadConfig kpConfig;
+        String kpModel;
+
         DeviceType type = device.getDeviceType();
 
         if (type != null) {
@@ -260,19 +275,60 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
                 case SEETOUCH_KEYPAD:
                 case HYBRID_SEETOUCH_KEYPAD:
-                    notifyDiscovery(THING_TYPE_KEYPAD, device.getIntegrationId(), label);
+                    buttons = getComponentIdList(device.getComponents(), ComponentType.BUTTON);
+                    kpConfig = new KeypadConfigSeetouch();
+                    kpModel = kpConfig.determineModelFromComponentIds(buttons);
+                    if (kpModel == null) {
+                        logger.info("Unable to determine model of seeTouch keypad {} with button IDs: {}",
+                                device.getIntegrationId(), buttons);
+                        notifyDiscovery(THING_TYPE_KEYPAD, device.getIntegrationId(), label);
+                    } else {
+                        logger.debug("Found seeTouch Keypad {} model: {}", device.getIntegrationId(), kpModel);
+                        notifyDiscovery(THING_TYPE_KEYPAD, device.getIntegrationId(), label, "model", kpModel);
+                    }
                     break;
 
                 case INTERNATIONAL_SEETOUCH_KEYPAD:
-                    notifyDiscovery(THING_TYPE_INTLKEYPAD, device.getIntegrationId(), label);
+                    buttons = getComponentIdList(device.getComponents(), ComponentType.BUTTON);
+                    kpConfig = new KeypadConfigIntlSeetouch();
+                    kpModel = kpConfig.determineModelFromComponentIds(buttons);
+                    if (kpModel == null) {
+                        logger.info("Unable to determine model of International seeTouch keypad {} with button IDs: {}",
+                                device.getIntegrationId(), buttons);
+                        notifyDiscovery(THING_TYPE_INTLKEYPAD, device.getIntegrationId(), label);
+                    } else {
+                        logger.debug("Found International seeTouch Keypad {} model: {}", device.getIntegrationId(),
+                                kpModel);
+                        notifyDiscovery(THING_TYPE_INTLKEYPAD, device.getIntegrationId(), label, "model", kpModel);
+                    }
                     break;
 
                 case SEETOUCH_TABLETOP_KEYPAD:
-                    notifyDiscovery(THING_TYPE_TTKEYPAD, device.getIntegrationId(), label);
+                    buttons = getComponentIdList(device.getComponents(), ComponentType.BUTTON);
+                    kpConfig = new KeypadConfigTabletopSeetouch();
+                    kpModel = kpConfig.determineModelFromComponentIds(buttons);
+                    if (kpModel == null) {
+                        logger.info("Unable to determine model of Tabletop seeTouch keypad {} with button IDs: {}",
+                                device.getIntegrationId(), buttons);
+                        notifyDiscovery(THING_TYPE_TTKEYPAD, device.getIntegrationId(), label);
+                    } else {
+                        logger.debug("Found Tabletop seeTouch Keypad {} model: {}", device.getIntegrationId(), kpModel);
+                        notifyDiscovery(THING_TYPE_TTKEYPAD, device.getIntegrationId(), label, "model", kpModel);
+                    }
                     break;
 
                 case PICO_KEYPAD:
-                    notifyDiscovery(THING_TYPE_PICO, device.getIntegrationId(), label);
+                    buttons = getComponentIdList(device.getComponents(), ComponentType.BUTTON);
+                    kpConfig = new KeypadConfigPico();
+                    kpModel = kpConfig.determineModelFromComponentIds(buttons);
+                    if (kpModel == null) {
+                        logger.info("Unable to determine model of Pico keypad {} with button IDs: {}",
+                                device.getIntegrationId(), buttons);
+                        notifyDiscovery(THING_TYPE_PICO, device.getIntegrationId(), label);
+                    } else {
+                        logger.debug("Found Pico Keypad {} model: {}", device.getIntegrationId(), kpModel);
+                        notifyDiscovery(THING_TYPE_PICO, device.getIntegrationId(), label, "model", kpModel);
+                    }
                     break;
 
                 case VISOR_CONTROL_RECEIVER:
@@ -288,12 +344,39 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                     break;
 
                 case GRAFIK_EYE_QS:
-                    notifyDiscovery(THING_TYPE_GRAFIKEYEKEYPAD, device.getIntegrationId(), label);
+                    buttons = getComponentIdList(device.getComponents(), ComponentType.BUTTON);
+                    // remove button IDs >= 300 which the handler does not recognize
+                    List<Integer> buttonsCopy = new ArrayList<>(buttons);
+                    for (Integer c : buttonsCopy) {
+                        if (c >= 300) {
+                            buttons.remove(Integer.valueOf(c));
+                        }
+                    }
+                    kpConfig = new KeypadConfigGrafikEye();
+                    kpModel = kpConfig.determineModelFromComponentIds(buttons);
+                    if (kpModel == null) {
+                        logger.info("Unable to determine model of GrafikEye Keypad {} with button IDs: {}",
+                                device.getIntegrationId(), buttons);
+                        notifyDiscovery(THING_TYPE_GRAFIKEYEKEYPAD, device.getIntegrationId(), label);
+                    } else {
+                        logger.debug("Found GrafikEye keypad {} model: {}", device.getIntegrationId(), kpModel);
+                        notifyDiscovery(THING_TYPE_GRAFIKEYEKEYPAD, device.getIntegrationId(), label, "model", kpModel);
+                    }
                     break;
             }
         } else {
             logger.warn("Unrecognized device type {}", device.getType());
         }
+    }
+
+    private List<Integer> getComponentIdList(List<Component> clist, ComponentType ctype) {
+        List<Integer> returnList = new LinkedList<>();
+        for (Component c : clist) {
+            if (c.getComponentType() == ctype) {
+                returnList.add(c.getComponentNumber());
+            }
+        }
+        return returnList;
     }
 
     private void processOutput(Output output, Stack<String> context) {
@@ -348,7 +431,8 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
         notifyDiscovery(THING_TYPE_GREENMODE, greenmode.getIntegrationId(), label);
     }
 
-    private void notifyDiscovery(ThingTypeUID thingTypeUID, Integer integrationId, String label) {
+    private void notifyDiscovery(ThingTypeUID thingTypeUID, Integer integrationId, String label, String propName,
+            Object propValue) {
         if (integrationId == null) {
             logger.info("Discovered {} with no integration ID", label);
 
@@ -362,12 +446,20 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
         properties.put(INTEGRATION_ID, integrationId);
 
+        if (propName != null && propValue != null) {
+            properties.put(propName, propValue);
+        }
+
         DiscoveryResult result = DiscoveryResultBuilder.create(uid).withBridge(bridgeUID).withLabel(label)
                 .withProperties(properties).withRepresentationProperty(INTEGRATION_ID).build();
 
         thingDiscovered(result);
 
         logger.debug("Discovered {}", uid);
+    }
+
+    private void notifyDiscovery(ThingTypeUID thingTypeUID, Integer integrationId, String label) {
+        notifyDiscovery(thingTypeUID, integrationId, label, null, null);
     }
 
     private String generateLabel(Stack<String> context, String deviceName) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/ComponentType.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/ComponentType.java
@@ -20,5 +20,6 @@ package org.openhab.binding.lutron.internal.discovery.project;
 public enum ComponentType {
     BUTTON,
     CCI,
-    LED
+    LED,
+    SCENE_CONTROLLER
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BaseKeypadHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfig;
 import org.openhab.binding.lutron.internal.protocol.LutronCommandType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,16 +72,45 @@ public abstract class BaseKeypadHandler extends LutronHandler {
 
     protected abstract void configureComponents(String model);
 
-    protected abstract boolean isLed(int id);
-
-    protected abstract boolean isButton(int id);
-
-    protected abstract boolean isCCI(int id);
-
     private final Object asyncInitLock = new Object();
+
+    protected KeypadConfig kp;
 
     public BaseKeypadHandler(Thing thing) {
         super(thing);
+    }
+
+    /**
+     * Determine if keypad component with the specified id is a LED. Keypad handlers which do not use a KeypadConfig
+     * object must override this to provide their own test.
+     *
+     * @param id The component id.
+     * @return True if the component is a LED.
+     */
+    protected boolean isLed(int id) {
+        return kp.isLed(id);
+    }
+
+    /**
+     * Determine if keypad component with the specified id is a button. Keypad handlers which do not use a KeypadConfig
+     * object must override this to provide their own test.
+     *
+     * @param id The component id.
+     * @return True if the component is a button.
+     */
+    protected boolean isButton(int id) {
+        return kp.isButton(id);
+    }
+
+    /**
+     * Determine if keypad component with the specified id is a CCI. Keypad handlers which do not use a KeypadConfig
+     * object must override this to provide their own test.
+     *
+     * @param id The component id.
+     * @return True if the component is a CCI.
+     */
+    protected boolean isCCI(int id) {
+        return kp.isCCI(id);
     }
 
     protected void configureChannels() {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GrafikEyeKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/GrafikEyeKeypadHandler.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.Arrays;
-import java.util.List;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigGrafikEye;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,155 +29,37 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class GrafikEyeKeypadHandler extends BaseKeypadHandler {
-
-    private static enum Component implements KeypadComponent {
-        BUTTON1(70, "button1", "Button 1"), // Scene button 1
-        BUTTON2(71, "button2", "Button 2"), // Scene button 2
-        BUTTON3(76, "button3", "Button 3"), // Scene button 3
-        BUTTON4(77, "button4", "Button 4"), // Scene button 4
-        BUTTON5(83, "button5", "Button 5"), // Scene button 5/Off
-
-        BUTTON10(38, "button10", "Button 10"), // Col 1
-        BUTTON11(39, "button11", "Button 11"), // Col 1
-        BUTTON12(40, "button12", "Button 12"), // Col 1
-        LOWER1(41, "buttonlower1", "Lower button col 1"), // Col 1 lower
-        RAISE1(47, "buttonraise1", "Raise button col 1"), // Col 1 raise
-
-        BUTTON20(44, "button20", "Button 20"), // Col 2
-        BUTTON21(45, "button21", "Button 21"), // Col 2
-        BUTTON22(46, "button22", "Button 22"), // Col 2
-        LOWER2(52, "buttonlower2", "Lower button col 2"), // Col 2 lower
-        RAISE2(53, "buttonraise2", "Raise button col 2"), // Col 2 raise
-
-        BUTTON30(50, "button30", "Button 30"), // Col 3
-        BUTTON31(51, "button31", "Button 31"), // Col 3
-        BUTTON32(56, "button32", "Button 32"), // Col 3
-        LOWER3(57, "buttonlower3", "Lower button col 3"), // Col 3 lower
-        RAISE3(58, "buttonraise3", "Raise button col 3"), // Col 3 raise
-
-        CCI1(163, "cci1", "CCI 1"),
-
-        LED1(201, "led1", "LED 1"), // Scene button LEDs
-        LED2(210, "led2", "LED 2"),
-        LED3(219, "led3", "LED 3"),
-        LED4(228, "led4", "LED 4"),
-        LED5(237, "led5", "LED 5"),
-
-        LED10(174, "led10", "LED 10"), // Col 1 LEDs
-        LED11(175, "led11", "LED 11"),
-        LED12(211, "led12", "LED 12"),
-
-        LED20(183, "led20", "LED 20"), // Col 2 LEDs
-        LED21(184, "led21", "LED 21"),
-        LED22(220, "led22", "LED 22"),
-
-        LED30(192, "led30", "LED 30"), // Col 3 LEDs
-        LED31(193, "led31", "LED 31"),
-        LED32(229, "led32", "LED 32");
-
-        private final int id;
-        private final String channel;
-        private final String description;
-
-        Component(int id, String channel, String description) {
-            this.id = id;
-            this.channel = channel;
-            this.description = description;
-        }
-
-        @Override
-        public int id() {
-            return this.id;
-        }
-
-        @Override
-        public String channel() {
-            return this.channel;
-        }
-
-        @Override
-        public String description() {
-            return this.description;
-        }
-
-    }
-
-    private static final List<Component> SCENE_BUTTON_GROUP = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
-            Component.BUTTON3, Component.BUTTON4, Component.BUTTON5);
-    private static final List<Component> SCENE_LED_GROUP = Arrays.asList(Component.LED1, Component.LED2, Component.LED3,
-            Component.LED4, Component.LED5);
-
-    private static final List<Component> CCI_GROUP = Arrays.asList(Component.CCI1);
-
-    private static final List<Component> COL1_BUTTON_GROUP = Arrays.asList(Component.BUTTON10, Component.BUTTON11,
-            Component.BUTTON12, Component.LOWER1, Component.RAISE1);
-    private static final List<Component> COL2_BUTTON_GROUP = Arrays.asList(Component.BUTTON20, Component.BUTTON21,
-            Component.BUTTON22, Component.LOWER2, Component.RAISE2);
-    private static final List<Component> COL3_BUTTON_GROUP = Arrays.asList(Component.BUTTON30, Component.BUTTON31,
-            Component.BUTTON32, Component.LOWER3, Component.RAISE3);
-
-    private static final List<Component> COL1_LED_GROUP = Arrays.asList(Component.LED10, Component.LED11,
-            Component.LED12);
-    private static final List<Component> COL2_LED_GROUP = Arrays.asList(Component.LED20, Component.LED21,
-            Component.LED22);
-    private static final List<Component> COL3_LED_GROUP = Arrays.asList(Component.LED30, Component.LED31,
-            Component.LED32);
 
     private final Logger logger = LoggerFactory.getLogger(GrafikEyeKeypadHandler.class);
 
     @Override
-    protected boolean isLed(int id) {
-        return (id >= 174 && id <= 237);
-    }
-
-    @Override
-    protected boolean isButton(int id) {
-        return (id >= 38 && id <= 83);
-    }
-
-    @Override
-    protected boolean isCCI(int id) {
-        return (id == 163);
-    }
-
-    @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         String mod = model == null ? "3COL" : model;
         logger.debug("Configuring components for GRAFIK Eye QS");
 
-        buttonList.addAll(SCENE_BUTTON_GROUP);
-        ledList.addAll(SCENE_LED_GROUP);
-        cciList.addAll(CCI_GROUP);
-
         switch (mod) {
+            case "3COL":
+            case "2COL":
+            case "1COL":
+            case "0COL":
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
+                cciList = kp.getComponents(mod, ComponentType.CCI);
+                break;
             default:
                 logger.warn("No valid keypad model defined ({}). Assuming model 3COL.", mod);
-            case "3COL":
-                buttonList.addAll(COL1_BUTTON_GROUP);
-                buttonList.addAll(COL2_BUTTON_GROUP);
-                buttonList.addAll(COL3_BUTTON_GROUP);
-                ledList.addAll(COL1_LED_GROUP);
-                ledList.addAll(COL2_LED_GROUP);
-                ledList.addAll(COL3_LED_GROUP);
-                break;
-            case "2COL":
-                buttonList.addAll(COL1_BUTTON_GROUP);
-                buttonList.addAll(COL2_BUTTON_GROUP);
-                ledList.addAll(COL1_LED_GROUP);
-                ledList.addAll(COL2_LED_GROUP);
-                break;
-            case "1COL":
-                buttonList.addAll(COL1_BUTTON_GROUP);
-                ledList.addAll(COL1_LED_GROUP);
-                break;
-            case "0COL":
+                buttonList = kp.getComponents("3COL", ComponentType.BUTTON);
+                ledList = kp.getComponents("3COL", ComponentType.LED);
+                cciList = kp.getComponents("3COL", ComponentType.CCI);
                 break;
         }
     }
 
     public GrafikEyeKeypadHandler(Thing thing) {
         super(thing);
+        kp = new KeypadConfigGrafikEye();
     }
 
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IntlKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IntlKeypadHandler.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.Arrays;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigIntlSeetouch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,135 +26,43 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class IntlKeypadHandler extends BaseKeypadHandler {
-
-    private static enum Component implements KeypadComponent {
-        BUTTON1(1, "button1", "Button 1"),
-        BUTTON2(2, "button2", "Button 2"),
-        BUTTON3(3, "button3", "Button 3"),
-        BUTTON4(4, "button4", "Button 4"),
-        BUTTON5(5, "button5", "Button 5"),
-        BUTTON6(6, "button6", "Button 6"),
-        BUTTON7(7, "button7", "Button 7"),
-        BUTTON8(8, "button8", "Button 8"),
-        BUTTON9(9, "button9", "Button 9"),
-        BUTTON10(10, "button10", "Button 10"),
-
-        LOWER1(18, "buttonlower", "Lower button"),
-        RAISE1(19, "buttonraise", "Raise button"),
-
-        CCI1(25, "cci1", ""),
-        CCI2(26, "cci2", ""),
-
-        LED1(81, "led1", "LED 1"),
-        LED2(82, "led2", "LED 2"),
-        LED3(83, "led3", "LED 3"),
-        LED4(84, "led4", "LED 4"),
-        LED5(85, "led5", "LED 5"),
-        LED6(86, "led6", "LED 6"),
-        LED7(87, "led7", "LED 7"),
-        LED8(88, "led8", "LED 8"),
-        LED9(89, "led9", "LED 9"),
-        LED10(90, "led10", "LED 10");
-
-        private final int id;
-        private final String channel;
-        private final String description;
-
-        Component(int id, String channel, String description) {
-            this.id = id;
-            this.channel = channel;
-            this.description = description;
-        }
-
-        @Override
-        public int id() {
-            return id;
-        }
-
-        @Override
-        public String channel() {
-            return channel;
-        }
-
-        @Override
-        public String description() {
-            return description;
-        }
-
-    }
 
     private final Logger logger = LoggerFactory.getLogger(IntlKeypadHandler.class);
 
     @Override
-    protected boolean isLed(int id) {
-        return (id >= 81 && id <= 90);
-    }
-
-    @Override
-    protected boolean isButton(int id) {
-        return ((id >= 1 && id <= 10) || (id >= 18 && id <= 19));
-    }
-
-    @Override
-    protected boolean isCCI(int id) {
-        return (id >= 25 && id <= 26);
-    }
-
-    @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         String mod = model == null ? "Generic" : model;
         logger.debug("Configuring components for keypad model {}", model);
 
-        cciList.addAll(Arrays.asList(Component.CCI1, Component.CCI2));
-        
         switch (mod) {
             case "2B":
-                buttonList.addAll(Arrays.asList(Component.BUTTON7, Component.BUTTON9));
-                ledList.addAll(Arrays.asList(Component.LED7, Component.LED9));
-                break;
             case "3B":
-                buttonList.addAll(Arrays.asList(Component.BUTTON6, Component.BUTTON8, Component.BUTTON10));
-                ledList.addAll(Arrays.asList(Component.LED6, Component.LED8, Component.LED10));
-                break;
             case "4B":
-                buttonList.addAll(Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON7, Component.BUTTON9));
-                ledList.addAll(Arrays.asList(Component.LED2, Component.LED4, Component.LED7, Component.LED9));
-                break;
             case "5BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
-                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
-                ledList.addAll(Arrays.asList(Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
-                break;
             case "6BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6, Component.BUTTON8, Component.BUTTON10));
-                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5, Component.LED6, Component.LED8, Component.LED10));
-                break;
             case "7BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
-                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
-                ledList.addAll(Arrays.asList(Component.LED2, Component.LED4, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
-                break;
             case "8BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
-                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
+                cciList = kp.getComponents(mod, ComponentType.CCI);
                 break;
             default:
                 logger.warn("No valid keypad model defined ({}). Assuming 10BRL model.", mod);
                 // fall through
             case "Generic":
             case "10BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10));
-                buttonList.addAll(Arrays.asList(Component.LOWER1, Component.RAISE1));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4, Component.LED5, Component.LED6, Component.LED7, Component.LED8, Component.LED9, Component.LED10));
+                buttonList = kp.getComponents("10BRL", ComponentType.BUTTON);
+                ledList = kp.getComponents("10BRL", ComponentType.LED);
+                cciList = kp.getComponents("10BRL", ComponentType.CCI);
                 break;
         }
     }
 
     public IntlKeypadHandler(Thing thing) {
         super(thing);
+        kp = new KeypadConfigIntlSeetouch();
     }
 
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/KeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/KeypadHandler.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.Arrays;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigSeetouch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,79 +26,13 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class KeypadHandler extends BaseKeypadHandler {
-
-    private static enum Component implements KeypadComponent {
-        BUTTON1(1, "button1", "Button 1"),
-        BUTTON2(2, "button2", "Button 2"),
-        BUTTON3(3, "button3", "Button 3"),
-        BUTTON4(4, "button4", "Button 4"),
-        BUTTON5(5, "button5", "Button 5"),
-        BUTTON6(6, "button6", "Button 6"),
-        BUTTON7(7, "button7", "Button 7"),
-
-        LOWER1(16, "buttontoplower", "Top lower button"),
-        RAISE1(17, "buttontopraise", "Top raise button"),
-        LOWER2(18, "buttonbottomlower", "Bottom lower button"),
-        RAISE2(19, "buttonbottomraise", "Bottom raise button"),
-
-        // CCI1(25, "cci1", ""), // listed in spec but currently unused in binding
-        // CCI2(26, "cci2", ""), // listed in spec but currently unused in binding
-
-        LED1(81, "led1", "LED 1"),
-        LED2(82, "led2", "LED 2"),
-        LED3(83, "led3", "LED 3"),
-        LED4(84, "led4", "LED 4"),
-        LED5(85, "led5", "LED 5"),
-        LED6(86, "led6", "LED 6"),
-        LED7(87, "led7", "LED 7");
-
-        private final int id;
-        private final String channel;
-        private final String description;
-
-        Component(int id, String channel, String description) {
-            this.id = id;
-            this.channel = channel;
-            this.description = description;
-        }
-
-        @Override
-        public int id() {
-            return id;
-        }
-
-        @Override
-        public String channel() {
-            return channel;
-        }
-
-        @Override
-        public String description() {
-            return description;
-        }
-
-    }
 
     private final Logger logger = LoggerFactory.getLogger(KeypadHandler.class);
 
     @Override
-    protected boolean isLed(int id) {
-        return (id >= 81 && id <= 87);
-    }
-
-    @Override
-    protected boolean isButton(int id) {
-        return ((id >= 1 && id <= 7) || (id >= 16 && id <= 19));
-    }
-
-    @Override
-    protected boolean isCCI(int id) {
-        return false;
-    }
-
-    @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         String mod = model == null ? "Generic" : model;
         logger.debug("Configuring components for keypad model {}", model);
 
@@ -105,97 +40,72 @@ public class KeypadHandler extends BaseKeypadHandler {
             case "W1RLD":
             case "H1RLD":
             case "HN1RLD":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON5, Component.BUTTON6));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(
-                        Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED5, Component.LED6));
+                buttonList = kp.getComponents("W1RLD", ComponentType.BUTTON);
+                ledList = kp.getComponents("W1RLD", ComponentType.LED);
                 break;
             case "W2RLD":
             case "H2RLD":
             case "HN2RLD":
-                buttonList.addAll(
-                        Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON5, Component.BUTTON6));
-                buttonList
-                        .addAll(Arrays.asList(Component.LOWER1, Component.RAISE1, Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED5, Component.LED6));
+                buttonList = kp.getComponents("W2RLD", ComponentType.BUTTON);
+                ledList = kp.getComponents("W2RLD", ComponentType.LED);
                 break;
             case "W3S":
             case "H3S":
             case "HN3S":
-                buttonList.addAll(
-                        Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON6));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED6));
+                buttonList = kp.getComponents("W3S", ComponentType.BUTTON);
+                ledList = kp.getComponents("W3S", ComponentType.LED);
+
                 break;
             case "W3BD":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON5, Component.BUTTON6, Component.BUTTON7));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED5,
-                        Component.LED6, Component.LED7));
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
                 break;
             case "W3BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON2, Component.BUTTON3, Component.BUTTON4));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED2, Component.LED3, Component.LED4));
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
                 break;
             case "W3BSRL":
             case "H3BSRL":
             case "HN3BSRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED3, Component.LED5));
+                buttonList = kp.getComponents("W3BSRL", ComponentType.BUTTON);
+                ledList = kp.getComponents("W3BSRL", ComponentType.LED);
                 break;
             case "W4S":
             case "H4S":
             case "HN4S":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON4, Component.BUTTON6));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(
-                        Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4, Component.LED6));
+                buttonList = kp.getComponents("W4S", ComponentType.BUTTON);
+                ledList = kp.getComponents("W4S", ComponentType.LED);
                 break;
             case "W5BRL":
             case "H5BRL":
             case "HN5BRL":
             case "W5BRLIR":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON4, Component.BUTTON5));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(
-                        Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4, Component.LED5));
+                buttonList = kp.getComponents("W5BRL", ComponentType.BUTTON);
+                ledList = kp.getComponents("W5BRL", ComponentType.LED);
                 break;
             case "W6BRL":
             case "H6BRL":
             case "HN6BRL":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON4, Component.BUTTON5, Component.BUTTON6));
-                buttonList.addAll(Arrays.asList(Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4,
-                        Component.LED5, Component.LED6));
+                buttonList = kp.getComponents("W6BRL", ComponentType.BUTTON);
+                ledList = kp.getComponents("W6BRL", ComponentType.LED);
                 break;
             case "W7B":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON4, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4,
-                        Component.LED5, Component.LED6, Component.LED7));
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
                 break;
             default:
                 logger.warn("No valid keypad model defined ({}). Assuming Generic model.", mod);
                 // fall through
             case "Generic":
-                buttonList.addAll(Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3,
-                        Component.BUTTON4, Component.BUTTON5, Component.BUTTON6, Component.BUTTON7));
-                buttonList
-                        .addAll(Arrays.asList(Component.LOWER1, Component.RAISE1, Component.LOWER2, Component.RAISE2));
-                ledList.addAll(Arrays.asList(Component.LED1, Component.LED2, Component.LED3, Component.LED4,
-                        Component.LED5, Component.LED6, Component.LED7));
+                buttonList = kp.getComponents("Generic", ComponentType.BUTTON);
+                ledList = kp.getComponents("Generic", ComponentType.LED);
                 break;
         }
     }
 
     public KeypadHandler(Thing thing) {
         super(thing);
+        kp = new KeypadConfigSeetouch();
     }
 
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/PicoKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/PicoKeypadHandler.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.Arrays;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigPico;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,96 +25,34 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class PicoKeypadHandler extends BaseKeypadHandler {
-
-    private static enum Component implements KeypadComponent {
-        // Buttons for 2B, 2BRL, 3B, and 3BRL models
-        BUTTON1(2, "button1", "Button 1"),
-        BUTTON2(3, "button2", "Button 2"),
-        BUTTON3(4, "button3", "Button 3"),
-
-        RAISE(5, "buttonraise", "Raise Button"),
-        LOWER(6, "buttonlower", "Lower Button"),
-
-        // Buttons for PJ2-4B model
-        BUTTON1_4B(8, "button01", "Button 1"),
-        BUTTON2_4B(9, "button02", "Button 2"),
-        BUTTON3_4B(10, "button03", "Button 3"),
-        BUTTON4_4B(11, "button04", "Button 4");
-
-        private final int id;
-        private final String channel;
-        private final String description;
-
-        Component(int id, String channel, String description) {
-            this.id = id;
-            this.channel = channel;
-            this.description = description;
-        }
-
-        @Override
-        public int id() {
-            return id;
-        }
-
-        @Override
-        public String channel() {
-            return channel;
-        }
-
-        @Override
-        public String description() {
-            return description;
-        }
-    }
 
     private final Logger logger = LoggerFactory.getLogger(PicoKeypadHandler.class);
 
     public PicoKeypadHandler(Thing thing) {
         super(thing);
+        kp = new KeypadConfigPico();
     }
 
     @Override
-    protected boolean isLed(int id) {
-        return false; // No LEDs on Picos
-    }
-
-    @Override
-    protected boolean isButton(int id) {
-        return (id >= 2 && id <= 11);
-    }
-
-    @Override
-    protected boolean isCCI(int id) {
-        return false;
-    }
-
-    @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         String mod = model == null ? "Generic" : model;
         logger.debug("Configuring components for keypad model {}", mod);
 
         switch (mod) {
             case "2B":
-                buttonList = Arrays.asList(Component.BUTTON1, Component.BUTTON3);
-                break;
             case "2BRL":
-                buttonList = Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.RAISE, Component.LOWER);
-                break;
             case "3B":
-                buttonList = Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3);
-                break;
             case "4B":
-                buttonList = Arrays.asList(Component.BUTTON1_4B, Component.BUTTON2_4B, Component.BUTTON3_4B,
-                        Component.BUTTON4_4B);
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
                 break;
             default:
                 logger.warn("No valid keypad model defined ({}). Assuming model 3BRL.", mod);
                 // fall through
             case "Generic":
             case "3BRL":
-                buttonList = Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.RAISE,
-                        Component.LOWER);
+                buttonList = kp.getComponents("3BRL", ComponentType.BUTTON);
                 break;
         }
     }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/QSIOHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/QSIOHandler.java
@@ -14,8 +14,11 @@ package org.openhab.binding.lutron.internal.handler;
 
 import java.util.Arrays;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,23 +27,26 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class QSIOHandler extends BaseKeypadHandler {
 
     private static enum Component implements KeypadComponent {
-        CCI1(1, "cci1", "CCI 1"),
-        CCI2(2, "cci2", "CCI 2"),
-        CCI3(3, "cci3", "CCI 3"),
-        CCI4(4, "cci4", "CCI 4"),
-        CCI5(5, "cci5", "CCI 5");
+        CCI1(1, "cci1", "CCI 1", ComponentType.CCI),
+        CCI2(2, "cci2", "CCI 2", ComponentType.CCI),
+        CCI3(3, "cci3", "CCI 3", ComponentType.CCI),
+        CCI4(4, "cci4", "CCI 4", ComponentType.CCI),
+        CCI5(5, "cci5", "CCI 5", ComponentType.CCI);
 
         private final int id;
         private final String channel;
         private final String description;
+        private final ComponentType type;
 
-        Component(int id, String channel, String description) {
+        Component(int id, String channel, String description, ComponentType type) {
             this.id = id;
             this.channel = channel;
             this.description = description;
+            this.type = type;
         }
 
         @Override
@@ -58,6 +64,10 @@ public class QSIOHandler extends BaseKeypadHandler {
             return this.description;
         }
 
+        @Override
+        public ComponentType type() {
+            return type;
+        }
     }
 
     private final Logger logger = LoggerFactory.getLogger(QSIOHandler.class);
@@ -78,7 +88,7 @@ public class QSIOHandler extends BaseKeypadHandler {
     }
 
     @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         logger.debug("Configuring components for VCRX");
 
         cciList.addAll(Arrays.asList(Component.CCI1, Component.CCI2, Component.CCI3, Component.CCI4, Component.CCI5));

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TabletopKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/TabletopKeypadHandler.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.Arrays;
-import java.util.List;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+import org.openhab.binding.lutron.internal.keypadconfig.KeypadConfigTabletopSeetouch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,162 +26,40 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class TabletopKeypadHandler extends BaseKeypadHandler {
-
-    private static enum Component implements KeypadComponent {
-        BUTTON1(1, "button1", "Button 1"),
-        BUTTON2(2, "button2", "Button 2"),
-        BUTTON3(3, "button3", "Button 3"),
-        BUTTON4(4, "button4", "Button 4"),
-        BUTTON5(5, "button5", "Button 5"),
-        BUTTON6(6, "button6", "Button 6"),
-        BUTTON7(7, "button7", "Button 7"),
-        BUTTON8(8, "button8", "Button 8"),
-        BUTTON9(9, "button9", "Button 9"),
-        BUTTON10(10, "button10", "Button 10"),
-        BUTTON11(11, "button11", "Button 11"),
-        BUTTON12(12, "button12", "Button 12"),
-        BUTTON13(13, "button13", "Button 13"),
-        BUTTON14(14, "button14", "Button 14"),
-        BUTTON15(15, "button15", "Button 15"),
-
-        BUTTON16(16, "button16", "Button 16"),
-        BUTTON17(17, "button17", "Button 17"),
-
-        LOWER1(20, "buttonlower1", "Lower button 1"),
-        RAISE1(21, "buttonraise1", "Raise button 1"),
-        LOWER2(22, "buttonlower2", "Lower button 2"),
-        RAISE2(23, "buttonraise2", "Raise button 2"),
-        LOWER3(24, "buttonlower3", "Lower button 3"),
-        RAISE3(25, "buttonraise3", "Raise button 3"),
-
-        LED1(81, "led1", "LED 1"),
-        LED2(82, "led2", "LED 2"),
-        LED3(83, "led3", "LED 3"),
-        LED4(84, "led4", "LED 4"),
-        LED5(85, "led5", "LED 5"),
-        LED6(86, "led6", "LED 6"),
-        LED7(87, "led7", "LED 7"),
-        LED8(88, "led8", "LED 8"),
-        LED9(89, "led9", "LED 9"),
-        LED10(90, "led10", "LED 10"),
-        LED11(91, "led11", "LED 11"),
-        LED12(92, "led12", "LED 12"),
-        LED13(93, "led13", "LED 13"),
-        LED14(94, "led14", "LED 14"),
-        LED15(95, "led15", "LED 15"),
-
-        LED16(96, "led16", "LED 16"),
-        LED17(97, "led17", "LED 17");
-
-        private final int id;
-        private final String channel;
-        private final String description;
-
-        Component(int id, String channel, String description) {
-            this.id = id;
-            this.channel = channel;
-            this.description = description;
-        }
-
-        @Override
-        public int id() {
-            return id;
-        }
-
-        @Override
-        public String channel() {
-            return channel;
-        }
-
-        @Override
-        public String description() {
-            return description;
-        }
-
-    }
-
-    private static final List<Component> buttonGroup1 = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
-            Component.BUTTON3, Component.BUTTON4, Component.BUTTON5);
-    private static final List<Component> buttonGroup2 = Arrays.asList(Component.BUTTON6, Component.BUTTON7,
-            Component.BUTTON8, Component.BUTTON9, Component.BUTTON10);
-    private static final List<Component> buttonGroup3 = Arrays.asList(Component.BUTTON11, Component.BUTTON12,
-            Component.BUTTON13, Component.BUTTON14, Component.BUTTON15);
-
-    private static final List<Component> buttonsBottomRL = Arrays.asList(Component.BUTTON16, Component.BUTTON17,
-            Component.LOWER3, Component.RAISE3);
-    private static final List<Component> buttonsBottomCRL = Arrays.asList(Component.LOWER1, Component.RAISE1,
-            Component.LOWER2, Component.RAISE2, Component.LOWER3, Component.RAISE3);
-
-    private static final List<Component> ledGroup1 = Arrays.asList(Component.LED1, Component.LED2, Component.LED3,
-            Component.LED4, Component.LED5);
-    private static final List<Component> ledGroup2 = Arrays.asList(Component.LED6, Component.LED7, Component.LED8,
-            Component.LED9, Component.LED10);
-    private static final List<Component> ledGroup3 = Arrays.asList(Component.LED11, Component.LED12, Component.LED13,
-            Component.LED14, Component.LED15);
-
-    private static final List<Component> LedsBottomRL = Arrays.asList(Component.LED16, Component.LED17);
 
     private final Logger logger = LoggerFactory.getLogger(TabletopKeypadHandler.class);
 
     @Override
-    protected boolean isLed(int id) {
-        return (id >= 81 && id <= 95);
-    }
-
-    @Override
-    protected boolean isButton(int id) {
-        return (id >= 1 && id <= 25);
-    }
-
-    @Override
-    protected boolean isCCI(int id) {
-        return false;
-    }
-
-    @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         String mod = model == null ? "Generic" : model;
         logger.debug("Configuring components for keypad model {}", model);
 
         switch (mod) {
+            case "T5RL":
+            case "T10RL":
+            case "T15RL":
+            case "T5CRL":
+            case "T10CRL":
+            case "T15CRL":
+                buttonList = kp.getComponents(mod, ComponentType.BUTTON);
+                ledList = kp.getComponents(mod, ComponentType.LED);
+                break;
+
             default:
                 logger.warn("No valid keypad model defined ({}). Assuming model T15RL.", mod);
                 // fall through
             case "Generic":
-            case "T15RL":
-                buttonList.addAll(buttonGroup3);
-                ledList.addAll(ledGroup3);
-                // fall through
-            case "T10RL":
-                buttonList.addAll(buttonGroup2);
-                ledList.addAll(ledGroup2);
-                // fall through
-            case "T5RL":
-                buttonList.addAll(buttonGroup1);
-                buttonList.addAll(buttonsBottomRL);
-                ledList.addAll(ledGroup1);
-                ledList.addAll(LedsBottomRL);
-                break;
-
-            case "T15CRL":
-                buttonList.addAll(buttonGroup3);
-                ledList.addAll(ledGroup3);
-                // fall through
-            case "T10CRL":
-                buttonList.addAll(buttonGroup2);
-                ledList.addAll(ledGroup2);
-                // fall through
-            case "T5CRL":
-                buttonList.addAll(buttonGroup1);
-                buttonList.addAll(buttonsBottomCRL);
-                ledList.addAll(ledGroup1);
+                buttonList = kp.getComponents("Generic", ComponentType.BUTTON);
+                ledList = kp.getComponents("Generic", ComponentType.LED);
                 break;
         }
     }
 
     public TabletopKeypadHandler(Thing thing) {
         super(thing);
+        kp = new KeypadConfigTabletopSeetouch();
     }
 
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/VcrxHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/VcrxHandler.java
@@ -15,8 +15,11 @@ package org.openhab.binding.lutron.internal.handler;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,36 +28,39 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class VcrxHandler extends BaseKeypadHandler {
 
     private static enum Component implements KeypadComponent {
-        BUTTON1(1, "button1", "Button 1"),
-        BUTTON2(2, "button2", "Button 2"),
-        BUTTON3(3, "button3", "Button 3"),
-        BUTTON4(4, "button4", "Button 4"),
-        BUTTON5(5, "button5", "Button 5"),
-        BUTTON6(6, "button6", "Button 6"),
+        BUTTON1(1, "button1", "Button 1", ComponentType.BUTTON),
+        BUTTON2(2, "button2", "Button 2", ComponentType.BUTTON),
+        BUTTON3(3, "button3", "Button 3", ComponentType.BUTTON),
+        BUTTON4(4, "button4", "Button 4", ComponentType.BUTTON),
+        BUTTON5(5, "button5", "Button 5", ComponentType.BUTTON),
+        BUTTON6(6, "button6", "Button 6", ComponentType.BUTTON),
 
-        CCI1(30, "cci1", "CCI 1"),
-        CCI2(31, "cci2", "CCI 2"),
-        CCI3(32, "cci3", "CCI 3"),
-        CCI4(33, "cci4", "CCI 4"),
+        CCI1(30, "cci1", "CCI 1", ComponentType.CCI),
+        CCI2(31, "cci2", "CCI 2", ComponentType.CCI),
+        CCI3(32, "cci3", "CCI 3", ComponentType.CCI),
+        CCI4(33, "cci4", "CCI 4", ComponentType.CCI),
 
-        LED1(81, "led1", "LED 1"),
-        LED2(82, "led2", "LED 2"),
-        LED3(83, "led3", "LED 3"),
-        LED4(84, "led4", "LED 4"),
-        LED5(85, "led5", "LED 5"),
-        LED6(86, "led6", "LED 6");
+        LED1(81, "led1", "LED 1", ComponentType.LED),
+        LED2(82, "led2", "LED 2", ComponentType.LED),
+        LED3(83, "led3", "LED 3", ComponentType.LED),
+        LED4(84, "led4", "LED 4", ComponentType.LED),
+        LED5(85, "led5", "LED 5", ComponentType.LED),
+        LED6(86, "led6", "LED 6", ComponentType.LED);
 
         private final int id;
         private final String channel;
         private final String description;
+        private final ComponentType type;
 
-        Component(int id, String channel, String description) {
+        Component(int id, String channel, String description, ComponentType type) {
             this.id = id;
             this.channel = channel;
             this.description = description;
+            this.type = type;
         }
 
         @Override
@@ -72,15 +78,19 @@ public class VcrxHandler extends BaseKeypadHandler {
             return this.description;
         }
 
+        @Override
+        public ComponentType type() {
+            return type;
+        }
     }
 
-    private static final List<Component> buttonGroup = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
+    private static final List<Component> BUTTONGROUP = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
             Component.BUTTON3, Component.BUTTON4, Component.BUTTON5, Component.BUTTON6);
 
-    private static final List<Component> ledGroup = Arrays.asList(Component.LED1, Component.LED2, Component.LED3,
+    private static final List<Component> LEDGROUP = Arrays.asList(Component.LED1, Component.LED2, Component.LED3,
             Component.LED4, Component.LED5, Component.LED6);
 
-    private static final List<Component> cciGroup = Arrays.asList(Component.CCI1, Component.CCI2, Component.CCI3,
+    private static final List<Component> CCIGROUP = Arrays.asList(Component.CCI1, Component.CCI2, Component.CCI3,
             Component.CCI4);
 
     private final Logger logger = LoggerFactory.getLogger(VcrxHandler.class);
@@ -101,12 +111,12 @@ public class VcrxHandler extends BaseKeypadHandler {
     }
 
     @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         logger.debug("Configuring components for VCRX");
 
-        buttonList.addAll(buttonGroup);
-        ledList.addAll(ledGroup);
-        cciList.addAll(cciGroup);
+        buttonList.addAll(BUTTONGROUP);
+        ledList.addAll(LEDGROUP);
+        cciList.addAll(CCIGROUP);
     }
 
     public VcrxHandler(Thing thing) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/VirtualKeypadHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/VirtualKeypadHandler.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.lutron.internal.handler;
 
-import java.util.EnumSet;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,219 +25,20 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Adair - Initial contribution
  */
+@NonNullByDefault
 public class VirtualKeypadHandler extends BaseKeypadHandler {
 
-    private static enum Component implements KeypadComponent {
-        BUTTON1(1, "button1", "Virtual button"),
-        BUTTON2(2, "button2", "Virtual button"),
-        BUTTON3(3, "button3", "Virtual button"),
-        BUTTON4(4, "button4", "Virtual button"),
-        BUTTON5(5, "button5", "Virtual button"),
-        BUTTON6(6, "button6", "Virtual button"),
-        BUTTON7(7, "button7", "Virtual button"),
-        BUTTON8(8, "button8", "Virtual button"),
-        BUTTON9(9, "button9", "Virtual button"),
-        BUTTON10(10, "button10", "Virtual button"),
-        BUTTON11(11, "button11", "Virtual button"),
-        BUTTON12(12, "button12", "Virtual button"),
-        BUTTON13(13, "button13", "Virtual button"),
-        BUTTON14(14, "button14", "Virtual button"),
-        BUTTON15(15, "button15", "Virtual button"),
-        BUTTON16(16, "button16", "Virtual button"),
-        BUTTON17(17, "button17", "Virtual button"),
-        BUTTON18(18, "button18", "Virtual button"),
-        BUTTON19(19, "button19", "Virtual button"),
-        BUTTON20(20, "button20", "Virtual button"),
-        BUTTON21(21, "button21", "Virtual button"),
-        BUTTON22(22, "button22", "Virtual button"),
-        BUTTON23(23, "button23", "Virtual button"),
-        BUTTON24(24, "button24", "Virtual button"),
-        BUTTON25(25, "button25", "Virtual button"),
-        BUTTON26(26, "button26", "Virtual button"),
-        BUTTON27(27, "button27", "Virtual button"),
-        BUTTON28(28, "button28", "Virtual button"),
-        BUTTON29(29, "button29", "Virtual button"),
-        BUTTON30(30, "button30", "Virtual button"),
-        BUTTON31(31, "button31", "Virtual button"),
-        BUTTON32(32, "button32", "Virtual button"),
-        BUTTON33(33, "button33", "Virtual button"),
-        BUTTON34(34, "button34", "Virtual button"),
-        BUTTON35(35, "button35", "Virtual button"),
-        BUTTON36(36, "button36", "Virtual button"),
-        BUTTON37(37, "button37", "Virtual button"),
-        BUTTON38(38, "button38", "Virtual button"),
-        BUTTON39(39, "button39", "Virtual button"),
-        BUTTON40(40, "button40", "Virtual button"),
-        BUTTON41(41, "button41", "Virtual button"),
-        BUTTON42(42, "button42", "Virtual button"),
-        BUTTON43(43, "button43", "Virtual button"),
-        BUTTON44(44, "button44", "Virtual button"),
-        BUTTON45(45, "button45", "Virtual button"),
-        BUTTON46(46, "button46", "Virtual button"),
-        BUTTON47(47, "button47", "Virtual button"),
-        BUTTON48(48, "button48", "Virtual button"),
-        BUTTON49(49, "button49", "Virtual button"),
-        BUTTON50(50, "button50", "Virtual button"),
-        BUTTON51(51, "button51", "Virtual button"),
-        BUTTON52(52, "button52", "Virtual button"),
-        BUTTON53(53, "button53", "Virtual button"),
-        BUTTON54(54, "button54", "Virtual button"),
-        BUTTON55(55, "button55", "Virtual button"),
-        BUTTON56(56, "button56", "Virtual button"),
-        BUTTON57(57, "button57", "Virtual button"),
-        BUTTON58(58, "button58", "Virtual button"),
-        BUTTON59(59, "button59", "Virtual button"),
-        BUTTON60(60, "button60", "Virtual button"),
-        BUTTON61(61, "button61", "Virtual button"),
-        BUTTON62(62, "button62", "Virtual button"),
-        BUTTON63(63, "button63", "Virtual button"),
-        BUTTON64(64, "button64", "Virtual button"),
-        BUTTON65(65, "button65", "Virtual button"),
-        BUTTON66(66, "button66", "Virtual button"),
-        BUTTON67(67, "button67", "Virtual button"),
-        BUTTON68(68, "button68", "Virtual button"),
-        BUTTON69(69, "button69", "Virtual button"),
-        BUTTON70(70, "button70", "Virtual button"),
-        BUTTON71(71, "button71", "Virtual button"),
-        BUTTON72(72, "button72", "Virtual button"),
-        BUTTON73(73, "button73", "Virtual button"),
-        BUTTON74(74, "button74", "Virtual button"),
-        BUTTON75(75, "button75", "Virtual button"),
-        BUTTON76(76, "button76", "Virtual button"),
-        BUTTON77(77, "button77", "Virtual button"),
-        BUTTON78(78, "button78", "Virtual button"),
-        BUTTON79(79, "button79", "Virtual button"),
-        BUTTON80(80, "button80", "Virtual button"),
-        BUTTON81(81, "button81", "Virtual button"),
-        BUTTON82(82, "button82", "Virtual button"),
-        BUTTON83(83, "button83", "Virtual button"),
-        BUTTON84(84, "button84", "Virtual button"),
-        BUTTON85(85, "button85", "Virtual button"),
-        BUTTON86(86, "button86", "Virtual button"),
-        BUTTON87(87, "button87", "Virtual button"),
-        BUTTON88(88, "button88", "Virtual button"),
-        BUTTON89(89, "button89", "Virtual button"),
-        BUTTON90(90, "button90", "Virtual button"),
-        BUTTON91(91, "button91", "Virtual button"),
-        BUTTON92(92, "button92", "Virtual button"),
-        BUTTON93(93, "button93", "Virtual button"),
-        BUTTON94(94, "button94", "Virtual button"),
-        BUTTON95(95, "button95", "Virtual button"),
-        BUTTON96(96, "button96", "Virtual button"),
-        BUTTON97(97, "button97", "Virtual button"),
-        BUTTON98(98, "button98", "Virtual button"),
-        BUTTON99(99, "button99", "Virtual button"),
-        BUTTON100(100, "button100", "Virtual button"),
-
-        LED1(101, "led1", "Virtual LED"),
-        LED2(102, "led2", "Virtual LED"),
-        LED3(103, "led3", "Virtual LED"),
-        LED4(104, "led4", "Virtual LED"),
-        LED5(105, "led5", "Virtual LED"),
-        LED6(106, "led6", "Virtual LED"),
-        LED7(107, "led7", "Virtual LED"),
-        LED8(108, "led8", "Virtual LED"),
-        LED9(109, "led9", "Virtual LED"),
-        LED10(110, "led10", "Virtual LED"),
-        LED11(111, "led11", "Virtual LED"),
-        LED12(112, "led12", "Virtual LED"),
-        LED13(113, "led13", "Virtual LED"),
-        LED14(114, "led14", "Virtual LED"),
-        LED15(115, "led15", "Virtual LED"),
-        LED16(116, "led16", "Virtual LED"),
-        LED17(117, "led17", "Virtual LED"),
-        LED18(118, "led18", "Virtual LED"),
-        LED19(119, "led19", "Virtual LED"),
-        LED20(120, "led20", "Virtual LED"),
-        LED21(121, "led21", "Virtual LED"),
-        LED22(122, "led22", "Virtual LED"),
-        LED23(123, "led23", "Virtual LED"),
-        LED24(124, "led24", "Virtual LED"),
-        LED25(125, "led25", "Virtual LED"),
-        LED26(126, "led26", "Virtual LED"),
-        LED27(127, "led27", "Virtual LED"),
-        LED28(128, "led28", "Virtual LED"),
-        LED29(129, "led29", "Virtual LED"),
-        LED30(130, "led30", "Virtual LED"),
-        LED31(131, "led31", "Virtual LED"),
-        LED32(132, "led32", "Virtual LED"),
-        LED33(133, "led33", "Virtual LED"),
-        LED34(134, "led34", "Virtual LED"),
-        LED35(135, "led35", "Virtual LED"),
-        LED36(136, "led36", "Virtual LED"),
-        LED37(137, "led37", "Virtual LED"),
-        LED38(138, "led38", "Virtual LED"),
-        LED39(139, "led39", "Virtual LED"),
-        LED40(140, "led40", "Virtual LED"),
-        LED41(141, "led41", "Virtual LED"),
-        LED42(142, "led42", "Virtual LED"),
-        LED43(143, "led43", "Virtual LED"),
-        LED44(144, "led44", "Virtual LED"),
-        LED45(145, "led45", "Virtual LED"),
-        LED46(146, "led46", "Virtual LED"),
-        LED47(147, "led47", "Virtual LED"),
-        LED48(148, "led48", "Virtual LED"),
-        LED49(149, "led49", "Virtual LED"),
-        LED50(150, "led50", "Virtual LED"),
-        LED51(151, "led51", "Virtual LED"),
-        LED52(152, "led52", "Virtual LED"),
-        LED53(153, "led53", "Virtual LED"),
-        LED54(154, "led54", "Virtual LED"),
-        LED55(155, "led55", "Virtual LED"),
-        LED56(156, "led56", "Virtual LED"),
-        LED57(157, "led57", "Virtual LED"),
-        LED58(158, "led58", "Virtual LED"),
-        LED59(159, "led59", "Virtual LED"),
-        LED60(160, "led60", "Virtual LED"),
-        LED61(161, "led61", "Virtual LED"),
-        LED62(162, "led62", "Virtual LED"),
-        LED63(163, "led63", "Virtual LED"),
-        LED64(164, "led64", "Virtual LED"),
-        LED65(165, "led65", "Virtual LED"),
-        LED66(166, "led66", "Virtual LED"),
-        LED67(167, "led67", "Virtual LED"),
-        LED68(168, "led68", "Virtual LED"),
-        LED69(169, "led69", "Virtual LED"),
-        LED70(170, "led70", "Virtual LED"),
-        LED71(171, "led71", "Virtual LED"),
-        LED72(172, "led72", "Virtual LED"),
-        LED73(173, "led73", "Virtual LED"),
-        LED74(174, "led74", "Virtual LED"),
-        LED75(175, "led75", "Virtual LED"),
-        LED76(176, "led76", "Virtual LED"),
-        LED77(177, "led77", "Virtual LED"),
-        LED78(178, "led78", "Virtual LED"),
-        LED79(179, "led79", "Virtual LED"),
-        LED80(180, "led80", "Virtual LED"),
-        LED81(181, "led81", "Virtual LED"),
-        LED82(182, "led82", "Virtual LED"),
-        LED83(183, "led83", "Virtual LED"),
-        LED84(184, "led84", "Virtual LED"),
-        LED85(185, "led85", "Virtual LED"),
-        LED86(186, "led86", "Virtual LED"),
-        LED87(187, "led87", "Virtual LED"),
-        LED88(188, "led88", "Virtual LED"),
-        LED89(189, "led89", "Virtual LED"),
-        LED90(190, "led90", "Virtual LED"),
-        LED91(191, "led91", "Virtual LED"),
-        LED92(192, "led92", "Virtual LED"),
-        LED93(193, "led93", "Virtual LED"),
-        LED94(194, "led94", "Virtual LED"),
-        LED95(195, "led95", "Virtual LED"),
-        LED96(196, "led96", "Virtual LED"),
-        LED97(197, "led97", "Virtual LED"),
-        LED98(198, "led98", "Virtual LED"),
-        LED99(199, "led99", "Virtual LED"),
-        LED100(200, "led100", "Virtual LED");
-
+    private class Component implements KeypadComponent {
         private final int id;
         private final String channel;
         private final String description;
+        private final ComponentType type;
 
-        Component(int id, String channel, String description) {
+        Component(int id, String channel, String description, ComponentType type) {
             this.id = id;
             this.channel = channel;
             this.description = description;
+            this.type = type;
         }
 
         @Override
@@ -254,6 +56,10 @@ public class VirtualKeypadHandler extends BaseKeypadHandler {
             return description;
         }
 
+        @Override
+        public ComponentType type() {
+            return type;
+        }
     }
 
     private final Logger logger = LoggerFactory.getLogger(VirtualKeypadHandler.class);
@@ -274,16 +80,12 @@ public class VirtualKeypadHandler extends BaseKeypadHandler {
     }
 
     @Override
-    protected void configureComponents(String model) {
+    protected void configureComponents(@Nullable String model) {
         logger.debug("Configuring components for virtual keypad");
 
-        for (Component x : EnumSet.allOf(Component.class)) {
-            if (isLed(x.id)) {
-                ledList.add(x);
-            }
-            if (isButton(x.id)) {
-                buttonList.add(x);
-            }
+        for (int x = 1; x <= 100; x++) {
+            buttonList.add(new Component(x, String.format("button%d", x), "Virtual Button", ComponentType.BUTTON));
+            ledList.add(new Component(x + 100, String.format("led%d", x), "Virtual LED", ComponentType.LED));
         }
     }
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfig.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfig.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Abstract base class for keypad configuration definition classes
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public abstract class KeypadConfig {
+    protected final HashMap<String, List<KeypadComponent>> modelData = new HashMap<>();
+
+    public abstract boolean isCCI(int id);
+
+    public abstract boolean isButton(int id);
+
+    public abstract boolean isLed(int id);
+
+    /**
+     * Get a list of all {@link KeypadComponent}s for the specified keypad model
+     *
+     * @param model The keypad model for which to return components.
+     * @return List of components. Will be empty if no components match.
+     */
+    public List<KeypadComponent> getComponents(String model) {
+        return modelData.get(model);
+    }
+
+    /**
+     * Get a list of {@link KeypadComponent}s of the specified type for the specified keypad model
+     *
+     * @param model The keypad model for which to return components.
+     * @param type The component type to include, or null for all components.
+     * @return List of components. Will be empty if no components match.
+     */
+    public List<KeypadComponent> getComponents(String model, @Nullable ComponentType type) {
+        List<KeypadComponent> filteredList = new LinkedList<>();
+        for (KeypadComponent i : modelData.get(model)) {
+            if (type == null || i.type() == type) {
+                filteredList.add(i);
+            }
+        }
+        return filteredList;
+    }
+
+    /**
+     * Get a list of all component IDs for the specified keypad model
+     *
+     * @param model The keypad model for which to return component IDs.
+     * @return List of component IDs. Will be empty if no components match.
+     */
+    public @Nullable List<Integer> getComponentIds(String model) {
+        return getComponentIds(model, null);
+    }
+
+    /**
+     * Get a list of component IDs of the specified type for the specified keypad model
+     *
+     * @param model The keypad model for which to return component IDs.
+     * @param type The component type to include, or null for all components.
+     * @return List of component IDs. Will be empty if no components match.
+     */
+    public List<Integer> getComponentIds(String model, @Nullable ComponentType type) {
+        List<Integer> idList = new LinkedList<>();
+        for (KeypadComponent i : modelData.get(model)) {
+            if (type == null || i.type() == type) {
+                idList.add(i.id());
+            }
+        }
+        return idList;
+    }
+
+    /**
+     * Determine keypad model from list of button component IDs
+     *
+     * @param buttonIds List of button component IDs for a keypad. Must be in ascending order.
+     * @return String containing the keypad model, or null if no models match.
+     */
+    public @Nullable String determineModelFromComponentIds(List<Integer> buttonIds) {
+        for (String k : modelData.keySet()) {
+            List<Integer> modelButtonIds = getComponentIds(k, ComponentType.BUTTON);
+            Collections.sort(modelButtonIds); // make sure button IDs are in ascending order for comparison
+            if (modelButtonIds.equals(buttonIds)) {
+                return k;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Utility routine to concatenate multiple lists of {@link KeypadComponent}s
+     *
+     * @param lists Lists to concatenate
+     * @return Concatenated list
+     */
+    @SafeVarargs
+    protected static final List<KeypadComponent> combinedList(final List<KeypadComponent>... lists) {
+        List<KeypadComponent> newlist = new LinkedList<>();
+        for (List<KeypadComponent> list : lists) {
+            newlist.addAll(list);
+        }
+        return newlist;
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigGrafikEye.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigGrafikEye.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Keypad configuration definition for Tabletop seeTouch line
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public final class KeypadConfigGrafikEye extends KeypadConfig {
+
+    private static enum Component implements KeypadComponent {
+        BUTTON1(70, "button1", "Button 1", ComponentType.BUTTON), // Scene button 1
+        BUTTON2(71, "button2", "Button 2", ComponentType.BUTTON), // Scene button 2
+        BUTTON3(76, "button3", "Button 3", ComponentType.BUTTON), // Scene button 3
+        BUTTON4(77, "button4", "Button 4", ComponentType.BUTTON), // Scene button 4
+        BUTTON5(83, "button5", "Button 5", ComponentType.BUTTON), // Scene button 5/Off
+
+        BUTTON10(38, "button10", "Button 10", ComponentType.BUTTON), // Col 1
+        BUTTON11(39, "button11", "Button 11", ComponentType.BUTTON), // Col 1
+        BUTTON12(40, "button12", "Button 12", ComponentType.BUTTON), // Col 1
+        LOWER1(41, "buttonlower1", "Lower button col 1", ComponentType.BUTTON), // Col 1 lower
+        RAISE1(47, "buttonraise1", "Raise button col 1", ComponentType.BUTTON), // Col 1 raise
+
+        BUTTON20(44, "button20", "Button 20", ComponentType.BUTTON), // Col 2
+        BUTTON21(45, "button21", "Button 21", ComponentType.BUTTON), // Col 2
+        BUTTON22(46, "button22", "Button 22", ComponentType.BUTTON), // Col 2
+        LOWER2(52, "buttonlower2", "Lower button col 2", ComponentType.BUTTON), // Col 2 lower
+        RAISE2(53, "buttonraise2", "Raise button col 2", ComponentType.BUTTON), // Col 2 raise
+
+        BUTTON30(50, "button30", "Button 30", ComponentType.BUTTON), // Col 3
+        BUTTON31(51, "button31", "Button 31", ComponentType.BUTTON), // Col 3
+        BUTTON32(56, "button32", "Button 32", ComponentType.BUTTON), // Col 3
+        LOWER3(57, "buttonlower3", "Lower button col 3", ComponentType.BUTTON), // Col 3 lower
+        RAISE3(58, "buttonraise3", "Raise button col 3", ComponentType.BUTTON), // Col 3 raise
+
+        CCI1(163, "cci1", "CCI 1", ComponentType.CCI),
+
+        LED1(201, "led1", "LED 1", ComponentType.LED), // Scene button LEDs
+        LED2(210, "led2", "LED 2", ComponentType.LED),
+        LED3(219, "led3", "LED 3", ComponentType.LED),
+        LED4(228, "led4", "LED 4", ComponentType.LED),
+        LED5(237, "led5", "LED 5", ComponentType.LED),
+
+        LED10(174, "led10", "LED 10", ComponentType.LED), // Col 1 LEDs
+        LED11(175, "led11", "LED 11", ComponentType.LED),
+        LED12(211, "led12", "LED 12", ComponentType.LED),
+
+        LED20(183, "led20", "LED 20", ComponentType.LED), // Col 2 LEDs
+        LED21(184, "led21", "LED 21", ComponentType.LED),
+        LED22(220, "led22", "LED 22", ComponentType.LED),
+
+        LED30(192, "led30", "LED 30", ComponentType.LED), // Col 3 LEDs
+        LED31(193, "led31", "LED 31", ComponentType.LED),
+        LED32(229, "led32", "LED 32", ComponentType.LED);
+
+        private final int id;
+        private final String channel;
+        private final String description;
+        private final ComponentType type;
+
+        Component(int id, String channel, String description, ComponentType type) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+            this.type = type;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public ComponentType type() {
+            return type;
+        }
+    }
+
+    private static final List<KeypadComponent> SCENE_BUTTON_GROUP = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
+            Component.BUTTON3, Component.BUTTON4, Component.BUTTON5);
+    private static final List<KeypadComponent> SCENE_LED_GROUP = Arrays.asList(Component.LED1, Component.LED2,
+            Component.LED3, Component.LED4, Component.LED5);
+
+    private static final List<KeypadComponent> CCI_GROUP = Arrays.asList(Component.CCI1);
+
+    private static final List<KeypadComponent> COL1_BUTTON_GROUP = Arrays.asList(Component.BUTTON10, Component.BUTTON11,
+            Component.BUTTON12, Component.LOWER1, Component.RAISE1);
+    private static final List<KeypadComponent> COL2_BUTTON_GROUP = Arrays.asList(Component.BUTTON20, Component.BUTTON21,
+            Component.BUTTON22, Component.LOWER2, Component.RAISE2);
+    private static final List<KeypadComponent> COL3_BUTTON_GROUP = Arrays.asList(Component.BUTTON30, Component.BUTTON31,
+            Component.BUTTON32, Component.LOWER3, Component.RAISE3);
+
+    private static final List<KeypadComponent> COL1_LED_GROUP = Arrays.asList(Component.LED10, Component.LED11,
+            Component.LED12);
+    private static final List<KeypadComponent> COL2_LED_GROUP = Arrays.asList(Component.LED20, Component.LED21,
+            Component.LED22);
+    private static final List<KeypadComponent> COL3_LED_GROUP = Arrays.asList(Component.LED30, Component.LED31,
+            Component.LED32);
+
+    @Override
+    public boolean isLed(int id) {
+        return (id >= 174 && id <= 237);
+    }
+
+    @Override
+    public boolean isButton(int id) {
+        return (id >= 38 && id <= 83);
+    }
+
+    @Override
+    public boolean isCCI(int id) {
+        return (id == 163);
+    }
+
+    public KeypadConfigGrafikEye() {
+        modelData.put("0COL", combinedList(SCENE_BUTTON_GROUP, CCI_GROUP, SCENE_LED_GROUP));
+
+        modelData.put("1COL",
+                combinedList(SCENE_BUTTON_GROUP, COL1_BUTTON_GROUP, CCI_GROUP, SCENE_LED_GROUP, COL1_LED_GROUP));
+
+        modelData.put("2COL", combinedList(SCENE_BUTTON_GROUP, COL1_BUTTON_GROUP, COL2_BUTTON_GROUP, CCI_GROUP,
+                SCENE_LED_GROUP, COL1_LED_GROUP, COL2_LED_GROUP));
+
+        modelData.put("3COL", combinedList(SCENE_BUTTON_GROUP, COL1_BUTTON_GROUP, COL2_BUTTON_GROUP, COL3_BUTTON_GROUP,
+                CCI_GROUP, SCENE_LED_GROUP, COL1_LED_GROUP, COL2_LED_GROUP, COL3_LED_GROUP));
+    }
+
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigIntlSeetouch.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigIntlSeetouch.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Keypad configuration definition for International seeTouch line
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public final class KeypadConfigIntlSeetouch extends KeypadConfig {
+
+    private static enum Component implements KeypadComponent {
+        BUTTON1(1, "button1", "Button 1", ComponentType.BUTTON),
+        BUTTON2(2, "button2", "Button 2", ComponentType.BUTTON),
+        BUTTON3(3, "button3", "Button 3", ComponentType.BUTTON),
+        BUTTON4(4, "button4", "Button 4", ComponentType.BUTTON),
+        BUTTON5(5, "button5", "Button 5", ComponentType.BUTTON),
+        BUTTON6(6, "button6", "Button 6", ComponentType.BUTTON),
+        BUTTON7(7, "button7", "Button 7", ComponentType.BUTTON),
+        BUTTON8(8, "button8", "Button 8", ComponentType.BUTTON),
+        BUTTON9(9, "button9", "Button 9", ComponentType.BUTTON),
+        BUTTON10(10, "button10", "Button 10", ComponentType.BUTTON),
+
+        LOWER1(18, "buttonlower", "Lower button", ComponentType.BUTTON),
+        RAISE1(19, "buttonraise", "Raise button", ComponentType.BUTTON),
+
+        CCI1(25, "cci1", "", ComponentType.CCI),
+        CCI2(26, "cci2", "", ComponentType.CCI),
+
+        LED1(81, "led1", "LED 1", ComponentType.LED),
+        LED2(82, "led2", "LED 2", ComponentType.LED),
+        LED3(83, "led3", "LED 3", ComponentType.LED),
+        LED4(84, "led4", "LED 4", ComponentType.LED),
+        LED5(85, "led5", "LED 5", ComponentType.LED),
+        LED6(86, "led6", "LED 6", ComponentType.LED),
+        LED7(87, "led7", "LED 7", ComponentType.LED),
+        LED8(88, "led8", "LED 8", ComponentType.LED),
+        LED9(89, "led9", "LED 9", ComponentType.LED),
+        LED10(90, "led10", "LED 10", ComponentType.LED);
+
+        private final int id;
+        private final String channel;
+        private final String description;
+        private final ComponentType type;
+
+        Component(int id, String channel, String description, ComponentType type) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+            this.type = type;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public ComponentType type() {
+            return type;
+        }
+    }
+
+    @Override
+    public boolean isLed(int id) {
+        return (id >= 81 && id <= 90);
+    }
+
+    @Override
+    public boolean isButton(int id) {
+        return ((id >= 1 && id <= 10) || (id >= 18 && id <= 19));
+    }
+
+    @Override
+    public boolean isCCI(int id) {
+        return (id >= 25 && id <= 26);
+    }
+
+    public KeypadConfigIntlSeetouch() {
+        modelData.put("2B", Arrays.asList(Component.BUTTON7, Component.BUTTON9, Component.LED7, Component.LED9,
+                Component.CCI1, Component.CCI2));
+
+        modelData.put("3B", Arrays.asList(Component.BUTTON6, Component.BUTTON8, Component.BUTTON10, Component.LED6,
+                Component.LED8, Component.LED10, Component.CCI1, Component.CCI2));
+
+        modelData.put("4B", Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON7, Component.BUTTON9,
+                Component.LED2, Component.LED4, Component.LED7, Component.LED9, Component.CCI1, Component.CCI2));
+
+        modelData.put("5BRL",
+                Arrays.asList(Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9,
+                        Component.BUTTON10, Component.LOWER1, Component.RAISE1, Component.LED6, Component.LED7,
+                        Component.LED8, Component.LED9, Component.LED10, Component.CCI1, Component.CCI2));
+
+        modelData.put("6BRL",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6,
+                        Component.BUTTON8, Component.BUTTON10, Component.LOWER1, Component.RAISE1, Component.LED1,
+                        Component.LED3, Component.LED5, Component.LED6, Component.LED8, Component.LED10, Component.CCI1,
+                        Component.CCI2));
+
+        modelData.put("7BRL",
+                Arrays.asList(Component.BUTTON2, Component.BUTTON4, Component.BUTTON6, Component.BUTTON7,
+                        Component.BUTTON8, Component.BUTTON9, Component.BUTTON10, Component.LOWER1, Component.RAISE1,
+                        Component.LED2, Component.LED4, Component.LED6, Component.LED7, Component.LED8, Component.LED9,
+                        Component.LED10, Component.CCI1, Component.CCI2));
+
+        modelData.put("8BRL", Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.BUTTON6,
+                Component.BUTTON7, Component.BUTTON8, Component.BUTTON9, Component.BUTTON10, Component.LOWER1,
+                Component.RAISE1, Component.LED1, Component.LED3, Component.LED5, Component.LED6, Component.LED7,
+                Component.LED8, Component.LED9, Component.LED10, Component.CCI1, Component.CCI2));
+
+        modelData.put("10BRL",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.BUTTON8, Component.BUTTON9,
+                        Component.BUTTON10, Component.LOWER1, Component.RAISE1, Component.LED1, Component.LED2,
+                        Component.LED3, Component.LED4, Component.LED5, Component.LED6, Component.LED7, Component.LED8,
+                        Component.LED9, Component.LED10, Component.CCI1, Component.CCI2));
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigPico.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigPico.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Keypad configuration definition for Pico models
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public final class KeypadConfigPico extends KeypadConfig {
+
+    private static enum Component implements KeypadComponent {
+        // Buttons for 2B, 2BRL, 3B, and 3BRL models
+        BUTTON1(2, "button1", "Button 1", ComponentType.BUTTON),
+        BUTTON2(3, "button2", "Button 2", ComponentType.BUTTON),
+        BUTTON3(4, "button3", "Button 3", ComponentType.BUTTON),
+
+        RAISE(5, "buttonraise", "Raise Button", ComponentType.BUTTON),
+        LOWER(6, "buttonlower", "Lower Button", ComponentType.BUTTON),
+
+        // Buttons for PJ2-4B model
+        BUTTON1_4B(8, "button01", "Button 1", ComponentType.BUTTON),
+        BUTTON2_4B(9, "button02", "Button 2", ComponentType.BUTTON),
+        BUTTON3_4B(10, "button03", "Button 3", ComponentType.BUTTON),
+        BUTTON4_4B(11, "button04", "Button 4", ComponentType.BUTTON);
+
+        private final int id;
+        private final String channel;
+        private final String description;
+        private final ComponentType type;
+
+        Component(int id, String channel, String description, ComponentType type) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+            this.type = type;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public ComponentType type() {
+            return type;
+        }
+    }
+
+    @Override
+    public boolean isLed(int id) {
+        return false;
+    }
+
+    @Override
+    public boolean isButton(int id) {
+        return (id >= 2 && id <= 11);
+    }
+
+    @Override
+    public boolean isCCI(int id) {
+        return false;
+    }
+
+    public KeypadConfigPico() {
+        modelData.put("2B", Arrays.asList(Component.BUTTON1, Component.BUTTON3));
+        modelData.put("2BRL", Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.RAISE, Component.LOWER));
+        modelData.put("3B", Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3));
+        modelData.put("3BRL", Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.RAISE,
+                Component.LOWER));
+        modelData.put("4B",
+                Arrays.asList(Component.BUTTON1_4B, Component.BUTTON2_4B, Component.BUTTON3_4B, Component.BUTTON4_4B));
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigSeetouch.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigSeetouch.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Keypad configuration definition for seeTouch and Hybrid seeTouch
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public final class KeypadConfigSeetouch extends KeypadConfig {
+
+    private static enum Component implements KeypadComponent {
+        BUTTON1(1, "button1", "Button 1", ComponentType.BUTTON),
+        BUTTON2(2, "button2", "Button 2", ComponentType.BUTTON),
+        BUTTON3(3, "button3", "Button 3", ComponentType.BUTTON),
+        BUTTON4(4, "button4", "Button 4", ComponentType.BUTTON),
+        BUTTON5(5, "button5", "Button 5", ComponentType.BUTTON),
+        BUTTON6(6, "button6", "Button 6", ComponentType.BUTTON),
+        BUTTON7(7, "button7", "Button 7", ComponentType.BUTTON),
+
+        LOWER1(16, "buttontoplower", "Top lower button", ComponentType.BUTTON),
+        RAISE1(17, "buttontopraise", "Top raise button", ComponentType.BUTTON),
+        LOWER2(18, "buttonbottomlower", "Bottom lower button", ComponentType.BUTTON),
+        RAISE2(19, "buttonbottomraise", "Bottom raise button", ComponentType.BUTTON),
+
+        // CCI1(25, "cci1", "CCI 1", ComponentType.CCI), // listed in spec but currently unused in binding
+        // CCI2(26, "cci2", "CCI 2", ComponentType.CCI), // listed in spec but currently unused in binding
+
+        LED1(81, "led1", "LED 1", ComponentType.LED),
+        LED2(82, "led2", "LED 2", ComponentType.LED),
+        LED3(83, "led3", "LED 3", ComponentType.LED),
+        LED4(84, "led4", "LED 4", ComponentType.LED),
+        LED5(85, "led5", "LED 5", ComponentType.LED),
+        LED6(86, "led6", "LED 6", ComponentType.LED),
+        LED7(87, "led7", "LED 7", ComponentType.LED);
+
+        private final int id;
+        private final String channel;
+        private final String description;
+        private final ComponentType type;
+
+        Component(int id, String channel, String description, ComponentType type) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+            this.type = type;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public ComponentType type() {
+            return type;
+        }
+    }
+
+    @Override
+    public boolean isLed(int id) {
+        return (id >= 81 && id <= 87);
+    }
+
+    @Override
+    public boolean isButton(int id) {
+        return ((id >= 1 && id <= 7) || (id >= 16 && id <= 19));
+    }
+
+    @Override
+    public boolean isCCI(int id) {
+        return false;
+    }
+
+    public KeypadConfigSeetouch() {
+        modelData.put("W1RLD",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON5,
+                        Component.BUTTON6, Component.LOWER2, Component.RAISE2, Component.LED1, Component.LED2,
+                        Component.LED3, Component.LED5, Component.LED6));
+
+        modelData.put("W2RLD",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON5, Component.BUTTON6,
+                        Component.LOWER1, Component.RAISE1, Component.LOWER2, Component.RAISE2, Component.LED1,
+                        Component.LED2, Component.LED5, Component.LED6));
+
+        modelData.put("W3S", Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON6,
+                Component.LOWER2, Component.RAISE2, Component.LED1, Component.LED2, Component.LED3, Component.LED6));
+
+        modelData.put("W3BD",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON5,
+                        Component.BUTTON6, Component.BUTTON7, Component.LED1, Component.LED2, Component.LED3,
+                        Component.LED5, Component.LED6, Component.LED7));
+
+        modelData.put("W3BRL", Arrays.asList(Component.BUTTON2, Component.BUTTON3, Component.BUTTON4, Component.LOWER2,
+                Component.RAISE2, Component.LED2, Component.LED3, Component.LED4));
+
+        modelData.put("W3BSRL", Arrays.asList(Component.BUTTON1, Component.BUTTON3, Component.BUTTON5, Component.LOWER2,
+                Component.RAISE2, Component.LED1, Component.LED3, Component.LED5));
+
+        modelData.put("W4S",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON6, Component.LOWER2, Component.RAISE2, Component.LED1, Component.LED2,
+                        Component.LED3, Component.LED4, Component.LED6));
+
+        modelData.put("W5BRL",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON5, Component.LOWER2, Component.RAISE2, Component.LED1, Component.LED2,
+                        Component.LED3, Component.LED4, Component.LED5));
+
+        modelData.put("W6BRL",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON5, Component.BUTTON6, Component.LOWER2, Component.RAISE2, Component.LED1,
+                        Component.LED2, Component.LED3, Component.LED4, Component.LED5, Component.LED6));
+
+        modelData.put("W7B",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.LED1, Component.LED2,
+                        Component.LED3, Component.LED4, Component.LED5, Component.LED6, Component.LED7));
+
+        modelData.put("Generic",
+                Arrays.asList(Component.BUTTON1, Component.BUTTON2, Component.BUTTON3, Component.BUTTON4,
+                        Component.BUTTON5, Component.BUTTON6, Component.BUTTON7, Component.LOWER1, Component.RAISE1,
+                        Component.LOWER2, Component.RAISE2, Component.LED1, Component.LED2, Component.LED3,
+                        Component.LED4, Component.LED5, Component.LED6, Component.LED7));
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigTabletopSeetouch.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfigTabletopSeetouch.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.keypadconfig;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lutron.internal.KeypadComponent;
+import org.openhab.binding.lutron.internal.discovery.project.ComponentType;
+
+/**
+ * Keypad configuration definition for Tabletop seeTouch line
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public final class KeypadConfigTabletopSeetouch extends KeypadConfig {
+
+    private static enum Component implements KeypadComponent {
+        BUTTON1(1, "button1", "Button 1", ComponentType.BUTTON),
+        BUTTON2(2, "button2", "Button 2", ComponentType.BUTTON),
+        BUTTON3(3, "button3", "Button 3", ComponentType.BUTTON),
+        BUTTON4(4, "button4", "Button 4", ComponentType.BUTTON),
+        BUTTON5(5, "button5", "Button 5", ComponentType.BUTTON),
+        BUTTON6(6, "button6", "Button 6", ComponentType.BUTTON),
+        BUTTON7(7, "button7", "Button 7", ComponentType.BUTTON),
+        BUTTON8(8, "button8", "Button 8", ComponentType.BUTTON),
+        BUTTON9(9, "button9", "Button 9", ComponentType.BUTTON),
+        BUTTON10(10, "button10", "Button 10", ComponentType.BUTTON),
+        BUTTON11(11, "button11", "Button 11", ComponentType.BUTTON),
+        BUTTON12(12, "button12", "Button 12", ComponentType.BUTTON),
+        BUTTON13(13, "button13", "Button 13", ComponentType.BUTTON),
+        BUTTON14(14, "button14", "Button 14", ComponentType.BUTTON),
+        BUTTON15(15, "button15", "Button 15", ComponentType.BUTTON),
+
+        BUTTON16(16, "button16", "Button 16", ComponentType.BUTTON),
+        BUTTON17(17, "button17", "Button 17", ComponentType.BUTTON),
+
+        LOWER1(20, "buttonlower1", "Lower button 1", ComponentType.BUTTON),
+        RAISE1(21, "buttonraise1", "Raise button 1", ComponentType.BUTTON),
+        LOWER2(22, "buttonlower2", "Lower button 2", ComponentType.BUTTON),
+        RAISE2(23, "buttonraise2", "Raise button 2", ComponentType.BUTTON),
+        LOWER3(24, "buttonlower3", "Lower button 3", ComponentType.BUTTON),
+        RAISE3(25, "buttonraise3", "Raise button 3", ComponentType.BUTTON),
+
+        LED1(81, "led1", "LED 1", ComponentType.LED),
+        LED2(82, "led2", "LED 2", ComponentType.LED),
+        LED3(83, "led3", "LED 3", ComponentType.LED),
+        LED4(84, "led4", "LED 4", ComponentType.LED),
+        LED5(85, "led5", "LED 5", ComponentType.LED),
+        LED6(86, "led6", "LED 6", ComponentType.LED),
+        LED7(87, "led7", "LED 7", ComponentType.LED),
+        LED8(88, "led8", "LED 8", ComponentType.LED),
+        LED9(89, "led9", "LED 9", ComponentType.LED),
+        LED10(90, "led10", "LED 10", ComponentType.LED),
+        LED11(91, "led11", "LED 11", ComponentType.LED),
+        LED12(92, "led12", "LED 12", ComponentType.LED),
+        LED13(93, "led13", "LED 13", ComponentType.LED),
+        LED14(94, "led14", "LED 14", ComponentType.LED),
+        LED15(95, "led15", "LED 15", ComponentType.LED),
+
+        LED16(96, "led16", "LED 16", ComponentType.LED),
+        LED17(97, "led17", "LED 17", ComponentType.LED);
+
+        private final int id;
+        private final String channel;
+        private final String description;
+        private final ComponentType type;
+
+        Component(int id, String channel, String description, ComponentType type) {
+            this.id = id;
+            this.channel = channel;
+            this.description = description;
+            this.type = type;
+        }
+
+        @Override
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String channel() {
+            return channel;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public ComponentType type() {
+            return type;
+        }
+    }
+
+    private static final List<KeypadComponent> BUTTONGROUP1 = Arrays.asList(Component.BUTTON1, Component.BUTTON2,
+            Component.BUTTON3, Component.BUTTON4, Component.BUTTON5);
+    private static final List<KeypadComponent> BUTTONGROUP2 = Arrays.asList(Component.BUTTON6, Component.BUTTON7,
+            Component.BUTTON8, Component.BUTTON9, Component.BUTTON10);
+    private static final List<KeypadComponent> BUTTONGROUP3 = Arrays.asList(Component.BUTTON11, Component.BUTTON12,
+            Component.BUTTON13, Component.BUTTON14, Component.BUTTON15);
+
+    private static final List<KeypadComponent> BUTTONGROUPBOTTOM_RL = Arrays.asList(Component.BUTTON16,
+            Component.BUTTON17, Component.LOWER3, Component.RAISE3);
+    private static final List<KeypadComponent> BUTTONGROUPBOTTOM_CRL = Arrays.asList(Component.LOWER1, Component.RAISE1,
+            Component.LOWER2, Component.RAISE2, Component.LOWER3, Component.RAISE3);
+    private static final List<KeypadComponent> BUTTONGROUPBOTTOM_GENERIC = Arrays.asList(Component.BUTTON16,
+            Component.BUTTON17, Component.LOWER1, Component.RAISE1, Component.LOWER2, Component.RAISE2,
+            Component.LOWER3, Component.RAISE3);
+
+    private static final List<KeypadComponent> LEDGROUP1 = Arrays.asList(Component.LED1, Component.LED2, Component.LED3,
+            Component.LED4, Component.LED5);
+    private static final List<KeypadComponent> LEDGROUP2 = Arrays.asList(Component.LED6, Component.LED7, Component.LED8,
+            Component.LED9, Component.LED10);
+    private static final List<KeypadComponent> LEDGROUP3 = Arrays.asList(Component.LED11, Component.LED12,
+            Component.LED13, Component.LED14, Component.LED15);
+
+    private static final List<KeypadComponent> LEDGROUPBOTTOM_RL = Arrays.asList(Component.LED16, Component.LED17);
+
+    @Override
+    public boolean isLed(int id) {
+        return (id >= 81 && id <= 97);
+    }
+
+    @Override
+    public boolean isButton(int id) {
+        return (id >= 1 && id <= 25);
+    }
+
+    @Override
+    public boolean isCCI(int id) {
+        return false;
+    }
+
+    public KeypadConfigTabletopSeetouch() {
+        modelData.put("T5RL", combinedList(BUTTONGROUP1, BUTTONGROUPBOTTOM_RL, LEDGROUP1, LEDGROUPBOTTOM_RL));
+
+        modelData.put("T10RL", combinedList(BUTTONGROUP1, BUTTONGROUP2, BUTTONGROUPBOTTOM_RL, LEDGROUP1, LEDGROUP2,
+                LEDGROUPBOTTOM_RL));
+
+        modelData.put("T15RL", combinedList(BUTTONGROUP1, BUTTONGROUP2, BUTTONGROUP3, BUTTONGROUPBOTTOM_RL, LEDGROUP1,
+                LEDGROUP2, LEDGROUP3, LEDGROUPBOTTOM_RL));
+
+        modelData.put("T5CRL", combinedList(BUTTONGROUP1, BUTTONGROUPBOTTOM_CRL, LEDGROUP1));
+
+        modelData.put("T10CRL", combinedList(BUTTONGROUP1, BUTTONGROUP2, BUTTONGROUPBOTTOM_CRL, LEDGROUP1, LEDGROUP2));
+
+        modelData.put("T15CRL", combinedList(BUTTONGROUP1, BUTTONGROUP2, BUTTONGROUP3, BUTTONGROUPBOTTOM_CRL, LEDGROUP1,
+                LEDGROUP2, LEDGROUP3));
+
+        modelData.put("Generic", combinedList(BUTTONGROUP1, BUTTONGROUP2, BUTTONGROUP3, BUTTONGROUPBOTTOM_GENERIC,
+                LEDGROUP1, LEDGROUP2, LEDGROUP3, LEDGROUPBOTTOM_RL)); // Superset of all models
+    }
+
+}


### PR DESCRIPTION
This PR adds support to the Lutron binding for discovery of keypad models. This will finally eliminate the need for RadioRA 2 and HomeWorks QS users to manually select their keypad models after discovery, which has proven to be a major source of confusion and errors. Unfortunately, implementing it required a considerable number of changes to the existing keypad handlers so that the discovery code could have access to the necessary keypad configuration information.

It includes the following changes:
* Moves keypad configuration data from keypad handlers to new keypad configuration classes (base class KeypadConfig) for all keypad handlers supporting multiple models.
* Adds ComponentType to keypad component definitions.
* Updates existing keypad handlers to use new keypad configuration classes.
* Modifies LutronDeviceDiscoveryService to make determination of keypad models using component data from Lutron's configuration XML files.
* Adds null annotations to all keypad handler and keypad config classes.
* Fixes static code analysis tool warnings.
* Documentation updates

Regards,
Bob