### PR TITLE
[homematic] correct SCA warnings - README.md

### DIFF
--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -43,6 +43,7 @@ All gateways which provides the Homematic BIN- or XML-RPC API:
 The Homematic IP Access Point **does not support** this API and and can't be used with this binding.
 
 Homematic IP support:
+
 - CCU2 with at least firmware 2.17.15
 - [RaspberryMatic](https://github.com/jens-maus/RaspberryMatic) with the [HM-MOD-RPI-PCB](https://www.elv.de/homematic-funkmodul-fuer-raspberry-pi-bausatz.html) or [RPI-RF-MOD](https://www.elv.de/homematic-funk-modulplatine-fuer-raspberry-pi-3-rpi-rf-mod-komplettbausatz.html) RF module
 - [piVCCU](https://github.com/alexreinert/piVCCU)
@@ -63,6 +64,7 @@ And **FROM** the gateway to the binding:
 - BIN-RPC: 9126
 
 CCU Autodiscovery:
+
 * UDP 43439
 
 **Note:** The binding tries to identify the gateway with XML-RPC and uses henceforth:
@@ -89,6 +91,7 @@ With Homegear or a CCU, variables and scripts are supported too.
 ## Discovery
 
 Gateway discovery is available:
+
 * CCU
 * RaspberryMatic >= 2.29.23.20171022
 * Homegear >= 0.6.x
@@ -177,8 +180,7 @@ If set to true, devices are automatically unpaired from the gateway when their c
 **Warning!** The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion completely, both options need to be set to false! (default = false)
 
 -   **factoryResetOnDeletion**
-If set to true, devices are automatically factory reset when their corresponding things are removed.
-Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
+If set to true, devices are automatically factory reset when their corresponding things are removed. Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
 
 The syntax for a bridge is:
 
@@ -266,6 +268,7 @@ Note that, for Homegear devices, in contrast to the specification of the Rhing a
 The channel configs are optional.
 
 Example without channel configs
+
 ```java
   Thing HM-LC-Dim1T-Pl-2    JEQ0999999 "Name"  @  "Location" {
       Channels:
@@ -460,6 +463,7 @@ end
 A virtual datapoint (String) to simulate a key press, available on all channels that contains PRESS_ datapoints.
 
 Available values:
+
 * `SHORT_PRESS`: triggered on a short key press
 * `LONG_PRESS`: triggered on a key press longer than `LONG_PRESS_TIME` (variable configuration per key, default is 0.4 s)
 * `DOUBLE_PRESS`: triggered on a short key press but only if the latest `SHORT_PRESS` or `DOUBLE_PRESS` event is not older than 2.0 s (not related to `DBL_PRESS_TIME` configuration, which is more like a key lock because if it is other than `0.0` single presses are not notified anymore)

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -180,7 +180,8 @@ If set to true, devices are automatically unpaired from the gateway when their c
 **Warning!** The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion completely, both options need to be set to false! (default = false)
 
 -   **factoryResetOnDeletion**
-If set to true, devices are automatically factory reset when their corresponding things are removed. Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
+If set to true, devices are automatically factory reset when their corresponding things are removed.
+Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
 
 The syntax for a bridge is:
 


### PR DESCRIPTION
make changes to README.md

SCA Jenkins analysis
* https://ci.openhab.org/job/PR-openHAB2-Addons/Static_20Code_20Analysis_20Report/

.binding.homematic/README.md
tool 	priority 	line 	category 	rule 	message
checkstyle 	2 	46 	style 	MarkdownCheck 	The line before a Markdown list must be empty.
checkstyle 	2 	66 	style 	MarkdownCheck 	The line before a Markdown list must be empty.
checkstyle 	2 	92 	style 	MarkdownCheck 	The line before a Markdown list must be empty.
checkstyle 	2 	179 	style 	MarkdownCheck 	The line after a Markdown list must be empty.
checkstyle 	2 	269 	style 	MarkdownCheck 	The line before code formatting section must be empty.
checkstyle 	2 	463 	style 	MarkdownCheck 	The line before a Markdown list must be empty.

Also-by: Michael Roßner <Schrott.Micha@web.de>
Signed-off-by: Rosi2143 <Schrott.Micha@web.de>