### PR TITLE
[spotify] Improve performance of handling data

### DIFF
--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.spotify.internal.SpotifyBindingConstants.*;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -82,13 +83,17 @@ import org.slf4j.LoggerFactory;
 public class SpotifyBridgeHandler extends BaseBridgeHandler
         implements SpotifyAccountHandler, AccessTokenRefreshListener {
 
-    private static final CurrentlyPlayingContext EMPTY_CURRENTLYPLAYINGCONTEXT = new CurrentlyPlayingContext();
+    private static final CurrentlyPlayingContext EMPTY_CURRENTLY_PLAYING_CONTEXT = new CurrentlyPlayingContext();
     private static final Album EMPTY_ALBUM = new Album();
     private static final Artist EMPTY_ARTIST = new Artist();
     private static final Item EMPTY_ITEM = new Item();
     private static final Device EMPTY_DEVICE = new Device();
     private static final SimpleDateFormat MUSIC_TIME_FORMAT = new SimpleDateFormat("m:ss");
     private static final int MAX_IMAGE_SIZE = 500000;
+    /**
+     * Only poll playlist once per hour (or when refresh is called).
+     */
+    private static final Duration POLL_PLAY_LIST_HOURS = Duration.ofHours(1);
     /**
      * After a command is handles. With the given delay a status poll request is triggered. The delay is to give Spotify
      * some time to handle the update.
@@ -147,12 +152,19 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
-            if (CHANNEL_PLAYED_ALBUMIMAGE.equals(channelUID.getId())) {
-                albumUpdater.refreshAlbumImage(channelUID);
-            } else if (CHANNEL_ACCESSTOKEN.equals(channelUID.getId())) {
-                onAccessTokenResponse(getAccessTokenResponse());
-            } else {
-                lastTrackId = StringType.EMPTY;
+            switch (channelUID.getId()) {
+                case CHANNEL_PLAYED_ALBUMIMAGE:
+                    albumUpdater.refreshAlbumImage(channelUID);
+                    break;
+                case CHANNEL_PLAYLISTS:
+                    playlistCache.invalidateValue();
+                    break;
+                case CHANNEL_ACCESSTOKEN:
+                    onAccessTokenResponse(getAccessTokenResponse());
+                    break;
+                default:
+                    lastTrackId = StringType.EMPTY;
+                    break;
             }
         } else {
             try {
@@ -276,13 +288,15 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
         spotifyApi = new SpotifyApi(oAuthService, scheduler, httpClient);
         handleCommand = new SpotifyHandleCommands(spotifyApi);
         playingContextCache = new ExpiringCache<>(configuration.refreshPeriod, spotifyApi::getPlayerInfo);
-        playlistCache = new ExpiringCache<>(configuration.refreshPeriod, spotifyApi::getPlaylists);
+        playlistCache = new ExpiringCache<>(POLL_PLAY_LIST_HOURS, spotifyApi::getPlaylists);
         devicesCache = new ExpiringCache<>(configuration.refreshPeriod, spotifyApi::getDevices);
 
         // Start with update status by calling Spotify. If no credentials available no polling should be started.
-        if (pollStatus()) {
-            startPolling();
-        }
+        scheduler.execute(() -> {
+            if (pollStatus()) {
+                startPolling();
+            }
+        });
     }
 
     @Override
@@ -340,22 +354,32 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
         synchronized (pollSynchronization) {
             try {
                 onAccessTokenResponse(getAccessTokenResponse());
-                // Collect devices and populate selection with available devices.
-                final List<Device> ld = devicesCache.getValue();
-                final List<Device> devices = ld == null ? Collections.emptyList() : ld;
-                spotifyDynamicStateDescriptionProvider.setDevices(devicesChannelUID, devices);
                 // Collect currently playing context.
                 final CurrentlyPlayingContext pc = playingContextCache.getValue();
-                final CurrentlyPlayingContext playingContext = pc == null ? EMPTY_CURRENTLYPLAYINGCONTEXT : pc;
-                final List<Playlist> lp = playlistCache.getValue();
-                final List<Playlist> playlists = lp == null ? Collections.emptyList() : lp;
+                // If Spotify returned a 204. Meaning everything is ok, but we got no data.
+                // Happens when no song is playing. And we know no device was active
+                // No need to continue because no new information will be available.
+                final boolean hasPlayData = pc != null && pc.getDevice() != null;
+                final CurrentlyPlayingContext playingContext = pc == null ? EMPTY_CURRENTLY_PLAYING_CONTEXT : pc;
+
+                // Collect devices and populate selection with available devices.
+                if (hasPlayData || hasAnyDeviceStatusUnknown()) {
+                    final List<Device> ld = devicesCache.getValue();
+                    final List<Device> devices = ld == null ? Collections.emptyList() : ld;
+                    spotifyDynamicStateDescriptionProvider.setDevices(devicesChannelUID, devices);
+                    handleCommand.setDevices(devices);
+                    updateDevicesStatus(devices, playingContext.isPlaying());
+                }
+
+                // Update play status information.
+                if (hasPlayData || getThing().getStatus() == ThingStatus.UNKNOWN) {
+                    final List<Playlist> lp = playlistCache.getValue();
+                    final List<Playlist> playlists = lp == null ? Collections.emptyList() : lp;
+                    handleCommand.setPlaylists(playlists);
+                    updatePlayerInfo(playingContext, playlists);
+                    spotifyDynamicStateDescriptionProvider.setPlayLists(playlistsChannelUID, playlists);
+                }
                 updateStatus(ThingStatus.ONLINE);
-
-                handleCommand.setLists(devices, playlists);
-                updatePlayerInfo(playingContext, playlists);
-                spotifyDynamicStateDescriptionProvider.setPlayLists(playlistsChannelUID, playlists);
-
-                updateDevicesStatus(devices, playingContext.isPlaying());
                 return true;
             } catch (SpotifyAuthorizationException e) {
                 logger.debug("Authorization error during polling: ", e);
@@ -407,6 +431,12 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
                 .forEach(thing -> ((SpotifyDeviceHandler) thing.getHandler()).setStatusGone());
     }
 
+    private boolean hasAnyDeviceStatusUnknown() {
+        return getThing().getThings().stream() //
+                .filter(thing -> thing.getHandler() instanceof SpotifyDeviceHandler) //
+                .anyMatch(sd -> ((SpotifyDeviceHandler) sd.getHandler()).getThing().getStatus() == ThingStatus.UNKNOWN);
+    }
+
     /**
      * Update the player data.
      *
@@ -415,7 +445,7 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
      */
     private void updatePlayerInfo(CurrentlyPlayingContext playerInfo, List<Playlist> playlists) {
         updateChannelState(CHANNEL_TRACKPLAYER, playerInfo.isPlaying() ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
-        updateChannelState(CHANNEL_DEVICESHUFFLE, playerInfo.isShuffleState() ? OnOffType.ON : OnOffType.OFF);
+        updateChannelState(CHANNEL_DEVICESHUFFLE, OnOffType.from(playerInfo.isShuffleState()));
         updateChannelState(CHANNEL_TRACKREPEAT, playerInfo.getRepeatState());
 
         final boolean hasItem = playerInfo.getItem() != null;
@@ -464,7 +494,7 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
             updateChannelState(CHANNEL_PLAYED_ARTISTTYPE, valueOrEmpty(firstArtist.getType()));
         }
         final Device device = playerInfo.getDevice() == null ? EMPTY_DEVICE : playerInfo.getDevice();
-        // Only update activeDeviceId if it has a value, otherwise keep old value.
+        // Only update lastKnownDeviceId if it has a value, otherwise keep old value.
         if (device.getId() != null) {
             lastKnownDeviceId = device.getId();
             updateChannelState(CHANNEL_DEVICEID, valueOrEmpty(lastKnownDeviceId));
@@ -472,7 +502,7 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
             updateChannelState(CHANNEL_DEVICENAME, valueOrEmpty(device.getName()));
         }
         lastKnownDeviceActive = device.isActive();
-        updateChannelState(CHANNEL_DEVICEACTIVE, lastKnownDeviceActive ? OnOffType.ON : OnOffType.OFF);
+        updateChannelState(CHANNEL_DEVICEACTIVE, OnOffType.from(lastKnownDeviceActive));
         updateChannelState(CHANNEL_DEVICETYPE, valueOrEmpty(device.getType()));
 
         // experienced situations where volume seemed to be undefined...

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyDeviceHandler.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyDeviceHandler.java
@@ -154,14 +154,16 @@ public class SpotifyDeviceHandler extends BaseThingHandler {
      */
     private boolean setOnlineStatus(boolean restricted) {
         updateChannelState(CHANNEL_DEVICERESTRICTED, OnOffType.from(restricted));
+        final boolean statusUnknown = thing.getStatus() == ThingStatus.UNKNOWN;
+
         if (restricted) {
             // Only change status if device is currently online
-            if (thing.getStatus() == ThingStatus.ONLINE) {
+            if (thing.getStatus() == ThingStatus.ONLINE || statusUnknown) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                         "Restricted. No Web API commands will be accepted by this device.");
             }
             return false;
-        } else if (thing.getStatus() != ThingStatus.ONLINE) {
+        } else if (statusUnknown || thing.getStatus() == ThingStatus.OFFLINE) {
             updateStatus(ThingStatus.ONLINE);
         }
         return true;

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyHandleCommands.java
@@ -57,8 +57,11 @@ class SpotifyHandleCommands {
         this.spotifyApi = spotifyApi;
     }
 
-    public void setLists(List<Device> devices, List<Playlist> playlists) {
+    public void setDevices(final List<Device> devices) {
         this.devices = devices;
+    }
+
+    public void setPlaylists(final List<Playlist> playlists) {
         this.playlists = playlists;
     }
 

--- a/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -197,7 +197,7 @@ bridge you have configured.</description>
 	<channel-type id="currentlyPlayedTrackUri" advanced="true">
 		<item-type>String</item-type>
 		<label>Track URI</label>
-		<description>The Spotify URI for the track currenlty played</description>
+		<description>The Spotify URI for the track currently played</description>
 		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="currentlyPlayedTrackType" advanced="true">


### PR DESCRIPTION
When Spotify returns a 204. It means it doesn't return any data. This can happen after a certain time of inactivity. When this is returned it doesn't make sense to update the states or poll for devices/playlists either.
Also let playlist refresh only once per hour or when an explicit refresh of the channel is given will it update on the next poll.