### PR TITLE
[hueemulation] Fix ipv4 or ipv6 only environment

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
@@ -60,10 +60,10 @@ class HueEmulationConfigWithRuntime extends Thread implements Runnable {
         address = InetAddress.getByName(addrString);
         if (address instanceof Inet6Address) {
             addressString = "[" + address.getHostAddress().split("%")[0] + "]";
-            multicastAddress = MULTI_ADDR_IPV4;
+            multicastAddress = MULTI_ADDR_IPV6;
         } else {
             addressString = address.getHostAddress();
-            multicastAddress = MULTI_ADDR_IPV6;
+            multicastAddress = MULTI_ADDR_IPV4;
         }
 
         port = config.discoveryHttpPort == 0 ? Integer.getInteger("org.osgi.service.http.port", 8080)
@@ -79,10 +79,10 @@ class HueEmulationConfigWithRuntime extends Thread implements Runnable {
         address = InetAddress.getByName("localhost");
         if (address instanceof Inet6Address) {
             addressString = "[" + address.getHostAddress().split("%")[0] + "]";
-            multicastAddress = MULTI_ADDR_IPV4;
+            multicastAddress = MULTI_ADDR_IPV6;
         } else {
             addressString = address.getHostAddress();
-            multicastAddress = MULTI_ADDR_IPV6;
+            multicastAddress = MULTI_ADDR_IPV4;
         }
         port = 8080;
     }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
@@ -61,6 +61,7 @@ import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.nio.ch.Net;
 
 /**
  * Advertises a Hue compatible bridge via UPNP and provides the announced /description.xml http endpoint.
@@ -412,24 +413,21 @@ public class UpnpServer extends HttpServlet implements Consumer<HueEmulationConf
         boolean hasIPv4 = false;
         boolean hasIPv6 = false;
 
-        try (
-                DatagramChannel channelV4 = DatagramChannel.open(StandardProtocolFamily.INET);
-                DatagramChannel channelV6 = DatagramChannel.open(StandardProtocolFamily.INET6);
-                Selector selector = Selector.open()) {
+        try (   Selector selector = Selector.open();
+                DatagramChannel channelV4 = createBoundDataGramChannelOrNull(StandardProtocolFamily.INET);
+                DatagramChannel channelV6 = createBoundDataGramChannelOrNull(StandardProtocolFamily.INET6)) {
 
             threadContext.asyncIOselector = selector;
 
-            bind(channelV4);
-            bind(channelV6);
             for (InetAddress address : cs.getDiscoveryIps()) {
                 NetworkInterface networkInterface = NetworkInterface.getByInetAddress(address);
                 if (networkInterface == null) {
                     continue;
                 }
-                if (address instanceof Inet4Address) {
+                if (address instanceof Inet4Address && channelV4 != null) {
                     channelV4.join(MULTI_ADDR_IPV4, networkInterface);
                     hasIPv4 = true;
-                } else {
+                } else if (channelV6 != null){
                     channelV6.join(MULTI_ADDR_IPV6, networkInterface);
                     hasIPv6 = true;
                 }
@@ -440,8 +438,6 @@ public class UpnpServer extends HttpServlet implements Consumer<HueEmulationConf
                         .completeExceptionally(new IllegalStateException("Could not join upnp multicast network!"));
                 return;
             }
-
-
 
             if (hasIPv4) {
                 channelV4.configureBlocking(false);
@@ -497,10 +493,16 @@ public class UpnpServer extends HttpServlet implements Consumer<HueEmulationConf
         }
     }
 
-    private void bind(DatagramChannel channel) throws IOException {
-        channel.setOption(StandardSocketOptions.SO_REUSEADDR, true)
-                .setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true)
-                .bind(new InetSocketAddress(UPNP_PORT));
+    @Nullable
+    private DatagramChannel createBoundDataGramChannelOrNull(StandardProtocolFamily family) throws IOException {
+        try {
+            return DatagramChannel.open(family)
+                                  .setOption(StandardSocketOptions.SO_REUSEADDR, true)
+                                  .setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true)
+                                  .bind(new InetSocketAddress(UPNP_PORT));
+        } catch (UnsupportedOperationException uoe) {
+            return null;
+        }
     }
 
     /**

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
@@ -61,7 +61,6 @@ import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.nio.ch.Net;
 
 /**
  * Advertises a Hue compatible bridge via UPNP and provides the announced /description.xml http endpoint.


### PR DESCRIPTION
This PR has two slightly different fixes for the same problem, I have split them into separate commits.

channel.open would throw if ipv6 was not enabled. This would cause ipv4 to fail as well.

     * @throws  UnsupportedOperationException
     *          If the specified protocol family is not supported. For example,
     *          suppose the parameter is specified as {@link
     *          java.net.StandardProtocolFamily#INET6 StandardProtocolFamily.INET6}
     *          but IPv6 is not enabled on the platform.

I also took the liberty of changing the boolean flags to just use the channels directly. I don't think a lot of readability is lost in the process and seems quite redundant. Also, I got some codestylewarnings when the boolean flags were used - they weren't treated as strong enough nullpointer-exception guards.