### PR TITLE
[mqtt] fix refresh/restoreOnStartup

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -106,15 +106,21 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         final @Nullable ChannelState data = getChannelState(channelUID);
 
         if (data == null) {
-            logger.warn("Channel {} not supported", channelUID.getId());
-            if (command instanceof RefreshType) {
-                updateState(channelUID.getId(), UnDefType.UNDEF);
+            logger.warn("Channel {} not supported!", channelUID);
+            return;
+        }
+
+        if (command instanceof RefreshType) {
+            if (data.config.retained==true) {
+                updateState(channelUID.getId(), data.getCache().getChannelState());
+            } else {
+                logger.trace("Refresh not supported on non-retained topics (channel {})", channelUID);
             }
             return;
         }
 
-        if (command instanceof RefreshType || data.isReadOnly()) {
-            updateState(channelUID.getId(), data.getCache().getChannelState());
+        if (data.isReadOnly()) {
+            logger.warn("Channel {} is a read-only channel!", channelUID);
             return;
         }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -99,7 +99,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (connection == null) {
+        if (connection == null || command instanceof RefreshType) {
             return;
         }
 
@@ -107,15 +107,6 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
         if (data == null) {
             logger.warn("Channel {} not supported!", channelUID);
-            return;
-        }
-
-        if (command instanceof RefreshType) {
-            if (data.config.retained==true) {
-                updateState(channelUID.getId(), data.getCache().getChannelState());
-            } else {
-                logger.trace("Refresh not supported on non-retained topics (channel {})", channelUID);
-            }
             return;
         }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -99,7 +99,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (connection == null || command instanceof RefreshType) {
+        if (connection == null) {
             return;
         }
 
@@ -110,8 +110,18 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
             return;
         }
 
+        if (command instanceof RefreshType) {
+            State state = data.getCache().getChannelState();
+            if (state instanceof UnDefType) {
+                logger.debug("Channel {} received REFRESH but no value cached, ignoring", channelUID);
+            } else {
+                updateState(channelUID, state);
+            }
+            return;
+        }
+
         if (data.isReadOnly()) {
-            logger.warn("Channel {} is a read-only channel!", channelUID);
+            logger.warn("Channel {} is a read-only channel, ignoring command {}", channelUID, command);
             return;
         }
 


### PR DESCRIPTION
Fixes #5879 

The binding can't request the state from the server. Therefore responding to refresh doesn't make sense and does not improve the situation.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
