### PR TITLE
[miele] Fixed bridge status handling upon initialization

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
@@ -25,6 +25,7 @@ import javax.jmdns.ServiceInfo;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.miele.internal.MieleBindingConstants;
@@ -107,11 +108,11 @@ public class MieleMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant {
      * must contain path with value /rest/
      *
      * @param service the service to check
-     * @return true, if the discoverd service is a Miele XGW3000 Gateway
+     * @return true, if the discovered service is a Miele XGW3000 Gateway
      */
     private boolean isMieleGateway(ServiceInfo service) {
         return service.getApplication().contains(SERVICE_NAME) && service.getPropertyString(PATH_PROPERTY_NAME) != null
-            && service.getPropertyString(PATH_PROPERTY_NAME).equalsIgnoreCase(PATH_TO_CHECK_FOR_XGW3000);
+                && service.getPropertyString(PATH_PROPERTY_NAME).equalsIgnoreCase(PATH_TO_CHECK_FOR_XGW3000);
     }
 
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -126,7 +126,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
 
         public String getApplianceId() {
             return ProtocolAdapterName.equals(PROTOCOL_LAN) ? StringUtils.right(UID, UID.length() - HDM_LAN.length())
-                : StringUtils.right(UID, UID.length() - HDM_ZIGBEE.length());
+                    : StringUtils.right(UID, UID.length() - HDM_ZIGBEE.length());
         }
     }
 
@@ -191,7 +191,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                 headers = new HashMap<>();
 
                 onUpdate();
-                updateStatus(ThingStatus.ONLINE);
+                updateStatus(ThingStatus.UNKNOWN);
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                         "Invalid IP address for the Miele@Home gateway or multicast interface:" + getConfig().get(HOST)
@@ -204,7 +204,6 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     }
 
     private Runnable pollingRunnable = new Runnable() {
-
         @Override
         public void run() {
             if (IP_PATTERN.matcher((String) getConfig().get(HOST)).matches()) {
@@ -213,10 +212,8 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                         currentBridgeConnectionState = true;
                     } else {
                         currentBridgeConnectionState = false;
-                        if (lastBridgeConnectionState) {
-                            lastBridgeConnectionState = false;
-                            onConnectionLost();
-                        }
+                        lastBridgeConnectionState = false;
+                        onConnectionLost();
                     }
 
                     if (!lastBridgeConnectionState && currentBridgeConnectionState) {
@@ -237,7 +234,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                     }
                                 }
                                 if (!isExisting) {
-                                    logger.info("A new appliance with ID '{}' has been added", hd.UID);
+                                    logger.debug("A new appliance with ID '{}' has been added", hd.UID);
                                     for (ApplianceStatusListener listener : applianceStatusListeners) {
                                         listener.onApplianceAdded(hd);
                                     }
@@ -253,7 +250,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                     }
                                 }
                                 if (!isCurrent) {
-                                    logger.info("The appliance with ID '{}' has been removed", hd);
+                                    logger.debug("The appliance with ID '{}' has been removed", hd);
                                     for (ApplianceStatusListener listener : applianceStatusListeners) {
                                         listener.onApplianceRemoved(hd);
                                     }
@@ -446,7 +443,6 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         }
     }
 
-
     protected JsonElement invokeRPC(String methodName, Object[] args) {
         int id = rand.nextInt(Integer.MAX_VALUE);
 
@@ -581,7 +577,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
      *
      */
     public void onConnectionLost() {
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.BRIDGE_OFFLINE);
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR);
     }
 
     /**


### PR DESCRIPTION
When a bridge was manually added with an invalid ip address, it was shown as ONLINE nonetheless.
This PR makes its status to start as UNKNOWN and upon the first polling result, it will be switched to ONLINE or OFFLINE.

Signed-off-by: Kai Kreuzer <kai@openhab.org>