### PR TITLE
[bluez] fix version check

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/discovery/BlueZDiscoveryService.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/discovery/BlueZDiscoveryService.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.bluetooth.bluez.internal.discovery;
 
 import java.util.Collections;
+import java.util.Vector;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -61,11 +62,11 @@ public class BlueZDiscoveryService extends AbstractDiscoveryService {
             return;
         } catch (RuntimeException e) {
             // we do not get anything more specific from TinyB here
-            if (e.getMessage().contains("AccessDenied")) {
+            if (e.getMessage() != null && e.getMessage().contains("AccessDenied")) {
                 logger.warn(
                         "Cannot access BlueZ stack due to permission problems. Make sure that your OS user is part of the 'bluetooth' group of BlueZ.");
             } else {
-                logger.warn("Failed to scan for Bluetooth devices: {} ", e.getMessage(), e);
+                logger.warn("Failed to scan for Bluetooth devices: {} ", e);
             }
         }
     }

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/package-info.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/package-info.java
@@ -10,7 +10,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-@org.osgi.annotation.bundle.Header(name = org.osgi.framework.Constants.BUNDLE_NATIVECODE, value = "lib/armv6hf/libjavatinyb.so;lib/armv6hf/libtinyb.so;processor=arm;osname=linux,lib/x86-64/libjavatinyb.so;lib/x86-64/libtinyb.so;processor=amd64;osname=linux,*")
+@org.osgi.annotation.bundle.Header(name = org.osgi.framework.Constants.BUNDLE_NATIVECODE, value = "lib/armv6hf/libjavatinyb.so;lib/armv6hf/libtinyb.so;processor=arm;osname=linux, lib/x86-64/libjavatinyb.so;lib/x86-64/libtinyb.so;processor=amd64;osname=linux, *")
+@org.osgi.annotation.bundle.Header(name = "Specification-Version", value = "0.5.0-28-gac6d308.0.5.0-28-gac6d308")
 package org.openhab.binding.bluetooth.bluez;
 
 /**


### PR DESCRIPTION
The TinyB library implements a version check based on the `Specification-Version` header of the manifest. Without that header the bundle initialization fails.

PR also fixes a potential NPE.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
