### PR TITLE
[plugwise] Use constructor injection

### DIFF
--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
@@ -35,6 +35,7 @@ import org.openhab.binding.plugwise.internal.handler.PlugwiseSenseHandler;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseStickHandler;
 import org.openhab.binding.plugwise.internal.handler.PlugwiseSwitchHandler;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -49,7 +50,12 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
 
     private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
 
-    private @NonNullByDefault({}) SerialPortManager serialPortManager;
+    private final SerialPortManager serialPortManager;
+
+    @Activate
+    public PlugwiseHandlerFactory(final @Reference SerialPortManager serialPortManager) {
+        this.serialPortManager = serialPortManager;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -97,12 +103,4 @@ public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
         }
     }
 
-    @Reference
-    protected void setSerialPortManager(SerialPortManager serialPortManager) {
-        this.serialPortManager = serialPortManager;
-    }
-
-    protected void unsetSerialPortManager(SerialPortManager serialPortManager) {
-        this.serialPortManager = null;
-    }
 }

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseStickDiscoveryService.java
@@ -68,14 +68,17 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService impl
     private final PlugwiseCommunicationHandler communicationHandler = new PlugwiseCommunicationHandler();
 
     private @Nullable ScheduledFuture<?> discoveryJob;
-    private @NonNullByDefault({}) SerialPortManager serialPortManager;
+    private final SerialPortManager serialPortManager;
 
     private boolean discovering;
     private final ReentrantLock discoveryLock = new ReentrantLock();
     private Condition continueDiscovery = discoveryLock.newCondition();
 
-    public PlugwiseStickDiscoveryService() throws IllegalArgumentException {
+    @Activate
+    public PlugwiseStickDiscoveryService(final @Reference SerialPortManager serialPortManager)
+            throws IllegalArgumentException {
         super(DISCOVERED_THING_TYPES_UIDS, 1, true);
+        this.serialPortManager = serialPortManager;
     }
 
     @Override
@@ -213,15 +216,6 @@ public class PlugwiseStickDiscoveryService extends AbstractDiscoveryService impl
                 discoveryLock.unlock();
             }
         }
-    }
-
-    @Reference
-    protected void setSerialPortManager(SerialPortManager serialPortManager) {
-        this.serialPortManager = serialPortManager;
-    }
-
-    protected void unsetSerialPortManager(SerialPortManager serialPortManager) {
-        this.serialPortManager = null;
     }
 
     @Override


### PR DESCRIPTION
Using constructor injection `@NonNullByDefault({})` is no longer necessary.