### PR TITLE
[modbus] fixed karaf build

### DIFF
--- a/bundles/org.openhab.binding.modbus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.modbus/src/main/feature/feature.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.modbus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>file:${basedirRoot}/bundles/org.openhab.io.transport.modbus/target/feature/feature.xml</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.addons.bundles/org.openhab.io.transport.modbus/${project.version}/xml/features</repository>
 
     <feature name="openhab-binding-modbus" description="Modbus Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>


### PR DESCRIPTION
The modbus binding is dependant on the io.transport.modbus bundle, wich is
also part of the openhab2-addons. By default these bundles are not in
the build repositories.

Previously this has been fixed by a direct file link, but that seems to
be unstable especially under travis builds.

Here I propose to use the direct maven repository of the required bundle.

@ssalonen please let me know what do you think about this change?