### PR TITLE
[lifx] Fix NPE when things don't have properties

### DIFF
--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/handler/LifxLightHandler.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/handler/LifxLightHandler.java
@@ -407,6 +407,9 @@ public class LifxLightHandler extends BaseThingHandler {
 
     private Product getProduct() {
         Object propertyValue = getThing().getProperties().get(LifxBindingConstants.PROPERTY_PRODUCT_ID);
+        if (propertyValue == null) {
+            return Product.getLikelyProduct(getThing().getThingTypeUID());
+        }
         try {
             // Without first conversion to double, on a very first thing creation from discovery inbox,
             // the product type is incorrectly parsed, as framework passed it as a floating point number


### PR DESCRIPTION
It might not have this property e.g. when using .things files.

This NPE was caused by the changes in https://github.com/openhab/openhab2-addons/pull/6180.