### PR TITLE
[ESH-INF] Fix indentation only tabs in ESH-INF files

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -19,18 +19,18 @@
 			<channel id="mediaStop" typeId="mediaStopType" />
 			<channel id="appLauncher" typeId="appLauncherChannelType" />
 		</channels>
-        
-        <properties>
-          <property name="deviceId" />
-          <property name="lastConnected" /> 
-          <property name="modelName" /> 
-          <property name="manufacturer" /> 
-          <property name="deviceOS" /> 
-          <property name="deviceOSVersion" /> 
-          <property name="deviceOSReleaseVersion" /> 
-        </properties>
+
+		<properties>
+			<property name="deviceId" />
+			<property name="lastConnected" />
+			<property name="modelName" />
+			<property name="manufacturer" />
+			<property name="deviceOS" />
+			<property name="deviceOSVersion" />
+			<property name="deviceOSReleaseVersion" />
+		</properties>
 		<representation-property>deviceId</representation-property>
-		
+
 
 		<config-description-ref uri="thing-type:lgwebos:WebOSTV" />
 	</thing-type>

--- a/bundles/org.openhab.binding.loxone/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.loxone/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -206,55 +206,55 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-    <channel-type id="iRoomV2ActiveModeTypeId">
-        <item-type>Number</item-type>
-        <label>Active Mode</label>
-        <description>Loxone Intelligent Room Controller V2 Active Mode.</description>
-        <state pattern="%d" min="0" max="3" step="1" readOnly="true">
-            <options>
-                <option value="0">Economy</option>
-                <option value="1">Comfort temperature</option>
-                <option value="2">Building protection</option>
-                <option value="3">Manual</option>
-            </options>
-        </state>
-    </channel-type>
+	<channel-type id="iRoomV2ActiveModeTypeId">
+		<item-type>Number</item-type>
+		<label>Active Mode</label>
+		<description>Loxone Intelligent Room Controller V2 Active Mode.</description>
+		<state pattern="%d" min="0" max="3" step="1" readOnly="true">
+			<options>
+				<option value="0">Economy</option>
+				<option value="1">Comfort temperature</option>
+				<option value="2">Building protection</option>
+				<option value="3">Manual</option>
+			</options>
+		</state>
+	</channel-type>
 
-    <channel-type id="iRoomV2OperatingModeTypeId">
-        <item-type>Number</item-type>
-        <label>Operating Mode</label>
-        <description>Loxone Intelligent Room Controller V2 Operating Mode.</description>
-        <state pattern="%d" min="0" max="5" step="1">
-            <options>
-                <option value="0">Automatic, heating and cooling allowed</option>
-                <option value="1">Automatic, only heating allowed</option>
-                <option value="2">Automatic, only cooling allowed</option>
-                <option value="3">Manual, heating and cooling allowed</option>
-                <option value="4">Manual, only heating allowed</option>
-                <option value="5">Manual, only cooling allowed</option>
-            </options>
-        </state>
-    </channel-type>
+	<channel-type id="iRoomV2OperatingModeTypeId">
+		<item-type>Number</item-type>
+		<label>Operating Mode</label>
+		<description>Loxone Intelligent Room Controller V2 Operating Mode.</description>
+		<state pattern="%d" min="0" max="5" step="1">
+			<options>
+				<option value="0">Automatic, heating and cooling allowed</option>
+				<option value="1">Automatic, only heating allowed</option>
+				<option value="2">Automatic, only cooling allowed</option>
+				<option value="3">Manual, heating and cooling allowed</option>
+				<option value="4">Manual, only heating allowed</option>
+				<option value="5">Manual, only cooling allowed</option>
+			</options>
+		</state>
+	</channel-type>
 
-    <channel-type id="iRoomV2PrepareStateTypeId">
-        <item-type>Number</item-type>
-        <label>Prepare State</label>
-        <description>Loxone Intelligent Room Controller V2 Prepare State.</description>
-        <state pattern="%d" min="-1" max="1" step="1" readOnly="true">
-            <options>
-                <option value="-1">Cooling down</option>
-                <option value="0">No action</option>
-                <option value="1">Heating up</option>
-            </options>
-        </state>
-    </channel-type>
+	<channel-type id="iRoomV2PrepareStateTypeId">
+		<item-type>Number</item-type>
+		<label>Prepare State</label>
+		<description>Loxone Intelligent Room Controller V2 Prepare State.</description>
+		<state pattern="%d" min="-1" max="1" step="1" readOnly="true">
+			<options>
+				<option value="-1">Cooling down</option>
+				<option value="0">No action</option>
+				<option value="1">Heating up</option>
+			</options>
+		</state>
+	</channel-type>
 
-    <channel-type id="iRoomV2ComfortToleranceTypeId">
-        <item-type>Number</item-type>
-        <label>Comfort Tolerance Temperature</label>
-        <description>Loxone Intelligent Room Controller V2 Comfort Tolerance.</description>
-        <state min="0.5" max="3"/>
-    </channel-type>
+	<channel-type id="iRoomV2ComfortToleranceTypeId">
+		<item-type>Number</item-type>
+		<label>Comfort Tolerance Temperature</label>
+		<description>Loxone Intelligent Room Controller V2 Comfort Tolerance.</description>
+		<state min="0.5" max="3" />
+	</channel-type>
 
 </thing:thing-descriptions>
 

--- a/bundles/org.openhab.binding.mail/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mail/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="mail"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://openhab.org/schemas/thing-description/v1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="http://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://openhab.org/schemas/thing-description/v1.0.0 http://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="smtp">

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/ESH-INF/config/homeassistant-channel-config.xml
@@ -10,11 +10,11 @@
 			<description>Type of the channel group.</description>
 			<default></default>
 		</parameter>
-        <parameter name="component" type="text" readOnly="true" required="true">
-            <label>Component</label>
-            <description>HomeAssistant component type (e.g. binary_sensor, switch, light)</description>
-            <default></default>
-        </parameter>
+		<parameter name="component" type="text" readOnly="true" required="true">
+			<label>Component</label>
+			<description>HomeAssistant component type (e.g. binary_sensor, switch, light)</description>
+			<default></default>
+		</parameter>
 		<parameter name="nodeid" type="text" readOnly="true">
 			<label>Node ID</label>
 			<description>Optional node name of the component</description>

--- a/bundles/org.openhab.binding.network/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.network/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -100,7 +100,7 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-	
+
 	<thing-type id="speedtest">
 		<label>SpeedTest</label>
 		<description>Provides information about bandwidth speed.</description>
@@ -113,7 +113,7 @@
 			<channel id="testStart" typeId="Timestamp">
 				<label>Test Start</label>
 			</channel>
-			 <channel id="testEnd" typeId="Timestamp">
+			<channel id="testEnd" typeId="Timestamp">
 				<label>Test End</label>
 			</channel>
 		</channels>
@@ -128,7 +128,7 @@
 				<label>Initial Delay</label>
 				<description>Delay before starting the first speed test (minutes) after initialization of the binding.</description>
 				<default>5</default>
-                <advanced>true</advanced>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="uploadSize" type="integer" min="5000">
 				<label>Upload size</label>
@@ -145,21 +145,21 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-	
+
 	<channel-type id="isRunning">
 		<item-type>Switch</item-type>
 		<label>Test Running</label>
 		<description>Indicates if a test is currently ongoing</description>
 		<state readOnly="false"></state>
 	</channel-type>
-	
+
 	<channel-type id="progress">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Progress</label>
 		<description>Current Test progression</description>
 		<state readOnly="true" min="0" max="100" pattern="%.0f %unit%" />
 	</channel-type>
-	
+
 	<channel-type id="rateUp">
 		<item-type>Number:DataTransferRate</item-type>
 		<label>Upload Rate</label>
@@ -173,7 +173,7 @@
 		<description>Current download rate</description>
 		<state readOnly="true" pattern="%d %unit%" />
 	</channel-type>
-	
+
 	<channel-type id="Timestamp">
 		<item-type>DateTime</item-type>
 		<label>Timestamp</label>

--- a/bundles/org.openhab.binding.omnikinverter/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.omnikinverter/src/main/resources/ESH-INF/binding/binding.xml
@@ -4,9 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>OmnikInverter Binding</name>
-	<description>This is the binding for the Omnik solar grid inverters. The integration is based on the 
-              undocumented API, which is reverse engineered at https://github.com/Woutrrr/Omnik-Data-Logger. 
-              As such, the known supported inverters are known to work with inverters with wifi bridge which start with the serial number '602' and '606'.
-        </description>
+	<description>This is the binding for the Omnik solar grid inverters. The integration is based on the undocumented API, which is reverse engineered at https://github.com/Woutrrr/Omnik-Data-Logger. As such, the known supported inverters are known to work with inverters with wifi bridge which start with the serial number '602' and '606'.</description>
 	<author>Hans van den Bogert</author>
 </binding:binding>

--- a/bundles/org.openhab.binding.omnikinverter/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.omnikinverter/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="omnikinverter"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"

--- a/bundles/org.openhab.binding.onewire/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.onewire/src/main/resources/ESH-INF/config/config.xml
@@ -31,32 +31,32 @@
 			<required>false</required>
 		</parameter>
 	</config-description>
-    <config-description uri="thing-type:onewire:mstxconfig">
-        <parameter name="id" type="text">
-            <label>Sensor ID</label>
-            <description>Sensor ID in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
-            <required>true</required>
-        </parameter>
-        <parameter name="refresh" type="integer" min="1">
-            <label>Refresh Time</label>
-            <description>Time in seconds after which the thing is refreshed</description>
-            <default>300</default>
-            <unitLabel>s</unitLabel>
-            <required>false</required>
-        </parameter>
-        <parameter name="manualsensor" type="text">
-                <label>Manual Sensor Type</label>
-                <description>Overrides detected sensor type</description>
-                <options>
-                    <option value="DS2438">Generic</option>
-                    <option value="MS_TH">MS-TH</option>
-                    <option value="MS_TV">MS-TV</option>
-                    <option value="MS_TL">MS-TL</option>
-                    <option value="MS_TC">MS-TC</option>
-                </options>
-                <limitToOptions>true</limitToOptions>
-                <required>false</required>
-                <advanced>true</advanced>
-            </parameter>
-    </config-description>	
+	<config-description uri="thing-type:onewire:mstxconfig">
+		<parameter name="id" type="text">
+			<label>Sensor ID</label>
+			<description>Sensor ID in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
+			<required>true</required>
+		</parameter>
+		<parameter name="refresh" type="integer" min="1">
+			<label>Refresh Time</label>
+			<description>Time in seconds after which the thing is refreshed</description>
+			<default>300</default>
+			<unitLabel>s</unitLabel>
+			<required>false</required>
+		</parameter>
+		<parameter name="manualsensor" type="text">
+			<label>Manual Sensor Type</label>
+			<description>Overrides detected sensor type</description>
+			<options>
+				<option value="DS2438">Generic</option>
+				<option value="MS_TH">MS-TH</option>
+				<option value="MS_TV">MS-TV</option>
+				<option value="MS_TL">MS-TL</option>
+				<option value="MS_TC">MS-TC</option>
+			</options>
+			<limitToOptions>true</limitToOptions>
+			<required>false</required>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.onewire/src/main/resources/ESH-INF/thing/deprecated.xml
+++ b/bundles/org.openhab.binding.onewire/src/main/resources/ESH-INF/thing/deprecated.xml
@@ -47,27 +47,27 @@
 		<config-description-ref uri="thing-type:onewire:basethingconfig" />
 	</thing-type>
 	<thing-type id="digitalio" listed="false">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="owserver" />
-        </supported-bridge-type-refs>
-        <label>Digital I/O</label>
-        <description>Digital I/O device (DS2405: single, DS2406/DS2413: dual, DS2408: octal)</description>
-        <config-description-ref uri="thing-type:onewire:fastthingconfig" />
-    </thing-type>
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="owserver" />
+		</supported-bridge-type-refs>
+		<label>Digital I/O</label>
+		<description>Digital I/O device (DS2405: single, DS2406/DS2413: dual, DS2408: octal)</description>
+		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
+	</thing-type>
 	<thing-type id="digitalio2" listed="false">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="owserver" />
-        </supported-bridge-type-refs>
-        <label>Dual Digital I/O</label>
-        <description>A dual digital I/O device (DS2406, DS2413)</description>
-        <config-description-ref uri="thing-type:onewire:fastthingconfig" />
-    </thing-type>
-    <thing-type id="digitalio8" listed="false">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="owserver" />
-        </supported-bridge-type-refs>
-        <label>Octal Digital I/O</label>
-        <description>A octal digital I/O device (DS2408)</description>
-        <config-description-ref uri="thing-type:onewire:fastthingconfig" />
-    </thing-type>
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="owserver" />
+		</supported-bridge-type-refs>
+		<label>Dual Digital I/O</label>
+		<description>A dual digital I/O device (DS2406, DS2413)</description>
+		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
+	</thing-type>
+	<thing-type id="digitalio8" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="owserver" />
+		</supported-bridge-type-refs>
+		<label>Octal Digital I/O</label>
+		<description>A octal digital I/O device (DS2408)</description>
+		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
+	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.windcentrale/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.windcentrale/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="windcentrale"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+<binding:binding id="windcentrale" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Windcentrale Binding</name>

--- a/bundles/org.openhab.binding.windcentrale/src/main/resources/ESH-INF/thing/millThing.xml
+++ b/bundles/org.openhab.binding.windcentrale/src/main/resources/ESH-INF/thing/millThing.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="windcentrale" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="windcentrale"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 


### PR DESCRIPTION
Due to incorrect configured SAT these errors violations were not reported. When the SAT will be updated these violations will cause build errors.

Related to: openhab/static-code-analysis#357