### PR TITLE
[miio] fix wrong channel for vacuum thing

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
@@ -294,7 +294,7 @@
 		<state pattern="%.0f" readOnly="true" />
 	</channel-type>
 	<channel-type id="last_clean_finish">
-		<item-type>Boolean</item-type>
+		<item-type>Number</item-type>
 		<label>Cleaning Finished</label>
 		<state readOnly="true" />
 	</channel-type>


### PR DESCRIPTION
fix invalid type 

see forum
https://community.openhab.org/t/xiaomi-robot-vacuum-binding/31317/1179

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
