### PR TITLE
Add gnu.io, javax.comm to forbidden packages

### DIFF
--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,6 +1,6 @@
 checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
 checkstyle.headerCheck.values=2010,2019
 checkstyle.pomXmlCheck.currentVersionRegex=^2\.5\.0
-checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common
+checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.requiredFilesCheck.files=pom.xml


### PR DESCRIPTION
Using the OHC serial transport (org.eclipse.smarthome.io.transport.serial) is preferred over directly using specific serial communication libraries.

---

The changes will log the following warnings (and add them to the SAT results):

```
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[32]
The package gnu.io.CommPortIdentifier should not be used.
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[33]
The package gnu.io.NoSuchPortException should not be used.
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[34]
The package gnu.io.PortInUseException should not be used.
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[35]
The package gnu.io.RXTXCommDriver should not be used.
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[36]
The package gnu.io.SerialPort should not be used.
[WARNING] org.openhab.binding.oceanic.internal.handler.SerialOceanicThingHandler.java:[37]
The package gnu.io.UnsupportedCommOperationException should not be used.
```

These warnings may save contributors some rework in case they are inspired by other add-ons to start using gnu.io directly.