### PR TITLE
[homematic] Explicit creation of numeric Objects is needed

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+import org.openhab.binding.homematic.internal.HomematicBindingConstants;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.message.RpcRequest;
 import org.openhab.binding.homematic.internal.communicator.parser.GetAllScriptsParser;
@@ -86,7 +87,7 @@ public abstract class RpcClient<T> {
         request.addArg(getRpcCallbackUrl());
         request.addArg(clientId);
         if (config.getGatewayInfo().isHomegear()) {
-            request.addArg(0x22);
+            request.addArg(new Integer(0x22));
         }
         sendMessage(config.getRpcPort(hmInterface), request);
     }
@@ -175,7 +176,6 @@ public abstract class RpcClient<T> {
             // The configuration channel only has a MASTER Paramset, so there is nothing to load
             return;
         }
-
         RpcRequest<T> request = createRpcRequest("getParamsetDescription");
         request.addArg(getRpcAddress(channel.getDevice().getAddress()) + getChannelSuffix(channel));
         request.addArg(paramsetType.toString());
@@ -326,7 +326,7 @@ public abstract class RpcClient<T> {
             request = createRpcRequest("putParamset");
             request.addArg(getRpcAddress(dp.getChannel().getDevice().getAddress()) + getChannelSuffix(dp.getChannel()));
             request.addArg(HmParamsetType.MASTER.toString());
-            Map<String, Object> paramSet = new HashMap<String, Object>();
+            Map<String, Object> paramSet = new HashMap<>();
             paramSet.put(dp.getName(), value);
             request.addArg(paramSet);
             configureRxMode(request, rxMode);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
@@ -93,9 +93,8 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
             offset += currentLength;
         }
         if (offset != datasize) {
-            throw new EOFException(
-                    "Only " + offset + " bytes received while reading message payload, expected " + datasize
-                            + " bytes");
+            throw new EOFException("Only " + offset + " bytes received while reading message payload, expected "
+                    + datasize + " bytes");
         }
         byte[] message = ArrayUtils.addAll(sig, payload);
         decodeMessage(message, methodHeader);
@@ -137,7 +136,7 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
 
     private void generateResponseData() throws IOException {
         offset = 8 + (methodName != null ? methodName.length() + 8 : 0);
-        List<Object> values = new ArrayList<Object>();
+        List<Object> values = new ArrayList<>();
         while (offset < binRpcData.length) {
             values.add(readRpcValue());
         }
@@ -215,7 +214,7 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
         int type = readInt();
         switch (type) {
             case 1:
-                return readInt();
+                return new Integer(readInt());
             case 2:
                 return binRpcData[offset++] != 0 ? Boolean.TRUE : Boolean.FALSE;
             case 3:
@@ -230,7 +229,7 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
             case 0x100:
                 // Array
                 int numElements = readInt();
-                Collection<Object> array = new ArrayList<Object>();
+                Collection<Object> array = new ArrayList<>();
                 while (numElements-- > 0) {
                     array.add(readRpcValue());
                 }
@@ -238,7 +237,7 @@ public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
             case 0x101:
                 // Struct
                 numElements = readInt();
-                Map<String, Object> struct = new TreeMap<String, Object>();
+                Map<String, Object> struct = new TreeMap<>();
                 while (numElements-- > 0) {
                     String name = readString();
                     struct.put(name, readRpcValue());

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcResponse.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcResponse.java
@@ -73,14 +73,14 @@ public class XmlRpcResponse implements RpcResponse {
      * @author Gerhard Riegler
      */
     private class XmlRpcHandler extends DefaultHandler {
-        private List<Object> result = new ArrayList<Object>();
-        private LinkedList<List<Object>> currentDataObject = new LinkedList<List<Object>>();
+        private List<Object> result = new ArrayList<>();
+        private LinkedList<List<Object>> currentDataObject = new LinkedList<>();
         private StringBuilder tagValue;
         private boolean isValueTag;
 
         @Override
         public void startDocument() throws SAXException {
-            currentDataObject.addLast(new ArrayList<Object>());
+            currentDataObject.addLast(new ArrayList<>());
         }
 
         @Override
@@ -94,7 +94,7 @@ public class XmlRpcResponse implements RpcResponse {
                 throws SAXException {
             String tag = qName.toLowerCase();
             if (tag.equals("array") || tag.equals("struct")) {
-                currentDataObject.addLast(new ArrayList<Object>());
+                currentDataObject.addLast(new ArrayList<>());
             }
             isValueTag = tag.equals("value");
             tagValue = new StringBuilder();
@@ -112,10 +112,10 @@ public class XmlRpcResponse implements RpcResponse {
                     break;
                 case "int":
                 case "i4":
-                    data.add(currentValue);
+                    data.add(new Integer(currentValue));
                     break;
                 case "double":
-                    data.add(currentValue);
+                    data.add(new Double(currentValue));
                     break;
                 case "string":
                 case "name":
@@ -133,7 +133,7 @@ public class XmlRpcResponse implements RpcResponse {
                     break;
                 case "struct":
                     List<Object> mapData = currentDataObject.removeLast();
-                    Map<Object, Object> resultMap = new HashMap<Object, Object>();
+                    Map<Object, Object> resultMap = new HashMap<>();
 
                     for (int i = 0; i < mapData.size(); i += 2) {
                         resultMap.put(mapData.get(i), mapData.get(i + 1));

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -76,7 +76,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
     private HomematicChannelTypeProvider channelTypeProvider;
     private HomematicChannelGroupTypeProvider channelGroupTypeProvider;
     private HomematicConfigDescriptionProvider configDescriptionProvider;
-    private final Map<String, Set<String>> firmwaresByType = new HashMap<String, Set<String>>();
+    private final Map<String, Set<String>> firmwaresByType = new HashMap<>();
 
     private static final String[] IGNORE_DATAPOINT_NAMES = new String[] { DATAPOINT_NAME_AES_KEY,
             VIRTUAL_DATAPOINT_NAME_RELOAD_FROM_GATEWAY };
@@ -142,9 +142,9 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 logger.debug("Generating ThingType for device '{}' with {} datapoints", device.getType(),
                         device.getDatapointCount());
 
-                List<ChannelGroupType> groupTypes = new ArrayList<ChannelGroupType>();
+                List<ChannelGroupType> groupTypes = new ArrayList<>();
                 for (HmChannel channel : device.getChannels()) {
-                    List<ChannelDefinition> channelDefinitions = new ArrayList<ChannelDefinition>();
+                    List<ChannelDefinition> channelDefinitions = new ArrayList<>();
                     // Omit thing channel definitions for reconfigurable channels;
                     // those will be populated dynamically during thing initialization
                     if (!channel.isReconfigurable()) {
@@ -207,7 +207,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 && !DEVICE_TYPE_VIRTUAL_WIRED.equals(device.getType())) {
             Set<String> firmwares = firmwaresByType.get(device.getType());
             if (firmwares == null) {
-                firmwares = new HashSet<String>();
+                firmwares = new HashSet<>();
                 firmwaresByType.put(device.getType(), firmwares);
             }
             firmwares.add(device.getFirmware());
@@ -221,11 +221,11 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
         String label = MetadataUtils.getDeviceName(device);
         String description = String.format("%s (%s)", label, device.getType());
 
-        List<String> supportedBridgeTypeUids = new ArrayList<String>();
+        List<String> supportedBridgeTypeUids = new ArrayList<>();
         supportedBridgeTypeUids.add(THING_TYPE_BRIDGE.toString());
         ThingTypeUID thingTypeUID = UidUtils.generateThingTypeUID(device);
 
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put(Thing.PROPERTY_VENDOR, PROPERTY_VENDOR_NAME);
         properties.put(Thing.PROPERTY_MODEL_ID, device.getType());
 
@@ -234,7 +234,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
             generateConfigDescription(device, configDescriptionURI);
         }
 
-        List<ChannelGroupDefinition> groupDefinitions = new ArrayList<ChannelGroupDefinition>();
+        List<ChannelGroupDefinition> groupDefinitions = new ArrayList<>();
         for (ChannelGroupType groupType : groupTypes) {
             String id = StringUtils.substringAfterLast(groupType.getUID().getId(), "_");
             groupDefinitions.add(new ChannelGroupDefinition(id, groupType.getUID()));
@@ -280,7 +280,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
 
                 BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
                 if (step == null) {
-                    step = MetadataUtils.createBigDecimal(dp.isFloatType() ? 0.1 : 1L);
+                    step = MetadataUtils.createBigDecimal(dp.isFloatType() ? new Float(0.1) : new Long(1L));
                 }
                 state = new StateDescription(min, max, step, MetadataUtils.getStatePattern(dp), dp.isReadOnly(),
                         options);
@@ -311,8 +311,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
     }
 
     private void generateConfigDescription(HmDevice device, URI configDescriptionURI) {
-        List<ConfigDescriptionParameter> parms = new ArrayList<ConfigDescriptionParameter>();
-        List<ConfigDescriptionParameterGroup> groups = new ArrayList<ConfigDescriptionParameterGroup>();
+        List<ConfigDescriptionParameter> parms = new ArrayList<>();
+        List<ConfigDescriptionParameterGroup> groups = new ArrayList<>();
 
         for (HmChannel channel : device.getChannels()) {
             String groupName = "HMG_" + channel.getNumber();
@@ -343,7 +343,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     if (dp.isNumberType()) {
                         builder.withMinimum(MetadataUtils.createBigDecimal(dp.getMinValue()));
                         builder.withMaximum(MetadataUtils.createBigDecimal(dp.getMaxValue()));
-                        builder.withStepSize(MetadataUtils.createBigDecimal(dp.isFloatType() ? 0.1 : 1L));
+                        builder.withStepSize(
+                                MetadataUtils.createBigDecimal(dp.isFloatType() ? new Float(0.1) : new Long(1L)));
                         builder.withUnitLabel(MetadataUtils.getUnit(dp));
                     }
 


### PR DESCRIPTION
Partial revert of #6531 because of conversion exceptions if numeric
values are not wrapped as objects.

Some additonal changes in generic object initializations were caused by applying the formatter and source cleanup.

Signed-off-by: Martin Herbst <develop@mherbst.de>