### PR TITLE
Assign labels using issue templates and improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
-about: Something isn't working correctly with a binding. This is the wrong place for user-interfaces or openhab core issues.
+about: Something isn't working correctly with an add-on. This is the wrong place for user-interfaces or openHAB Core issues.
+labels: bug
 
 ---
 
@@ -19,8 +20,9 @@ about: Something isn't working correctly with a binding. This is the wrong place
 
 ## Current Behavior
 <!-- If describing a bug, tell us what happens instead of the expected behavior -->
-<!-- Include related log information (preferably debug level) and related configs. -->
-<!-- Use file attachment for log and config information longer than a few lines -->
+<!-- Include related log information (preferably debug level) and related configs -->
+<!-- Use a file attachment for log and config information longer than a few lines -->
+<!-- Enclose multi-line log/code snippets with ``` on new lines for proper formatting -->
 <!-- If suggesting a change/improvement, explain the difference from current behavior -->
 <!-- For improvements, discuss at community.openhab.org first and include link to topic -->
 
@@ -40,6 +42,6 @@ about: Something isn't working correctly with a binding. This is the wrong place
 
 ## Your Environment
 <!-- Include as many relevant details about the environment you experienced the bug in -->
-* Version used: (e.g., openhab and addon versions)
-* Environment name and version (e.g. Chrome 39, node.js 5.4, Java 8, ...):
-* Operating System and version (desktop or mobile, Windows 10, Raspbian Jessie, ...):
+* Version used: (e.g., openHAB and add-on versions)
+* Environment name and version (e.g. Chrome 76, Java 8, Node.js 12.9, ...):
+* Operating System and version (desktop or mobile, Windows 10, Raspbian Buster, ...):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,18 +1,19 @@
 ---
 name: "Feature request"
-about: You think that your favourite binding should gain another feature
+about: You think that your favorite add-on should gain another feature
+labels: enhancement
 
 ---
 
 <!-- Provide a general summary of the feature request in the *Title* above -->
-<!-- If the feature request is related to a binding, please include its short name in -->
-<!-- square brackets in the title - Example: "[astro][feature] My feature request..." -->
+<!-- If the feature request is related to an add-on, please include its short name in -->
+<!-- square brackets in the title - Example: "[astro] My feature request..." -->
 
 <!-- Important: Please contact the openHAB community forum for questions or -->
 <!-- for configuration and usage guidance: https://community.openhab.org -->
 
 ## Your Environment
-<!-- Include as many relevant details about the environment you experienced the bug in -->
-* Version used: (e.g., openhab and addon versions)
-* Environment name and version (e.g. Chrome 39, node.js 5.4, Java 8, ...):
-* Operating System and version (desktop or mobile, Windows 10, Raspbian Jessie, ...):
+<!-- Include as many relevant details about the environment when applicable -->
+* Version used: (e.g., openHAB and add-on versions)
+* Environment name and version (e.g. Chrome 76, Java 8, Node.js 12.9, ...):
+* Operating System and version (desktop or mobile, Windows 10, Raspbian Buster, ...):

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F914 Support/Usage Question"
 about: For usage questions, please use the openHAB community board!
+labels: question
 
 ---
 


### PR DESCRIPTION
The template labels are also being used in [openhab-android](https://github.com/openhab/openhab-android/issues) and I think it might save us some labelling work. I think we might only need to update labels for issues of new add-ons when these are not created using "Open a regular issue.". 

Improvements:

* Replace binding with add-on because the repo contains more than just bindings
* Add note on using triple backticks to format log/code
* Update versions in examples so users can easier relate to these