### PR TITLE
[chromecast] Update API lib to 0.11.2

### DIFF
--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>su.litvak.chromecast</groupId>
       <artifactId>api-v2</artifactId>
-      <version>0.11.1</version>
+      <version>0.11.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes the following exceptions:

```
org.codehaus.jackson.map.JsonMappingException: Could not resolve type id 'MULTIZONE_STATUS' into a subtype of [simple type, class su.litvak.chromecast.api.v2.StandardResponse]
```

See also: https://github.com/vitalidze/chromecast-java-api-v2/issues/117