### PR TITLE
[Lutron] Add support for venetian blinds

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -38,7 +38,7 @@ This binding currently supports the following thing types:
 * **qsio** - HomeWorks QS IO Interface
 * **cco** - Contact closure output module or VCRX CCO
 * **shade** - Lutron shade or motorized drape
-* **blind** - Lutron venetian blind or horizontal sheer blind [**Beta**]
+* **blind** - Lutron venetian blind or horizontal sheer blind [**Experimental**]
 * **greenmode** - Green Mode subsystem
 * **timeclock** - Scheduling subsystem
 
@@ -369,12 +369,12 @@ Thing configuration file example:
 Thing shade libraryshade [ integrationId=33]
 ```
 
-### Blinds [**Beta**]
+### Blinds [**Experimental**]
 
 Each Lutron Sivoia QS Venetian Blind or Horizontal Sheer Blind is controlled by a **blind** thing.
 Besides `integrationId`, it requires that the parameter `type` be set to either "Venetian" for venetian blinds or "Sheer" for horizontal sheer blinds.
 There is no default.
-If discovery is used, the `type` parameter will automatically be correctly set when the **blind** thing is created.
+If discovery is used, the `type` parameter will set automatically when the **blind** thing is created.
 
 Two channels, *blindliftlevel* and *blindtiltlevel*, with item type Rollershutter and category Rollershutter will be created for each **blind** thing.
 They control the up/down motion and the slat tilt motions of the blinds, respectively.
@@ -386,9 +386,8 @@ It is specified as a percentage, where 0% = closed and 100% = fully open. Moveme
 **Note:** While a blind is moving to a specific level because of a Percent command, the Lutron system will report the target position for the blind rather than the actual current position.
 While a blind is moving because of an Up or Down command, it will report the previous level until it stops moving.
 
-**Beta Notice:** Support for Sivoia QS blinds is new and has been through very limited testing.
-Please comment on your use of it in the openHAB [community forum](https://community.openhab.org/).
-Any problems should be reported in a [GitHub issue](https://github.com/openhab/openhab2-addons/issues).
+**Note:** Support for Sivoia QS blinds is new and has been through very limited testing.
+Please comment on your use of it in the openHAB community forum.
 
 Thing configuration file example:
 

--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -30,14 +30,15 @@ This binding currently supports the following thing types:
 * **occupancysensor** - Occupancy/vacancy sensor
 * **keypad** - Lutron seeTouch or Hybrid seeTouch Keypad
 * **ttkeypad** - Tabletop seeTouch Keypad
-* **intlkeypad** - International seeTouch Keypad (HomeWorks QS only)
+* **intlkeypad** - International seeTouch Keypad (HomeWorks QS only) [**New in 2.5**]
 * **pico** - Pico Keypad
-* **grafikeyekeypad** - GRAFIK Eye QS Keypad (RadioRA 2/HomeWorks QS only)
+* **grafikeyekeypad** - GRAFIK Eye QS Keypad (RadioRA 2/HomeWorks QS only) [**New in 2.5**]
 * **virtualkeypad** - Repeater virtual keypad
 * **vcrx** - Visor control receiver module (VCRX)
 * **qsio** - HomeWorks QS IO Interface
 * **cco** - Contact closure output module or VCRX CCO
 * **shade** - Lutron shade or motorized drape
+* **blind** - Lutron venetian blind or horizontal sheer blind [**Beta**]
 * **greenmode** - Green Mode subsystem
 * **timeclock** - Scheduling subsystem
 
@@ -197,7 +198,7 @@ Thing configuration file example:
 Thing ttkeypad bedroomkeypad [ integrationId=11, model="T10RL" autorelease=true ]
 ```
 
-### International seeTouch Keypads (Homeworks QS)
+### International seeTouch Keypads (Homeworks QS) [**New in 2.5**]
 
 International seeTouch keypads used in the Homeworks QS system use the **intlkeypad** thing.
 It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same button and led channel types as the **keypad** thing.
@@ -236,7 +237,7 @@ Thing configuration file example:
 Thing pico hallpico [ integrationId=12, model="3BRL", autorelease=true ]
 ```
 
-### GRAFIK Eye QS Keypads (in RadioRA 2/HomeWorks QS systems)
+### GRAFIK Eye QS Keypads (in RadioRA 2/HomeWorks QS systems) [**New in 2.5**]
 
 GRAFIK Eye devices can contain up to 6 lighting dimmers, a scene controller, a time clock, and a front panel with a column of 5 programmable scene buttons and 0 to 3 columns of programmable shade or lighting control buttons.
 They can be used as peripheral devices in a RadioRA 2 or HomeWorks QS system, or can be used as stand-alone controllers that themselves can control other Lutron devices.
@@ -368,6 +369,33 @@ Thing configuration file example:
 Thing shade libraryshade [ integrationId=33]
 ```
 
+### Blinds [**Beta**]
+
+Each Lutron Sivoia QS Venetian Blind or Horizontal Sheer Blind is controlled by a **blind** thing.
+Besides `integrationId`, it requires that the parameter `type` be set to either "Venetian" for venetian blinds or "Sheer" for horizontal sheer blinds.
+There is no default.
+If discovery is used, the `type` parameter will automatically be correctly set when the **blind** thing is created.
+
+Two channels, *blindliftlevel* and *blindtiltlevel*, with item type Rollershutter and category Rollershutter will be created for each **blind** thing.
+They control the up/down motion and the slat tilt motions of the blinds, respectively.
+Each channel accepts Percent, Up, Down, Stop and Refresh commands.
+Sending a Percent command will cause the blind to immediately move so as to be open the specified percentage.
+You can also read the current setting from each channel.
+It is specified as a percentage, where 0% = closed and 100% = fully open. Movement delays are not currently supported.
+
+**Note:** While a blind is moving to a specific level because of a Percent command, the Lutron system will report the target position for the blind rather than the actual current position.
+While a blind is moving because of an Up or Down command, it will report the previous level until it stops moving.
+
+**Beta Notice:** Support for Sivoia QS blinds is new and has been through very limited testing.
+Please comment on your use of it in the openHAB [community forum](https://community.openhab.org/).
+Any problems should be reported in a [GitHub issue](https://github.com/openhab/openhab2-addons/issues).
+
+Thing configuration file example:
+
+```
+Thing blind officeblinds [ integrationId=76, type="Venetian"]
+```
+
 ### Green Mode
 
 Radio RA2 and HomeWorks QS systems have a "Green Mode" or "Green Button" feature which allows the system to be placed in to one or more user-defined power saving modes called "steps".
@@ -452,6 +480,8 @@ The following is a summary of channels for all RadioRA 2 binding things:
 | keypads(except pico)| led*              | Switch        | LED indicator for the associated button      |
 | vcrx                | cci*              | Contact       | Contact closure input on/off status          |
 | shade               | shadelevel        | Rollershutter | Level of the shade (100% = full open)        |
+| blind               | blindliftlevel    | Rollershutter | Level of the blind (100% = full open)        |
+| blind               | blindtiltlevel    | Rollershutter | Tilt of the blind slats                      |
 | greenmode           | step              | Number        | Get/set active green mode step number        |
 | timeclock           | clockmode         | Number        | Get/set active clock mode index number       |
 | timeclock           | sunrise           | DateTime      | Get the timeclock's sunrise time             |
@@ -475,6 +505,8 @@ Appropriate channels will be created automatically by the keypad, ttkeypad, intl
 |           |led*           |OnOffType     |OnOffType, RefreshType                                 |
 |           |cci*           |OpenClosedType|(*readonly*)                                           |
 |shade      |shadelevel     |PercentType   |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
+|blind      |blindliftlevel |PercentType   |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
+|           |blindtiltlevel |PercentType   |PercentType, UpDownType, StopMoveType.STOP, RefreshType|
 |greenmode  |step           |DecimalType   |DecimalType, OnOffType (ON=2,OFF=1), RefreshType       |
 |timeclock  |clockmode      |DecimalType   |DecimalType, RefreshType                               |
 |           |sunrise        |DateTimeType  |RefreshType (*readonly*)                               |

--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -30,9 +30,9 @@ This binding currently supports the following thing types:
 * **occupancysensor** - Occupancy/vacancy sensor
 * **keypad** - Lutron seeTouch or Hybrid seeTouch Keypad
 * **ttkeypad** - Tabletop seeTouch Keypad
-* **intlkeypad** - International seeTouch Keypad (HomeWorks QS only) [**New in 2.5**]
+* **intlkeypad** - International seeTouch Keypad (HomeWorks QS only)
 * **pico** - Pico Keypad
-* **grafikeyekeypad** - GRAFIK Eye QS Keypad (RadioRA 2/HomeWorks QS only) [**New in 2.5**]
+* **grafikeyekeypad** - GRAFIK Eye QS Keypad (RadioRA 2/HomeWorks QS only)
 * **virtualkeypad** - Repeater virtual keypad
 * **vcrx** - Visor control receiver module (VCRX)
 * **qsio** - HomeWorks QS IO Interface
@@ -198,7 +198,7 @@ Thing configuration file example:
 Thing ttkeypad bedroomkeypad [ integrationId=11, model="T10RL" autorelease=true ]
 ```
 
-### International seeTouch Keypads (Homeworks QS) [**New in 2.5**]
+### International seeTouch Keypads (Homeworks QS)
 
 International seeTouch keypads used in the Homeworks QS system use the **intlkeypad** thing.
 It accepts the same `integrationID`, `model`, and `autorelease` parameters and creates the same button and led channel types as the **keypad** thing.
@@ -237,7 +237,7 @@ Thing configuration file example:
 Thing pico hallpico [ integrationId=12, model="3BRL", autorelease=true ]
 ```
 
-### GRAFIK Eye QS Keypads (in RadioRA 2/HomeWorks QS systems) [**New in 2.5**]
+### GRAFIK Eye QS Keypads (in RadioRA 2/HomeWorks QS systems)
 
 GRAFIK Eye devices can contain up to 6 lighting dimmers, a scene controller, a time clock, and a front panel with a column of 5 programmable scene buttons and 0 to 3 columns of programmable shade or lighting control buttons.
 They can be used as peripheral devices in a RadioRA 2 or HomeWorks QS system, or can be used as stand-alone controllers that themselves can control other Lutron devices.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -47,6 +47,7 @@ public class LutronBindingConstants {
     public static final ThingTypeUID THING_TYPE_GREENMODE = new ThingTypeUID(BINDING_ID, "greenmode");
     public static final ThingTypeUID THING_TYPE_QSIO = new ThingTypeUID(BINDING_ID, "qsio");
     public static final ThingTypeUID THING_TYPE_GRAFIKEYEKEYPAD = new ThingTypeUID(BINDING_ID, "grafikeyekeypad");
+    public static final ThingTypeUID THING_TYPE_BLIND = new ThingTypeUID(BINDING_ID, "blind");
 
     // List of all Channel ids
     public static final String CHANNEL_LIGHTLEVEL = "lightlevel";
@@ -60,6 +61,8 @@ public class LutronBindingConstants {
     public static final String CHANNEL_ENABLEEVENT = "enableevent";
     public static final String CHANNEL_DISABLEEVENT = "disableevent";
     public static final String CHANNEL_STEP = "step";
+    public static final String CHANNEL_BLINDLIFTLEVEL = "blindliftlevel";
+    public static final String CHANNEL_BLINDTILTLEVEL = "blindtiltlevel";
 
     // Bridge config properties (used by discovery service)
     public static final String HOST = "ipAddress";
@@ -79,4 +82,9 @@ public class LutronBindingConstants {
 
     // GreenMode config properties
     public static final String POLL_INTERVAL = "pollInterval";
+
+    // Blind types
+    public static final String BLIND_TYPE_PARAMETER = "type";
+    public static final String BLIND_TYPE_SHEER = "Sheer";
+    public static final String BLIND_TYPE_VENETIAN = "Venetian";
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -38,6 +38,7 @@ import org.openhab.binding.lutron.internal.discovery.LutronDeviceDiscoveryServic
 import org.openhab.binding.lutron.internal.grxprg.GrafikEyeHandler;
 import org.openhab.binding.lutron.internal.grxprg.PrgBridgeHandler;
 import org.openhab.binding.lutron.internal.grxprg.PrgConstants;
+import org.openhab.binding.lutron.internal.handler.BlindHandler;
 import org.openhab.binding.lutron.internal.handler.CcoHandler;
 import org.openhab.binding.lutron.internal.handler.DimmerHandler;
 import org.openhab.binding.lutron.internal.handler.GrafikEyeKeypadHandler;
@@ -81,12 +82,12 @@ import org.slf4j.LoggerFactory;
 public class LutronHandlerFactory extends BaseThingHandlerFactory {
 
     // Used by LutronDeviceDiscoveryService to discover these types
-    public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = Collections.unmodifiableSet(Stream
-            .of(THING_TYPE_DIMMER, THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR, THING_TYPE_KEYPAD,
-                    THING_TYPE_TTKEYPAD, THING_TYPE_INTLKEYPAD, THING_TYPE_PICO, THING_TYPE_VIRTUALKEYPAD,
-                    THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED, THING_TYPE_SHADE,
-                    THING_TYPE_TIMECLOCK, THING_TYPE_GREENMODE, THING_TYPE_QSIO, THING_TYPE_GRAFIKEYEKEYPAD)
-            .collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_DIMMER, THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR,
+                    THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_INTLKEYPAD, THING_TYPE_PICO,
+                    THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED,
+                    THING_TYPE_SHADE, THING_TYPE_TIMECLOCK, THING_TYPE_GREENMODE, THING_TYPE_QSIO,
+                    THING_TYPE_GRAFIKEYEKEYPAD, THING_TYPE_BLIND).collect(Collectors.toSet()));
 
     // Used by the HwDiscoveryService
     public static final Set<ThingTypeUID> HW_DISCOVERABLE_DEVICE_TYPES_UIDS = Collections
@@ -167,6 +168,8 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
             return new GreenModeHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_QSIO)) {
             return new QSIOHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_BLIND)) {
+            return new BlindHandler(thing);
         } else if (thingTypeUID.equals(PrgConstants.THING_TYPE_PRGBRIDGE)) {
             return new PrgBridgeHandler((Bridge) thing);
         } else if (thingTypeUID.equals(PrgConstants.THING_TYPE_GRAFIKEYE)) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/BlindConfig.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/BlindConfig.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.config;
+
+/**
+ * Configuration settings for an {@link org.openhab.binding.lutron.internal.handler.BlindHandler}.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+public class BlindConfig {
+    public int integrationId = 0;
+    public String type;
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -415,6 +415,16 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                 case SYSTEM_SHADE:
                     notifyDiscovery(THING_TYPE_SHADE, output.getIntegrationId(), label);
                     break;
+
+                case SHEER_BLIND:
+                    notifyDiscovery(THING_TYPE_BLIND, output.getIntegrationId(), label, BLIND_TYPE_PARAMETER,
+                            BLIND_TYPE_SHEER);
+                    break;
+
+                case VENETIAN_BLIND:
+                    notifyDiscovery(THING_TYPE_BLIND, output.getIntegrationId(), label, BLIND_TYPE_PARAMETER,
+                            BLIND_TYPE_VENETIAN);
+                    break;
             }
         } else {
             logger.warn("Unrecognized output type {}", output.getType());

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.handler;
+
+import static org.openhab.binding.lutron.internal.LutronBindingConstants.*;
+
+import java.math.BigDecimal;
+
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.lutron.internal.config.BlindConfig;
+import org.openhab.binding.lutron.internal.protocol.LutronCommandType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler responsible for communicating with Lutron blinds
+ *
+ * @author Bob Adair - Initial contribution based on Alan Tong's DimmerHandler
+ */
+public class BlindHandler extends LutronHandler {
+    private static final Integer ACTION_LIFTLEVEL = 1;
+    private static final Integer ACTION_TILTLEVEL = 9;
+    private static final Integer ACTION_LIFTTILTLEVEL = 10;
+    private static final Integer ACTION_STARTRAISINGTILT = 11;
+    private static final Integer ACTION_STARTLOWERINGTILT = 12;
+    private static final Integer ACTION_STOPTILT = 13;
+    private static final Integer ACTION_STARTRAISINGLIFT = 14;
+    private static final Integer ACTION_STARTLOWERINGLIFT = 15;
+    private static final Integer ACTION_STOPLIFT = 16;
+    private static final Integer ACTION_POSITION_UPDATE = 32; // undocumented in integration protocol guide
+    private static final Integer PARAMETER_POSITION_UPDATE = 2; // undocumented in integration protocol guide
+
+    private int tiltMax = 100; // max 50 for horizontal sheer, 100 for venetian
+
+    private final Logger logger = LoggerFactory.getLogger(BlindHandler.class);
+
+    private BlindConfig config;
+
+    public BlindHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public int getIntegrationId() {
+        if (config == null) {
+            throw new IllegalStateException("handler configuration not initialized");
+        }
+        return config.integrationId;
+    }
+
+    @Override
+    public void initialize() {
+        config = getThing().getConfiguration().as(BlindConfig.class);
+        if (config.integrationId <= 0) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");
+            return;
+        }
+        if (config.type == null || (!(config.type.equalsIgnoreCase(BLIND_TYPE_SHEER))
+                && !(config.type.equalsIgnoreCase(BLIND_TYPE_VENETIAN)))) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Parameter type not set to valid value");
+            return;
+        }
+        String blindType = config.type;
+        if (blindType.equalsIgnoreCase(BLIND_TYPE_SHEER)) {
+            tiltMax = 50;
+        }
+        logger.debug("Initializing Blind handler with type {} for integration ID {}", blindType, config.integrationId);
+        initDeviceState();
+    }
+
+    @Override
+    protected void initDeviceState() {
+        logger.debug("Initializing device state for Shade {}", getIntegrationId());
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");
+        } else if (bridge.getStatus() == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Awaiting initial response");
+            queryOutput(ACTION_LIFTLEVEL); // handleUpdate() will set thing status to online when response arrives
+            queryOutput(ACTION_TILTLEVEL);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        // Refresh state when new item is linked.
+        if (channelUID.getId().equals(CHANNEL_BLINDLIFTLEVEL)) {
+            queryOutput(ACTION_LIFTLEVEL);
+        } else if (channelUID.getId().equals(CHANNEL_BLINDTILTLEVEL)) {
+            queryOutput(ACTION_TILTLEVEL);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_BLINDLIFTLEVEL)) {
+            handleLiftCommand(command);
+        } else if (channelUID.getId().equals(CHANNEL_BLINDTILTLEVEL)) {
+            handleTiltCommand(command);
+        }
+    }
+
+    private void handleLiftCommand(Command command) {
+        if (command instanceof PercentType) {
+            int level = ((PercentType) command).intValue();
+            output(ACTION_LIFTLEVEL, level, 0);
+        } else if (command.equals(UpDownType.UP)) {
+            output(ACTION_STARTRAISINGLIFT);
+        } else if (command.equals(UpDownType.DOWN)) {
+            output(ACTION_STARTLOWERINGLIFT);
+        } else if (command.equals(StopMoveType.STOP)) {
+            output(ACTION_STOPLIFT);
+        } else if (command instanceof RefreshType) {
+            queryOutput(ACTION_LIFTLEVEL);
+        }
+    }
+
+    private void handleTiltCommand(Command command) {
+        if (command instanceof PercentType) {
+            int level = ((PercentType) command).intValue();
+            output(ACTION_TILTLEVEL, Math.min(level, tiltMax), 0);
+        } else if (command.equals(UpDownType.UP)) {
+            output(ACTION_STARTRAISINGTILT);
+        } else if (command.equals(UpDownType.DOWN)) {
+            output(ACTION_STARTLOWERINGTILT);
+        } else if (command.equals(StopMoveType.STOP)) {
+            output(ACTION_STOPTILT);
+        } else if (command instanceof RefreshType) {
+            queryOutput(ACTION_TILTLEVEL);
+        }
+    }
+
+    @Override
+    public void handleUpdate(LutronCommandType type, String... parameters) {
+        if (type == LutronCommandType.OUTPUT && parameters.length >= 2) {
+            if (getThing().getStatus() == ThingStatus.UNKNOWN) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+
+            if (ACTION_LIFTLEVEL.toString().equals(parameters[0])) {
+                BigDecimal liftLevel = new BigDecimal(parameters[1]);
+                logger.trace("Blind {} received lift level: {}", getIntegrationId(), liftLevel);
+                updateState(CHANNEL_BLINDLIFTLEVEL, new PercentType(liftLevel));
+            } else if (ACTION_TILTLEVEL.toString().equals(parameters[0])) {
+                BigDecimal tiltLevel = new BigDecimal(parameters[1]);
+                logger.trace("Blind {} received tilt level: {}", getIntegrationId(), tiltLevel);
+                updateState(CHANNEL_BLINDTILTLEVEL, new PercentType(tiltLevel));
+            } else if (ACTION_LIFTTILTLEVEL.toString().equals(parameters[0]) && parameters.length > 2) {
+                BigDecimal liftLevel = new BigDecimal(parameters[1]);
+                BigDecimal tiltLevel = new BigDecimal(parameters[2]);
+                logger.trace("Blind {} received lift/tilt level: {} {}", getIntegrationId(), liftLevel, tiltLevel);
+                updateState(CHANNEL_BLINDLIFTLEVEL, new PercentType(liftLevel));
+                updateState(CHANNEL_BLINDTILTLEVEL, new PercentType(tiltLevel));
+            } else if (ACTION_POSITION_UPDATE.toString().equals(parameters[0])
+                    && PARAMETER_POSITION_UPDATE.toString().equals(parameters[1]) && parameters.length >= 3) {
+                BigDecimal level = new BigDecimal(parameters[2]);
+                logger.trace("Blind {} received lift level position update: {}", getIntegrationId(), level);
+                updateState(CHANNEL_BLINDLIFTLEVEL, new PercentType(level));
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
@@ -74,14 +74,14 @@ public class BlindHandler extends LutronHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");
             return;
         }
-        if (config.type == null || (!(config.type.equalsIgnoreCase(BLIND_TYPE_SHEER))
-                && !(config.type.equalsIgnoreCase(BLIND_TYPE_VENETIAN)))) {
+        if (config.type == null || (!(BLIND_TYPE_SHEER.equalsIgnoreCase(config.type))
+                && !(BLIND_TYPE_VENETIAN.equalsIgnoreCase(config.type)))) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "Parameter type not set to valid value");
             return;
         }
         String blindType = config.type;
-        if (blindType.equalsIgnoreCase(BLIND_TYPE_SHEER)) {
+        if (BLIND_TYPE_SHEER.equalsIgnoreCase(blindType)) {
             tiltMax = 50;
         }
         logger.debug("Initializing Blind handler with type {} for integration ID {}", blindType, config.integrationId);

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -320,8 +320,12 @@ public class IPBridgeHandler extends BaseBridgeHandler {
             if (thing.getHandler() instanceof LutronHandler) {
                 LutronHandler handler = (LutronHandler) thing.getHandler();
 
-                if (handler != null && handler.getIntegrationId() == integrationId) {
-                    return handler;
+                try {
+                    if (handler != null && handler.getIntegrationId() == integrationId) {
+                        return handler;
+                    }
+                } catch (IllegalStateException e) {
+                    logger.trace("Handler for id {} not initialized", integrationId);
                 }
             }
         }

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -103,6 +103,37 @@
 		</config-description>
 	</thing-type>
 
+	<thing-type id="blind">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Lutron Blind</label>
+		<description>Controls venetian and horizontal sheer blinds</description>
+		<category>Blinds</category>
+
+		<channels>
+			<channel id="blindliftlevel" typeId="blindLift"/>
+			<channel id="blindtiltlevel" typeId="blindTilt"/>
+		</channels>
+
+		<config-description>
+			<parameter name="integrationId" type="integer" required="true">
+				<label>Integration ID</label>
+				<description>Address of blind in the Lutron system</description>
+			</parameter>
+			<parameter name="type" type="text" required="true">
+				<label>Type</label>
+				<description>Type of blind</description>
+				<options>
+					<option value="Sheer">Sheer</option>
+					<option value="Venetian">Venetian</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<thing-type id="switch">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>
@@ -956,6 +987,22 @@
 		<description>Raise/lower the shade level</description>
 		<category>Rollershutter</category>
 		<state min="0" max="100" pattern="%d %%"/>
+	</channel-type>
+
+	<channel-type id="blindLift">
+		<item-type>Rollershutter</item-type>
+		<label>Blind Level</label>
+		<description>Raise/lower the blind level</description>
+		<category>Rollershutter</category>
+		<state min="0" max="100" pattern="%d %%"/>
+	</channel-type>
+
+	<channel-type id="blindTilt">
+		<item-type>Rollershutter</item-type>
+		<label>Blind Tilt</label>
+		<description>Tilt the blinds up/down</description>
+		<category>Rollershutter</category>
+		<state min="0" max="50" pattern="%d %%"/>
 	</channel-type>
 
 	<channel-type id="switchState">


### PR DESCRIPTION
This PR adds support for Lutron Sivoia QS Venetian Blinds and Horizontal Sheer Blinds through a new "blind" thing. It also contains a minor fix to IPBridgeHandler for a problem that was discovered during testing. I have tagged the blind thing as "Beta" in README.md, because I have had no success getting anyone in the community forum to test it out.  However, I have tested it myself using dummy devices on my RadioRA 2 system and found no problems.

Closes #3962 
