### PR TITLE
[lifx] Add support for LIFX Candle

### DIFF
--- a/bundles/org.openhab.binding.lifx/README.md
+++ b/bundles/org.openhab.binding.lifx/README.md
@@ -17,6 +17,7 @@ The following table lists the thing types of the supported LIFX devices:
 | Color 1000 BR30              | colorlight   |
 | LIFX A19                     | colorlight   |
 | LIFX BR30                    | colorlight   |
+| LIFX Candle                  | colorlight   |
 | LIFX Downlight               | colorlight   |
 | LIFX GU10                    | colorlight   |
 | LIFX Mini Color              | colorlight   |

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/protocol/Product.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/protocol/Product.java
@@ -58,10 +58,12 @@ public enum Product {
     PRODUCT_50(50, "LIFX Mini Day and Dusk", TR_1500_4000),
     PRODUCT_51(51, "LIFX Mini White", TR_2700_2700),
     PRODUCT_52(52, "LIFX GU10", TR_2500_9000, COLOR),
-    PRODUCT_55(55, "LIFX Tile", TR_2500_9000, CHAIN, COLOR, TILE_EFFECT),
+    PRODUCT_55(55, "LIFX Tile", TR_2500_9000, CHAIN, COLOR, MATRIX, TILE_EFFECT),
+    PRODUCT_57(57, "LIFX Candle", TR_2500_9000, COLOR, MATRIX),
     PRODUCT_59(59, "LIFX Mini Color", TR_2500_9000, COLOR),
     PRODUCT_60(60, "LIFX Mini Day and Dusk", TR_1500_4000),
-    PRODUCT_61(61, "LIFX Mini White", TR_2700_2700);
+    PRODUCT_61(61, "LIFX Mini White", TR_2700_2700),
+    PRODUCT_68(68, "LIFX Candle", TR_2500_9000, COLOR, MATRIX);
 
     /**
      * Enumerates the product features.
@@ -70,6 +72,7 @@ public enum Product {
         CHAIN,
         COLOR,
         INFRARED,
+        MATRIX,
         MULTIZONE,
         TILE_EFFECT
     }


### PR DESCRIPTION
Adds the [LIFX Candle](https://www.lifx.com/products/candle-color) to the Product enum so it can be discovered and the binding can enable the supported features.

See: https://github.com/LIFX/products/commit/128d4e2935bb872b799af8e71885bee1bc956802