### PR TITLE
[lgwebos] Properly handle optional SessionID in response

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlMute.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlMute.java
@@ -62,7 +62,6 @@ public class VolumeControlMute extends BaseChannelHandler<Boolean> {
                 handler.postUpdate(channelId, OnOffType.from(value));
             }
         }));
-
     }
 
 }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/VolumeControlVolume.java
@@ -43,13 +43,15 @@ public class VolumeControlVolume extends BaseChannelHandler<Float> {
 
     @Override
     public void onReceiveCommand(String channelId, LGWebOSHandler handler, Command command) {
-        PercentType percent = null;
+        final PercentType percent;
         if (command instanceof PercentType) {
             percent = (PercentType) command;
         } else if (command instanceof DecimalType) {
             percent = new PercentType(((DecimalType) command).toBigDecimal());
         } else if (command instanceof StringType) {
             percent = new PercentType(((StringType) command).toString());
+        } else {
+            percent = null;
         }
 
         if (percent != null) {

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSConfiguration.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSConfiguration.java
@@ -12,21 +12,40 @@
  */
 package org.openhab.binding.lgwebos.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link LGWebOSConfiguration} class contains the thing configuration
  * parameters for LGWebOS devices
  *
  * @author Sebastian Prehn - Initial contribution
  */
+@NonNullByDefault
 public class LGWebOSConfiguration {
+    @Nullable
     String host; // name has to match LGWebOSBindingConstants.CONFIG_HOST
     int port = 3000; // 3001 for TLS
+    @Nullable
     String key; // name has to match LGWebOSBindingConstants.CONFIG_KEY
+
+    public String getHost() {
+        String h = host;
+        return h == null ? "" : h;
+    }
+
+    public String getKey() {
+        String k = key;
+        return k == null ? "" : k;
+    }
+
+    public int getPort() {
+        return port;
+    }
 
     @Override
     public String toString() {
-        return "WebOSConfiguration [host=" + host + ", port=" + port + ", key.length="
-                + (key == null ? "null" : key.length()) + "]";
+        return "WebOSConfiguration [host=" + host + ", port=" + port + ", key.length=" + getKey().length() + "]";
     }
 
 }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -244,7 +244,7 @@ public class LGWebOSTVSocket {
 
         JsonObject payload = new JsonObject();
         String key = config.getKey();
-        if (key != null && !key.isEmpty()) {
+        if (!key.isEmpty()) {
             payload.addProperty("client-key", key);
         }
         payload.addProperty("pairingType", "PROMPT"); // PIN, COMBINED
@@ -648,8 +648,12 @@ public class LGWebOSTVSocket {
             LaunchSession launchSession = new LaunchSession();
             launchSession.setService(this);
             launchSession.setAppId(appId); // note that response uses id to mean appId
-            launchSession.setSessionId(obj.get("sessionId").getAsString());
-            launchSession.setSessionType(LaunchSessionType.App);
+            if (obj.has("sessionId")) {
+                launchSession.setSessionId(obj.get("sessionId").getAsString());
+                launchSession.setSessionType(LaunchSessionType.App);
+            } else {
+                launchSession.setSessionType(LaunchSessionType.Unknown);
+            }
             return launchSession;
         }, listener);
         sendCommand(request);
@@ -664,8 +668,12 @@ public class LGWebOSTVSocket {
             LaunchSession launchSession = new LaunchSession();
             launchSession.setService(this);
             launchSession.setAppId(obj.get("id").getAsString()); // note that response uses id to mean appId
-            launchSession.setSessionId(obj.get("sessionId").getAsString());
-            launchSession.setSessionType(LaunchSessionType.App);
+            if (obj.has("sessionId")) {
+                launchSession.setSessionId(obj.get("sessionId").getAsString());
+                launchSession.setSessionType(LaunchSessionType.App);
+            } else {
+                launchSession.setSessionType(LaunchSessionType.Unknown);
+            }
             return launchSession;
         }, listener);
         sendCommand(request);
@@ -706,12 +714,10 @@ public class LGWebOSTVSocket {
 
     public void closeApp(LaunchSession launchSession, ResponseListener<CommandConfirmation> listener) {
         String uri = "ssap://system.launcher/close";
-        String appId = launchSession.getAppId();
-        String sessionId = launchSession.getSessionId();
 
         JsonObject payload = new JsonObject();
-        payload.addProperty("id", appId);
-        payload.addProperty("sessionId", sessionId);
+        payload.addProperty("id", launchSession.getAppId());
+        payload.addProperty("sessionId", launchSession.getSessionId());
 
         ServiceCommand<CommandConfirmation> request = new ServiceCommand<>(uri, payload,
                 x -> GSON.fromJson(x, CommandConfirmation.class), listener);
@@ -807,11 +813,10 @@ public class LGWebOSTVSocket {
     }
 
     public interface ConfigProvider {
-        void storeKey(@Nullable String key);
+        void storeKey(String key);
 
         void storeProperties(Map<String, String> properties);
 
-        @Nullable
         String getKey();
     }
 

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceCommand.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceCommand.java
@@ -60,8 +60,6 @@ public class ServiceCommand<T> {
     protected String target;
     protected Function<JsonObject, T> converter;
 
-    int requestId;
-
     ResponseListener<T> responseListener;
 
     public ServiceCommand(String targetURL, JsonObject payload, Function<JsonObject, T> converter,
@@ -71,8 +69,6 @@ public class ServiceCommand<T> {
         this.converter = converter;
         this.responseListener = listener;
         this.type = Type.request;
-        requestId = -1;
-
     }
 
     public JsonElement getPayload() {
@@ -101,8 +97,7 @@ public class ServiceCommand<T> {
 
     @Override
     public String toString() {
-        return "ServiceCommand [requestId=" + requestId + ", type=" + type + ", target=" + target + ", payload="
-                + payload + "]";
+        return "ServiceCommand [type=" + type + ", target=" + target + ", payload=" + payload + "]";
     }
 
 }


### PR DESCRIPTION
- Fixed exception processing response after launching apps, as sessionId is optional in the response.
- Fixed various warnings on handling potential null values.

Signed-off-by: Sebastian Prehn <sebastian.prehn@gmx.de>
