### PR TITLE
[homematic] fix SCA warnings in java classes

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -23,6 +23,7 @@ import org.openhab.binding.homematic.internal.model.HmInterface;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicConfig {
     private static final String ISO_ENCODING = "ISO-8859-1";
     private static final String UTF_ENCODING = "UTF-8";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -85,6 +85,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractHomematicGateway implements RpcEventListener, HomematicGateway, VirtualGateway {
     private final Logger logger = LoggerFactory.getLogger(AbstractHomematicGateway.class);
     public static final double DEFAULT_DISABLE_DELAY = 2.0;
@@ -898,6 +899,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
      * Thread which validates the connection to the gateway and restarts the RPC client if necessary.
      * It also polls for the current duty cycle ratio of the gateway after every successful connection validation.
      */
+    @NonNullByDefault
     private class ConnectionTrackerThread implements Runnable {
         private boolean connectionLost;
         private boolean ping;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -54,6 +54,7 @@ import com.thoughtworks.xstream.io.xml.StaxDriver;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuGateway extends AbstractHomematicGateway {
     private final Logger logger = LoggerFactory.getLogger(CcuGateway.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/DefaultGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/DefaultGateway.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DefaultGateway extends AbstractHomematicGateway {
 
     protected DefaultGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomegearGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomegearGateway.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomegearGateway extends AbstractHomematicGateway {
 
     protected HomegearGateway(String id, HomematicConfig config, HomematicGatewayAdapter gatewayAdapter,

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGateway.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicGateway {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayAdapter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayAdapter.java
@@ -21,6 +21,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicGatewayAdapter {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayFactory.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicGatewayFactory.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.communicator.client.XmlRpcClient;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicGatewayFactory {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BinRpcClient extends RpcClient<byte[]> {
     private final Logger logger = LoggerFactory.getLogger(BinRpcClient.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public abstract class RpcClient<T> {
     private final Logger logger = LoggerFactory.getLogger(RpcClient.class);
     protected static final int MAX_RPC_RETRY = 1;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketHandler.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class SocketHandler {
     private final Logger logger = LoggerFactory.getLogger(SocketHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketInfo.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/SocketInfo.java
@@ -19,6 +19,7 @@ import java.net.Socket;
  * 
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class SocketInfo {
     private Socket socket;
     private long created;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/UnknownParameterSetException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/UnknownParameterSetException.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class UnknownParameterSetException extends IOException {
     private static final long serialVersionUID = -246970996431236583L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/UnknownRpcFailureException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/UnknownRpcFailureException.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class UnknownRpcFailureException extends IOException {
     private static final long serialVersionUID = -5695414238422364040L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/BinRpcMessage.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BinRpcMessage implements RpcRequest<byte[]>, RpcResponse {
     private final Logger logger = LoggerFactory.getLogger(BinRpcMessage.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcRequest.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcRequest.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.communicator.message;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface RpcRequest<T> {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcResponse.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcResponse.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.communicator.message;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface RpcResponse {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/RpcUtils.java
@@ -19,6 +19,7 @@ import java.util.Map;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class RpcUtils {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcRequest.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcRequest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.StringEscapeUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class XmlRpcRequest implements RpcRequest<String> {
 
     public enum TYPE {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcResponse.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/message/XmlRpcResponse.java
@@ -36,6 +36,7 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class XmlRpcResponse implements RpcResponse {
     private String methodName;
     private Object[] responseData;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuLoadDeviceNamesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuLoadDeviceNamesParser.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.TclScriptDataList;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuLoadDeviceNamesParser extends CommonRpcParser<TclScriptDataList, Void> {
     private Collection<HmDevice> devices;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuParamsetDescriptionParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuParamsetDescriptionParser.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.model.TclScriptDataList;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuParamsetDescriptionParser extends CommonRpcParser<TclScriptDataList, Void> {
     private HmParamsetType paramsetType;
     private HmChannel channel;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuValueParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuValueParser.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuValueParser extends CommonRpcParser<TclScriptDataList, Void> {
     private final Logger logger = LoggerFactory.getLogger(CcuValueParser.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuVariablesAndScriptsParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuVariablesAndScriptsParser.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.model.TclScriptDataList;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuVariablesAndScriptsParser extends CommonRpcParser<TclScriptDataList, Void> {
     private HmChannel channel;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CommonRpcParser.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public abstract class CommonRpcParser<M, R> implements RpcParser<M, R> {
 
     private final Logger logger = LoggerFactory.getLogger(CommonRpcParser.class);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DeleteDevicesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DeleteDevicesParser.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DeleteDevicesParser extends CommonRpcParser<Object[], List<String>> {
     @Override
     public List<String> parse(Object[] message) throws IOException {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/DisplayOptionsParser.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class DisplayOptionsParser extends CommonRpcParser<Object, Void> {
     private final Logger logger = LoggerFactory.getLogger(DisplayOptionsParser.class);
     private static final String[] onOff = new String[] { "ON", "OFF" };

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/EventParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/EventParser.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.HmParamsetType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class EventParser extends CommonRpcParser<Object[], HmDatapointInfo> {
     private Object value;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetAllScriptsParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetAllScriptsParser.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetAllScriptsParser extends CommonRpcParser<Object[], Void> {
     private HmChannel channel;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetAllSystemVariablesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetAllSystemVariablesParser.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetAllSystemVariablesParser extends CommonRpcParser<Object[], Void> {
     private HmChannel channel;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetDeviceDescriptionParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetDeviceDescriptionParser.java
@@ -20,6 +20,7 @@ import java.util.Map;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetDeviceDescriptionParser extends CommonRpcParser<Object[], GetDeviceDescriptionParser> {
     private String type;
     private String firmware;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetDescriptionParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetDescriptionParser.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetParamsetDescriptionParser extends CommonRpcParser<Object[], Void> {
     private final Logger logger = LoggerFactory.getLogger(GetParamsetDescriptionParser.class);
     private HmParamsetType paramsetType;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
     private final Logger logger = LoggerFactory.getLogger(GetParamsetParser.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetValueParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetValueParser.java
@@ -22,6 +22,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GetValueParser extends CommonRpcParser<Object[], Void> {
     private HmDatapoint dp;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/HomegearLoadDeviceNamesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/HomegearLoadDeviceNamesParser.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomegearLoadDeviceNamesParser extends CommonRpcParser<Object[], Void> {
     private Collection<HmDevice> devices;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListBidcosInterfacesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListBidcosInterfacesParser.java
@@ -20,6 +20,7 @@ import java.util.Map;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ListBidcosInterfacesParser extends CommonRpcParser<Object[], ListBidcosInterfacesParser> {
     private String type;
     private String gatewayAddress;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/ListDevicesParser.java
@@ -31,6 +31,7 @@ import org.openhab.binding.homematic.internal.model.HmInterface;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ListDevicesParser extends CommonRpcParser<Object[], Collection<HmDevice>> {
     private HmInterface hmInterface;
     private HomematicConfig config;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/NewDevicesParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/NewDevicesParser.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class NewDevicesParser extends CommonRpcParser<Object[], List<String>> {
     @Override
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RpcParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RpcParser.java
@@ -19,6 +19,7 @@ import java.io.IOException;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface RpcParser<M, R> {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RpcResponseParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RpcResponseParser.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.communicator.message.RpcRequest;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class RpcResponseParser extends CommonRpcParser<Object[], Object[]> {
     private RpcRequest<?> request;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RssiInfoParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/RssiInfoParser.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmRssiInfo;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class RssiInfoParser extends CommonRpcParser<Object[], List<HmRssiInfo>> {
     private HomematicConfig config;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.communicator.message.RpcRequest;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BinRpcNetworkService implements Runnable {
     private static final byte BIN_EMPTY_STRING[] = { 'B', 'i', 'n', 1, 0, 0, 0, 8, 0, 0, 0, 3, 0, 0, 0, 0 };
     private static final byte BIN_EMPTY_ARRAY[] = { 'B', 'i', 'n', 1, 0, 0, 0, 8, 0, 0, 1, 0, 0, 0, 0, 0 };

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcResponseHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcResponseHandler.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BinRpcResponseHandler implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(BinRpcResponseHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcServer.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/BinRpcServer.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BinRpcServer implements RpcServer {
     private final Logger logger = LoggerFactory.getLogger(BinRpcServer.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcEventListener.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcEventListener.java
@@ -21,6 +21,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapointInfo;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface RpcEventListener {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcResponseHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcResponseHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public abstract class RpcResponseHandler<T> {
     private final Logger logger = LoggerFactory.getLogger(RpcResponseHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcServer.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/RpcServer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface RpcServer {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/server/XmlRpcServer.java
@@ -37,6 +37,7 @@ import org.xml.sax.SAXException;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class XmlRpcServer implements RpcServer {
     private final Logger logger = LoggerFactory.getLogger(XmlRpcServer.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/AbstractVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/AbstractVirtualDatapointHandler.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractVirtualDatapointHandler implements VirtualDatapointHandler {
     private final Logger logger = LoggerFactory.getLogger(AbstractVirtualDatapointHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/BatteryTypeVirtualDatapointHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class BatteryTypeVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     private final Logger logger = LoggerFactory.getLogger(BatteryTypeVirtualDatapointHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Michael Reitler - Initial contribution
  */
+@NonNullByDefault
 public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     private final Logger logger = LoggerFactory.getLogger(ButtonVirtualDatapointHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceModeVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceModeVirtualDatapointHandler.java
@@ -30,6 +30,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DeleteDeviceModeVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     protected static final String MODE_LOCKED = "LOCKED";
     protected static final String MODE_RESET = "RESET";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DeleteDeviceVirtualDatapointHandler.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DeleteDeviceVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     private final Logger logger = LoggerFactory.getLogger(DeleteDeviceVirtualDatapointHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayOptionsVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayOptionsVirtualDatapointHandler.java
@@ -33,6 +33,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DisplayOptionsVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
@@ -40,7 +40,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class DisplayTextVirtualDatapoint extends AbstractVirtualDatapointHandler {
 
     private static final String DATAPOINT_NAME_DISPLAY_LINE = "DISPLAY_LINE_";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/FirmwareVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/FirmwareVirtualDatapointHandler.java
@@ -22,6 +22,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class FirmwareVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/HmwIoModuleVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/HmwIoModuleVirtualDatapointHandler.java
@@ -28,6 +28,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmwIoModuleVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/InstallModeDurationVirtualDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/InstallModeDurationVirtualDatapoint.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class InstallModeDurationVirtualDatapoint extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/InstallModeVirtualDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/InstallModeVirtualDatapoint.java
@@ -31,6 +31,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class InstallModeVirtualDatapoint extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class OnTimeAutomaticVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     private final Logger logger = LoggerFactory.getLogger(OnTimeAutomaticVirtualDatapointHandler.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadAllFromGatewayVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadAllFromGatewayVirtualDatapointHandler.java
@@ -30,6 +30,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ReloadAllFromGatewayVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadFromGatewayVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadFromGatewayVirtualDatapointHandler.java
@@ -29,6 +29,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ReloadFromGatewayVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadRssiVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ReloadRssiVirtualDatapointHandler.java
@@ -29,6 +29,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ReloadRssiVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/RssiVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/RssiVirtualDatapointHandler.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class RssiVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/SignalStrengthVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/SignalStrengthVirtualDatapointHandler.java
@@ -25,7 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class SignalStrengthVirtualDatapointHandler extends RssiVirtualDatapointHandler {
     private static final int RSSI_START = 40;
     private static final int RSSI_STEP = 25;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
@@ -25,6 +25,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class StateContactVirtualDatapointHandler extends AbstractVirtualDatapointHandler {
     @Override
     public String getName() {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/VirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/VirtualDatapointHandler.java
@@ -26,6 +26,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface VirtualDatapointHandler {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/VirtualGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/VirtualGateway.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.model.HmInterface;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface VirtualGateway extends HomematicGateway {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterException.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.converter;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ConverterException extends Exception {
     private static final long serialVersionUID = 78045670450002L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterFactory.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterFactory.java
@@ -30,6 +30,7 @@ import org.openhab.binding.homematic.internal.converter.type.StringTypeConverter
  * @author Gerhard Riegler - Initial contribution
  * @author Michael Reitler - QuantityType support
  */
+@NonNullByDefault
 public class ConverterFactory {
     private static Map<String, TypeConverter<?>> converterCache = new HashMap<String, TypeConverter<?>>();
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterTypeException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/ConverterTypeException.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.converter;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class ConverterTypeException extends ConverterException {
     private static final long serialVersionUID = 7114173349077221055L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/StateInvertInfo.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/StateInvertInfo.java
@@ -19,6 +19,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class StateInvertInfo {
     private String deviceType;
     private int minChannel;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/TypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/TypeConverter.java
@@ -21,6 +21,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface TypeConverter<T extends State> {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/AbstractTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/AbstractTypeConverter.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractTypeConverter<T extends State> implements TypeConverter<T> {
     private final Logger logger = LoggerFactory.getLogger(AbstractTypeConverter.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/DecimalTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/DecimalTypeConverter.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DecimalTypeConverter extends AbstractTypeConverter<DecimalType> {
     @Override
     protected boolean toBindingValidation(HmDatapoint dp, Class<? extends Type> typeClass) {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/OnOffTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/OnOffTypeConverter.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class OnOffTypeConverter extends AbstractTypeConverter<OnOffType> {
     @Override
     protected boolean toBindingValidation(HmDatapoint dp, Class<? extends Type> typeClass) {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/OpenClosedTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/OpenClosedTypeConverter.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class OpenClosedTypeConverter extends AbstractTypeConverter<OpenClosedType> {
     @Override
     protected boolean toBindingValidation(HmDatapoint dp, Class<? extends Type> typeClass) {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/PercentTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/PercentTypeConverter.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class PercentTypeConverter extends AbstractTypeConverter<PercentType> {
     private final Logger logger = LoggerFactory.getLogger(PercentTypeConverter.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/QuantityTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/QuantityTypeConverter.java
@@ -41,6 +41,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  *
  * @author Michael Reitler - Initial contribution
  */
+@NonNullByDefault
 public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? extends Quantity<?>>> {
 
     // this literal is required because some gateway types are mixing up encodings in their XML-RPC responses

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/StringTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/StringTypeConverter.java
@@ -23,6 +23,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapointInfo;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class StringTypeConverter extends AbstractTypeConverter<StringType> {
     @Override
     protected boolean toBindingValidation(HmDatapoint dp, Class<? extends Type> typeClass) {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/CcuDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/CcuDiscoveryService.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.homematic")
 public class CcuDiscoveryService extends AbstractDiscoveryService {
     private final Logger logger = LoggerFactory.getLogger(CcuDiscoveryService.class);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomegearDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomegearDiscoveryParticipant.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class HomegearDiscoveryParticipant implements UpnpDiscoveryParticipant {
     private final Logger logger = LoggerFactory.getLogger(HomegearDiscoveryParticipant.class);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService
         implements DiscoveryService, ThingHandlerService {
     private final Logger logger = LoggerFactory.getLogger(HomematicDeviceDiscoveryService.class);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/eq3udp/Eq3UdpRequest.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/eq3udp/Eq3UdpRequest.java
@@ -21,7 +21,7 @@ import java.util.Random;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class Eq3UdpRequest {
     private static final byte UDP_IDENTIFY = 73;
     private static final byte UDP_SEPARATOR = 0;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/eq3udp/Eq3UdpResponse.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/eq3udp/Eq3UdpResponse.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class Eq3UdpResponse {
     private int senderId;
     private String deviceTypeId;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/GatewayNotAvailableException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/GatewayNotAvailableException.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.handler;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class GatewayNotAvailableException extends Exception {
     private static final long serialVersionUID = 95628391238530L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicBridgeHandler extends BaseBridgeHandler implements HomematicGatewayAdapter {
     private final Logger logger = LoggerFactory.getLogger(HomematicBridgeHandler.class);
     private static final long REINITIALIZE_DELAY_SECONDS = 10;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicThingHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HomematicThingHandler.class);
     private Future<?> initFuture;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandlerFactory.java
@@ -32,6 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.homematic")
 public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/SimplePortPool.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/SimplePortPool.java
@@ -21,6 +21,7 @@ import java.util.List;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class SimplePortPool {
     private static int START_PORT = 9125;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/DelayedExecuter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/DelayedExecuter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class DelayedExecuter {
     private final Logger logger = LoggerFactory.getLogger(DelayedExecuter.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicClientException.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/HomematicClientException.java
@@ -17,6 +17,7 @@ package org.openhab.binding.homematic.internal.misc;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HomematicClientException extends Exception {
     private static final long serialVersionUID = 76348991234346L;
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/MiscUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/MiscUtils.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class MiscUtils {
     private static final Logger logger = LoggerFactory.getLogger(MiscUtils.class);
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmChannel.java
@@ -27,6 +27,7 @@ import org.openhab.binding.homematic.internal.misc.HomematicConstants;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmChannel {
     public static final String TYPE_GATEWAY_EXTRAS = "GATEWAY-EXTRAS";
     public static final String TYPE_GATEWAY_VARIABLE = "GATEWAY-VARIABLE";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
@@ -22,6 +22,7 @@ import org.openhab.binding.homematic.internal.misc.MiscUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmDatapoint implements Cloneable {
 
     private HmChannel channel;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapointConfig.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapointConfig.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmDatapointConfig {
     private Double delay;
     private Double receiveDelay;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapointInfo.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapointInfo.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmDatapointInfo {
     private String address;
     private Integer channel;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDevice.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDevice.java
@@ -28,6 +28,7 @@ import org.openhab.binding.homematic.internal.misc.MiscUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmDevice {
     public static final String TYPE_GATEWAY_EXTRAS = "GATEWAY-EXTRAS";
     public static final String ADDRESS_GATEWAY_EXTRAS = "GWE00000000";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmGatewayInfo.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmGatewayInfo.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class HmGatewayInfo {
     public static final String ID_HOMEGEAR = "HOMEGEAR";
     public static final String ID_CCU = "CCU";

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmResult.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmResult.java
@@ -19,6 +19,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @XStreamAlias("result")
 public class HmResult {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmRssiInfo.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmRssiInfo.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-
+@NonNullByDefault
 public class HmRssiInfo {
     private String address;
     private Integer device;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScript.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScript.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @XStreamAlias("script")
 public class TclScript {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptDataEntry.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptDataEntry.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @XStreamAlias("entry")
 public class TclScriptDataEntry {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptDataList.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptDataList.java
@@ -23,6 +23,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @XStreamAlias("list")
 public class TclScriptDataList {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptList.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/TclScriptList.java
@@ -24,6 +24,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @XStreamAlias("scripts")
 public class TclScriptList {
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelGroupTypeProvider.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelGroupTypeProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
  *
  * @author Michael Reitler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicChannelGroupTypeProvider extends ChannelGroupTypeProvider {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelGroupTypeProviderImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelGroupTypeProviderImpl.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Michael Reitler - Initial contribution
  */
+@NonNullByDefault
 @Component(service = { HomematicChannelGroupTypeProvider.class, ChannelGroupTypeProvider.class }, immediate = true)
 public class HomematicChannelGroupTypeProviderImpl implements HomematicChannelGroupTypeProvider {
     private final Map<ChannelGroupTypeUID, ChannelGroupType> channelGroupTypesByUID = new HashMap<ChannelGroupTypeUID, ChannelGroupType>();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelTypeProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicChannelTypeProvider extends ChannelTypeProvider {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelTypeProviderImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicChannelTypeProviderImpl.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Gerhard Riegler - Initial contribution
  * @author Michael Reitler - Added HomematicThingTypeExcluder
  */
+@NonNullByDefault
 @Component(service = { HomematicChannelTypeProvider.class, ChannelTypeProvider.class }, immediate = true)
 public class HomematicChannelTypeProviderImpl implements HomematicChannelTypeProvider {
     private final Map<ChannelTypeUID, ChannelType> channelTypesByUID = new HashMap<ChannelTypeUID, ChannelType>();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicConfigDescriptionProvider.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicConfigDescriptionProvider.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicConfigDescriptionProvider extends ConfigDescriptionProvider {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicConfigDescriptionProviderImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicConfigDescriptionProviderImpl.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Gerhard Riegler - Initial contribution
  * @author Michael Reitler - Added HomematicThingTypeExcluder
  */
+@NonNullByDefault
 @Component(service = { HomematicConfigDescriptionProvider.class, ConfigDescriptionProvider.class }, immediate = true)
 public class HomematicConfigDescriptionProviderImpl implements HomematicConfigDescriptionProvider {
     private Map<URI, ConfigDescription> configDescriptionsByURI = new HashMap<URI, ConfigDescription>();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicThingTypeProvider.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicThingTypeProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.type.ThingType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicThingTypeProvider extends ThingTypeProvider {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicThingTypeProviderImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicThingTypeProviderImpl.java
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Gerhard Riegler - Initial contribution
  * @author Michael Reitler - Added HomematicThingTypeExcluder
  */
+@NonNullByDefault
 @Component(service = { HomematicThingTypeProvider.class, ThingTypeProvider.class }, immediate = true)
 public class HomematicThingTypeProviderImpl implements HomematicThingTypeProvider {
     private Map<ThingTypeUID, ThingType> thingTypesByUID = new HashMap<ThingTypeUID, ThingType>();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGenerator.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGenerator.java
@@ -18,6 +18,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public interface HomematicTypeGenerator {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
     private final Logger logger = LoggerFactory.getLogger(HomematicTypeGeneratorImpl.class);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * @author Gerhard Riegler - Initial contribution
  * @author Michael Reitler - QuantityType support
  */
-
+@NonNullByDefault
 public class MetadataUtils {
     private static final Logger logger = LoggerFactory.getLogger(MetadataUtils.class);
     private static ResourceBundle descriptionsBundle;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/UidUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/UidUtils.java
@@ -34,6 +34,7 @@ import org.openhab.binding.homematic.internal.model.HmParamsetType;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class UidUtils {
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/generator/CcuMetadataExtractor.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/generator/CcuMetadataExtractor.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang.StringUtils;
  *
  * @author Gerhard Riegler - Initial contribution
  */
+@NonNullByDefault
 public class CcuMetadataExtractor {
     private static final String CCU_URL = "http://ccu";
 

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/client/RpcClientTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/client/RpcClientTest.java
@@ -32,6 +32,7 @@ import org.openhab.binding.homematic.test.util.RpcClientMockImpl;
 /**
  * @author Florian Stolte - Initial contribution
  */
+@NonNullByDefault
 public class RpcClientTest extends JavaTest {
 
     private RpcClientMockImpl rpcClient;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
@@ -38,6 +38,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
  * @author Michael Reitler - Initial Contribution
  *
  */
+@NonNullByDefault
 public class ButtonDatapointTest extends JavaTest {
 
     private static final int DISABLE_DATAPOINT_DELAY = 50;
@@ -53,6 +54,7 @@ public class ButtonDatapointTest extends JavaTest {
     @Test
     public void testShortPress() throws IOException, HomematicClientException {
         HmDatapoint shortPressDp = createPressDatapoint("PRESS_SHORT", Boolean.TRUE);
+        @NonNullByDefault
         HmDatapoint buttonVirtualDatapoint = getButtonVirtualDatapoint(shortPressDp);
 
         mockEventReceiver.eventReceived(shortPressDp);
@@ -135,6 +137,7 @@ public class ButtonDatapointTest extends JavaTest {
     /**
      * Mock parts of {@linkplain org.openhab.binding.homematic.internal.communicator.AbstractHomematicGateway}
      */
+    @NonNullByDefault
     private class MockEventReceiver {
 
         public void eventReceived(HmDatapoint dp) throws IOException, HomematicClientException {

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
@@ -23,6 +23,7 @@ import org.openhab.binding.homematic.internal.model.HmValueType;
 /**
  * @author Michael Reitler - Initial contribution
  */
+@NonNullByDefault
 public class BaseConverterTest {
 
     protected final HmDatapoint floatDp = new HmDatapoint("floatDp", "", HmValueType.FLOAT, null, false,

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
@@ -32,6 +32,7 @@ import tec.uom.se.quantity.QuantityDimension;
  * @author Michael Reitler - Initial Contribution
  *
  */
+@NonNullByDefault
 public class ConvertFromBindingTest extends BaseConverterTest {
 
     @Test

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertToBindingTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertToBindingTest.java
@@ -36,6 +36,7 @@ import org.openhab.binding.homematic.internal.model.HmDatapoint;
  * @author Michael Reitler - Initial Contribution
  *
  */
+@NonNullByDefault
 public class ConvertToBindingTest extends BaseConverterTest {
 
     @Test

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConverterFactoryTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConverterFactoryTest.java
@@ -31,6 +31,7 @@ import org.openhab.binding.homematic.internal.converter.type.StringTypeConverter
  * @author Michael Reitler - Initial Contribution
  *
  */
+@NonNullByDefault
 public class ConverterFactoryTest {
 
     @Test

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
@@ -41,6 +41,7 @@ import org.openhab.binding.homematic.test.util.SimpleDiscoveryListener;
  * @author Florian Stolte - Initial Contribution
  *
  */
+@NonNullByDefault
 public class HomematicDeviceDiscoveryServiceTest extends JavaTest {
 
     private HomematicDeviceDiscoveryService homematicDeviceDiscoveryService;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/handler/SimplePortPoolTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/handler/SimplePortPoolTest.java
@@ -29,6 +29,7 @@ import org.openhab.binding.homematic.internal.handler.SimplePortPool;
  * @author Florian Stolte - Initial Contribution
  *
  */
+@NonNullByDefault
 public class SimplePortPoolTest {
 
     private SimplePortPool simplePortPool;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/type/UidUtilsTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/type/UidUtilsTest.java
@@ -37,6 +37,7 @@ import org.openhab.binding.homematic.internal.type.UidUtils;
  * @author Florian Stolte - Initial Contribution
  *
  */
+@NonNullByDefault
 public class UidUtilsTest {
 
     @Test

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/BridgeHelper.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/BridgeHelper.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder;
  * @author Florian Stolte - Initial Contribution
  * 
  */
+@NonNullByDefault
 public class BridgeHelper {
 
     public static Bridge createHomematicBridge() {

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/DimmerHelper.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/DimmerHelper.java
@@ -28,6 +28,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
  * @author Florian Stolte - Initial Contribution
  * 
  */
+@NonNullByDefault
 public class DimmerHelper {
 
     public static HmDevice createDimmerHmDevice() {

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/RpcClientMockImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/RpcClientMockImpl.java
@@ -24,6 +24,7 @@ import org.openhab.binding.homematic.internal.communicator.message.RpcRequest;
 /**
  * @author Florian Stolte - Initial contribution
  */
+@NonNullByDefault
 public class RpcClientMockImpl extends RpcClient<String> {
 
     public static final String GET_PARAMSET_DESCRIPTION_NAME = "getParamsetDescription";

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
  * @author Florian Stolte - Initial Contribution
  *
  */
+@NonNullByDefault
 public class SimpleDiscoveryListener implements DiscoveryListener {
 
     public Queue<DiscoveryResult> discoveredResults = new ConcurrentLinkedQueue<DiscoveryResult>();


### PR DESCRIPTION
org.openhab.binding.homematic.internal.communicator.HomematicGateway.java
tool priority line category rule message
checkstyle 2 30 style NullAnnotationsCheck Classes/Interfaces should be annotated with @NonNullByDefault

and other files

add @NonNullByDefault to classes that had been reported by SCA

Also-by: Michael Roßner <Schrott.Micha@web.de>
Signed-off-by: Rosi2143 <Schrott.Micha@web.de>