### PR TITLE
[tradfri] removed explicit Californium dependency to avoid embedding

### DIFF
--- a/bundles/org.openhab.binding.tradfri/pom.xml
+++ b/bundles/org.openhab.binding.tradfri/pom.xml
@@ -13,22 +13,4 @@
 
   <name>openHAB Add-ons :: Bundles :: TRÅDFRI Binding</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.eclipse.californium</groupId>
-      <artifactId>californium-core</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.californium</groupId>
-      <artifactId>scandium</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.californium</groupId>
-      <artifactId>element-connector</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -61,4 +61,8 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
+	org.eclipse.californium.core;version='[2.0.0,2.0.1)',\
+	org.eclipse.californium.element-connector;version='[2.0.0,2.0.1)',\
+	org.eclipse.californium.scandium;version='[2.0.0,2.0.1)'


### PR DESCRIPTION
depends on https://github.com/openhab/openhab-core/pull/1262

Signed-off-by: Kai Kreuzer <kai@openhab.org>