### PR TITLE
[lutron] Doc update

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -3,19 +3,19 @@
 This binding integrates with [Lutron](http://www.lutron.com) lighting control and home automation systems.
 It contains separate binding support for four different types of Lutron systems:
 
-* RadioRA 2 and other systems that can be controlled by Lutron Integration Protocol, such as Homeworks QS, RA2 Select, and Caseta PRO
+* RadioRA 2, HomeWorks QS, and other systems that can be controlled by Lutron Integration Protocol, such as RA2 Select, and Caseta Pro
 * The original RadioRA system, referred to here as RadioRA Classic
 * Legacy HomeWorks RS232 Processors
 * Grafik Eye 3x/4x systems with GRX-PRG or GRX-CI-PRG control interfaces
 
 Each is described in a separate section below.
 
-# Lutron RadioRA 2 Binding
+# Lutron RadioRA 2/HomeWorks QS Binding
 
-**Note:** While the integration protocol used by this binding should largely be compatible with other current Lutron systems, this binding has only been fully tested with RadioRA 2 and Caseta.
-Homeworks QS support is still a work in progress.
-RA2 Select is believed to work, but it is unconfirmed.
-It has not yet been tested with Quantum, QS Standalone, or myRoom plus systems.
+**Note:** While the integration protocol used by this binding should largely be compatible with other current Lutron systems, this binding has only been fully tested with RadioRA 2, HomeWorks QS, and Caseta with Smart Bridge Pro.
+Homeworks QS support is still a work in progress, since not all features/devices are supported yet.
+RA2 Select has been reported to work with the binding, but support is unconfirmed.
+The binding has not been tested with Quantum, QS Standalone, or myRoom Plus systems.
 
 **Note:** Caseta support is only possible with the Smart Bridge **Pro** hub.
 The standard Caseta hub does not support Lutron Integration Protocol.
@@ -81,7 +81,9 @@ It also defaults to 5.
 The optional advanced parameter `delay` can be used to set a delay (in milliseconds) between transmission of integration commands to the bridge device.
 This may be used for command send rate throttling.
 It can be set to an integer value between 0 and 250 ms, and defaults to 0 (no delay).
-It is recommended to leave it set to 0 unless you experience problems with commands sent to Caseta hubs being dropped/ignored.
+It is recommended that this parameter be left at the default unless you experience problems with sent commands being dropped/ignored.
+This has been reported in some rare cases when large numbers of commands were sent in short periods to Caseta hubs.
+If you experience this problem, try setting a delay value of around 100 ms as a starting point.
 
 The optional advanced parameter `discoveryFile` can be set to force the device discovery service to read the Lutron configuration XML from a local file rather than retrieving it via HTTP from the RadioRA 2 or HomeWorks QS bridge device.
 This is useful in the case of some older Lutron software versions, where the discovery service may have problems retrieving the file from the bridge device.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -209,7 +209,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
     /**
      * Register a discovery service for an IP bridge handler.
      *
-     * @param thingHandler bridge handler for which to register the discovery service
+     * @param bridgeHandler bridge handler for which to register the discovery service
      */
     private synchronized void registerDiscoveryService(IPBridgeHandler bridgeHandler) {
         logger.debug("Registering discovery service.");

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/binding/binding.xml
@@ -5,7 +5,7 @@
 		xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Lutron Binding</name>
-	<description>The Lutron binding controls Lutron lighting control systems such as RadioRA, RadioRA 2, HomeWorks, HomeWorks QS, RA2 Select, and Caseta.</description>
-	<author>Allan Tong</author>
+	<description>The Lutron binding interfaces with Lutron lighting control and home automation systems such as RadioRA, RadioRA 2, HomeWorks, HomeWorks QS, RA2 Select, Caseta, and GRAFIK Eye.</description>
+	<author>Allan Tong, Bob Adair</author>
 
 </binding:binding>


### PR DESCRIPTION
This PR is a documentation-only update to README.md and binding.xml.  It clarifies supported configurations, and adds recommendations regarding the new “delay” bridge parameter. I also took the opportunity to add myself to the author line in binding.xml since, for better or worse, a lot of the code in the binding is mine now and I’ve been more or less maintaining it through the 2.5 dev cycle.

@actong  - Is this ok with you?

Closes #6012
