### PR TITLE
Remove NullAnnotationsCheck suppression

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -3,7 +3,7 @@
 <suppressions>
     <suppress files=".classpath" checks="MavenPomderivedInClasspathCheck" />
     <!-- These suppressions define which files to be suppressed for which checks. -->
-    <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck"/>
+    <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
     <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
 


### PR DESCRIPTION
According to the [coding guidelines](https://www.openhab.org/docs/developer/guidelines.html#null-annotations) we should use null annotations so I was surprised to find the SAT check for this suppressed.