### PR TITLE
[rfxcom] Made lighting1 message always send the unit-code

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
@@ -148,18 +148,7 @@ public class RFXComLighting1Message extends RFXComDeviceMessageImpl<RFXComLighti
         data[2] = subType.toByte();
         data[3] = seqNbr;
         data[4] = (byte) houseCode;
-        // When an SS13 sends a DIM/BRIGHT it broadcasts to the all-units code (X0)
-        // and it is up to the dimmers to ignore the message if the last X<n> they
-        // saw wasn't for them. Sending to an actual X<n> may or may not work.
-        // It is untested against _any_ dimmer never mind all so we stick to doing
-        // the same as an SS13. At least for now. Using an explicit X<n> would be
-        // better (if it works) because X10 RF and PLM are lossy and different
-        // modules may have seen different traffic.
-        if ((command == Commands.DIM) || (command == Commands.BRIGHT)) {
-            data[5] = 0;
-        } else {
-            data[5] = unitCode;
-        }
+        data[5] = unitCode;
         data[6] = command.toByte();
         data[7] = (byte) ((signalLevel & 0x0F) << 4);
 


### PR DESCRIPTION
Resolved #6285, following suggestions of @mjagdis