### PR TITLE
Upgrade to Karaf 4.2.7

### DIFF
--- a/bundles/org.openhab.binding.amazondashbutton/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
     <feature name="openhab-binding-amazondashbutton" description="Amazon Dash Button Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <bundle dependency="true">mvn:net.java.dev.jna/jna/5.4.0</bundle>
+        <feature>openhab-runtime-jna</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.amazondashbutton/${project.version}</bundle>
     </feature>
 </features>

--- a/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
   <feature name="openhab-binding-doorbird" description="Doorbird Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
-    <bundle dependency="true">mvn:net.java.dev.jna/jna/5.4.0</bundle>
+    <feature>openhab-runtime-jna</feature>
     <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.doorbird/${project.version}</bundle>
   </feature>
 </features>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -4,8 +4,7 @@
 
     <feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <bundle dependency="true">mvn:net.java.dev.jna/jna/5.4.0</bundle>
-        <bundle dependency="true">mvn:net.java.dev.jna/jna-platform/5.4.0</bundle>
+        <feature>openhab-runtime-jna</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.systeminfo/${project.version}</bundle>
     </feature>
 </features>

--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.2.1</version>
+      <version>4.5.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
@@ -4,9 +4,10 @@
 
     <feature name="openhab-binding-tellstick" description="Tellstick Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-runtime-jna</feature>
         <feature>openhab-transport-serial</feature>
         <feature dependency="true">openhab.tp-jaxb</feature>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna/4.5.2</bundle>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna-platform/4.5.2</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.tellstick/${project.version}</bundle>
     </feature>
 </features>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -28,6 +28,13 @@
       <version>${karaf.version}</version>
       <type>kar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- This should have been an optional dependency and will be fixed in Karaf 4.2.8 (KARAF-6462). -->
+          <groupId>org.knopflerfish.kf6</groupId>
+          <artifactId>log-API</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Repositories -->

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
     <bnd.version>4.2.0</bnd.version>
-    <karaf.version>4.2.6</karaf.version>
+    <karaf.version>4.2.7</karaf.version>
     <sat.version>0.8.0</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
 


### PR DESCRIPTION
For Karaf 4.2.7 release notes, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12345539

Also updates dependencies:

* Jetty 9.4.20.v20190813
* JNA 5.4.0 (used by most add-ons)

---

Should be merged together with:

* https://github.com/openhab/openhab-core/pull/1197
* https://github.com/openhab/openhab-webui/pull/139
* https://github.com/openhab/openhab-distro/pull/996

See also : https://github.com/openhab/openhab-distro/issues/995