### PR TITLE
[modbus] Ignore failing tests

### DIFF
--- a/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
+++ b/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
@@ -84,6 +84,7 @@ import org.eclipse.smarthome.test.java.JavaTest;
 import org.eclipse.smarthome.test.storage.VolatileStorageService;
 import org.hamcrest.Matcher;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -117,6 +118,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 
 @RunWith(MockitoJUnitRunner.class)
+@Ignore("Tests fail because the thingRegistry field has been removed from BaseThingHandler, "
+        + "see: https://github.com/openhab/openhab2-addons/issues/6171")
 public class ModbusDataHandlerTest extends JavaTest {
 
     private class ItemChannelLinkRegistryTestImpl extends ItemChannelLinkRegistry {

--- a/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
+++ b/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
@@ -42,6 +42,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -62,6 +63,8 @@ import org.openhab.io.transport.modbus.ModbusRegisterArray;
 import org.openhab.io.transport.modbus.PollTask;
 
 @RunWith(MockitoJUnitRunner.class)
+@Ignore("Tests fail because the thingRegistry field has been removed from BaseThingHandler, "
+        + "see: https://github.com/openhab/openhab2-addons/issues/6171")
 public class ModbusPollerThingHandlerTest {
 
     @Mock


### PR DESCRIPTION
Fix the build by ignoring the tests that fail because reflection is used to modify the BaseThingHandler.thingRegistry field that has been removed in openhab/openhab-core#1041.

See: https://github.com/openhab/openhab2-addons/issues/6171