### PR TITLE
[ambientweather] Add model WS-0265

### DIFF
--- a/bundles/org.openhab.binding.ambientweather/README.md
+++ b/bundles/org.openhab.binding.ambientweather/README.md
@@ -9,8 +9,9 @@ The binding currently supports weather data from these weather stations
 
 - WS-0900-IP,
 - WS-1400-IP / WS-1401-IP,
-- WS-2902A, and
-- WS-8482.
+- WS-2902A,
+- WS-8482, and
+- WS-0265.
 
 Other stations can be added relatively easily with changes in just several places in the source code.
 
@@ -76,6 +77,8 @@ The following channels are supported by the binding. Note that specific weather 
 | indoorSensor                 | batteryIndicator                | String                  | Battery indicator                                             |
 |                              |                                 |                         |                                                               |
 | remoteSensor\<1-10\>         | temperature                     | Number:Temperature      | Temperature                                                   |
+| remoteSensor\<1-10\>         | dewPoint                        | Number:Temperature      | Dew Point                                                     |
+| remoteSensor\<1-10\>         | feelingTemperature              | Number:Temperature      | "Real feel" temperature                                       |
 | remoteSensor\<1-10\>         | humidity                        | Number:Dimensionless    | Humidity                                                      |
 | remoteSensor\<1-10\>         | batteryIndicator                | String                  | Battery indicator                                             |
 | remoteSensor\<1-10\>         | co2                             | Number:Dimensionless    | Carbon Dioxide level                                          |

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/AmbientWeatherBindingConstants.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/AmbientWeatherBindingConstants.java
@@ -49,13 +49,17 @@ public class AmbientWeatherBindingConstants {
     public static final String THING_TYPE_WS8482 = "ws8482";
     public static final ThingTypeUID UID_WS8482 = new ThingTypeUID(BINDING_ID, THING_TYPE_WS8482);
 
-    // WS-1400-IP series weather stations
+    // WS-0900-IP series weather stations
     public static final String THING_TYPE_WS0900IP = "ws0900ip";
     public static final ThingTypeUID UID_WS0900IP = new ThingTypeUID(BINDING_ID, THING_TYPE_WS0900IP);
 
+    // WS-0265 weather station
+    public static final String THING_TYPE_WS0265 = "ws0265";
+    public static final ThingTypeUID UID_WS0265 = new ThingTypeUID(BINDING_ID, THING_TYPE_WS0265);
+
     // Collection of weather station thing types
     public static final Set<ThingTypeUID> SUPPORTED_STATION_THING_TYPES_UIDS = Collections.unmodifiableSet(
-            Stream.of(UID_WS1400IP, UID_WS2902A, UID_WS8482, UID_WS0900IP).collect(Collectors.toSet()));
+            Stream.of(UID_WS1400IP, UID_WS2902A, UID_WS8482, UID_WS0900IP, UID_WS0265).collect(Collectors.toSet()));
 
     // Collection of all supported thing types
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
@@ -67,6 +71,7 @@ public class AmbientWeatherBindingConstants {
     public static final String CHGRP_WS2902A = "weatherDataWs2902a";
     public static final String CHGRP_WS8482 = "weatherDataWs8482";
     public static final String CHGRP_WS0900IP = "weatherDataWs0900ip";
+    public static final String CHGRP_WS0265 = "weatherDataWs0265";
 
     // Channel groups used across weather station types
     public static final String CHGRP_STATION = "station";

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/AmbientWeatherHandlerFactory.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/AmbientWeatherHandlerFactory.java
@@ -24,10 +24,9 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.ambientweather.internal.handler.AmbientWeatherBridgeHandler;
 import org.openhab.binding.ambientweather.internal.handler.AmbientWeatherStationHandler;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link AmbientWeatherHandlerFactory} is responsible for creating the
@@ -37,10 +36,14 @@ import org.slf4j.LoggerFactory;
  */
 @Component(configurationPid = "binding.ambientweather", service = ThingHandlerFactory.class)
 public class AmbientWeatherHandlerFactory extends BaseThingHandlerFactory {
-    private final Logger logger = LoggerFactory.getLogger(AmbientWeatherHandlerFactory.class);
 
     // Needed for converting UTC time to local time
-    private TimeZoneProvider timeZoneProvider;
+    private final TimeZoneProvider timeZoneProvider;
+
+    @Activate
+    public AmbientWeatherHandlerFactory(@Reference TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = timeZoneProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -59,14 +62,4 @@ public class AmbientWeatherHandlerFactory extends BaseThingHandlerFactory {
         }
         return null;
     }
-
-    @Reference
-    protected void setTimeZoneProvider(TimeZoneProvider timeZoneProvider) {
-        this.timeZoneProvider = timeZoneProvider;
-    }
-
-    protected void unsetTimeZoneProvider(TimeZoneProvider timeZone) {
-        this.timeZoneProvider = null;
-    }
-
 }

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/ProcessorFactory.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/ProcessorFactory.java
@@ -39,6 +39,7 @@ public class ProcessorFactory {
     private @Nullable static Ws2902aProcessor WS2902A_PROCESSOR;
     private @Nullable static Ws8482Processor WS8482_PROCESSOR;
     private @Nullable static Ws0900ipProcessor WS0900IP_PROCESSOR;
+    private @Nullable static Ws0265Processor WS0265_PROCESSOR;
 
     /**
      * Individual weather station processors use this one Gson instance,
@@ -90,6 +91,14 @@ public class ProcessorFactory {
                 if (processor == null) {
                     processor = new Ws0900ipProcessor();
                     WS0900IP_PROCESSOR = processor;
+                }
+                return processor;
+            }
+            case "ambientweather:ws0265": {
+                Ws0265Processor processor = WS0265_PROCESSOR;
+                if (processor == null) {
+                    processor = new Ws0265Processor();
+                    WS0265_PROCESSOR = processor;
                 }
                 return processor;
             }

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/RemoteSensor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/RemoteSensor.java
@@ -83,6 +83,12 @@ public class RemoteSensor {
                 if (("temp" + sensorNumber + "f").equals(name)) {
                     handler.updateQuantity(CHGRP_REMOTE_SENSOR + sensorNumber, CH_TEMPERATURE, reader.nextDouble(),
                             ImperialUnits.FAHRENHEIT);
+                } else if (("dewPoint" + sensorNumber).equals(name)) {
+                    handler.updateQuantity(CHGRP_REMOTE_SENSOR + sensorNumber, CH_DEW_POINT, reader.nextDouble(),
+                            ImperialUnits.FAHRENHEIT);
+                } else if (("feelsLike" + sensorNumber).equals(name)) {
+                    handler.updateQuantity(CHGRP_REMOTE_SENSOR + sensorNumber, CH_FEELING_TEMPERATURE,
+                            reader.nextDouble(), ImperialUnits.FAHRENHEIT);
                 } else if (("humidity" + sensorNumber).equals(name)) {
                     handler.updateQuantity(CHGRP_REMOTE_SENSOR + sensorNumber, CH_HUMIDITY, reader.nextDouble(),
                             SmartHomeUnits.PERCENT);

--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws0265Processor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws0265Processor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ambientweather.internal.processor;
+
+import static org.openhab.binding.ambientweather.internal.AmbientWeatherBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.openhab.binding.ambientweather.internal.handler.AmbientWeatherStationHandler;
+import org.openhab.binding.ambientweather.internal.model.EventDataJson;
+
+/**
+ * The {@link Ws0265Processor} is responsible for updating
+ * the channels associated with the WS-0265 series weather stations in
+ * response to the receipt of a weather data update from the Ambient
+ * Weather real-time API.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+@NonNullByDefault
+public class Ws0265Processor extends AbstractProcessor {
+
+    @Override
+    public void setChannelGroupId() {
+        channelGroupId = CHGRP_WS0265;
+    }
+
+    @Override
+    public void setNumberOfSensors() {
+        remoteSensor.setNumberOfSensors(7);
+    }
+
+    @Override
+    public void processInfoUpdate(AmbientWeatherStationHandler handler, String station, String name, String location) {
+        // Update name and location channels
+        handler.updateString(CHGRP_STATION, CH_NAME, name);
+        handler.updateString(CHGRP_STATION, CH_LOCATION, location);
+    }
+
+    @Override
+    public void processWeatherData(AmbientWeatherStationHandler handler, String station, String jsonData) {
+        EventDataJson data = parseEventData(station, jsonData);
+        if (data == null) {
+            return;
+        }
+
+        // Update the weather data channels
+        handler.updateDate(channelGroupId, CH_OBSERVATION_TIME, data.date);
+        handler.updateQuantity(channelGroupId, CH_TEMPERATURE, data.tempinf, ImperialUnits.FAHRENHEIT);
+
+        // Update the remote sensor channels
+        remoteSensor.updateChannels(handler, jsonData);
+    }
+}

--- a/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/channel-group-types.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/channel-group-types.xml
@@ -29,6 +29,8 @@
 		<description>Remote Sensor</description>
 		<channels>
 			<channel id="temperature" typeId="temperature" />
+			<channel id="dewPoint" typeId="dewPoint" />
+			<channel id="feelingTemperature" typeId="feelingTemperature" />
 			<channel id="relativeHumidity" typeId="relativeHumidity" />
 			<channel id="soilTemperature" typeId="soilTemperature" />
 			<channel id="soilMoisture" typeId="soilMoisture" />

--- a/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/ws0265.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/resources/ESH-INF/thing/ws0265.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="ambientweather" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Ambient Weather WS-0265 -->
+	<thing-type id="ws0265">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+
+		<label>WS-0265</label>
+		<description>Ambient Weather Station WS-0265</description>
+		<channel-groups>
+			<channel-group id="station" typeId="station">
+				<label>Weather Station</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="weatherDataWs0265" typeId="weatherDataWs0265">
+				<label>Weather Data</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor1" typeId="remoteSensor">
+				<label>Remote Sensor 1</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor2" typeId="remoteSensor">
+				<label>Remote Sensor 2</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor3" typeId="remoteSensor">
+				<label>Remote Sensor 3</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor4" typeId="remoteSensor">
+				<label>Remote Sensor 4</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor5" typeId="remoteSensor">
+				<label>Remote Sensor 5</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor6" typeId="remoteSensor">
+				<label>Remote Sensor 6</label>
+				<description></description>
+			</channel-group>
+			<channel-group id="remoteSensor7" typeId="remoteSensor">
+				<label>Remote Sensor 7</label>
+				<description></description>
+			</channel-group>
+		</channel-groups>
+		<config-description-ref uri="thing-type:ambientweather:station" />
+	</thing-type>
+
+	<channel-group-type id="weatherDataWs0265">
+		<label>Weather Data</label>
+		<description>Weather Data</description>
+		<channels>
+			<channel id="observationTime" typeId="observationTime" />
+			<channel id="temperature" typeId="temperature" />
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
Add the model WS-0265 weather station, which includes support for 2 new channels for remote sensors.

Also convert to constructor injection.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
