### PR TITLE
[weathercompany] Fix handling of thing status

### DIFF
--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/WeatherCompanyHandlerFactory.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/WeatherCompanyHandlerFactory.java
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.net.http.HttpClientFactory;
 import org.openhab.binding.weathercompany.internal.discovery.WeatherCompanyDiscoveryService;
+import org.openhab.binding.weathercompany.internal.handler.WeatherCompanyBridgeHandler;
 import org.openhab.binding.weathercompany.internal.handler.WeatherCompanyForecastHandler;
 import org.openhab.binding.weathercompany.internal.handler.WeatherCompanyObservationsHandler;
 import org.osgi.framework.ServiceRegistration;

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/discovery/WeatherCompanyDiscoveryService.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/discovery/WeatherCompanyDiscoveryService.java
@@ -27,8 +27,8 @@ import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.LocationProvider;
 import org.eclipse.smarthome.core.library.types.PointType;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.openhab.binding.weathercompany.internal.WeatherCompanyBridgeHandler;
 import org.openhab.binding.weathercompany.internal.handler.WeatherCompanyAbstractHandler;
+import org.openhab.binding.weathercompany.internal.handler.WeatherCompanyBridgeHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyAbstractHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyAbstractHandler.java
@@ -55,7 +55,6 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
-import org.openhab.binding.weathercompany.internal.WeatherCompanyBridgeHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +72,7 @@ import com.google.gson.GsonBuilder;
  */
 @NonNullByDefault
 public abstract class WeatherCompanyAbstractHandler extends BaseThingHandler {
-    protected static final int WEATHER_COMPANY_API_TIMEOUT_SECONDS = 10;
+    protected static final int WEATHER_COMPANY_API_TIMEOUT_SECONDS = 15;
     protected static final int REFRESH_JOB_INITIAL_DELAY_SECONDS = 6;
 
     private final Logger logger = LoggerFactory.getLogger(WeatherCompanyAbstractHandler.class);

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyBridgeHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyBridgeHandler.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.weathercompany.internal;
+package org.openhab.binding.weathercompany.internal.handler;
 
 import java.io.IOException;
 import java.util.concurrent.Future;

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyForecastHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyForecastHandler.java
@@ -195,8 +195,9 @@ public class WeatherCompanyForecastHandler extends WeatherCompanyAbstractHandler
     }
 
     private synchronized void refreshForecast() {
-        if (thing.getStatus() != ThingStatus.ONLINE) {
-            logger.debug("Handler: Can't refresh forecast because thing is not online");
+        if (!isBridgeOnline()) {
+            // If bridge is not online, API has not been validated yet
+            logger.debug("Handler: Can't refresh forecast because bridge is not online");
             return;
         }
         logger.debug("Handler: Requesting forecast from The Weather Company API");

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyObservationsHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyObservationsHandler.java
@@ -122,8 +122,9 @@ public class WeatherCompanyObservationsHandler extends WeatherCompanyAbstractHan
     }
 
     private synchronized void refreshPwsObservations() {
-        if (thing.getStatus() != ThingStatus.ONLINE) {
-            logger.debug("Handler: Can't refresh PWS observations because thing is not online");
+        if (!isBridgeOnline()) {
+            // If bridge is not online, API has not been validated yet
+            logger.debug("Handler: Can't refresh PWS observations because bridge is not online");
             return;
         }
         logger.debug("Handler: Requesting PWS observations from The Weather Company API");
@@ -135,6 +136,7 @@ public class WeatherCompanyObservationsHandler extends WeatherCompanyAbstractHan
             logger.debug("Handler: Parsing PWS observations response: {}", response);
             PwsObservations pwsObservations = gson.fromJson(response, PwsObservations.class);
             logger.debug("Handler: Successfully parsed PWS observations response object");
+            updateStatus(ThingStatus.ONLINE);
             updatePwsObservations(pwsObservations);
         } catch (JsonSyntaxException e) {
             logger.debug("Handler: Error parsing pws observations response object: {}", e.getMessage(), e);


### PR DESCRIPTION
When I reworked the binding to create a bridge handler, I screwed up the handling of the thing status. If the forecast and/or observations things go offline for any reason, they will never come back online (unless the binding is restarted).

Also moved the bridge handler to the handler package where it should've been originally.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
