### PR TITLE
 [dsmr] integer parsing errors should be catched

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/device/cosem/CosemHexString.java
+++ b/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/device/cosem/CosemHexString.java
@@ -50,7 +50,11 @@ class CosemHexString extends CosemValueDescriptor<StringType> {
                 final String hexValue = cosemHexValue.substring(i, i + 2);
 
                 if (!NO_VALUE.equals(hexValue)) {
-                    sb.append((char) Integer.parseInt(hexValue, 16));
+                    try {
+                        sb.append((char) Integer.parseInt(hexValue, 16));
+                    } catch (NumberFormatException e) {
+                        throw new ParseException("Failed to parse hex value from '" + cosemValue + "' as char", i);
+                    }
                 }
             }
             return new StringType(sb.toString());


### PR DESCRIPTION
When parsing integer values these should be catched for errors and re-thrown.
Because the re-thrown ParseException is correctly handled and doesn't pollute the log.
This catching was missing from the CosemHexString.

Errors can occur due to garbled data. These are simply ignored and should not pollute the log.
