### PR TITLE
[telegram] Allow to send pictures from a local network + basic authentication

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -96,6 +96,7 @@ These actions will send a message to all chat ids configured for this bot.
 | sendTelegramQuery(String message, String replyId, String... buttons) | Sends a question to the user that can be answered via the defined buttons. The replyId can be freely choosen and is sent back with the answer. Then, the id is required to identify what question has been answered (e.g. in case of multiple open questions). The final result looks like this: ![Telegram Inline Keyboard](doc/queryExample.png). |
 | sendTelegramAnswer(String replyId, String message) | Sends a message after the user has answered a question. You should *always* call this method after you received an answer. It will remove buttons from the specific question and will also stop the progress bar displayed at the client side. If no message is necessary, just pass `null` here. |
 | sendTelegramPhoto(String photoURL, String caption) | Sends a picture. The URL can be specified using the http, https, and file protocols or a base64 encoded image. |
+| sendTelegramPhoto(String photoURL, String caption, String username, String password) | Sends a picture which is downloaded from a username/password protected http/https address. |
 
 ### Actions to send messages to a particular chat
 
@@ -162,6 +163,18 @@ then
     val telegramAction = getActions("telegram","telegram:telegramBot:2b155b22")
     telegramAction.sendTelegramPhoto("http://www.openhab.org/assets/images/openhab-logo-top.png",
         null)
+end
+```
+
+telegram.rules
+
+```java
+rule "Send telegram with image from password protected http source"
+when
+    Item Light_GF_Living_Table changed
+then
+    val telegramAction = getActions("telegram","telegram:telegramBot:2b155b22")
+    telegramAction.sendTelegramPhoto("http://192.168.1.5/doorcam/picture.jpg", "Door Camera", "user", "mypassword")
 end
 ```
 

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
@@ -19,16 +19,19 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
- * The {@link TelegramHandlerFactory} is responsible for creating things and thing
- * handlers.
+ * The {@link TelegramHandlerFactory} is responsible for creating things and
+ * thing handlers.
  *
  * @author Jens Runge - Initial contribution
  */
@@ -37,6 +40,7 @@ import org.osgi.service.component.annotations.Component;
 public class TelegramHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(TELEGRAM_THING);
+    private @Nullable HttpClient httpClient;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -48,8 +52,17 @@ public class TelegramHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (TELEGRAM_THING.equals(thingTypeUID)) {
-            return new TelegramHandler(thing);
+            return new TelegramHandler(thing, httpClient);
         }
         return null;
+    }
+
+    @Reference
+    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = null;
     }
 }


### PR DESCRIPTION
Although the used Telegram library supports the sending of images from a http/https source, it actually doesn't send the content of the picture, but only the URL where either the Telegram server or the client itself finally downloads that picture. In case the image comes from a local network, nothing it sent.

Therefore, (similar to the old binding) the provided image url is first downloaded and then send to the Telegram server. This difference was found by Mark (https://community.openhab.org/t/new-telegram-binding-and-updated-action-tester-and-feedback-welcome/54806/148) and I agree that it is probably a common use-case to send pictures that e.g. come from a local camera server.

A few design considerations:
- I thought about keeping the memory efficient sending of images via an URL, but this would make the API quite complicated (I couldn't think of a good name or adding an ugly parameter flag to distinguish that) and I think that sending an image which is public might not be that common for OH users. So, I decided to always download that image.
- It looks strange that we have now two clients: one is required by the library (okhttp) and one for downloading the pictures where I used the default OH2 Jetty client. I think it makes sense, because then we can make use of global configurations (e.g. SSL certificates etc.)
- Btw. is it necessary to start/stop the Jetty client or dispose anything? I didn't do that here.
- As part of this, I was also able to add back the "basic authentication" which was also present in the old binding. If you think it's not required, let me know (I copied some code from RobonectClient)
- However, I neither made the timeout configurable again (it will always use 30s) nor the number of retries. Let me know, if you think that's necessary to add back.