### PR TITLE
[hueemulation] fix to fit non-nullness expectations

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
@@ -93,7 +93,7 @@ public class CommonSetup {
             if (name.equals("hueEmulationUsers")) {
                 return (Storage<T>) new DummyUsersStorage();
             }
-            return null;
+            throw new IllegalStateException();
         }
     };
 


### PR DESCRIPTION
Fixes build issue seen in https://ci.openhab.org/job/openHAB2-Bundles/784, which turned up after merging https://github.com/openhab/openhab-core/pull/1099.

Signed-off-by: Kai Kreuzer <kai@openhab.org>