### PR TITLE
[LG WebOS] Fixing Changing volume with external speaker

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
@@ -76,7 +76,7 @@ public class VolumeControlVolume extends BaseChannelHandler<Float> {
 
             @Override
             public void onSuccess(@Nullable Float value) {
-                if (value != null) {
+                if (value != null && !Float.isNaN(value)) {
                     handler.postUpdate(channelUID, new PercentType(Math.round(value * 100)));
                 }
             }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -447,7 +447,10 @@ public class LGWebOSTVSocket {
 
     public ServiceSubscription<Float> subscribeVolume(ResponseListener<Float> listener) {
         ServiceSubscription<Float> request = new ServiceSubscription<>(VOLUME, null,
-                jsonObj -> (float) (jsonObj.get("volume").getAsInt() / 100.0), listener);
+                jsonObj -> "mastervolume_tv_speaker".equals(jsonObj.get("scenario").getAsString())
+                        ? (float) (jsonObj.get("volume").getAsInt() / 100.0)
+                        : Float.NaN,
+                listener);
         sendCommand(request);
         return request;
     }


### PR DESCRIPTION
It does not make sense to subscribe to relative volume changes, as this binding will not know which absolute volume is set on the receiver or amplifier.