### PR TITLE
[telegram] Use the username from the user who sent the reply to a query

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -42,9 +42,7 @@ import org.openhab.binding.telegram.bot.TelegramActions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.pengrad.telegrambot.ExceptionHandler;
 import com.pengrad.telegrambot.TelegramBot;
-import com.pengrad.telegrambot.TelegramException;
 import com.pengrad.telegrambot.UpdatesListener;
 import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;
@@ -178,7 +176,7 @@ public class TelegramHandler extends BaseThingHandler {
                             lastMessageDate = update.callbackQuery().message().date();
                             lastMessageFirstName = update.callbackQuery().from().firstName();
                             lastMessageLastName = update.callbackQuery().from().lastName();
-                            lastMessageUsername = update.callbackQuery().message().from().username();
+                            lastMessageUsername = update.callbackQuery().from().username();
                             chatId = update.callbackQuery().message().chat().id();
                             replyIdToCallbackId.put(new ReplyKey(chatId, replyId), update.callbackQuery().id());
                             logger.debug("Received callbackId {} for chatId {} and replyId {}",


### PR DESCRIPTION
When sending normal messages to the OH Telegram Bot, the username, message, date ... channel is correctly updated.
However, when the bot sends a question and the user clicks a button to answer it, the field "username" wrongly contains the name of the bot and not the username of the user who sent the reply.

Thanks to @HerzScheisse who found that issue.