### PR TITLE
[hdpowerview] simplify polling initialization; downgrade and improve some error logging

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -94,15 +94,14 @@ public class HDPowerViewWebTargets {
             response = invocation.invoke();
         }
 
-        if (response.getStatus() != 200) {
-            if (response.getStatus() == 423) {
-                // bridge seems to return a 423 error (resource locked) once per day around midnight
-                // we assume this is a regular re-initialization process, so suppress the error log
-                logger.warn("Bridge returned '423' while invoking {}", target.getUri());
-            } else {
-                logger.error("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),
-                        response.readEntity(String.class));
-            }
+        if (response.getStatus() == 423) {
+            // the hub seems to return a 423 error (resource locked) once per day around midnight
+            // this is probably some kind of regular re-initialization process, so suppress the error log
+            logger.warn("Bridge returned '423' while invoking {}", target.getUri());
+            return null;
+        } else if (response.getStatus() != 200) {
+            logger.error("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),
+                    response.readEntity(String.class));
             return null;
         } else if (!response.hasEntity()) {
             logger.error("Bridge returned null response while invoking {}", target.getUri());

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -14,6 +14,7 @@ package org.openhab.binding.hdpowerview.internal;
 
 import java.io.IOException;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -55,7 +56,7 @@ public class HDPowerViewWebTargets {
         gson = new Gson();
     }
 
-    public Shades getShades() throws IOException {
+    public Shades getShades() throws JsonParseException, IOException {
         Response response = invoke(shades.request().buildGet(), shades);
         if (response != null) {
             String result = response.readEntity(String.class);
@@ -88,7 +89,7 @@ public class HDPowerViewWebTargets {
         invoke(target.request().buildGet(), sceneActivate);
     }
 
-    private Response invoke(Invocation invocation, WebTarget target) {
+    private Response invoke(Invocation invocation, WebTarget target) throws ProcessingException {
         Response response;
         synchronized (this) {
             response = invocation.invoke();
@@ -100,11 +101,11 @@ public class HDPowerViewWebTargets {
             logger.debug("Bridge returned '423' while invoking {}", target.getUri());
             return null;
         } else if (response.getStatus() != 200) {
-            logger.error("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),
+            logger.warn("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),
                     response.readEntity(String.class));
             return null;
         } else if (!response.hasEntity()) {
-            logger.error("Bridge returned null response while invoking {}", target.getUri());
+            logger.warn("Bridge returned null response while invoking {}", target.getUri());
             return null;
         }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -95,8 +95,14 @@ public class HDPowerViewWebTargets {
         }
 
         if (response.getStatus() != 200) {
-            logger.error("Bridge returned {} while invoking {} : {}", response.getStatus(), target.getUri(),
-                    response.readEntity(String.class));
+            if (response.getStatus() == 423) {
+                // bridge seems to return a 423 error (resource locked) once per day around midnight
+                // we assume this is a regular re-initialization process, so suppress the error log
+                logger.warn("Bridge returned '423' while invoking {}", target.getUri());
+            } else {
+                logger.error("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),
+                        response.readEntity(String.class));
+            }
             return null;
         } else if (!response.hasEntity()) {
             logger.error("Bridge returned null response while invoking {}", target.getUri());

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -97,7 +97,7 @@ public class HDPowerViewWebTargets {
         if (response.getStatus() == 423) {
             // the hub seems to return a 423 error (resource locked) once per day around midnight
             // this is probably some kind of regular re-initialization process, so suppress the error log
-            logger.warn("Bridge returned '423' while invoking {}", target.getUri());
+            logger.debug("Bridge returned '423' while invoking {}", target.getUri());
             return null;
         } else if (response.getStatus() != 200) {
             logger.error("Bridge returned '{}' while invoking {} : {}", response.getStatus(), target.getUri(),

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
@@ -78,7 +78,7 @@ public class HDPowerViewShadeDiscoveryService extends AbstractDiscoveryService {
             try {
                 shades = targets.getShades();
             } catch (IOException e) {
-                logger.error("{}", e.getMessage(), e);
+                logger.error("Unexpected error: {}", e.getMessage());
                 stopScan();
                 return;
             }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewShadeDiscoveryService.java
@@ -78,7 +78,7 @@ public class HDPowerViewShadeDiscoveryService extends AbstractDiscoveryService {
             try {
                 shades = targets.getShades();
             } catch (IOException e) {
-                logger.error("Unexpected error: {}", e.getMessage());
+                logger.warn("Unexpected error: {}", e.getMessage());
                 stopScan();
                 return;
             }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -137,7 +137,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             pollShades();
             pollScenes();
         } catch (ProcessingException e) {
-            logger.debug("Could not connect to bridge: {}", e.getMessage());
+            logger.debug("Error connecting to bridge: {}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
             logger.warn("Unexpected error connecting to bridge: {}", e.getMessage());

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
@@ -135,11 +136,11 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             logger.debug("Polling for state");
             pollShades();
             pollScenes();
-        } catch (IOException e) {
-            logger.debug("Could not connect to bridge", e);
+        } catch (ProcessingException e) {
+            logger.debug("Could not connect to bridge: {}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.warn("Unexpected error connecting to bridge", e);
+            logger.warn("Unexpected error connecting to bridge: {}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -136,16 +136,15 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             logger.debug("Polling for state");
             pollShades();
             pollScenes();
-        } catch (ProcessingException e) {
-            logger.debug("Error connecting to bridge: {}", e.getMessage());
+        } catch (JsonParseException e) {
+            logger.warn("Bridge returned a bad JSON response: {}", e.getMessage());
+        } catch (ProcessingException | IOException e) {
+            logger.warn("Error connecting to bridge: {}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
-        } catch (Exception e) {
-            logger.warn("Unexpected error connecting to bridge: {}", e.getMessage());
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 
-    private void pollShades() throws IOException {
+    private void pollShades() throws JsonParseException, ProcessingException, IOException {
         Shades shades = webTargets.getShades();
         updateStatus(ThingStatus.ONLINE);
         if (shades != null) {
@@ -170,7 +169,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         }
     }
 
-    private void pollScenes() throws JsonParseException, IOException {
+    private void pollScenes() throws JsonParseException, ProcessingException, IOException {
         Scenes scenes = webTargets.getScenes();
         if (scenes != null) {
             logger.debug("Received {} scenes", scenes.sceneIds.size());

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -51,7 +51,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
     @Override
     public void initialize() {
         updateStatus(ThingStatus.ONLINE);
-//        getBridgeHandler().pollNow();
+//      getBridgeHandler().pollNow(); 
     }
 
     @Override

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -51,7 +51,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
     @Override
     public void initialize() {
         updateStatus(ThingStatus.ONLINE);
-        getBridgeHandler().pollNow();
+//        getBridgeHandler().pollNow();
     }
 
     @Override
@@ -117,7 +117,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         try {
             response = bridge.getWebTargets().moveShade(shadeId, position);
         } catch (IOException e) {
-            logger.error("{}", e.getMessage(), e);
+            logger.error("Unexpected error: {}", e.getMessage());
             return;
         }
         if (response != null) {

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -51,7 +51,6 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
     @Override
     public void initialize() {
         updateStatus(ThingStatus.ONLINE);
-//      getBridgeHandler().pollNow(); 
     }
 
     @Override
@@ -117,7 +116,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         try {
             response = bridge.getWebTargets().moveShade(shadeId, position);
         } catch (IOException e) {
-            logger.error("Unexpected error: {}", e.getMessage());
+            logger.warn("Unexpected error: {}", e.getMessage());
             return;
         }
         if (response != null) {


### PR DESCRIPTION
The Powerview hub seems to return an HTTP 423 (resource locked) response every night that caused a full "horror" log entry with a complete dump of the exception. Such HTTP 423 errors seem to be a regular occurrence and they are always resolved on the next polling cycle 60 seconds later. So such an event should not produce a "horror dump" in the log file that might scare the user.

Furthermore it was noted that each Shade Handler on being initialized would unnecessarily destroy and re-create the Hub Handler's polling timer. This is unnecessary because the Hub Handler has already created a perfectly good polling timer in the first place.

So the following changes have been made..

1. Explicitly catch HTTP 423 errors and return a logger warning only (rather than a logger error).
2. Modify all logger.warn() and logger.error() calls so that they do not do a complete dump of the exception.
3. Remove the Shade handler's unnecessary call to destroy and re-create the Hub's polling timer.