### PR TITLE
[mqtt] fix incoming transformation in case of failure

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -213,6 +213,7 @@ Here are a few examples to unwrap a value from a complex response:
 | `THEVALUE:23.2°C`                                                   | REGEX       | `REGEX::(.*?)°`                           |
 
 Transformations can be chained by separating them with the mathematical intersection character "∩".
+Please note that the incoming value will be discarded if one transformation fails (e.g. REGEX did not match).
 
 ## Outgoing Value Transformation
 
@@ -242,6 +243,4 @@ Here are a few examples:
 ## Troubleshooting
 
 * If you get the error "No MQTT client": Please update your installation.
-* If you use the Mosquitto broker: Please be aware that there is a relatively low setting 
-for retained messages. At some point messages will just not being delivered anymore: 
-Change the setting 
+* If you use the Mosquitto broker: Please be aware that there is a relatively low setting for retained messages. At some point messages will just not being delivered anymore: Change the setting. 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -153,21 +153,29 @@ public class ChannelState implements MqttMessageSubscriber {
         }
 
         // String value: Apply transformations
-        String strvalue = new String(payload, StandardCharsets.UTF_8);
+        String strValue = new String(payload, StandardCharsets.UTF_8);
         for (ChannelStateTransformation t : transformationsIn) {
-            strvalue = t.processValue(strvalue);
+            String transformedValue = t.processValue(strValue);
+            if (transformedValue != null) {
+                strValue = transformedValue;
+            } else {
+                logger.info("Transformation '{}' returned null on '{}', discarding message", strValue,
+                        t.serviceName);
+                receivedOrTimeout();
+                return;
+            }
         }
 
         // Is trigger?: Special handling
         if (config.trigger) {
-            channelStateUpdateListener.triggerChannel(channelUID, strvalue);
+            channelStateUpdateListener.triggerChannel(channelUID, strValue);
             receivedOrTimeout();
             return;
         }
 
-        Command command = TypeParser.parseCommand(cachedValue.getSupportedCommandTypes(), strvalue);
+        Command command = TypeParser.parseCommand(cachedValue.getSupportedCommandTypes(), strValue);
         if (command == null) {
-            logger.warn("Incoming payload '{}' not supported by type '{}'", strvalue,
+            logger.warn("Incoming payload '{}' not supported by type '{}'", strValue,
                     cachedValue.getClass().getSimpleName());
             receivedOrTimeout();
             return;
@@ -184,7 +192,7 @@ public class ChannelState implements MqttMessageSubscriber {
         try {
             cachedValue.update(command);
         } catch (IllegalArgumentException | IllegalStateException e) {
-            logger.warn("Command '{}' not supported by type '{}': {}", strvalue, cachedValue.getClass().getSimpleName(),
+            logger.warn("Command '{}' not supported by type '{}': {}", strValue, cachedValue.getClass().getSimpleName(),
                     e.getMessage());
             receivedOrTimeout();
             return;

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelStateTransformation.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelStateTransformation.java
@@ -58,7 +58,7 @@ public class ChannelStateTransformation {
     /**
      * Creates a new channel state transformer.
      *
-     * @param type A transformation service name.
+     * @param serviceName A transformation service name.
      * @param pattern A transformation. An Example:
      *            $.device.status.temperature for a json {device: {status: {
      *            temperature: 23.2 }}} (for type <code>JSONPATH</code>).
@@ -76,7 +76,7 @@ public class ChannelStateTransformation {
      * @param value The incoming value
      * @return The transformed value
      */
-    protected String processValue(String value) {
+    protected @Nullable String processValue(String value) {
         TransformationService transformationService = this.transformationService.get();
         if (transformationService == null) {
             transformationService = provider.getTransformationService(serviceName);
@@ -86,12 +86,12 @@ public class ChannelStateTransformation {
             }
             this.transformationService = new WeakReference<>(transformationService);
         }
-        String temp = null;
+        String returnValue = null;
         try {
-            temp = transformationService.transform(pattern, value);
+            returnValue = transformationService.transform(pattern, value);
         } catch (TransformationException e) {
             logger.warn("Executing the {}-transformation failed: {}", serviceName, e.getMessage());
         }
-        return (temp != null) ? temp : value;
+        return returnValue;
     }
 }


### PR DESCRIPTION
Fixes #6224

Abort transformation if one returns null or fails. The previous implementation returned the original value. This is unexpected and not what would be expected if e.g. a regex doesn't match.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>