### PR TITLE
Replace Charset.forName calls with StandardCharsets constants

### DIFF
--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdEvent.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdEvent.java
@@ -15,7 +15,7 @@ package org.openhab.binding.doorbird.internal.listener;
 import java.net.DatagramPacket;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -149,7 +149,7 @@ public class DoorbirdEvent {
             bb.rewind();
             // Check for proper event signature
             if (!isValidSignature(bb)) {
-                logger.trace("Received event not a doorbell event: {}", new String(data, Charset.forName("US-ASCII")));
+                logger.trace("Received event not a doorbell event: {}", new String(data, StandardCharsets.US_ASCII));
                 return;
             }
             // Get the decryption version

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
@@ -18,7 +18,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -65,7 +65,7 @@ public class LxServerHandlerDummy implements LxServerHandlerApi {
     void loadConfiguration() {
         InputStream stream = LxServerHandlerDummy.class.getResourceAsStream("LoxAPP3.json");
         assertNotNull(stream);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8")));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
         assertNotNull(reader);
         String msg = reader.lines().collect(Collectors.joining(System.lineSeparator()));
         assertNotNull(msg);

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/net/HttpResponse.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/net/HttpResponse.java
@@ -14,7 +14,7 @@ package org.openhab.binding.neeo.internal.net;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -101,8 +101,7 @@ public class HttpResponse {
             return "";
         }
 
-        final Charset charSet = Charset.forName("utf-8");
-        return new String(localContents, charSet);
+        return new String(localContents, StandardCharsets.UTF_8);
     }
 
     /**

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/http/WemoHttpCall.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/http/WemoHttpCall.java
@@ -15,7 +15,7 @@ package org.openhab.binding.wemo.internal.http;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.eclipse.smarthome.io.net.http.HttpUtil;
@@ -39,7 +39,7 @@ public class WemoHttpCall {
             wemoHeaders.setProperty("CONTENT-TYPE", WemoBindingConstants.HTTP_CALL_CONTENT_HEADER);
             wemoHeaders.put("SOAPACTION", soapHeader);
 
-            InputStream wemoContent = new ByteArrayInputStream(content.getBytes(Charset.forName("UTF-8")));
+            InputStream wemoContent = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
 
             String wemoCallResponse = HttpUtil.executeUrl("POST", wemoURL, wemoHeaders, wemoContent, null, 2000);
             return wemoCallResponse;

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesExtractStringFromRegistersTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesExtractStringFromRegistersTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertThat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -69,18 +70,18 @@ public class BitUtilitiesExtractStringFromRegistersTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Collections.unmodifiableList(Stream.of(
-                new Object[] { new StringType(""), shortArrayToRegisterArray(0), 0, 0, Charset.forName("UTF-8") },
+                new Object[] { new StringType(""), shortArrayToRegisterArray(0), 0, 0, StandardCharsets.UTF_8 },
                 new Object[] { new StringType("hello"), shortArrayToRegisterArray(0x6865, 0x6c6c, 0x6f00), 0, 5,
-                        Charset.forName("UTF-8") },
+                        StandardCharsets.UTF_8 },
                 new Object[] { new StringType("hello "), shortArrayToRegisterArray(0, 0, 0x6865, 0x6c6c, 0x6f20, 0, 0),
-                        2, 6, Charset.forName("UTF-8") },
+                        2, 6, StandardCharsets.UTF_8 },
                 new Object[] { new StringType("hello"),
                         shortArrayToRegisterArray(0x6865, 0x6c6c, 0x6f00, 0x0000, 0x0000), 0, 10,
-                        Charset.forName("UTF-8") },
+                        StandardCharsets.UTF_8 },
                 new Object[] { new StringType("árvíztűrő tükörfúrógép"),
                         shortArrayToRegisterArray(0xc3a1, 0x7276, 0xc3ad, 0x7a74, 0xc5b1, 0x72c5, 0x9120, 0x74c3,
                                 0xbc6b, 0xc3b6, 0x7266, 0xc3ba, 0x72c3, 0xb367, 0xc3a9, 0x7000),
-                        0, 32, Charset.forName("UTF-8") },
+                        0, 32, StandardCharsets.UTF_8 },
                 new Object[] { new StringType("árvíztűrő tükörfúrógép"),
                         shortArrayToRegisterArray(0xe172, 0x76ed, 0x7a74, 0xfb72, 0xf520, 0x74fc, 0x6bf6, 0x7266,
                                 0xfa72, 0xf367, 0xe970),
@@ -88,11 +89,11 @@ public class BitUtilitiesExtractStringFromRegistersTest {
 
                 // Invalid values
                 new Object[] { IllegalArgumentException.class, shortArrayToRegisterArray(0, 0), 2, 4,
-                        Charset.forName("UTF-8") },
+                        StandardCharsets.UTF_8 },
                 new Object[] { IllegalArgumentException.class, shortArrayToRegisterArray(0, 0), 0, -1,
-                        Charset.forName("UTF-8") },
+                        StandardCharsets.UTF_8 },
                 new Object[] { IllegalArgumentException.class, shortArrayToRegisterArray(0, 0), 0, 5,
-                        Charset.forName("UTF-8") })
+                        StandardCharsets.UTF_8 })
                 .collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
This prevents typos, improves performance and makes it easier to find other code using these standard charsets.