### PR TITLE
[mqtt.homeassistant] Improve initialization sequence

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -243,6 +243,7 @@ public class ChannelState implements MqttMessageSubscriber {
     }
 
     private void internalStop() {
+        logger.debug("Unsubscribed channel {} form topic: {}", this.channelUID, config.stateTopic);
         this.connection = null;
         this.channelStateUpdateListener = null;
         hasSubscribed = false;
@@ -274,7 +275,6 @@ public class ChannelState implements MqttMessageSubscriber {
      * @param connection A broker connection
      * @param scheduler A scheduler to realize the timeout
      * @param timeout A timeout in milliseconds. Can be 0 to disable the timeout and let the future return earlier.
-     * @param channelStateUpdateListener An update listener
      * @return A future that completes with true if the subscribing worked, with false if the stateTopic is not set
      *         and exceptionally otherwise.
      */

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CFactory.java
@@ -44,11 +44,10 @@ public class CFactory {
      * @return A HA MQTT Component
      */
     public static @Nullable AbstractComponent<?> createComponent(ThingUID thingUID, HaID haID,
-            String channelConfigurationJSON, @Nullable ChannelStateUpdateListener updateListener, Gson gson,
+            String channelConfigurationJSON, ChannelStateUpdateListener updateListener, Gson gson,
             TransformationServiceProvider transformationServiceProvider) {
         ComponentConfiguration componentConfiguration = new ComponentConfiguration(thingUID, haID,
-                channelConfigurationJSON, gson).listener(updateListener)
-                        .transformationProvider(transformationServiceProvider);
+                channelConfigurationJSON, gson, updateListener).transformationProvider(transformationServiceProvider);
         try {
             switch (haID.component) {
                 case "alarm_control_panel":
@@ -83,19 +82,16 @@ public class CFactory {
         private HaID haID;
         private String configJSON;
         private @Nullable TransformationServiceProvider transformationServiceProvider;
-        private @Nullable ChannelStateUpdateListener updateListener;
+        private ChannelStateUpdateListener updateListener;
         private Gson gson;
 
-        protected ComponentConfiguration(ThingUID thingUID, HaID haID, String configJSON, Gson gson) {
+        protected ComponentConfiguration(ThingUID thingUID, HaID haID, String configJSON, Gson gson,
+                ChannelStateUpdateListener updateListener) {
             this.thingUID = thingUID;
             this.haID = haID;
             this.configJSON = configJSON;
             this.gson = gson;
-        }
-
-        public ComponentConfiguration listener(@Nullable ChannelStateUpdateListener updateListener) {
             this.updateListener = updateListener;
-            return this;
         }
 
         public ComponentConfiguration transformationProvider(
@@ -116,7 +112,6 @@ public class CFactory {
             return configJSON;
         }
 
-        @Nullable
         public ChannelStateUpdateListener getUpdateListener() {
             return updateListener;
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentAlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentAlarmControlPanel.java
@@ -61,25 +61,25 @@ public class ComponentAlarmControlPanel extends AbstractComponent<ComponentAlarm
         final String[] state_enum = { channelConfiguration.state_disarmed, channelConfiguration.state_armed_home,
                 channelConfiguration.state_armed_away, channelConfiguration.state_pending,
                 channelConfiguration.state_triggered };
-        buildChannel(stateChannelID, new TextValue(state_enum), channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())
-                .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                .build();
+        buildChannel(stateChannelID, new TextValue(state_enum), channelConfiguration.name,
+                componentConfiguration.getUpdateListener())
+                        .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
+                        .build();
 
         String command_topic = channelConfiguration.command_topic;
         if (command_topic != null) {
             buildChannel(switchDisarmChannelID, new TextValue(new String[] { channelConfiguration.payload_disarm }),
-                    channelConfiguration.name).listener(componentConfiguration.getUpdateListener())//
+                    channelConfiguration.name, componentConfiguration.getUpdateListener())//
                             .commandTopic(command_topic, channelConfiguration.retain)//
                             .build();
 
             buildChannel(switchArmHomeChannelID, new TextValue(new String[] { channelConfiguration.payload_arm_home }),
-                    channelConfiguration.name).listener(componentConfiguration.getUpdateListener())//
+                    channelConfiguration.name, componentConfiguration.getUpdateListener())//
                             .commandTopic(command_topic, channelConfiguration.retain)//
                             .build();
 
             buildChannel(switchArmAwayChannelID, new TextValue(new String[] { channelConfiguration.payload_arm_away }),
-                    channelConfiguration.name).listener(componentConfiguration.getUpdateListener())//
+                    channelConfiguration.name, componentConfiguration.getUpdateListener())//
                             .commandTopic(command_topic, channelConfiguration.retain)//
                             .build();
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentBinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentBinarySensor.java
@@ -51,7 +51,7 @@ public class ComponentBinarySensor extends AbstractComponent<ComponentBinarySens
         }
 
         buildChannel(sensorChannelID, new OnOffValue(channelConfiguration.payload_on, channelConfiguration.payload_off),
-                channelConfiguration.name).listener(componentConfiguration.getUpdateListener())//
+                channelConfiguration.name, componentConfiguration.getUpdateListener())//
                         .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
                         .unit(channelConfiguration.unit_of_measurement)//
                         .build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentCamera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentCamera.java
@@ -42,8 +42,7 @@ public class ComponentCamera extends AbstractComponent<ComponentCamera.ChannelCo
 
         ImageValue value = new ImageValue();
 
-        buildChannel(cameraChannelID, value, channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())//
+        buildChannel(cameraChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.topic)//
                 .build();
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentCover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentCover.java
@@ -48,8 +48,7 @@ public class ComponentCover extends AbstractComponent<ComponentCover.ChannelConf
         RollershutterValue value = new RollershutterValue(channelConfiguration.payload_open,
                 channelConfiguration.payload_close, channelConfiguration.payload_stop);
 
-        buildChannel(switchChannelID, value, channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())//
+        buildChannel(switchChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
                 .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
                 .build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentFan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentFan.java
@@ -45,8 +45,7 @@ public class ComponentFan extends AbstractComponent<ComponentFan.ChannelConfigur
         super(componentConfiguration, ChannelConfiguration.class);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payload_on, channelConfiguration.payload_off);
-        buildChannel(switchChannelID, value, channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())//
+        buildChannel(switchChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
                 .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
                 .build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentLight.java
@@ -103,17 +103,17 @@ public class ComponentLight extends AbstractComponent<ComponentLight.ChannelConf
         ColorValue value = new ColorValue(true, channelConfiguration.payload_on, channelConfiguration.payload_off, 100);
 
         // Create three MQTT subscriptions and use this class object as update listener
-        switchChannel = buildChannel(switchChannelID, value, channelConfiguration.name).listener(this)//
+        switchChannel = buildChannel(switchChannelID, value, channelConfiguration.name, this)//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.state_value_template)//
                 .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
                 .build(false);
 
-        colorChannel = buildChannel(colorChannelID, value, channelConfiguration.name).listener(this)//
+        colorChannel = buildChannel(colorChannelID, value, channelConfiguration.name, this)//
                 .stateTopic(channelConfiguration.rgb_state_topic, channelConfiguration.rgb_value_template)//
                 .commandTopic(channelConfiguration.rgb_command_topic, channelConfiguration.retain)//
                 .build(false);
 
-        brightnessChannel = buildChannel(brightnessChannelID, value, channelConfiguration.name).listener(this)//
+        brightnessChannel = buildChannel(brightnessChannelID, value, channelConfiguration.name, this)//
                 .stateTopic(channelConfiguration.brightness_state_topic, channelConfiguration.brightness_value_template)//
                 .commandTopic(channelConfiguration.brightness_command_topic, channelConfiguration.retain)//
                 .build(false);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentLock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentLock.java
@@ -52,7 +52,7 @@ public class ComponentLock extends AbstractComponent<ComponentLock.ChannelConfig
 
         buildChannel(switchChannelID,
                 new OnOffValue(channelConfiguration.payload_lock, channelConfiguration.payload_unlock),
-                channelConfiguration.name).listener(componentConfiguration.getUpdateListener())//
+                channelConfiguration.name, componentConfiguration.getUpdateListener())//
                         .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
                         .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
                         .build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
@@ -48,11 +48,11 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
             throw new UnsupportedOperationException("Component:Sensor does not support forced updates");
         }
 
-        buildChannel(sensorChannelID, new TextValue(), channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())//
-                .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                .unit(channelConfiguration.unit_of_measurement)//
-                .build();
+        buildChannel(sensorChannelID, new TextValue(), channelConfiguration.name,
+                componentConfiguration.getUpdateListener())//
+                        .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
+                        .unit(channelConfiguration.unit_of_measurement)//
+                        .build();
     }
 
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
@@ -55,8 +55,7 @@ public class ComponentSwitch extends AbstractComponent<ComponentSwitch.ChannelCo
         OnOffValue value = new OnOffValue(channelConfiguration.state_on, channelConfiguration.state_off,
                 channelConfiguration.payload_on, channelConfiguration.payload_off);
 
-        buildChannel(switchChannelID, value, channelConfiguration.name)
-                .listener(componentConfiguration.getUpdateListener())//
+        buildChannel(switchChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
                 .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
                 .build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
@@ -45,7 +45,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     private final Logger logger = LoggerFactory.getLogger(DiscoverComponents.class);
     private final ThingUID thingUID;
     private final ScheduledExecutorService scheduler;
-    private final @Nullable ChannelStateUpdateListener updateListener;
+    private final ChannelStateUpdateListener updateListener;
     private final TransformationServiceProvider transformationServiceProvider;
 
     protected final CompletableFuture<@Nullable Void> discoverFinishedFuture = new CompletableFuture<>();
@@ -72,7 +72,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
      * @param channelStateUpdateListener Channel update listener. Usually the handler.
      */
     public DiscoverComponents(ThingUID thingUID, ScheduledExecutorService scheduler,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson,
+            ChannelStateUpdateListener channelStateUpdateListener, Gson gson,
             TransformationServiceProvider transformationServiceProvider) {
         this.thingUID = thingUID;
         this.scheduler = scheduler;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.mqtt.homeassistant.internal.discovery;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,6 +29,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -62,6 +65,8 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     private final Logger logger = LoggerFactory.getLogger(HomeAssistantDiscovery.class);
     protected final Map<String, Set<HaID>> componentsPerThingID = new TreeMap<>();
     protected final Map<String, ThingUID> thingIDPerTopic = new TreeMap<>();
+    protected final Map<String, DiscoveryResult> results = new TreeMap<>();
+
     private @Nullable ScheduledFuture<?> future;
     private final Gson gson;
 
@@ -138,7 +143,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         if (future != null) {
             future.cancel(false);
         }
-        this.future = scheduler.schedule(componentsPerThingID::clear, 2, TimeUnit.SECONDS);
+        this.future = scheduler.schedule(this::publishResults, 2, TimeUnit.SECONDS);
 
         BaseChannelConfiguration config = BaseChannelConfiguration
                 .fromString(new String(payload, StandardCharsets.UTF_8), gson);
@@ -152,9 +157,6 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
         final ThingTypeUID typeID = new ThingTypeUID(MqttBindingConstants.BINDING_ID,
                 MqttBindingConstants.HOMEASSISTANT_MQTT_THING.getId() + "_" + thingID);
-
-        ThingType type = typeProvider.derive(typeID, MqttBindingConstants.HOMEASSISTANT_MQTT_THING).build();
-        typeProvider.setThingTypeIfAbsent(typeID, type);
 
         final ThingUID thingUID = new ThingUID(typeID, connectionBridge, thingID);
 
@@ -173,12 +175,31 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         HandlerConfiguration handlerConfig = new HandlerConfiguration(haID.baseTopic, topics);
         properties = handlerConfig.appendToProperties(properties);
         properties = config.appendToProperties(properties);
-        // First remove an already discovered thing with the same ID
-        thingRemoved(thingUID);
-        // Because we need the new properties map with the updated "components" list
-        thingDiscovered(DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                .withRepresentationProperty("objectid").withBridge(connectionBridge)
-                .withLabel(config.getThingName() + " (" + componentNames + ")").build());
+
+        synchronized (results) {
+            // Because we need the new properties map with the updated "components" list
+            results.put(thingUID.getAsString(),
+                    DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                            .withRepresentationProperty("objectid").withBridge(connectionBridge)
+                            .withLabel(config.getThingName() + " (" + componentNames + ")").build());
+        }
+    }
+
+    protected void publishResults() {
+        Collection<DiscoveryResult> localResults;
+
+        synchronized (results) {
+            localResults = new ArrayList<>(results.values());
+            results.clear();
+            componentsPerThingID.clear();
+        }
+        for (DiscoveryResult result : localResults) {
+            final ThingTypeUID typeID = result.getThingTypeUID();
+            ThingType type = typeProvider.derive(typeID, MqttBindingConstants.HOMEASSISTANT_MQTT_THING).build();
+            typeProvider.setThingTypeIfAbsent(typeID, type);
+
+            thingDiscovered(result);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
@@ -7,11 +7,6 @@
 	<config-description uri="mqtt:ha_channel">
 		<parameter name="component" type="text" readOnly="true" required="true">
 			<label>Component</label>
-			<description>Type of the channel group.</description>
-			<default></default>
-		</parameter>
-		<parameter name="component" type="text" readOnly="true" required="true">
-			<label>Component</label>
 			<description>HomeAssistant component type (e.g. binary_sensor, switch, light)</description>
 			<default></default>
 		</parameter>

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
@@ -26,11 +26,16 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.homeassistant.internal.ChannelConfigurationTypeAdapterFactory;
 import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents;
@@ -78,7 +83,19 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
         Gson gson = new GsonBuilder().registerTypeAdapterFactory(new ChannelConfigurationTypeAdapterFactory()).create();
 
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing,
-                scheduler, null, gson, transformationServiceProvider));
+                scheduler, new ChannelStateUpdateListener() {
+                    @Override
+                    public void updateChannelState(@NonNull ChannelUID channelUID, @NonNull State value) {
+                    }
+
+                    @Override
+                    public void triggerChannel(@NonNull ChannelUID channelUID, @NonNull String eventPayload) {
+                    }
+
+                    @Override
+                    public void postChannelCommand(@NonNull ChannelUID channelUID, @NonNull Command value) {
+                    }
+                }, gson, transformationServiceProvider));
 
         HandlerConfiguration config = new HandlerConfiguration("homeassistant",
                 Collections.singletonList("switch/object"));


### PR DESCRIPTION
Initialization was not stable so i investigated and found some problems:
* <code>stop()</code> on the thing handler would not unsubscribe from the topics (<code>map()</code> as last thing on a stream is noop)
* starting a previously stoped CChannel laked the updateListener callback.
* During initialization (<code>accept()</code>) would add channels to the thing by using <code>updateThing</code> which in turn would stop and start the thing.
* discovery would find and remove things multiple times, if multiple components where found.

<code>stop()</code> will now unregister subscriptions (if started before) and wait for it to finish. The wait is needed or else a later <code>start()</code> might be executed before the actual unsubscribe. (Was this a memory leak?)

New channels are added to the thing using <code>ThingHelper.addChannelsToThing()</code>. This eliminates the restarts.

Discovery now publishes the results only after a timeout. This eleminates the need to remove already discovered things to modify them.

I also removed a duplicate parameter <code>component</code> from the chanel config.