### PR TITLE
 [enocean] Issue #6279, EnOcean EEP-A5-02-20/30 used wrong unscaled values

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_02/A5_02_20.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_02/A5_02_20.java
@@ -33,6 +33,16 @@ public class A5_02_20 extends A5_02 {
     protected double getScaledMax() {
         return 41.2;
     }
+    
+    @Override
+    protected double getUnscaledMin() {
+        return 1023;
+    }
+    
+    @Override
+    protected double getUnscaledMax() {
+        return 0;
+    }
 
     @Override
     protected int getUnscaledTemperatureValue() {

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_02/A5_02_30.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_02/A5_02_30.java
@@ -35,6 +35,16 @@ public class A5_02_30 extends A5_02 {
     }
 
     @Override
+    protected double getUnscaledMin() {
+        return 1023;
+    }
+    
+    @Override
+    protected double getUnscaledMax() {
+        return 0;
+    }
+    
+    @Override
     protected int getUnscaledTemperatureValue() {
         return getDB_1Value() + ((getDB_2Value() & 0b11) << 8);
     }


### PR DESCRIPTION
Fixes for suggested fix for #6279 , using the right unscaled values for EEP EP-A5-02-20/30

<!-- DESCRIPTION -->
Overwritten as discussed in the issue the getUnscaledMin and getUnscaledMax functions for correct calculation of the temperature values.

