### PR TITLE
fixed XML formatting

### DIFF
--- a/bundles/org.openhab.binding.ambientweather/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/feature/feature.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ambientweather-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features
-	</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
 	<feature name="openhab-binding-ambientweather" description="Ambient Weather Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.doorbird-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-  <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+<features name="org.openhab.binding.doorbird-${project.version}"
+	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
-  <feature name="openhab-binding-doorbird" description="Doorbird Binding" version="${project.version}">
-    <feature>openhab-runtime-base</feature>
-    <feature>openhab-runtime-jna</feature>
-    <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.doorbird/${project.version}</bundle>
-  </feature>
+	<feature name="openhab-binding-doorbird" description="Doorbird Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-runtime-jna</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.doorbird/${project.version}</bundle>
+	</feature>
 </features>

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/feature/feature.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.innogysmarthome-${project.version}"
-	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="org.openhab.binding.innogysmarthome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
-	<feature name="openhab-binding-innogysmarthome" description="innogy Smarthome Binding"
-		version="${project.version}">
+	<feature name="openhab-binding-innogysmarthome" description="innogy Smarthome Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.innogysmarthome/${project.version}</bundle>

--- a/bundles/org.openhab.binding.lghombot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lghombot/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lghombot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
 	<feature name="openhab-binding-lghombot" description="LG HomBot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>


### PR DESCRIPTION
Fixes the feature.xml format of a few bindings.

For some reason, the new line in https://github.com/openhab/openhab2-addons/blob/master/bundles/org.openhab.binding.innogysmarthome/src/main/feature/feature.xml#L6 seems to have completely broken the build, I hope this PR will fix it again.

Signed-off-by: Kai Kreuzer <kai@openhab.org>