### PR TITLE
[openhabcloud] Log error upon connection problems

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -202,7 +202,7 @@ public class CloudClient {
         }).on(Socket.EVENT_ERROR, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                logger.debug("Socket.IO error: {}", args[0]);
+                logger.error("Error connecting to the openHAB Cloud instance: {}", args[0]);
             }
         }).on("request", new Emitter.Listener() {
             @Override


### PR DESCRIPTION
So far, there is no trace in the log file, if the initial cloud connection fails for some reason.

Signed-off-by: Kai Kreuzer <kai@openhab.org>