### PR TITLE
[sinope] Bugfix - Handlers staying in uninitialized state.

### DIFF
--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
@@ -76,19 +76,26 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
     public void initialize() {
         logger.debug("Initializing Sinope Gateway");
 
-        SinopeConfig config = getConfigAs(SinopeConfig.class);
-        if (config.hostname == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Gateway hostname must be set");
-        } else if (config.port == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Gateway port must be set");
-        } else if (config.gatewayId == null || SinopeConfig.convert(config.gatewayId) == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Gateway Id must be set");
-        } else if (config.apiKey == null || SinopeConfig.convert(config.apiKey) == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Api Key must be set");
-        } else {
+        try {
+            SinopeConfig config = getConfigAs(SinopeConfig.class);
             refreshInterval = config.refresh;
-            schedulePoll();
-            updateStatus(ThingStatus.ONLINE);
+            if (config.hostname == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Gateway hostname must be set");
+            } else if (config.port == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Gateway port must be set");
+            } else if (config.gatewayId == null || SinopeConfig.convert(config.gatewayId) == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Gateway Id must be set");
+            } else if (config.apiKey == null || SinopeConfig.convert(config.apiKey) == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Api Key must be set");
+            } else if (connectToBridge()) {
+                schedulePoll();
+                updateStatus(ThingStatus.ONLINE);
+                return;
+            }
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    "Can't connect to gateway. Please make sure that another instance is not connected.");
         }
 
     }

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeThermostatHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeThermostatHandler.java
@@ -267,6 +267,7 @@ public class SinopeThermostatHandler extends BaseThingHandler {
         if (handler != null) {
             handler.registerThermostatHandler(this);
         }
+        updateStatus(ThingStatus.ONLINE);
     }
 
     private @Nullable SinopeGatewayHandler getSinopeGatewayHandler() {


### PR DESCRIPTION
<!-- TITLE -->
Thermostat handler was staying uninitialized. The same could also happen to the gateway in some condition (two openhab trying to connect to the same gateway.)


<!-- DESCRIPTION -->
This is a bugfix. The bundle should be considered broken without it. Basically, the handlers were staying uninitialized and there were not processing any commands.

<!-- TESTING -->
The test bundle is available at [here](https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.sinope/2.5.0-SNAPSHOT/org.openhab.binding.sinope-2.5.0-SNAPSHOT.jar)


