### PR TITLE
[onewire] Extend documentation: Parameter value "ignorepor" must not use quotation marks

### DIFF
--- a/bundles/org.openhab.binding.onewire/README.md
+++ b/bundles/org.openhab.binding.onewire/README.md
@@ -206,6 +206,7 @@ Some sensors (e.g. DS18x20) report 85 °C as Power-On-Reset value.
 In some installations this leads to errorneous temperature readings.
 If the `ignorepor` parameter is set to `true` 85 °C values will be filtered.
 The default is `false` as correct reading of 85 °C will otherwise be filtered, too.
+Please note that the parameter value must not be set in quotation marks (see example below).
 
 A channel of type `temperature-por-res` has one parameter: `resolution`.
 OneWire temperature sensors are capable of different resolutions: `9`, `10`, `11` and `12` bits.
@@ -261,6 +262,7 @@ Bridge onewire:owserver:mybridge [
         ] {
             Channels:
                 Type temperature-por-res : temperature [
+                    ignorepor=true,
                     resolution="11"
                 ]
         } 
@@ -273,6 +275,7 @@ Bridge onewire:owserver:mybridge [
         ] {
             Channels:
                 Type temperature-por-res : temperature [
+                    ignorepor=false,
                     resolution="9"
                 ]
         } 


### PR DESCRIPTION
Figured out that parameter value true/false for parameter "ignorepor" must not be set in quotation marks otherwise initialization of thing fails with "[...] changed from OFFLINE (CONFIGURATION_ERROR): required properties missing to UNINITIALIZED [...]"

Therefore added one sentence in documentation chapter "temperature" and according parameter in example section.

Tested on 2.5M2

Signed-off-by: Michael Hoffmann <bitforker@gmail.com>