### PR TITLE
[yamaha] Binding remain offline after device comes back online

### DIFF
--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/ConnectionStateListener.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/ConnectionStateListener.java
@@ -18,7 +18,5 @@ package org.openhab.binding.yamahareceiver.internal.protocol;
  * @author David Graeff - Initial contribution
  */
 public interface ConnectionStateListener {
-    void connectionFailed(String host, Throwable throwable);
-
-    void connectionEstablished(AbstractConnection connection);
+    void onConnectionCreated(AbstractConnection connection);
 }

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLConnection.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLConnection.java
@@ -59,7 +59,7 @@ public class XMLConnection extends AbstractConnection {
     private <T> T postMessage(String prefix, String message, String suffix,
             CheckedConsumer<HttpURLConnection, T> responseConsumer) throws IOException {
         if (message.startsWith("<?xml")) {
-            throw new IOException("No preformatted xml allowed!");
+            throw new IOException("No pre-formatted xml allowed!");
         }
         message = prefix + message + suffix;
 
@@ -74,6 +74,7 @@ public class XMLConnection extends AbstractConnection {
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Length", Integer.toString(message.length()));
 
+            connection.setConnectTimeout(5); // set a timeout in case the device is not reachable (went offline)
             connection.setUseCaches(false);
             connection.setDoInput(true);
             connection.setDoOutput(true);

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLProtocolFactory.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLProtocolFactory.java
@@ -47,7 +47,7 @@ import org.openhab.binding.yamahareceiver.internal.state.ZoneControlStateListene
 public class XMLProtocolFactory implements ProtocolFactory {
     @Override
     public void createConnection(String host, ConnectionStateListener connectionStateListener) {
-        connectionStateListener.connectionEstablished(new XMLConnection(host));
+        connectionStateListener.onConnectionCreated(new XMLConnection(host));
     }
 
     @Override
@@ -132,8 +132,6 @@ public class XMLProtocolFactory implements ProtocolFactory {
 
     @Override
     public InputConverter InputConverter(AbstractConnection connection, String setting) {
-
         return new InputConverterXML(connection, setting);
     }
-
 }

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
@@ -95,7 +95,7 @@ public class YamahaReceiverHandlerTest extends AbstractXMLProtocolTest {
         subject.setCallback(callback);
 
         doAnswer(a -> {
-            ((ConnectionStateListener) a.getArgument(1)).connectionEstablished(ctx.getConnection());
+            ((ConnectionStateListener) a.getArgument(1)).onConnectionCreated(ctx.getConnection());
             return null;
         }).when(protocolFactory).createConnection(anyString(), same(subject));
     }


### PR DESCRIPTION
Fixes #5495.

Fix already verified by the requesting user & myself (see issue for more details).
Potentially other users can confirm that too.

Approach taken to fix this:
- When it is detected the connectivity has been lost to the Yamaha device the bridge and zones are marked as offline.
- The device status refresh poll is still happening with the user configured interval. 
- Once communication to the device is successful in a refresh poll, the bridge and zones are marked as online and binding becomes operational.


-----
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
