### PR TITLE
[dlinksmarthome] Changed to openHAB Core feature of JAX-WS (#6439)

### DIFF
--- a/bundles/org.openhab.binding.dlinksmarthome/pom.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/pom.xml
@@ -12,27 +12,9 @@
   <artifactId>org.openhab.binding.dlinksmarthome</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: D-Link Smart Home Binding</name>
-
-  <dependencies>
-    <!-- JAX-WS -->
-    <dependency>
-      <groupId>javax.xml.soap</groupId>
-      <artifactId>javax.xml.soap-api</artifactId>
-      <version>1.4.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.ws</groupId>
-      <artifactId>jaxws-rt</artifactId>
-      <version>2.2.10</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.messaging.saaj</groupId>
-      <artifactId>saaj-impl</artifactId>
-      <version>1.5.1</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
+  
+  <properties>
+    <bnd.importpackage>!javax.xml.soap, com.sun.xml.messaging.saaj.soap</bnd.importpackage>
+  </properties>
 
 </project>

--- a/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
@@ -5,12 +5,7 @@
     <feature name="openhab-binding-dlinksmarthome" description="D-Link Smart Home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-mdns</feature>
-        <feature dependency="true">openhab.tp-jaxb</feature>
-        <feature prerequisite="true">wrap</feature>
-        <!-- JAX-WS (SOAP) bundles -->
-        <bundle dependency="true">mvn:javax.xml.soap/javax.xml.soap-api/1.4.0</bundle>
-        <bundle dependency="true">wrap:mvn:com.sun.xml.ws/jaxws-rt/2.2.10$Bundle-Name=JAX%20WS%20RI%20Runtime%20Bundle&amp;Bundle-SymbolicName=com.sun.xml.ws.jaxws-rt&amp;Bundle-Version=2.3.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.messaging.saaj/saaj-impl/1.5.1</bundle>
+        <feature dependency="true">openhab.tp-jaxws</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.dlinksmarthome/${project.version}</bundle>
     </feature>
 </features>


### PR DESCRIPTION
Fixes binding so that it works in OH 2.5. Confirmed that it works with a real device.

Fixes #6439

Signed-off-by: Mike Major <mike_j_major@hotmail.com>