### PR TITLE
[hueemulation] Allow Group items to be exposed as devices

### DIFF
--- a/bundles/org.openhab.io.hueemulation/README.md
+++ b/bundles/org.openhab.io.hueemulation/README.md
@@ -32,6 +32,7 @@ By default the pairing mode disables itself after 1 minute (can be configured).
 
 It is important to note that you are exposing *Items* not *Things* or *Channels*.
 Only Color, Dimmer, Rollershutter, Switch and Group type *Items* are supported.
+Group type items require the "Huelight" tag to be exposed as devices instead of Groups.
 
 This service can emulate 3 different devices:
 

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
@@ -98,6 +98,7 @@ import io.swagger.annotations.ApiResponses;
 @Path("")
 @Produces(MediaType.APPLICATION_JSON)
 public class LightsAndGroups implements RegistryChangeListener<Item> {
+    public static final String EXPOSE_AS_DEVICE_TAG = "huelight";
     private final Logger logger = LoggerFactory.getLogger(LightsAndGroups.class);
     private static final String ITEM_TYPE_GROUP = "Group";
     private static final Set<String> ALLOWED_ITEM_TYPES = Stream.of(CoreItemFactory.COLOR, CoreItemFactory.DIMMER,
@@ -153,7 +154,7 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
 
         String hueID = cs.mapItemUIDtoHueID(element);
 
-        if (element instanceof GroupItem) {
+        if (element instanceof GroupItem && !element.hasTag(EXPOSE_AS_DEVICE_TAG)) {
             GroupItem g = (GroupItem) element;
             HueGroupEntry group = new HueGroupEntry(g.getName(), g, deviceType);
 

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -127,6 +127,17 @@ public class LightsAndGroupsTests {
     }
 
     @Test
+    public void addDeviceAsGroupSwitchableByTag() {
+        GroupItem item = new GroupItem("group1", new SwitchItem("switch1"));
+        item.addTag("Switchable");
+        item.addTag("Huelight");
+        itemRegistry.add(item);
+        HueLightEntry device = cs.ds.lights.get(cs.mapItemUIDtoHueID(item));
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+    }
+
+    @Test
     public void addGroupWithoutTypeByTag() {
         GroupItem item = new GroupItem("group1", null);
         item.addTag("Switchable");


### PR DESCRIPTION
I made this PR as a result of the discussion in https://community.openhab.org/t/hueemulation-group-items-can-no-longer-be-exposed-as-hue-devices/85679

For us who use Group type items as items, the new addition to the hue-emulation, group support, was a breaking change. I added support for a new tag "huelight" that can be put on a group type item so it will work as before.