### PR TITLE
[miio] Update MiIoDevices.java

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoDevices.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoDevices.java
@@ -89,6 +89,7 @@ public enum MiIoDevices {
     TOOTHBRUSH("soocare.toothbrush.x3", "Mi Toothbrush", THING_TYPE_UNSUPPORTED),
     VACUUM("rockrobo.vacuum.v1", "Mi Robot Vacuum", THING_TYPE_VACUUM),
     VACUUM2("roborock.vacuum.s5", "Mi Robot Vacuum v2", THING_TYPE_VACUUM),
+    VACUUM1S("roborock.vacuum.m1s", "Mi Robot Vacuum 1S", THING_TYPE_VACUUM),
     VACUUMS6("roborock.vacuum.s6", "Roborock Vacuum S6", THING_TYPE_VACUUM),
     VACUUMSS6("rockrobo.vacuum.s6", "Roborock Vacuum S6", THING_TYPE_VACUUM),
     VACUUME2("roborock.vacuum.e2", "Rockrobo Xiaowa Vacuum v2", THING_TYPE_UNSUPPORTED),


### PR DESCRIPTION
Adds support for Mi Robot Vacuum 1S
https://xiaomi-mi.com/cleaning-gear/mijia-1s-robot-vacuum-cleaner-/

Related community post: https://community.openhab.org/t/xiaomi-robot-vacuum-binding/31317/1092

Signed-off-by: Siegfried Huismann <sihui@gmx.de>
