### PR TITLE
[hue] Decoupling of 'sensorRefreshInterval' and time gap for lastchange check

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -301,7 +301,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             logger.warn("No bridge connected or selected. Cannot set sensor state.");
         }
     }
-    
+
     @Override
     public void updateSensorConfig(FullSensor sensor, ConfigUpdate configUpdate) {
         if (hueBridge != null) {
@@ -356,7 +356,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             logger.trace("Error while accessing sensor: {}", e.getMessage());
         }
     }
-    
+
     private void handleConfigUpdateException(FullSensor sensor, ConfigUpdate configUpdate, Throwable e) {
         if (e instanceof IOException) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
@@ -796,9 +796,5 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         }
 
         return configStatusMessages;
-    }
-
-    public long getSensorPollingInterval() {
-        return sensorPollingInterval;
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.hue.internal.handler.sensors;
 
-import static org.openhab.binding.hue.internal.FullSensor.STATE_LAST_UPDATED;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
 import java.time.Instant;
@@ -25,20 +24,16 @@ import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.SensorConfigUpdate;
-import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
 import org.openhab.binding.hue.internal.handler.HueSensorHandler;
 
 /**
@@ -49,25 +44,11 @@ import org.openhab.binding.hue.internal.handler.HueSensorHandler;
  */
 @NonNullByDefault
 public class DimmerSwitchHandler extends HueSensorHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_DIMMER_SWITCH);
 
-    private long refreshIntervalInNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_DIMMER_SWITCH);
 
     public DimmerSwitchHandler(Thing thing) {
         super(thing);
-    }
-
-    @Override
-    public void initialize() {
-        super.initialize();
-        Bridge bridge = getBridge();
-        if (bridge != null) {
-            ThingHandler bridgeHandler = bridge.getHandler();
-            if (bridgeHandler instanceof HueBridgeHandler) {
-                refreshIntervalInNanos = TimeUnit.MILLISECONDS
-                        .toNanos(((HueBridgeHandler) bridgeHandler).getSensorPollingInterval() * 2);
-            }
-        }
     }
 
     @Override
@@ -80,7 +61,7 @@ public class DimmerSwitchHandler extends HueSensorHandler {
         ZoneId zoneId = ZoneId.systemDefault();
         ZonedDateTime now = ZonedDateTime.now(zoneId), timestamp = now;
 
-        Object lastUpdated = sensor.getState().get(STATE_LAST_UPDATED);
+        Object lastUpdated = sensor.getState().get(FullSensor.STATE_LAST_UPDATED);
         if (lastUpdated != null) {
             try {
                 timestamp = ZonedDateTime.ofInstant(
@@ -96,7 +77,7 @@ public class DimmerSwitchHandler extends HueSensorHandler {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_DIMMER_SWITCH, new DecimalType(value));
             Instant then = timestamp.toInstant();
-            Instant someSecondsEarlier = now.minusNanos(refreshIntervalInNanos).toInstant();
+            Instant someSecondsEarlier = now.minusSeconds(5).toInstant();
             if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
                 triggerChannel(EVENT_DIMMER_SWITCH, value);
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
@@ -76,8 +76,9 @@ public class DimmerSwitchHandler extends HueSensorHandler {
         if (buttonState != null) {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_DIMMER_SWITCH, new DecimalType(value));
+            // Avoid dispatching events if "lastupdated" is older than now minus 3 seconds (e.g. during restart)
             Instant then = timestamp.toInstant();
-            Instant someSecondsEarlier = now.minusSeconds(5).toInstant();
+            Instant someSecondsEarlier = now.minusSeconds(3).toInstant();
             if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
                 triggerChannel(EVENT_DIMMER_SWITCH, value);
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/TapSwitchHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/TapSwitchHandler.java
@@ -75,8 +75,9 @@ public class TapSwitchHandler extends HueSensorHandler {
         if (buttonState != null) {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_TAP_SWITCH, new DecimalType(value));
+            // Avoid dispatching events if "lastupdated" is older than now minus 3 seconds (e.g. during restart)
             Instant then = timestamp.toInstant();
-            Instant someSecondsEarlier = now.minusSeconds(5).toInstant();
+            Instant someSecondsEarlier = now.minusSeconds(3).toInstant();
             if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
                 triggerChannel(EVENT_TAP_SWITCH, value);
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/TapSwitchHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/TapSwitchHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.hue.internal.handler.sensors;
 
-import static org.openhab.binding.hue.internal.FullSensor.STATE_LAST_UPDATED;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
 import java.time.Instant;
@@ -25,20 +24,16 @@ import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.SensorConfigUpdate;
-import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
 import org.openhab.binding.hue.internal.handler.HueSensorHandler;
 
 /**
@@ -48,25 +43,11 @@ import org.openhab.binding.hue.internal.handler.HueSensorHandler;
  */
 @NonNullByDefault
 public class TapSwitchHandler extends HueSensorHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_TAP_SWITCH);
 
-    private long refreshIntervalInNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_TAP_SWITCH);
 
     public TapSwitchHandler(Thing thing) {
         super(thing);
-    }
-
-    @Override
-    public void initialize() {
-        super.initialize();
-        Bridge bridge = getBridge();
-        if (bridge != null) {
-            ThingHandler bridgeHandler = bridge.getHandler();
-            if (bridgeHandler instanceof HueBridgeHandler) {
-                refreshIntervalInNanos = TimeUnit.MILLISECONDS
-                        .toNanos(((HueBridgeHandler) bridgeHandler).getSensorPollingInterval() * 2);
-            }
-        }
     }
 
     @Override
@@ -79,7 +60,7 @@ public class TapSwitchHandler extends HueSensorHandler {
         ZoneId zoneId = ZoneId.systemDefault();
         ZonedDateTime now = ZonedDateTime.now(zoneId), timestamp = now;
 
-        Object lastUpdated = sensor.getState().get(STATE_LAST_UPDATED);
+        Object lastUpdated = sensor.getState().get(FullSensor.STATE_LAST_UPDATED);
         if (lastUpdated != null) {
             try {
                 timestamp = ZonedDateTime.ofInstant(
@@ -95,7 +76,7 @@ public class TapSwitchHandler extends HueSensorHandler {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_TAP_SWITCH, new DecimalType(value));
             Instant then = timestamp.toInstant();
-            Instant someSecondsEarlier = now.minusNanos(refreshIntervalInNanos).toInstant();
+            Instant someSecondsEarlier = now.minusSeconds(5).toInstant();
             if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
                 triggerChannel(EVENT_TAP_SWITCH, value);
             }


### PR DESCRIPTION
- Decoupling of `sensorRefreshInterval` and time gap for lastchange check

The accuracy of time values returned by the hue API is seconds. The `sensorRefreshInterval` are milliseconds. Reducing the `sensorRefreshInterval` leads to ignored events because of that.

Fixes #6577
Does not fix https://github.com/openhab/openhab2-addons/issues/6577#issuecomment-565160525 or #6578

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
