### PR TITLE
[amazondashbutton] Fix ServiceLoader

### DIFF
--- a/bundles/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/package-info.java
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/package-info.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@Requirement(namespace = ExtenderNamespace.EXTENDER_NAMESPACE, filter = "(osgi.extender=osgi.serviceloader.registrar)")
+@Requirement(namespace = ExtenderNamespace.EXTENDER_NAMESPACE, filter = "(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0)(!(version>=2.0)))")
+@Requirement(namespace = "osgi.serviceloader", filter = "(osgi.serviceloader=org.pcap4j.packet.factory.PacketFactoryBinderProvider)", cardinality = Cardinality.MULTIPLE)
+@Capability(namespace = "osgi.serviceloader", name="org.pcap4j.packet.factory.PacketFactoryBinderProvider")
+package org.openhab.binding.bluetooth.bluez;
+
+import org.osgi.annotation.bundle.Capability;
+import org.osgi.annotation.bundle.Requirement;
+import org.osgi.annotation.bundle.Requirement.Cardinality;
+import org.osgi.namespace.extender.ExtenderNamespace;
+/**
+ * Additional information for AmazonDashButton package
+ *
+ * @author Jan N. Klug - Initial contribution
+ *
+ */


### PR DESCRIPTION
PCap4J uses the java service loader for packet captures. If services are not properly declares they will not load in an OSGi environment due to classloader context.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
