### PR TITLE
fix SNMP startup exceptions

### DIFF
--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -96,11 +96,9 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (target.getAddress() == null) {
-            if (!renewTargetAddress()) {
-                logger.info("failed to renew target address, can't process '{}' to '{}'.", command, channelUID);
-                return;
-            }
+        if (target.getAddress() == null &&!renewTargetAddress()) {
+            logger.info("failed to renew target address, can't process '{}' to '{}'.", command, channelUID);
+            return;
         }
 
         try {

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -96,6 +96,13 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        if (target.getAddress() == null) {
+            if (!renewTargetAddress()) {
+                logger.info("failed to renew target address, can't process '{}' to '{}'.", command, channelUID);
+                return;
+            }
+        }
+
         try {
             if (command instanceof RefreshType) {
                 SnmpInternalChannelConfiguration channel = readChannelSet.stream()


### PR DESCRIPTION
Fixes #6055 

If a channel receives a command before the SNMP target address has been resolved, the bindings tries to send to a null target address. This leads to an NPE in SNMP4J.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
