### PR TITLE
Resolve itest runbundles for update to Mockito 3.1.0

### DIFF
--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -30,9 +30,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
@@ -40,4 +37,7 @@ Fragment-Host: org.openhab.binding.astro
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -52,9 +52,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.3,7.2.4)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
@@ -67,4 +64,7 @@ Fragment-Host: org.openhab.binding.avmfritz
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -25,7 +25,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.bundles.jdom;version='[2.0.6,2.0.7)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -53,7 +52,6 @@ Fragment-Host: org.openhab.binding.feed
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	slf4j.simple;version='[1.7.21,1.7.22)',\
-	com.rometools.rome;version='[1.12.0,1.12.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -41,7 +39,6 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.binding.mqtt;version='[2.5.0,2.5.1)',\
 	org.openhab.binding.mqtt.generic;version='[2.5.0,2.5.1)',\
@@ -75,7 +72,9 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	moquette-broker;version='[0.13.0,0.13.1)',\
-	org.apache.commons.codec;version='[1.10.0,1.10.1)'
+	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'
 
 -runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -40,7 +38,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.binding.mqtt;version='[2.5.0,2.5.1)',\
 	org.openhab.binding.mqtt.generic;version='[2.5.0,2.5.1)',\
@@ -74,8 +71,9 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	jaxb-api;version='[2.2.11,2.2.12)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	moquette-broker;version='[0.13.0,0.13.1)',\
-	org.apache.commons.codec;version='[1.10.0,1.10.1)'
+	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'
 -runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -38,9 +38,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
@@ -70,4 +67,7 @@ Fragment-Host: org.openhab.binding.nest
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.binding.ntp
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -37,7 +35,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.binding.ntp;version='[2.5.0,2.5.1)',\
 	org.openhab.binding.ntp.tests;version='[2.5.0,2.5.1)',\
@@ -60,4 +57,7 @@ Fragment-Host: org.openhab.binding.ntp
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -47,12 +47,9 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -61,6 +58,8 @@ Fragment-Host: org.openhab.binding.systeminfo
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	com.github.oshi.oshi-core;version='[4.0.0,4.0.1)',\
 	com.sun.jna;version='[5.4.0,5.4.1)',\
-	com.sun.jna.platform;version='[5.4.0,5.4.1)'
+	com.sun.jna.platform;version='[5.4.0,5.4.1)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -37,15 +37,11 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.eclipse.californium.core;version='[1.0.7,1.0.8)',\
 	org.eclipse.californium.element-connector;version='[1.0.7,1.0.8)',\
-	org.eclipse.californium.scandium;version='[1.0.7,1.0.8)',\
 	org.openhab.binding.tradfri;version='[2.5.0,2.5.1)',\
 	org.openhab.binding.tradfri.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.mdns;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mdns;version='[2.5.0,2.5.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.jetty.http;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.io;version='[9.4.11,9.4.12)',\
@@ -53,7 +49,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
@@ -65,4 +60,7 @@ Fragment-Host: org.openhab.binding.tradfri
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -20,8 +20,6 @@ Fragment-Host: org.openhab.binding.wemo
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -44,7 +42,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.eclipse.jetty.websocket.common;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[7.0.0,7.0.1)',\
 	org.objectweb.asm.commons;version='[7.0.0,7.0.1)',\
 	org.objectweb.asm.tree;version='[7.0.0,7.0.1)',\
@@ -75,4 +72,7 @@ Fragment-Host: org.openhab.binding.wemo
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 # done
 #
 -runbundles: \
-	jaxb-api;version='[2.2.11,2.2.12)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
@@ -31,9 +30,6 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	io.netty.resolver;version='[4.1.34,4.1.35)',\
 	io.netty.transport;version='[4.1.34,4.1.35)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	moquette-broker;version='[0.13.0,0.13.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -48,7 +44,6 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -60,6 +55,9 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -38,7 +38,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/1127.