### PR TITLE
[mqtt] make rollershutter symmetric

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -167,11 +167,15 @@ The channel expects values on the corresponding MQTT topic to be in this format 
 
 ### Channel Type "rollershutter"
 
-* __on__: An optional string (like "Open") that is recognized as UP state.
-* __off__: An optional string (like "Close") that is recognized as DOWN state.
-* __stop__: An optional string (like "Stop") that is recognized as STOP state.
+* __on__: An optional string (like "Open") that is recognized as `UP` state.
+* __off__: An optional string (like "Close") that is recognized as `DOWN` state.
+* __stop__: An optional string (like "Stop") that is recognized as `STOP` state.
+
+Internally `UP` is converted to 100%, `DOWN` to 0%.
+If strings are defined for these values, they are used for sending commands to the broker, too.
 
 You can connect this channel to a Rollershutter or Dimmer item.
+
 
 ## Rule Actions
 

--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -171,7 +171,7 @@ The channel expects values on the corresponding MQTT topic to be in this format 
 * __off__: An optional string (like "Close") that is recognized as `DOWN` state.
 * __stop__: An optional string (like "Stop") that is recognized as `STOP` state.
 
-Internally `UP` is converted to 100%, `DOWN` to 0%.
+Internally `UP` is converted to 0%, `DOWN` to 100%.
 If strings are defined for these values, they are used for sending commands to the broker, too.
 
 You can connect this channel to a Rollershutter or Dimmer item.

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -118,7 +118,16 @@ public class RollershutterValue extends Value {
         if (this.nextIsStop) {
             this.nextIsStop = false;
             return stopString;
+        } else if (state instanceof PercentType) {
+            if (state.equals(PercentType.HUNDRED) && upString != null) {
+                return upString;
+            } else if (state.equals(PercentType.ZERO) && downString != null) {
+                return downString;
+            } else {
+                return String.valueOf(((PercentType) state).intValue());
+            }
+        } else {
+            return "UNDEF";
         }
-        return (state == UnDefType.UNDEF) ? "0" : String.valueOf(((PercentType) state).intValue());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -121,10 +121,10 @@ public class RollershutterValue extends Value {
             this.nextIsStop = false;
             return stopString;
         } else if (state instanceof PercentType) {
-            if (state.equals(PercentType.HUNDRED) && upString != null) {
-                return upString;
-            } else if (state.equals(PercentType.ZERO) && downString != null) {
+            if (state.equals(PercentType.HUNDRED) && downString != null) {
                 return downString;
+            } else if (state.equals(PercentType.ZERO) && upString != null) {
+                return upString;
             } else {
                 return String.valueOf(((PercentType) state).intValue());
             }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -115,6 +115,8 @@ public class RollershutterValue extends Value {
 
     @Override
     public String getMQTTpublishValue() {
+        final String upString = this.upString;
+        final String downString = this.downString;
         if (this.nextIsStop) {
             this.nextIsStop = false;
             return stopString;

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -164,8 +164,31 @@ public class ValueTests {
     }
 
     @Test
-    public void rollershutterUpdate() {
+    public void rollershutterUpdateWithStrings () {
         RollershutterValue v = new RollershutterValue("fancyON", "fancyOff", "fancyStop");
+        // Test with command
+        v.update(UpDownType.UP);
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(PercentType.ZERO));
+        v.update(UpDownType.DOWN);
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(PercentType.HUNDRED));
+
+        // Test with custom string
+        v.update(new StringType("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(PercentType.ZERO));
+        v.update(new StringType("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(PercentType.HUNDRED));
+        v.update(new PercentType(27));
+        assertThat(v.getMQTTpublishValue(), is("27"));
+        assertThat(v.getChannelState(), is(new PercentType(27)));
+    }
+
+    @Test
+    public void rollershutterUpdateWithOutStrings () {
+        RollershutterValue v = new RollershutterValue(null, null, "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
         assertThat(v.getMQTTpublishValue(), is("0"));
@@ -175,10 +198,10 @@ public class ValueTests {
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
-        v.update(new StringType("fancyON"));
+        v.update(PercentType.ZERO);
         assertThat(v.getMQTTpublishValue(), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
-        v.update(new StringType("fancyOff"));
+        v.update(PercentType.HUNDRED);
         assertThat(v.getMQTTpublishValue(), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));


### PR DESCRIPTION
Fixes #6067 

This makes the rollershutter implementation symmetric and documents the behaviour. 

Previously it was possible to define strings for `UP` and `DOWN` (which were converted to `PercentType.HUNDRED` and `PercentType.ZERO`) for inbound messages. These strings were not used for sending values to the broker, which is at least unexpected. Now `PercentType.HUNDERED` and `PercentType.ZERO` are converted to the corresponding strings (if defined, otherwise `100` or `0` are sent). 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
