### PR TITLE
[systeminfo] Upgrade jna/oshi due to "Failed to read process file" spam on raspberry.

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -21,19 +21,19 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>4.0.0</version>
+      <version>4.2.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -4,7 +4,9 @@
 
     <feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-runtime-jna</feature>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna/5.5.0</bundle>
+        <bundle dependency="true">mvn:net.java.dev.jna/jna-platform/5.5.0</bundle>
+        <bundle dependency="true">mvn:com.github.oshi/oshi-core/4.2.1</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.systeminfo/${project.version}</bundle>
     </feature>
 </features>

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -52,8 +52,8 @@ Fragment-Host: org.openhab.binding.systeminfo
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)',\
-	com.sun.jna;version='[5.4.0,5.4.1)',\
-	com.sun.jna.platform;version='[5.4.0,5.4.1)',\
+	com.sun.jna;version='[5.5.0,5.5.1)',\
+	com.sun.jna.platform;version='[5.5.0,5.5.1)',\
 	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
 	org.mockito.mockito-core;version='[3.1.0,3.1.1)',\

--- a/itests/org.openhab.binding.systeminfo.tests/pom.xml
+++ b/itests/org.openhab.binding.systeminfo.tests/pom.xml
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.0</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>4.0.0</version>
+      <version>4.2.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Current oshi/jna spams openhab.log with 
[WARN ] [ftware.os.linux.LinuxOperatingSystem] - Failed to read process file:
on Raspberry Pi. Upgrade fixes the problem.

Signed-off-by: Alexander Falkenstern <alexander.falkenstern@gmail.com>
