### PR TITLE
[Volvooncall] Updates to include Volvo V90 XC and to handle lock, heater and engine commands

### DIFF
--- a/bundles/org.openhab.binding.volvooncall/README.md
+++ b/bundles/org.openhab.binding.volvooncall/README.md
@@ -94,9 +94,20 @@ sitemap voc label="Volvo On Call" {
 
 ## Rule Actions
 
-Multiple actions are supported by this binding. In classic rules these are accessible as shown in this example (adjust getActions with your ThingId):
+Multiple actions are supported by this binding. In classic rules these are accessible as shown in the example below:
 
-Example
+Example 1a: If Thing has been created using autodiscovery
+
+```
+ val actions = getActions("volvooncall","volvooncall:vehicle:thingId")
+ if(null === actions) {
+        logInfo("actions", "Actions not found, check thing ID")
+        return
+ } else {
+        actions.openCarCommand()
+ }
+```
+Example 1b: If Thing has been created using script
 
 ```
  val actions = getActions("volvooncall","volvooncall:vehicle:bridgeId:thingId")
@@ -128,11 +139,19 @@ Sends the command to start the engine for a given runtime. Default 5 minutes.
 
  ### heaterStartCommand()
 
-Sends the command to start the car heater.
+Sends the command to start the car heater (if remoteHeaterSupported).
 
  ### heaterStopCommand()
 
-Sends the command to stop the car heater.
+Sends the command to stop the car heater (if remoteHeaterSupported).
+
+ ### preclimatizationStartCommand()
+
+Sends the command to start the car heater (if preclimatizationSupported).
+
+ ### preclimatizationStopCommand()
+
+Sends the command to stop the car heater (if preclimatizationSupported).
 
  ### honkBlinkCommand(honk, blink)
 

--- a/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/action/VolvoOnCallActions.java
+++ b/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/action/VolvoOnCallActions.java
@@ -125,6 +125,24 @@ public class VolvoOnCallActions implements ThingActions {
         }
     }
 
+    @RuleAction(label = "Volvo On Call : Preclimatization Start", description = "Starts car heater")
+    public void preclimatizationStartCommand() {
+        logger.debug("preclimatizationStartCommand called");
+        if (handler != null) {
+            handler.actionPreclimatization(true);
+        } else {
+            logger.warn("VolvoOnCall Action service ThingHandler is null!");
+        }
+    }
+
+    public static void preclimatizationStartCommand(@Nullable ThingActions actions) {
+        if (actions instanceof VolvoOnCallActions) {
+            ((VolvoOnCallActions) actions).preclimatizationStartCommand();
+        } else {
+            throw new IllegalArgumentException("Instance is not an VolvoThingActionsService class.");
+        }
+    }
+
     @RuleAction(label = "Volvo On Call : Heater Stop", description = "Stops car heater")
     public void heaterStopCommand() {
         logger.debug("heaterStopCommand called");
@@ -138,6 +156,24 @@ public class VolvoOnCallActions implements ThingActions {
     public static void heaterStopCommand(@Nullable ThingActions actions) {
         if (actions instanceof VolvoOnCallActions) {
             ((VolvoOnCallActions) actions).heaterStopCommand();
+        } else {
+            throw new IllegalArgumentException("Instance is not an VolvoThingActionsService class.");
+        }
+    }
+
+    @RuleAction(label = "Volvo On Call : Preclimatization Stop", description = "Stops car heater")
+    public void preclimatizationStopCommand() {
+        logger.debug("preclimatizationStopCommand called");
+        if (handler != null) {
+            handler.actionPreclimatization(false);
+        } else {
+            logger.warn("VolvoOnCall Action service ThingHandler is null!");
+        }
+    }
+
+    public static void preclimatizationStopCommand(@Nullable ThingActions actions) {
+        if (actions instanceof VolvoOnCallActions) {
+            ((VolvoOnCallActions) actions).preclimatizationStopCommand();
         } else {
             throw new IllegalArgumentException("Instance is not an VolvoThingActionsService class.");
         }
@@ -161,5 +197,4 @@ public class VolvoOnCallActions implements ThingActions {
             throw new IllegalArgumentException("Instance is not an VolvoThingActionsService class.");
         }
     }
-
 }

--- a/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/handler/VolvoOnCallBridgeHandler.java
+++ b/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/handler/VolvoOnCallBridgeHandler.java
@@ -67,9 +67,11 @@ public class VolvoOnCallBridgeHandler extends BaseBridgeHandler {
         super(bridge);
 
         httpHeader.put("cache-control", "no-cache");
-        httpHeader.put("X-OS-Type", "Android");
-        httpHeader.put("X-Originator-Type", "App");
-        httpHeader.put("Content-Type", JSON_CONTENT_TYPE);
+        httpHeader.put("content-type", JSON_CONTENT_TYPE);
+        httpHeader.put("x-device-id", "Device");
+        httpHeader.put("x-originator-type", "App");
+        httpHeader.put("x-os-type", "Android");
+        httpHeader.put("x-os-version", "22");
 
         gson = new GsonBuilder()
                 .registerTypeAdapter(ZonedDateTime.class,
@@ -159,6 +161,7 @@ public class VolvoOnCallBridgeHandler extends BaseBridgeHandler {
     public void postURL(String URL, @Nullable String body) throws IOException, JsonSyntaxException {
         InputStream inputStream = body != null ? new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)) : null;
         String jsonString = HttpUtil.executeUrl("POST", URL, httpHeader, inputStream, null, REQUEST_TIMEOUT);
+        logger.debug("Post URL: {} Attributes {}", URL, httpHeader);
         PostResponse postResponse = gson.fromJson(jsonString, PostResponse.class);
         if (postResponse.errorLabel == null) {
             pendingActions


### PR DESCRIPTION
Updates to also enable actions for Volvo models being preclimatizationSupported rather than remoteHeaterSupported.
 
Also made changes to commands (heater/preclimatization and lock) as a "{}" attribute apparently is required included as part of the POST request sent to vocapi (as identified by bundle created for Homey).
 
Relate to ongoing discussion in OH forum:
https://community.openhab.org/t/solved-help-with-sending-command/7046/202
 
**NOTE:** Disregard changes/commit to 'VehicleStateDescriptionProvider.java' as the changes in my commit relate to changes needed to run the binding under my setup: OH 2.4.0 stable release. Later versions of volvooncall binding have implemented 'BaseDynamicStateDescriptionProvider' which apparently is not supported by 2.4.0 stable release.
